### PR TITLE
refactor(geoip): resolve hostnames to real IPs before rule matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "mihomo-dns",
  "mihomo-proxy",
  "mihomo-rules",
+ "mihomo-trie",
  "parking_lot",
  "serde",
  "serde_json",

--- a/crates/mihomo-common/src/rule.rs
+++ b/crates/mihomo-common/src/rule.rs
@@ -57,7 +57,6 @@ impl fmt::Display for RuleType {
 
 /// Helper passed to Rule::match_metadata for lazy evaluation
 pub struct RuleMatchHelper {
-    pub resolve_ip: Box<dyn Fn() + Send + Sync>,
     pub find_process: Box<dyn Fn() + Send + Sync>,
 }
 

--- a/crates/mihomo-common/src/rule.rs
+++ b/crates/mihomo-common/src/rule.rs
@@ -55,7 +55,8 @@ impl fmt::Display for RuleType {
     }
 }
 
-/// Helper passed to Rule::match_metadata for lazy evaluation
+/// Helper passed to `Rule::match_metadata` to supply platform-specific lookups
+/// (currently only process-name lookup) without coupling rules to the host OS.
 pub struct RuleMatchHelper {
     pub find_process: Box<dyn Fn() + Send + Sync>,
 }

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -224,16 +224,17 @@ impl Resolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::Ipv4Addr;
 
     #[tokio::test]
-    async fn resolve_ip_real_uses_hosts_and_skips_fakeip() {
-        use std::net::Ipv4Addr;
+    async fn resolve_ip_real_uses_hosts_file() {
+        // Sanity check: when the host is in the hosts file, resolve_ip_real
+        // returns the mapped IP regardless of FakeIP mode.
         let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
         let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
         hosts.insert("example.test", vec![real]);
 
         let pool = Arc::new(FakeIpPool::new("198.18.0.0/15").unwrap());
-
         let resolver = Resolver::new(
             vec![],
             vec![],
@@ -242,8 +243,42 @@ mod tests {
             hosts,
         );
 
-        let got = resolver.resolve_ip_real("example.test").await;
-        assert_eq!(got, Some(real));
+        assert_eq!(resolver.resolve_ip_real("example.test").await, Some(real));
+    }
+
+    #[tokio::test]
+    async fn resolve_ip_real_returns_cached_ip_instead_of_fake_ip() {
+        // The real bypass test: with a host NOT in the hosts file, in FakeIP
+        // mode, `resolve_ip` would return a fake IP (from the 198.18.0.0/15
+        // pool). `resolve_ip_real` must instead return the cached real IP,
+        // bypassing the fake pool entirely.
+        let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let pool = Arc::new(FakeIpPool::new("198.18.0.0/15").unwrap());
+        let resolver = Resolver::new(
+            vec![],
+            vec![],
+            Some(pool),
+            DnsMode::FakeIp,
+            hosts,
+        );
+
+        let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        resolver
+            .cache
+            .put("cached.test", vec![real], Duration::from_secs(60));
+
+        // Sanity: `resolve_ip` in FakeIp mode should hand out a fake IP,
+        // NOT the cached real one (FakeIP branch fires before the cache).
+        let via_resolve_ip = resolver.resolve_ip("cached.test").await.unwrap();
+        assert!(
+            resolver.is_fake_ip(via_resolve_ip),
+            "resolve_ip should have returned a fake IP, got {}",
+            via_resolve_ip
+        );
+
+        // The real test: `resolve_ip_real` must bypass the fake pool and
+        // return the cached real IP.
+        assert_eq!(resolver.resolve_ip_real("cached.test").await, Some(real));
     }
 
     #[test]

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -235,13 +235,7 @@ mod tests {
         hosts.insert("example.test", vec![real]);
 
         let pool = Arc::new(FakeIpPool::new("198.18.0.0/15").unwrap());
-        let resolver = Resolver::new(
-            vec![],
-            vec![],
-            Some(pool),
-            DnsMode::FakeIp,
-            hosts,
-        );
+        let resolver = Resolver::new(vec![], vec![], Some(pool), DnsMode::FakeIp, hosts);
 
         assert_eq!(resolver.resolve_ip_real("example.test").await, Some(real));
     }
@@ -254,13 +248,7 @@ mod tests {
         // bypassing the fake pool entirely.
         let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
         let pool = Arc::new(FakeIpPool::new("198.18.0.0/15").unwrap());
-        let resolver = Resolver::new(
-            vec![],
-            vec![],
-            Some(pool),
-            DnsMode::FakeIp,
-            hosts,
-        );
+        let resolver = Resolver::new(vec![], vec![], Some(pool), DnsMode::FakeIp, hosts);
 
         let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
         resolver
@@ -293,11 +281,17 @@ mod tests {
 
     #[test]
     fn clamp_ttl_in_range_returns_raw() {
-        assert_eq!(clamp_ttl(Duration::from_secs(120)), Duration::from_secs(120));
+        assert_eq!(
+            clamp_ttl(Duration::from_secs(120)),
+            Duration::from_secs(120)
+        );
     }
 
     #[test]
     fn clamp_ttl_above_max_returns_max() {
-        assert_eq!(clamp_ttl(Duration::from_secs(99_999)), Duration::from_secs(3600));
+        assert_eq!(
+            clamp_ttl(Duration::from_secs(99_999)),
+            Duration::from_secs(3600)
+        );
     }
 }

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -25,6 +25,22 @@ pub struct Resolver {
     inflight: DashMap<String, ()>,
 }
 
+/// Extract a usable cache TTL from a hickory LookupIp response.
+/// Clamps to [10s, 3600s] and falls back to 60s if the value is zero/negative.
+fn ttl_from_lookup(lookup: &hickory_resolver::lookup_ip::LookupIp) -> Duration {
+    const MIN_TTL: Duration = Duration::from_secs(10);
+    const MAX_TTL: Duration = Duration::from_secs(3600);
+    const FALLBACK_TTL: Duration = Duration::from_secs(60);
+    let valid_until = lookup.valid_until();
+    let now = std::time::Instant::now();
+    let raw = valid_until.saturating_duration_since(now);
+    if raw.is_zero() {
+        FALLBACK_TTL
+    } else {
+        raw.clamp(MIN_TTL, MAX_TTL)
+    }
+}
+
 impl Resolver {
     pub fn new(
         main_servers: Vec<SocketAddr>,
@@ -121,9 +137,10 @@ impl Resolver {
         // Try main resolver
         match self.main.lookup_ip(host).await {
             Ok(lookup) => {
+                let ttl = ttl_from_lookup(&lookup);
                 let ips: Vec<IpAddr> = lookup.iter().collect();
                 if !ips.is_empty() {
-                    self.cache.put(host, ips.clone(), Duration::from_secs(300));
+                    self.cache.put(host, ips.clone(), ttl);
                     return Some(ips);
                 }
             }
@@ -136,9 +153,10 @@ impl Resolver {
         if let Some(fallback) = &self.fallback {
             match fallback.lookup_ip(host).await {
                 Ok(lookup) => {
+                    let ttl = ttl_from_lookup(&lookup);
                     let ips: Vec<IpAddr> = lookup.iter().collect();
                     if !ips.is_empty() {
-                        self.cache.put(host, ips.clone(), Duration::from_secs(300));
+                        self.cache.put(host, ips.clone(), ttl);
                         return Some(ips);
                     }
                 }

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -106,6 +106,25 @@ impl Resolver {
         self.lookup_actual(host).await
     }
 
+    /// Resolve a hostname to a real (routable) IP address, bypassing the
+    /// FakeIP pool. This is intended for rule matching (GeoIP / IP-CIDR)
+    /// where a synthetic fake IP would be useless.
+    ///
+    /// Order: hosts file -> cache -> upstream DNS. Results are cached with
+    /// the TTL from the DNS response (see `lookup_actual_all`).
+    pub async fn resolve_ip_real(&self, host: &str) -> Option<IpAddr> {
+        // 1. Hosts file
+        if let Some(ips) = self.hosts.search(host) {
+            return ips.first().copied();
+        }
+        // 2. Cache
+        if let Some(ips) = self.cache.get(host) {
+            return ips.first().copied();
+        }
+        // 3. Upstream DNS (skips FakeIP allocation)
+        self.lookup_actual(host).await
+    }
+
     pub async fn lookup_ipv4(&self, host: &str) -> Option<IpAddr> {
         if let Some(ips) = self.hosts.search(host) {
             return ips.iter().find(|ip| ip.is_ipv4()).copied();
@@ -205,6 +224,27 @@ impl Resolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn resolve_ip_real_uses_hosts_and_skips_fakeip() {
+        use std::net::Ipv4Addr;
+        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        hosts.insert("example.test", vec![real]);
+
+        let pool = Arc::new(FakeIpPool::new("198.18.0.0/15").unwrap());
+
+        let resolver = Resolver::new(
+            vec![],
+            vec![],
+            Some(pool),
+            DnsMode::FakeIp,
+            hosts,
+        );
+
+        let got = resolver.resolve_ip_real("example.test").await;
+        assert_eq!(got, Some(real));
+    }
 
     #[test]
     fn clamp_ttl_zero_returns_min() {

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -25,20 +25,22 @@ pub struct Resolver {
     inflight: DashMap<String, ()>,
 }
 
-/// Extract a usable cache TTL from a hickory LookupIp response.
-/// Clamps to [10s, 3600s] and falls back to 60s if the value is zero/negative.
-fn ttl_from_lookup(lookup: &hickory_resolver::lookup_ip::LookupIp) -> Duration {
+fn clamp_ttl(raw: Duration) -> Duration {
     const MIN_TTL: Duration = Duration::from_secs(10);
     const MAX_TTL: Duration = Duration::from_secs(3600);
-    const FALLBACK_TTL: Duration = Duration::from_secs(60);
-    let valid_until = lookup.valid_until();
-    let now = std::time::Instant::now();
-    let raw = valid_until.saturating_duration_since(now);
-    if raw.is_zero() {
-        FALLBACK_TTL
-    } else {
-        raw.clamp(MIN_TTL, MAX_TTL)
-    }
+    raw.clamp(MIN_TTL, MAX_TTL)
+}
+
+/// Extract a usable cache TTL from a hickory LookupIp response.
+/// Clamps the time-until-expiry reported by hickory to [10s, 3600s].
+/// If hickory reports an already-expired entry (`valid_until` in the past),
+/// this returns `MIN_TTL` so we cache for the shortest allowed window
+/// instead of a misleading longer fallback.
+fn ttl_from_lookup(lookup: &hickory_resolver::lookup_ip::LookupIp) -> Duration {
+    let raw = lookup
+        .valid_until()
+        .saturating_duration_since(std::time::Instant::now());
+    clamp_ttl(raw)
 }
 
 impl Resolver {
@@ -197,5 +199,30 @@ impl Resolver {
 
     pub fn clear_cache(&self) {
         self.cache.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_ttl_zero_returns_min() {
+        assert_eq!(clamp_ttl(Duration::ZERO), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn clamp_ttl_below_min_returns_min() {
+        assert_eq!(clamp_ttl(Duration::from_secs(3)), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn clamp_ttl_in_range_returns_raw() {
+        assert_eq!(clamp_ttl(Duration::from_secs(120)), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn clamp_ttl_above_max_returns_max() {
+        assert_eq!(clamp_ttl(Duration::from_secs(99_999)), Duration::from_secs(3600));
     }
 }

--- a/crates/mihomo-rules/src/geoip.rs
+++ b/crates/mihomo-rules/src/geoip.rs
@@ -36,10 +36,7 @@ impl Rule for GeoIpRule {
         RuleType::GeoIp
     }
 
-    fn match_metadata(&self, metadata: &Metadata, helper: &RuleMatchHelper) -> bool {
-        if !self.no_resolve && !metadata.resolved() {
-            (helper.resolve_ip)();
-        }
+    fn match_metadata(&self, metadata: &Metadata, _helper: &RuleMatchHelper) -> bool {
         if let Some(ip) = metadata.dst_ip {
             if let Some(code) = self.lookup_country(ip) {
                 return code.to_uppercase() == self.country;

--- a/crates/mihomo-rules/src/ipcidr.rs
+++ b/crates/mihomo-rules/src/ipcidr.rs
@@ -36,13 +36,10 @@ impl Rule for IpCidrRule {
         }
     }
 
-    fn match_metadata(&self, metadata: &Metadata, helper: &RuleMatchHelper) -> bool {
+    fn match_metadata(&self, metadata: &Metadata, _helper: &RuleMatchHelper) -> bool {
         let ip = if self.is_src {
             metadata.src_ip
         } else {
-            if !self.no_resolve && !metadata.resolved() {
-                (helper.resolve_ip)();
-            }
             metadata.dst_ip
         };
         ip.is_some_and(|addr| self.cidr.contains(&addr))

--- a/crates/mihomo-rules/src/logic.rs
+++ b/crates/mihomo-rules/src/logic.rs
@@ -39,6 +39,10 @@ impl Rule for AndRule {
     fn payload(&self) -> &str {
         &self.payload
     }
+
+    fn should_resolve_ip(&self) -> bool {
+        self.rules.iter().any(|r| r.should_resolve_ip())
+    }
 }
 
 pub struct OrRule {
@@ -80,6 +84,10 @@ impl Rule for OrRule {
     fn payload(&self) -> &str {
         &self.payload
     }
+
+    fn should_resolve_ip(&self) -> bool {
+        self.rules.iter().any(|r| r.should_resolve_ip())
+    }
 }
 
 pub struct NotRule {
@@ -114,5 +122,9 @@ impl Rule for NotRule {
 
     fn payload(&self) -> &str {
         &self.payload
+    }
+
+    fn should_resolve_ip(&self) -> bool {
+        self.rule.should_resolve_ip()
     }
 }

--- a/crates/mihomo-rules/src/parser.rs
+++ b/crates/mihomo-rules/src/parser.rs
@@ -69,7 +69,6 @@ mod tests {
 
     fn noop_helper() -> RuleMatchHelper {
         RuleMatchHelper {
-            resolve_ip: Box::new(|| {}),
             find_process: Box::new(|| {}),
         }
     }

--- a/crates/mihomo-rules/tests/rules_test.rs
+++ b/crates/mihomo-rules/tests/rules_test.rs
@@ -15,7 +15,6 @@ use mihomo_rules::process::ProcessRule;
 
 fn helper() -> RuleMatchHelper {
     RuleMatchHelper {
-        resolve_ip: Box::new(|| {}),
         find_process: Box::new(|| {}),
     }
 }

--- a/crates/mihomo-rules/tests/rules_test.rs
+++ b/crates/mihomo-rules/tests/rules_test.rs
@@ -710,3 +710,11 @@ fn rule_chain_ip_match() {
     let r4 = rules.iter().find(|r| r.match_metadata(&m4, &h)).unwrap();
     assert_eq!(r4.adapter(), "DIRECT");
 }
+
+#[test]
+fn and_rule_should_resolve_ip_recurses_into_children() {
+    use mihomo_rules::ipcidr::IpCidrRule;
+    let inner = IpCidrRule::new("1.2.3.0/24", "PROXY", false, false).unwrap();
+    let and = AndRule::new(vec![Box::new(inner)], "PROXY");
+    assert!(and.should_resolve_ip());
+}

--- a/crates/mihomo-tunnel/Cargo.toml
+++ b/crates/mihomo-tunnel/Cargo.toml
@@ -20,4 +20,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+mihomo-trie = { workspace = true }

--- a/crates/mihomo-tunnel/src/match_engine.rs
+++ b/crates/mihomo-tunnel/src/match_engine.rs
@@ -9,10 +9,7 @@ pub struct MatchResult {
 /// Match metadata against rules. Returns the adapter name and matched rule info.
 /// Pre-resolution of `metadata.dst_ip` from a hostname must happen before this
 /// function is called (see `TunnelInner::pre_resolve`).
-pub fn match_rules(
-    metadata: &Metadata,
-    rules: &[Box<dyn Rule>],
-) -> Option<MatchResult> {
+pub fn match_rules(metadata: &Metadata, rules: &[Box<dyn Rule>]) -> Option<MatchResult> {
     let helper = RuleMatchHelper {
         find_process: Box::new(|| {
             // Process lookup is platform-specific and not yet implemented.

--- a/crates/mihomo-tunnel/src/match_engine.rs
+++ b/crates/mihomo-tunnel/src/match_engine.rs
@@ -1,6 +1,4 @@
 use mihomo_common::{Metadata, Rule, RuleMatchHelper};
-use mihomo_dns::Resolver;
-use std::sync::Arc;
 
 pub struct MatchResult {
     pub adapter_name: String,
@@ -9,22 +7,15 @@ pub struct MatchResult {
 }
 
 /// Match metadata against rules. Returns the adapter name and matched rule info.
+/// Pre-resolution of `metadata.dst_ip` from a hostname must happen before this
+/// function is called (see `TunnelInner::pre_resolve`).
 pub fn match_rules(
     metadata: &Metadata,
     rules: &[Box<dyn Rule>],
-    _resolver: &Arc<Resolver>,
 ) -> Option<MatchResult> {
-    // Create the lazy helper.
-    // Note: In a real implementation, resolve_ip would mutate metadata.dst_ip via interior
-    // mutability. For now, we provide the callbacks that the rules can use.
     let helper = RuleMatchHelper {
-        resolve_ip: Box::new(|| {
-            // This is called lazily when a rule needs IP resolution.
-            // The actual resolution happens in the tunnel's pre-handle phase.
-        }),
         find_process: Box::new(|| {
-            // This is called lazily when a rule needs process info.
-            // Process lookup is platform-specific.
+            // Process lookup is platform-specific and not yet implemented.
         }),
     };
 

--- a/crates/mihomo-tunnel/src/tcp.rs
+++ b/crates/mihomo-tunnel/src/tcp.rs
@@ -1,6 +1,5 @@
 use crate::tunnel::TunnelInner;
-use mihomo_common::{DnsMode, Metadata, ProxyConn};
-use mihomo_dns::Resolver;
+use mihomo_common::{Metadata, ProxyConn};
 use tokio::io;
 use tracing::{debug, info, warn};
 
@@ -9,8 +8,8 @@ pub async fn handle_tcp(
     mut conn: Box<dyn ProxyConn>,
     mut metadata: Metadata,
 ) {
-    // Fix metadata: resolve FakeIP back to real host
-    pre_handle_metadata(&mut metadata, &tunnel.resolver);
+    // Pre-resolve metadata (FakeIP reverse + host -> real IP if rules need it)
+    tunnel.pre_resolve(&mut metadata).await;
 
     // Match rules to find the right proxy
     let (proxy, rule_name, rule_payload) = match tunnel.resolve_proxy(&metadata) {
@@ -64,19 +63,4 @@ pub async fn handle_tcp(
     }
 
     tunnel.stats.close_connection(&conn_id);
-}
-
-fn pre_handle_metadata(metadata: &mut Metadata, resolver: &Resolver) {
-    // If the destination IP is a FakeIP, look up the real host
-    if let Some(dst_ip) = metadata.dst_ip {
-        if resolver.is_fake_ip(dst_ip) {
-            if let Some(host) = resolver.fake_ip_reverse(dst_ip) {
-                metadata.host = host;
-                metadata.dns_mode = DnsMode::FakeIp;
-            }
-        }
-    }
-
-    // If we have a host but no resolved IP, the actual resolution
-    // happens lazily during rule matching.
 }

--- a/crates/mihomo-tunnel/src/tunnel.rs
+++ b/crates/mihomo-tunnel/src/tunnel.rs
@@ -49,7 +49,7 @@ impl TunnelInner {
             }
             TunnelMode::Rule => {
                 let rules = self.rules.read();
-                let result = match_engine::match_rules(metadata, &rules, &self.resolver);
+                let result = match_engine::match_rules(metadata, &rules);
                 match result {
                     Some(m) => {
                         let proxies = self.proxies.read();

--- a/crates/mihomo-tunnel/src/tunnel.rs
+++ b/crates/mihomo-tunnel/src/tunnel.rs
@@ -48,6 +48,8 @@ impl TunnelInner {
         if metadata.host.is_empty() {
             return;
         }
+        // Step 1 populated `metadata.host` but left `dst_ip` as the (still-fake)
+        // address. Detect that here and replace it with the real routable IP.
         let needs_resolve = match metadata.dst_ip {
             None => true,
             Some(ip) => self.resolver.is_fake_ip(ip),
@@ -153,10 +155,15 @@ impl Tunnel {
 
     pub fn update_rules(&self, rules: Vec<Box<dyn Rule>>) {
         let needs = rules.iter().any(|r| r.should_resolve_ip());
-        *self.inner.rules.write() = rules;
-        self.inner
-            .needs_ip_resolution
-            .store(needs, Ordering::Relaxed);
+        {
+            let mut guard = self.inner.rules.write();
+            *guard = rules;
+            // Store under the write lock so any reader that acquires the rules
+            // lock after this point also sees the updated flag.
+            self.inner
+                .needs_ip_resolution
+                .store(needs, Ordering::Relaxed);
+        }
         info!("Rules updated (needs_ip_resolution={})", needs);
     }
 

--- a/crates/mihomo-tunnel/src/tunnel.rs
+++ b/crates/mihomo-tunnel/src/tunnel.rs
@@ -1,11 +1,12 @@
 use crate::match_engine;
 use crate::statistics::Statistics;
 use crate::udp::{self, NatTable};
-use mihomo_common::{Metadata, Proxy, ProxyAdapter, Rule, TunnelMode};
+use mihomo_common::{DnsMode, Metadata, Proxy, ProxyAdapter, Rule, TunnelMode};
 use mihomo_dns::Resolver;
 use mihomo_proxy::DirectAdapter;
 use parking_lot::RwLock;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -16,9 +17,50 @@ pub struct TunnelInner {
     pub resolver: Arc<Resolver>,
     pub nat_table: NatTable,
     pub stats: Arc<Statistics>,
+    /// Cached: true if any rule needs the dst_ip resolved (GeoIP / IP-CIDR).
+    /// Recomputed by `Tunnel::update_rules`.
+    pub needs_ip_resolution: AtomicBool,
 }
 
 impl TunnelInner {
+    /// Pre-process metadata before rule matching:
+    /// 1. Reverse FakeIP back to the original host (so domain rules see the host).
+    /// 2. If any rule needs IP resolution and we don't yet have a real IP,
+    ///    resolve `metadata.host` via the internal resolver and populate `dst_ip`.
+    ///
+    /// `Metadata::remote_address()` prefers `host` over `dst_ip`, so overwriting
+    /// `dst_ip` here does not change which destination the proxy adapter dials.
+    pub async fn pre_resolve(&self, metadata: &mut Metadata) {
+        // Step 1: FakeIP reverse
+        if let Some(dst_ip) = metadata.dst_ip {
+            if self.resolver.is_fake_ip(dst_ip) {
+                if let Some(host) = self.resolver.fake_ip_reverse(dst_ip) {
+                    metadata.host = host;
+                    metadata.dns_mode = DnsMode::FakeIp;
+                }
+            }
+        }
+
+        // Step 2: Resolve host -> real IP for rule matching
+        if !self.needs_ip_resolution.load(Ordering::Relaxed) {
+            return;
+        }
+        if metadata.host.is_empty() {
+            return;
+        }
+        let needs_resolve = match metadata.dst_ip {
+            None => true,
+            Some(ip) => self.resolver.is_fake_ip(ip),
+        };
+        if !needs_resolve {
+            return;
+        }
+        if let Some(real_ip) = self.resolver.resolve_ip_real(&metadata.host).await {
+            debug!("pre_resolve: {} -> {}", metadata.host, real_ip);
+            metadata.dst_ip = Some(real_ip);
+        }
+    }
+
     /// Resolve which proxy to use for the given metadata
     pub fn resolve_proxy(
         &self,
@@ -91,6 +133,7 @@ impl Tunnel {
                 resolver,
                 nat_table: udp::new_nat_table(),
                 stats: Arc::new(Statistics::new()),
+                needs_ip_resolution: AtomicBool::new(false),
             }),
         }
     }
@@ -109,8 +152,12 @@ impl Tunnel {
     }
 
     pub fn update_rules(&self, rules: Vec<Box<dyn Rule>>) {
+        let needs = rules.iter().any(|r| r.should_resolve_ip());
         *self.inner.rules.write() = rules;
-        info!("Rules updated");
+        self.inner
+            .needs_ip_resolution
+            .store(needs, Ordering::Relaxed);
+        info!("Rules updated (needs_ip_resolution={})", needs);
     }
 
     pub fn update_proxies(&self, proxies: HashMap<String, Arc<dyn Proxy>>) {

--- a/crates/mihomo-tunnel/src/udp.rs
+++ b/crates/mihomo-tunnel/src/udp.rs
@@ -1,6 +1,6 @@
 use crate::tunnel::TunnelInner;
 use dashmap::DashMap;
-use mihomo_common::{DnsMode, Metadata, ProxyPacketConn};
+use mihomo_common::{Metadata, ProxyPacketConn};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -24,15 +24,8 @@ pub async fn handle_udp(
     src: SocketAddr,
     mut metadata: Metadata,
 ) {
-    // Fix metadata for FakeIP
-    if let Some(dst_ip) = metadata.dst_ip {
-        if tunnel.resolver.is_fake_ip(dst_ip) {
-            if let Some(host) = tunnel.resolver.fake_ip_reverse(dst_ip) {
-                metadata.host = host;
-                metadata.dns_mode = DnsMode::FakeIp;
-            }
-        }
-    }
+    // Pre-resolve metadata (FakeIP reverse + host -> real IP if rules need it)
+    tunnel.pre_resolve(&mut metadata).await;
 
     let key = format!("{}:{}", src, metadata.remote_address());
 

--- a/crates/mihomo-tunnel/tests/pre_resolve_test.rs
+++ b/crates/mihomo-tunnel/tests/pre_resolve_test.rs
@@ -1,0 +1,66 @@
+//! Verify that hostname-only metadata is resolved to a real IP before
+//! IP-CIDR / GeoIP rule matching, using the internal Resolver.
+
+use mihomo_common::{DnsMode, Metadata, Network, Rule};
+use mihomo_dns::Resolver;
+use mihomo_rules::ipcidr::IpCidrRule;
+use mihomo_trie::DomainTrie;
+use mihomo_tunnel::Tunnel;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+
+fn build_resolver_with_host(host: &str, ip: IpAddr) -> Arc<Resolver> {
+    let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+    hosts.insert(host, vec![ip]);
+    Arc::new(Resolver::new(
+        vec![],
+        vec![],
+        None,
+        DnsMode::Normal,
+        hosts,
+    ))
+}
+
+#[tokio::test]
+async fn pre_resolve_populates_dst_ip_for_ipcidr_rule() {
+    let real_ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+    let resolver = build_resolver_with_host("example.test", real_ip);
+    let tunnel = Tunnel::new(resolver);
+
+    let rule: Box<dyn Rule> =
+        Box::new(IpCidrRule::new("1.2.3.0/24", "PROXY", false, false).unwrap());
+    tunnel.update_rules(vec![rule]);
+
+    let mut md = Metadata {
+        host: "example.test".to_string(),
+        dst_port: 443,
+        network: Network::Tcp,
+        ..Default::default()
+    };
+    assert!(md.dst_ip.is_none());
+
+    tunnel.inner().pre_resolve(&mut md).await;
+
+    assert_eq!(md.dst_ip, Some(real_ip), "pre_resolve should fill dst_ip");
+    let (_proxy, rule_name, _payload) =
+        tunnel.inner().resolve_proxy(&md).expect("rule should match");
+    assert_eq!(rule_name, "IP-CIDR");
+}
+
+#[tokio::test]
+async fn pre_resolve_skips_when_no_rule_needs_ip() {
+    let real_ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+    let resolver = build_resolver_with_host("example.test", real_ip);
+    let tunnel = Tunnel::new(resolver);
+
+    // Empty rules => needs_ip_resolution is false. pre_resolve must not
+    // populate dst_ip.
+    let mut md = Metadata {
+        host: "example.test".to_string(),
+        dst_port: 443,
+        network: Network::Tcp,
+        ..Default::default()
+    };
+    tunnel.inner().pre_resolve(&mut md).await;
+    assert!(md.dst_ip.is_none(), "no rules need ip => no resolution");
+}

--- a/crates/mihomo-tunnel/tests/pre_resolve_test.rs
+++ b/crates/mihomo-tunnel/tests/pre_resolve_test.rs
@@ -12,13 +12,7 @@ use std::sync::Arc;
 fn build_resolver_with_host(host: &str, ip: IpAddr) -> Arc<Resolver> {
     let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
     hosts.insert(host, vec![ip]);
-    Arc::new(Resolver::new(
-        vec![],
-        vec![],
-        None,
-        DnsMode::Normal,
-        hosts,
-    ))
+    Arc::new(Resolver::new(vec![], vec![], None, DnsMode::Normal, hosts))
 }
 
 #[tokio::test]
@@ -42,8 +36,10 @@ async fn pre_resolve_populates_dst_ip_for_ipcidr_rule() {
     tunnel.inner().pre_resolve(&mut md).await;
 
     assert_eq!(md.dst_ip, Some(real_ip), "pre_resolve should fill dst_ip");
-    let (_proxy, rule_name, _payload) =
-        tunnel.inner().resolve_proxy(&md).expect("rule should match");
+    let (_proxy, rule_name, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&md)
+        .expect("rule should match");
     assert_eq!(rule_name, "IP-CIDR");
 }
 


### PR DESCRIPTION
## Summary

- Fixes GeoIP/IP-CIDR rules silently failing for hostname-only connections (SOCKS5-by-hostname, HTTP CONNECT, etc.) and returning fake IPs in FakeIP mode.
- Adds async pre-resolution in the tunnel: before rule matching, `TunnelInner::pre_resolve` reverses FakeIP and, when any rule needs IP resolution, calls the new `Resolver::resolve_ip_real` (FakeIP-bypassing) to populate `metadata.dst_ip`.
- DNS cache now uses the real TTL from hickory responses (clamped to [10s, 3600s]) instead of a hardcoded 300s.

## Why

Before this change, `GeoIpRule::match_metadata` called a no-op `(helper.resolve_ip)()` closure and then read `metadata.dst_ip`, which was `None` for hostname-only connections. The rule silently returned `false`. In FakeIP mode the rule saw the fake IP (from the 198.18.0.0/15 range) and never matched any country. Same bug on `IpCidrRule`.

## How

- **DNS layer** (`mihomo-dns`) — `lookup_actual_all` extracts real TTL via `LookupIp::valid_until()` through a new `clamp_ttl` helper. Added `Resolver::resolve_ip_real()` that goes hosts → cache → upstream, skipping the FakeIP allocation in `resolve_ip`.
- **Rules layer** (`mihomo-rules`) — `AndRule`/`OrRule`/`NotRule` recurse `should_resolve_ip()` into children so nested GeoIP/IP-CIDR under logic rules is detected. The now-dead no-op `resolve_ip` closure is dropped from `RuleMatchHelper` workspace-wide.
- **Tunnel layer** (`mihomo-tunnel`) — new `TunnelInner::pre_resolve()` async method runs FakeIP reverse + hostname→real-IP resolution. Gated by a cached `needs_ip_resolution: AtomicBool` computed inside the `rules` write lock (so readers see a consistent `(rules, flag)` snapshot). Wired into both TCP and UDP handlers; the old sync `pre_handle_metadata` and the inline UDP FakeIP block are deleted.
- `Metadata::remote_address()` prefers `host` over `dst_ip`, so overwriting `dst_ip` with the resolved IP is safe — proxy adapters still dial the original destination.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all green (0 failures)
- [x] New unit tests in `mihomo-dns`: clamp_ttl boundaries + FakeIP bypass via cached entry
- [x] New recursion test in `mihomo-rules` for `AndRule::should_resolve_ip`
- [x] New integration test `crates/mihomo-tunnel/tests/pre_resolve_test.rs`: hostname → IP-CIDR end-to-end, and no-op when no rule needs IP resolution
- [ ] Manual smoke test: run with a `GEOIP,CN,DIRECT` rule and a `curl --socks5-hostname` request to verify the rule now matches (before this PR it would silently fall through)

## Follow-ups (not in this PR)

- `RuleType::SrcGeoIp` variant exists in `mihomo-common` with no backing struct — latent trap for future implementors.
- IPv6/IPv4 selection in `resolve_ip_real` returns the first IP regardless of family; may not align with GeoIP DB coverage.
- `Resolver::inflight` DashMap is allocated but unused — either implement in-flight dedup or remove.
- No test coverage for `GEOIP,...,no-resolve` flag.
- Pre-existing bug in `udp.rs`: `metadata.remote_address().parse::<SocketAddr>()` silently fails when `host` is set, dropping packets on hostname-keyed NAT sessions. Not introduced by this PR.