### PR TITLE
Remove TUN QEMU integration tests from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,11 +87,3 @@ jobs:
 
       - name: Trojan integration tests
         run: cargo test --test trojan_integration -- --nocapture
-
-      - name: Install QEMU and busybox for TUN test
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq qemu-system-x86 busybox-static
-
-      - name: TUN QEMU integration tests
-        run: bash tests/test_tun_qemu.sh


### PR DESCRIPTION
The test script (tests/test_tun_qemu.sh) does not exist, so these CI
steps were always going to fail. Remove the QEMU/busybox install step
and the TUN test step.

https://claude.ai/code/session_0137gnwjoTswaz1CyY6ve6kY