### PR TITLE
test: add CI tests for systemd service config file write access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Config persistence tests
         run: cargo test --test config_persistence_test -- --nocapture
 
+      - name: Systemd config tests
+        run: cargo test -p mihomo-app --test systemd_config_test -- --nocapture
+
       - name: Trojan integration tests
         run: cargo test --test trojan_integration -- --nocapture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "parking_lot",
  "rustls",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/mihomo-api/src/routes.rs
+++ b/crates/mihomo-api/src/routes.rs
@@ -30,7 +30,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/version", get(version))
         .route("/proxies", get(get_proxies))
         .route("/proxies/{name}", get(get_proxy).put(update_proxy))
-        .route("/rules", get(get_rules).post(replace_rules).put(update_rule_at_index))
+        .route(
+            "/rules",
+            get(get_rules).post(replace_rules).put(update_rule_at_index),
+        )
         .route("/rules/{index}", delete(delete_rule))
         .route("/rules/reorder", post(reorder_rules))
         .route("/connections", get(get_connections))
@@ -41,13 +44,28 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         // Config save
         .route("/api/config/save", post(save_config))
         // Subscriptions
-        .route("/api/subscriptions", get(get_subscriptions).post(add_subscription))
+        .route(
+            "/api/subscriptions",
+            get(get_subscriptions).post(add_subscription),
+        )
         .route("/api/subscriptions/{name}", delete(delete_subscription))
-        .route("/api/subscriptions/{name}/refresh", post(refresh_subscription))
+        .route(
+            "/api/subscriptions/{name}/refresh",
+            post(refresh_subscription),
+        )
         // Proxy groups
-        .route("/api/proxy-groups", get(get_proxy_groups).post(create_proxy_group))
-        .route("/api/proxy-groups/{name}", put(update_proxy_group).delete(delete_proxy_group))
-        .route("/api/proxy-groups/{name}/select", put(select_proxy_in_group))
+        .route(
+            "/api/proxy-groups",
+            get(get_proxy_groups).post(create_proxy_group),
+        )
+        .route(
+            "/api/proxy-groups/{name}",
+            put(update_proxy_group).delete(delete_proxy_group),
+        )
+        .route(
+            "/api/proxy-groups/{name}/select",
+            put(select_proxy_in_group),
+        )
         // Web UI
         .route("/ui", get(ui::serve_ui))
         .route("/ui/{*rest}", get(ui::serve_ui))
@@ -62,10 +80,16 @@ async fn hello() -> &'static str {
 }
 
 #[derive(Serialize)]
-struct VersionResponse { version: String, meta: bool }
+struct VersionResponse {
+    version: String,
+    meta: bool,
+}
 
 async fn version() -> Json<VersionResponse> {
-    Json(VersionResponse { version: env!("CARGO_PKG_VERSION").to_string(), meta: true })
+    Json(VersionResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        meta: true,
+    })
 }
 
 #[derive(Serialize)]
@@ -87,13 +111,16 @@ async fn get_proxies(State(state): State<Arc<AppState>>) -> Json<ProxiesResponse
     let proxies = state.tunnel.proxies();
     let mut result = std::collections::HashMap::new();
     for (name, proxy) in &proxies {
-        result.insert(name.clone(), ProxyInfo {
-            name: proxy.name().to_string(),
-            proxy_type: proxy.adapter_type().to_string(),
-            alive: proxy.alive(),
-            history: proxy.delay_history(),
-            udp: proxy.support_udp(),
-        });
+        result.insert(
+            name.clone(),
+            ProxyInfo {
+                name: proxy.name().to_string(),
+                proxy_type: proxy.adapter_type().to_string(),
+                alive: proxy.alive(),
+                history: proxy.delay_history(),
+                udp: proxy.support_udp(),
+            },
+        );
     }
     Json(ProxiesResponse { proxies: result })
 }
@@ -114,7 +141,9 @@ async fn get_proxy(
 }
 
 #[derive(Deserialize)]
-struct UpdateProxyRequest { name: String }
+struct UpdateProxyRequest {
+    name: String,
+}
 
 async fn update_proxy(
     State(state): State<Arc<AppState>>,
@@ -124,7 +153,10 @@ async fn update_proxy(
     use mihomo_proxy::SelectorGroup;
     let proxies = state.tunnel.proxies();
     if let Some(proxy) = proxies.get(&group_name) {
-        if let Some(selector) = proxy.as_any().and_then(|a| a.downcast_ref::<SelectorGroup>()) {
+        if let Some(selector) = proxy
+            .as_any()
+            .and_then(|a| a.downcast_ref::<SelectorGroup>())
+        {
             if selector.select(&body.name) {
                 info!("Selector '{}' switched to '{}'", group_name, body.name);
                 return StatusCode::NO_CONTENT;
@@ -144,13 +176,19 @@ struct RuleInfo {
 }
 
 #[derive(Serialize)]
-struct RulesResponse { rules: Vec<RuleInfo> }
+struct RulesResponse {
+    rules: Vec<RuleInfo>,
+}
 
 async fn get_rules(State(state): State<Arc<AppState>>) -> Json<RulesResponse> {
     let rules = state.tunnel.rules_info();
     let result: Vec<RuleInfo> = rules
         .into_iter()
-        .map(|(rt, payload, adapter)| RuleInfo { rule_type: rt, payload, proxy: adapter })
+        .map(|(rt, payload, adapter)| RuleInfo {
+            rule_type: rt,
+            payload,
+            proxy: adapter,
+        })
         .collect();
     Json(RulesResponse { rules: result })
 }
@@ -168,16 +206,25 @@ async fn get_connections(State(state): State<Arc<AppState>>) -> Json<Connections
     let conns = stats.active_connections();
     let connections: Vec<serde_json::Value> = conns
         .into_iter()
-        .map(|c| serde_json::json!({
-            "id": c.id, "upload": c.upload, "download": c.download,
-            "start": c.start, "chains": c.chains, "rule": c.rule,
-            "rulePayload": c.rule_payload,
-        }))
+        .map(|c| {
+            serde_json::json!({
+                "id": c.id, "upload": c.upload, "download": c.download,
+                "start": c.start, "chains": c.chains, "rule": c.rule,
+                "rulePayload": c.rule_payload,
+            })
+        })
         .collect();
-    Json(ConnectionsResponse { upload_total: up, download_total: down, connections })
+    Json(ConnectionsResponse {
+        upload_total: up,
+        download_total: down,
+        connections,
+    })
 }
 
-async fn close_connection(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> StatusCode {
+async fn close_connection(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> StatusCode {
     state.tunnel.statistics().close_connection(&id);
     StatusCode::NO_CONTENT
 }
@@ -193,7 +240,10 @@ struct ConfigResponse {
     socks_port: Option<u16>,
     #[serde(rename = "port", skip_serializing_if = "Option::is_none")]
     http_port: Option<u16>,
-    #[serde(rename = "external-controller", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "external-controller",
+        skip_serializing_if = "Option::is_none"
+    )]
     external_controller: Option<String>,
 }
 
@@ -210,12 +260,22 @@ async fn get_configs(State(state): State<Arc<AppState>>) -> Json<ConfigResponse>
 }
 
 #[derive(Deserialize)]
-struct UpdateConfigRequest { mode: Option<String>, #[serde(rename = "log-level")] log_level: Option<String> }
+struct UpdateConfigRequest {
+    mode: Option<String>,
+    #[serde(rename = "log-level")]
+    log_level: Option<String>,
+}
 
-async fn update_configs(State(state): State<Arc<AppState>>, Json(body): Json<UpdateConfigRequest>) -> StatusCode {
+async fn update_configs(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<UpdateConfigRequest>,
+) -> StatusCode {
     if let Some(mode_str) = body.mode {
         match mode_str.parse::<TunnelMode>() {
-            Ok(mode) => { state.tunnel.set_mode(mode); info!("Mode changed to {}", mode); }
+            Ok(mode) => {
+                state.tunnel.set_mode(mode);
+                info!("Mode changed to {}", mode);
+            }
             Err(_) => return StatusCode::BAD_REQUEST,
         }
     }
@@ -224,7 +284,10 @@ async fn update_configs(State(state): State<Arc<AppState>>, Json(body): Json<Upd
 }
 
 #[derive(Serialize)]
-struct TrafficResponse { up: i64, down: i64 }
+struct TrafficResponse {
+    up: i64,
+    down: i64,
+}
 
 async fn get_traffic(State(state): State<Arc<AppState>>) -> Json<TrafficResponse> {
     let (up, down) = state.tunnel.statistics().snapshot();
@@ -232,9 +295,16 @@ async fn get_traffic(State(state): State<Arc<AppState>>) -> Json<TrafficResponse
 }
 
 #[derive(Deserialize)]
-struct DnsQueryRequest { name: String, #[serde(rename = "type")] qtype: Option<String> }
+struct DnsQueryRequest {
+    name: String,
+    #[serde(rename = "type")]
+    qtype: Option<String>,
+}
 
-async fn dns_query(State(state): State<Arc<AppState>>, Json(body): Json<DnsQueryRequest>) -> Json<serde_json::Value> {
+async fn dns_query(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<DnsQueryRequest>,
+) -> Json<serde_json::Value> {
     let resolver = state.tunnel.resolver();
     let result = resolver.resolve_ip(&body.name).await;
     let _ = body.qtype;
@@ -295,7 +365,11 @@ async fn get_subscriptions(State(state): State<Arc<AppState>>) -> Json<Vec<Subsc
 }
 
 #[derive(Deserialize)]
-struct AddSubscriptionRequest { name: String, url: String, interval: Option<u64> }
+struct AddSubscriptionRequest {
+    name: String,
+    url: String,
+    interval: Option<u64>,
+}
 
 async fn add_subscription(
     State(state): State<Arc<AppState>>,
@@ -314,7 +388,10 @@ async fn add_subscription(
 
     if let Some(ref subs) = raw.subscriptions {
         if subs.iter().any(|s| s.name == body.name) {
-            return Err((StatusCode::CONFLICT, "subscription name already exists".into()));
+            return Err((
+                StatusCode::CONFLICT,
+                "subscription name already exists".into(),
+            ));
         }
     }
 
@@ -484,13 +561,18 @@ async fn create_proxy_group(
         }
     }
     let group = RawProxyGroup {
-        name: body.name.clone(), group_type: body.group_type,
-        proxies: Some(body.proxies), url: body.url,
-        interval: body.interval, tolerance: body.tolerance,
+        name: body.name.clone(),
+        group_type: body.group_type,
+        proxies: Some(body.proxies),
+        url: body.url,
+        interval: body.interval,
+        tolerance: body.tolerance,
     };
     raw.proxy_groups.get_or_insert_with(Vec::new).push(group);
     apply_raw_to_tunnel(&raw, &state.tunnel)?;
-    Ok(Json(serde_json::json!({"message": "group created", "name": body.name})))
+    Ok(Json(
+        serde_json::json!({"message": "group created", "name": body.name}),
+    ))
 }
 
 async fn update_proxy_group(
@@ -499,7 +581,9 @@ async fn update_proxy_group(
     Json(body): Json<CreateProxyGroupRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let mut raw = state.raw_config.write();
-    let group = raw.proxy_groups.as_mut()
+    let group = raw
+        .proxy_groups
+        .as_mut()
         .and_then(|groups| groups.iter_mut().find(|g| g.name == name))
         .ok_or_else(|| (StatusCode::NOT_FOUND, "group not found".into()))?;
     group.group_type = body.group_type;
@@ -536,7 +620,9 @@ async fn delete_proxy_group(
 }
 
 #[derive(Deserialize)]
-struct SelectProxyRequest { name: String }
+struct SelectProxyRequest {
+    name: String,
+}
 
 async fn select_proxy_in_group(
     State(state): State<Arc<AppState>>,
@@ -546,7 +632,10 @@ async fn select_proxy_in_group(
     use mihomo_proxy::SelectorGroup;
     let proxies = state.tunnel.proxies();
     if let Some(proxy) = proxies.get(&group_name) {
-        if let Some(selector) = proxy.as_any().and_then(|a| a.downcast_ref::<SelectorGroup>()) {
+        if let Some(selector) = proxy
+            .as_any()
+            .and_then(|a| a.downcast_ref::<SelectorGroup>())
+        {
             if selector.select(&body.name) {
                 info!("Selector '{}' switched to '{}'", group_name, body.name);
                 return StatusCode::NO_CONTENT;
@@ -560,7 +649,9 @@ async fn select_proxy_in_group(
 // ── Rules CRUD ───────────────────────────────────────────────────────
 
 #[derive(Deserialize)]
-struct ReplaceRulesRequest { rules: Vec<String> }
+struct ReplaceRulesRequest {
+    rules: Vec<String>,
+}
 
 async fn replace_rules(
     State(state): State<Arc<AppState>>,
@@ -573,7 +664,10 @@ async fn replace_rules(
 }
 
 #[derive(Deserialize)]
-struct UpdateRuleRequest { index: usize, rule: String }
+struct UpdateRuleRequest {
+    index: usize,
+    rule: String,
+}
 
 async fn update_rule_at_index(
     State(state): State<Arc<AppState>>,
@@ -604,7 +698,10 @@ async fn delete_rule(
 }
 
 #[derive(Deserialize)]
-struct ReorderRulesRequest { from: usize, to: usize }
+struct ReorderRulesRequest {
+    from: usize,
+    to: usize,
+}
 
 async fn reorder_rules(
     State(state): State<Arc<AppState>>,

--- a/crates/mihomo-api/src/routes.rs
+++ b/crates/mihomo-api/src/routes.rs
@@ -612,7 +612,7 @@ async fn delete_proxy_group(
     if let Some(ref mut rules) = raw.rules {
         rules.retain(|r| {
             let parts: Vec<&str> = r.split(',').collect();
-            !parts.last().is_some_and(|target| target.trim() == name)
+            parts.last().is_none_or(|target| target.trim() != name)
         });
     }
     apply_raw_to_tunnel(&raw, &state.tunnel)?;

--- a/crates/mihomo-api/tests/api_test.rs
+++ b/crates/mihomo-api/tests/api_test.rs
@@ -1,6 +1,6 @@
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
-use mihomo_api::routes::{AppState, create_router};
+use mihomo_api::routes::{create_router, AppState};
 use mihomo_common::DnsMode;
 use mihomo_config::raw::{RawConfig, RawProxyGroup, RawSubscription};
 use mihomo_dns::Resolver;
@@ -128,7 +128,11 @@ async fn version_endpoint() {
     let state = test_state_default();
     let app = create_router(state);
     let resp = app
-        .oneshot(Request::get("/version").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/version")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -142,7 +146,11 @@ async fn get_proxies_contains_builtins() {
     let state = test_state_default();
     let app = create_router(state);
     let resp = app
-        .oneshot(Request::get("/proxies").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/proxies")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -190,7 +198,11 @@ async fn get_configs_returns_mode() {
     let state = test_state_default();
     let app = create_router(state);
     let resp = app
-        .oneshot(Request::get("/configs").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/configs")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -218,7 +230,11 @@ async fn patch_configs_change_mode() {
     // Verify the mode changed
     let app2 = create_router(state);
     let resp2 = app2
-        .oneshot(Request::get("/configs").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/configs")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     let json = body_json(resp2).await;
@@ -248,7 +264,11 @@ async fn get_traffic() {
     let state = test_state_default();
     let app = create_router(state);
     let resp = app
-        .oneshot(Request::get("/traffic").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/traffic")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -262,7 +282,11 @@ async fn get_connections_empty() {
     let state = test_state_default();
     let app = create_router(state);
     let resp = app
-        .oneshot(Request::get("/connections").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/connections")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -279,7 +303,11 @@ async fn get_rules_returns_initial() {
     let state = test_state_default();
     let app = create_router(state);
     let resp = app
-        .oneshot(Request::get("/rules").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/rules")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -314,7 +342,11 @@ async fn replace_rules() {
     // Verify
     let app2 = create_router(state.clone());
     let resp2 = app2
-        .oneshot(Request::get("/rules").body(axum::body::Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/rules")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     let json = body_json(resp2).await;
@@ -809,7 +841,9 @@ async fn get_subscriptions_reports_counts() {
         name: "G".into(),
         group_type: "select".into(),
         proxies: Some(vec!["S1".into()]),
-        url: None, interval: None, tolerance: None,
+        url: None,
+        interval: None,
+        tolerance: None,
     }]);
     raw.rules = Some(vec!["MATCH,DIRECT".into()]);
 
@@ -863,7 +897,9 @@ async fn delete_subscription_clears_data() {
         name: "G".into(),
         group_type: "select".into(),
         proxies: Some(vec!["DIRECT".into(), "S1".into()]),
-        url: None, interval: None, tolerance: None,
+        url: None,
+        interval: None,
+        tolerance: None,
     }]);
 
     let state = test_state(raw);
@@ -995,32 +1031,43 @@ async fn select_proxy_roundtrip() {
         name: "Sel".into(),
         group_type: "select".into(),
         proxies: Some(vec!["DIRECT".into(), "REJECT".into()]),
-        url: None, interval: None, tolerance: None,
+        url: None,
+        interval: None,
+        tolerance: None,
     }]);
     let state = test_state(raw);
-    
+
     // Select REJECT
     let app = create_router(state.clone());
-    let resp = app.oneshot(
-        Request::builder()
-            .method("PUT")
-            .uri("/api/proxy-groups/Sel/select")
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(r#"{"name":"REJECT"}"#))
-            .unwrap(),
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/proxy-groups/Sel/select")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(r#"{"name":"REJECT"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::NO_CONTENT, "select failed");
-    
+
     // Read back proxy groups
     let app = create_router(state.clone());
-    let resp = app.oneshot(
-        Request::get("/api/proxy-groups")
-            .body(axum::body::Body::empty())
-            .unwrap(),
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::get("/api/proxy-groups")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let groups: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let sel = &groups[0];
-    assert_eq!(sel["now"], "REJECT", "now field should be REJECT after select");
+    assert_eq!(
+        sel["now"], "REJECT",
+        "now field should be REJECT after select"
+    );
 }

--- a/crates/mihomo-app/Cargo.toml
+++ b/crates/mihomo-app/Cargo.toml
@@ -24,3 +24,9 @@ serde_yaml = { workspace = true }
 parking_lot = { workspace = true }
 rustls = { workspace = true }
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"
+serde_yaml = { workspace = true }
+mihomo-config = { workspace = true }
+libc = "0.2"

--- a/crates/mihomo-app/src/lib.rs
+++ b/crates/mihomo-app/src/lib.rs
@@ -1,1 +1,42 @@
+/// Generate a systemd unit file for the mihomo service.
+///
+/// Returns the unit file content as a string.
+///
+/// # Arguments
+/// * `exe_path` - Absolute path to the mihomo binary
+/// * `config_path` - Absolute path to the configuration file
+pub fn generate_systemd_unit(exe_path: &str, config_path: &str) -> String {
+    let work_dir = std::path::Path::new(config_path)
+        .parent()
+        .unwrap_or(std::path::Path::new("/"))
+        .to_string_lossy()
+        .to_string();
 
+    format!(
+        r#"[Unit]
+Description=mihomo-rust proxy service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart={exe} -f {config}
+WorkingDirectory={work_dir}
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=1048576
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths={work_dir}
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+"#,
+        exe = exe_path,
+        config = config_path,
+        work_dir = work_dir,
+    )
+}

--- a/crates/mihomo-app/src/main.rs
+++ b/crates/mihomo-app/src/main.rs
@@ -118,40 +118,7 @@ fn install_service(config_override: Option<&str>, args: &Args) -> Result<()> {
         cwd.join(config_rel).to_string_lossy().to_string()
     };
 
-    // Determine working directory (config file's parent)
-    let work_dir = std::path::Path::new(&config_path)
-        .parent()
-        .unwrap_or(std::path::Path::new("/"))
-        .to_string_lossy()
-        .to_string();
-
-    let unit = format!(
-        r#"[Unit]
-Description=mihomo-rust proxy service
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=simple
-ExecStart={exe} -f {config}
-WorkingDirectory={work_dir}
-Restart=on-failure
-RestartSec=5
-LimitNOFILE=1048576
-
-# Hardening
-NoNewPrivileges=true
-ProtectSystem=strict
-ReadWritePaths={work_dir}
-PrivateTmp=true
-
-[Install]
-WantedBy=multi-user.target
-"#,
-        exe = exe_path,
-        config = config_path,
-        work_dir = work_dir,
-    );
+    let unit = mihomo_app::generate_systemd_unit(&exe_path, &config_path);
 
     let service_path = format!("/etc/systemd/system/{}.service", SERVICE_NAME);
 

--- a/crates/mihomo-app/tests/systemd_config_test.rs
+++ b/crates/mihomo-app/tests/systemd_config_test.rs
@@ -1,0 +1,206 @@
+use mihomo_config::raw::RawConfig;
+use mihomo_config::save_raw_config;
+use std::os::unix::fs::PermissionsExt;
+
+fn minimal_raw_config() -> RawConfig {
+    RawConfig {
+        port: None,
+        socks_port: None,
+        mixed_port: Some(7890),
+        allow_lan: None,
+        bind_address: None,
+        mode: Some("rule".into()),
+        log_level: None,
+        ipv6: None,
+        external_controller: None,
+        secret: None,
+        dns: None,
+        proxies: None,
+        proxy_groups: None,
+        rules: Some(vec![
+            "DOMAIN,example.com,DIRECT".into(),
+            "MATCH,REJECT".into(),
+        ]),
+        subscriptions: None,
+    }
+}
+
+// ── systemd unit generation tests ───────────────────────────────────
+
+#[test]
+fn unit_contains_read_write_paths_for_config_dir() {
+    let unit = mihomo_app::generate_systemd_unit(
+        "/usr/bin/mihomo",
+        "/etc/mihomo/config.yaml",
+    );
+
+    assert!(
+        unit.contains("ReadWritePaths=/etc/mihomo"),
+        "Unit must grant ReadWritePaths to config directory:\n{}",
+        unit,
+    );
+}
+
+#[test]
+fn unit_working_directory_matches_config_parent() {
+    let unit = mihomo_app::generate_systemd_unit(
+        "/usr/bin/mihomo",
+        "/opt/mihomo/config.yaml",
+    );
+
+    assert!(unit.contains("WorkingDirectory=/opt/mihomo"));
+    assert!(unit.contains("ReadWritePaths=/opt/mihomo"));
+}
+
+#[test]
+fn unit_exec_start_uses_absolute_config_path() {
+    let unit = mihomo_app::generate_systemd_unit(
+        "/usr/bin/mihomo",
+        "/etc/mihomo/config.yaml",
+    );
+
+    assert!(
+        unit.contains("ExecStart=/usr/bin/mihomo -f /etc/mihomo/config.yaml"),
+        "ExecStart should use the absolute config path:\n{}",
+        unit,
+    );
+}
+
+#[test]
+fn unit_has_protect_system_strict() {
+    let unit = mihomo_app::generate_systemd_unit(
+        "/usr/bin/mihomo",
+        "/etc/mihomo/config.yaml",
+    );
+
+    assert!(unit.contains("ProtectSystem=strict"));
+}
+
+#[test]
+fn unit_paths_consistent_for_nested_config() {
+    let unit = mihomo_app::generate_systemd_unit(
+        "/usr/bin/mihomo",
+        "/var/lib/mihomo/configs/config.yaml",
+    );
+
+    assert!(unit.contains("WorkingDirectory=/var/lib/mihomo/configs"));
+    assert!(unit.contains("ReadWritePaths=/var/lib/mihomo/configs"));
+}
+
+#[test]
+fn unit_root_config_path_defaults_to_slash() {
+    // Edge case: config at filesystem root
+    let unit = mihomo_app::generate_systemd_unit(
+        "/usr/bin/mihomo",
+        "/config.yaml",
+    );
+
+    assert!(unit.contains("WorkingDirectory=/"));
+    assert!(unit.contains("ReadWritePaths=/"));
+}
+
+// ── config save under restricted permissions (simulates ProtectSystem=strict) ──
+
+#[test]
+fn save_config_works_in_writable_subdir_of_readonly_parent() {
+    // Simulates the systemd ProtectSystem=strict scenario:
+    // parent directory is read-only, but config dir is writable via ReadWritePaths.
+    let parent = tempfile::tempdir().unwrap();
+    let config_dir = parent.path().join("mihomo");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    let config_path = config_dir.join("config.yaml");
+    let config_str = config_path.to_str().unwrap();
+
+    // Write initial config
+    let raw = minimal_raw_config();
+    save_raw_config(config_str, &raw).unwrap();
+
+    // Make the parent directory read-only (simulating ProtectSystem=strict)
+    let parent_perms = std::fs::Permissions::from_mode(0o555);
+    std::fs::set_permissions(parent.path(), parent_perms).unwrap();
+
+    // Config directory stays writable (simulating ReadWritePaths)
+    let config_perms = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(&config_dir, config_perms).unwrap();
+
+    // save_raw_config should succeed — .tmp and .bak are in the config dir
+    let mut updated = minimal_raw_config();
+    updated.mixed_port = Some(8080);
+    let result = save_raw_config(config_str, &updated);
+
+    // Restore parent permissions so tempdir cleanup works
+    let restore_perms = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(parent.path(), restore_perms).unwrap();
+
+    result.expect("save_raw_config must succeed when config dir is writable");
+
+    // Verify the updated config was written
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    let loaded: RawConfig = serde_yaml::from_str(&content).unwrap();
+    assert_eq!(loaded.mixed_port, Some(8080));
+}
+
+#[test]
+fn save_config_fails_in_readonly_directory() {
+    // Root bypasses filesystem permission checks, so this test is only
+    // meaningful for non-root users (which matches the systemd scenario
+    // where the service runs as a non-root user or with ProtectSystem=strict).
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("Skipping: running as root (permission checks are bypassed)");
+        return;
+    }
+
+    // Verifies that without ReadWritePaths (i.e. config dir is also read-only),
+    // saving would fail — confirming the test above is meaningful.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.yaml");
+    let config_str = config_path.to_str().unwrap();
+
+    // Write initial config while we still can
+    let raw = minimal_raw_config();
+    save_raw_config(config_str, &raw).unwrap();
+
+    // Make directory read-only
+    let ro_perms = std::fs::Permissions::from_mode(0o555);
+    std::fs::set_permissions(dir.path(), ro_perms).unwrap();
+
+    // Attempt to save — should fail because .tmp cannot be created
+    let result = save_raw_config(config_str, &raw);
+
+    // Restore permissions for cleanup
+    let rw_perms = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(dir.path(), rw_perms).unwrap();
+
+    assert!(
+        result.is_err(),
+        "save_raw_config should fail when directory is read-only"
+    );
+}
+
+#[test]
+fn save_creates_tmp_and_bak_in_same_dir_as_config() {
+    // Verifies that atomic write artifacts (.tmp, .bak) are co-located with
+    // the config file, so a single ReadWritePaths entry covers everything.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.yaml");
+    let config_str = config_path.to_str().unwrap();
+
+    // First save — creates config, no .bak
+    let raw = minimal_raw_config();
+    save_raw_config(config_str, &raw).unwrap();
+    assert!(!dir.path().join("config.yaml.bak").exists());
+
+    // Second save — creates .bak from previous
+    save_raw_config(config_str, &raw).unwrap();
+    assert!(
+        dir.path().join("config.yaml.bak").exists(),
+        ".bak must be in the same directory as the config"
+    );
+
+    // .tmp should have been renamed away (not left behind)
+    assert!(
+        !dir.path().join("config.yaml.tmp").exists(),
+        ".tmp must not be left behind after successful save"
+    );
+}

--- a/crates/mihomo-app/tests/systemd_config_test.rs
+++ b/crates/mihomo-app/tests/systemd_config_test.rs
@@ -29,10 +29,7 @@ fn minimal_raw_config() -> RawConfig {
 
 #[test]
 fn unit_contains_read_write_paths_for_config_dir() {
-    let unit = mihomo_app::generate_systemd_unit(
-        "/usr/bin/mihomo",
-        "/etc/mihomo/config.yaml",
-    );
+    let unit = mihomo_app::generate_systemd_unit("/usr/bin/mihomo", "/etc/mihomo/config.yaml");
 
     assert!(
         unit.contains("ReadWritePaths=/etc/mihomo"),
@@ -43,10 +40,7 @@ fn unit_contains_read_write_paths_for_config_dir() {
 
 #[test]
 fn unit_working_directory_matches_config_parent() {
-    let unit = mihomo_app::generate_systemd_unit(
-        "/usr/bin/mihomo",
-        "/opt/mihomo/config.yaml",
-    );
+    let unit = mihomo_app::generate_systemd_unit("/usr/bin/mihomo", "/opt/mihomo/config.yaml");
 
     assert!(unit.contains("WorkingDirectory=/opt/mihomo"));
     assert!(unit.contains("ReadWritePaths=/opt/mihomo"));
@@ -54,10 +48,7 @@ fn unit_working_directory_matches_config_parent() {
 
 #[test]
 fn unit_exec_start_uses_absolute_config_path() {
-    let unit = mihomo_app::generate_systemd_unit(
-        "/usr/bin/mihomo",
-        "/etc/mihomo/config.yaml",
-    );
+    let unit = mihomo_app::generate_systemd_unit("/usr/bin/mihomo", "/etc/mihomo/config.yaml");
 
     assert!(
         unit.contains("ExecStart=/usr/bin/mihomo -f /etc/mihomo/config.yaml"),
@@ -68,20 +59,15 @@ fn unit_exec_start_uses_absolute_config_path() {
 
 #[test]
 fn unit_has_protect_system_strict() {
-    let unit = mihomo_app::generate_systemd_unit(
-        "/usr/bin/mihomo",
-        "/etc/mihomo/config.yaml",
-    );
+    let unit = mihomo_app::generate_systemd_unit("/usr/bin/mihomo", "/etc/mihomo/config.yaml");
 
     assert!(unit.contains("ProtectSystem=strict"));
 }
 
 #[test]
 fn unit_paths_consistent_for_nested_config() {
-    let unit = mihomo_app::generate_systemd_unit(
-        "/usr/bin/mihomo",
-        "/var/lib/mihomo/configs/config.yaml",
-    );
+    let unit =
+        mihomo_app::generate_systemd_unit("/usr/bin/mihomo", "/var/lib/mihomo/configs/config.yaml");
 
     assert!(unit.contains("WorkingDirectory=/var/lib/mihomo/configs"));
     assert!(unit.contains("ReadWritePaths=/var/lib/mihomo/configs"));
@@ -90,10 +76,7 @@ fn unit_paths_consistent_for_nested_config() {
 #[test]
 fn unit_root_config_path_defaults_to_slash() {
     // Edge case: config at filesystem root
-    let unit = mihomo_app::generate_systemd_unit(
-        "/usr/bin/mihomo",
-        "/config.yaml",
-    );
+    let unit = mihomo_app::generate_systemd_unit("/usr/bin/mihomo", "/config.yaml");
 
     assert!(unit.contains("WorkingDirectory=/"));
     assert!(unit.contains("ReadWritePaths=/"));

--- a/crates/mihomo-config/src/lib.rs
+++ b/crates/mihomo-config/src/lib.rs
@@ -128,7 +128,10 @@ pub fn rebuild_from_raw(
         if still_remaining.len() == remaining.len() {
             // No progress — log remaining failures and break
             for raw_group in &still_remaining {
-                warn!("Failed to parse proxy group '{}': unresolved dependencies", raw_group.name);
+                warn!(
+                    "Failed to parse proxy group '{}': unresolved dependencies",
+                    raw_group.name
+                );
             }
             break;
         }

--- a/crates/mihomo-config/src/lib.rs
+++ b/crates/mihomo-config/src/lib.rs
@@ -71,10 +71,11 @@ pub fn save_raw_config(path: &str, raw: &raw::RawConfig) -> Result<(), anyhow::E
     Ok(())
 }
 
+/// The result of rebuilding proxies and rules from a RawConfig.
+pub type RebuildResult = (HashMap<String, Arc<dyn Proxy>>, Vec<Box<dyn Rule>>);
+
 /// Rebuild proxies and rules from a RawConfig (used for runtime updates).
-pub fn rebuild_from_raw(
-    raw: &raw::RawConfig,
-) -> Result<(HashMap<String, Arc<dyn Proxy>>, Vec<Box<dyn Rule>>), anyhow::Error> {
+pub fn rebuild_from_raw(raw: &raw::RawConfig) -> Result<RebuildResult, anyhow::Error> {
     let mut proxies: HashMap<String, Arc<dyn Proxy>> = HashMap::new();
     // Built-in proxies
     proxies.insert(

--- a/crates/mihomo-config/src/subscription.rs
+++ b/crates/mihomo-config/src/subscription.rs
@@ -43,10 +43,7 @@ pub fn parse_subscription_yaml(text: &str) -> Result<SubscriptionData, anyhow::E
             .keys()
             .filter_map(|k| k.as_str().map(|s| s.to_string()))
             .collect();
-        anyhow::anyhow!(
-            "subscription missing 'proxies' key; found keys: {:?}",
-            keys
-        )
+        anyhow::anyhow!("subscription missing 'proxies' key; found keys: {:?}", keys)
     })?;
     let proxies_seq = proxies_val
         .as_sequence()

--- a/crates/mihomo-config/tests/config_persistence_test.rs
+++ b/crates/mihomo-config/tests/config_persistence_test.rs
@@ -60,7 +60,10 @@ fn save_creates_backup_of_existing() {
 
     // Backup should have original content
     assert!(bak_path.exists());
-    assert_eq!(std::fs::read_to_string(&bak_path).unwrap(), "original-content");
+    assert_eq!(
+        std::fs::read_to_string(&bak_path).unwrap(),
+        "original-content"
+    );
 
     // Main file should have new content
     let content = std::fs::read_to_string(&path).unwrap();
@@ -230,10 +233,7 @@ fn rebuild_from_raw_with_groups() {
 fn rebuild_from_raw_skips_invalid_proxy() {
     let mut raw = minimal_raw_config();
     let mut bad_proxy = HashMap::new();
-    bad_proxy.insert(
-        "name".to_string(),
-        serde_yaml::Value::String("bad".into()),
-    );
+    bad_proxy.insert("name".to_string(), serde_yaml::Value::String("bad".into()));
     bad_proxy.insert(
         "type".to_string(),
         serde_yaml::Value::String("unknown_protocol".into()),

--- a/crates/mihomo-config/tests/config_test.rs
+++ b/crates/mihomo-config/tests/config_test.rs
@@ -379,4 +379,3 @@ fn test_invalid_yaml() {
     let yaml = "{{invalid yaml}}";
     assert!(load_config_from_str(yaml).is_err());
 }
-

--- a/crates/mihomo-listener/src/http_proxy.rs
+++ b/crates/mihomo-listener/src/http_proxy.rs
@@ -136,7 +136,9 @@ async fn handle_http_inner(
         let (proxy, rule_name, rule_payload) = match inner.resolve_proxy(&metadata) {
             Some(v) => v,
             None => {
-                stream.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await?;
+                stream
+                    .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                    .await?;
                 return Err("no matching rule".into());
             }
         };
@@ -193,7 +195,9 @@ async fn handle_http_inner(
             }
             Err(e) => {
                 warn!("HTTP dial error: {}", e);
-                stream.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await?;
+                stream
+                    .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                    .await?;
             }
         }
 
@@ -237,5 +241,8 @@ fn extract_path_from_url(url: &str) -> &str {
         .strip_prefix("http://")
         .or_else(|| url.strip_prefix("https://"))
         .unwrap_or(url);
-    without_scheme.find('/').map(|i| &without_scheme[i..]).unwrap_or("/")
+    without_scheme
+        .find('/')
+        .map(|i| &without_scheme[i..])
+        .unwrap_or("/")
 }


### PR DESCRIPTION
Extract generate_systemd_unit() into lib.rs for testability.
Verify ReadWritePaths covers the config directory so save_raw_config
can create .tmp/.bak files under ProtectSystem=strict.

https://claude.ai/code/session_01LBB5L8f52h2krPg5Br3WGD