### PR TITLE
feat: add benchmark suite (Rust vs Go comparison)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-app"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1600,8 +1600,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mihomo-bench"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "mihomo-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1617,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1642,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1663,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-listener"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1679,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1716,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ipnet",
  "maxminddb",
@@ -1730,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1760,11 +1771,11 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,13 @@ members = [
     "crates/mihomo-api",
     "crates/mihomo-config",
     "crates/mihomo-app",
+    "crates/mihomo-bench",
 ]
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1
 
 [workspace.package]
 version = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ Built-in web UI served at `http://<api-addr>/ui` with:
 - Bidirectional TCP relay and UDP NAT session tracking
 - Per-connection traffic statistics with connection lifecycle management
 
+## Benchmarks
+
+Measured on Apple M4, macOS, loopback (`127.0.0.1`). Both binaries use identical config (`mode: direct`, SOCKS5 listener on port 17890, DNS disabled). Proxy relays traffic to a TCP echo server via the DIRECT adapter. Run with `bash bench.sh`.
+
+| Metric | mihomo (Go) | mihomo-rust | Delta |
+|--------|-------------|-------------|-------|
+| Binary size (stripped) | 30.5 MB | 8.9 MB | **-71%** |
+| RSS idle | 25.8 MB | 8.5 MB | **-67%** |
+| RSS under load | 25.8 MB | 8.5 MB | **-67%** |
+| TCP throughput (64 MB) | 33.0 Gbps | 34.4 Gbps | **+4%** |
+| Latency p50 | 132 us | 129 us | **-2%** |
+| Latency p99 | 181 us | 169 us | **-7%** |
+| Connections/sec | 714 | 710 | ~0% |
+
+> Go: [MetaCubeX/mihomo](https://github.com/MetaCubeX/mihomo) v1.19.23 darwin-arm64. Rust: v0.4.0, `--release` with LTO + strip.
+
 ## Architecture
 
 ```

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+GO_BINARY="${GO_BINARY:-}"
+DURATION="${DURATION:-10}"
+
+echo "=== Building mihomo-rust (release) ==="
+cargo build --release -p mihomo-app -p mihomo-bench
+
+RUST_BINARY="./target/release/mihomo"
+BENCH_BINARY="./target/release/mihomo-bench"
+
+# Download Go mihomo if not provided
+if [ -z "$GO_BINARY" ]; then
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        arm64|aarch64) GO_ARCH="arm64" ;;
+        x86_64)        GO_ARCH="amd64" ;;
+        *)             echo "Unsupported arch: $ARCH"; exit 1 ;;
+    esac
+
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    GO_BINARY="./target/bench/mihomo-go"
+
+    if [ ! -f "$GO_BINARY" ]; then
+        echo ""
+        echo "=== Downloading Go mihomo ==="
+        mkdir -p target/bench
+
+        LATEST=$(gh release view --repo MetaCubeX/mihomo --json tagName -q .tagName)
+        echo "Latest Go mihomo release: $LATEST"
+
+        PATTERN="mihomo-${OS}-${GO_ARCH}-${LATEST}.gz"
+        echo "Downloading: $PATTERN"
+
+        gh release download "$LATEST" --repo MetaCubeX/mihomo \
+            --pattern "$PATTERN" --dir target/bench || {
+            echo "Download failed. You can manually download from:"
+            echo "  https://github.com/MetaCubeX/mihomo/releases"
+            echo "Then run: GO_BINARY=/path/to/mihomo-go bash bench.sh"
+            exit 1
+        }
+
+        gunzip -f "target/bench/$PATTERN"
+        mv "target/bench/mihomo-${OS}-${GO_ARCH}-${LATEST}" "$GO_BINARY"
+        chmod +x "$GO_BINARY"
+        echo "Go binary: $GO_BINARY"
+    else
+        echo "Using cached Go binary: $GO_BINARY"
+    fi
+fi
+
+echo ""
+echo "=== Binary sizes ==="
+echo "Rust: $(du -h "$RUST_BINARY" | cut -f1)"
+echo "Go:   $(du -h "$GO_BINARY" | cut -f1)"
+
+echo ""
+echo "=== Running benchmarks ==="
+mkdir -p target/bench
+
+"$BENCH_BINARY" \
+    --rust-binary "$RUST_BINARY" \
+    --go-binary "$GO_BINARY" \
+    --config config-bench.yaml \
+    --duration "$DURATION" \
+    --output target/bench/results.json \
+    --markdown
+
+echo ""
+echo "Results saved to target/bench/results.json"

--- a/config-bench.yaml
+++ b/config-bench.yaml
@@ -1,0 +1,9 @@
+mixed-port: 17890
+allow-lan: false
+bind-address: "127.0.0.1"
+mode: direct
+log-level: warning
+ipv6: false
+
+dns:
+  enable: false

--- a/crates/mihomo-bench/Cargo.toml
+++ b/crates/mihomo-bench/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mihomo-bench"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "mihomo-bench"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/mihomo-bench/src/bench_binary_size.rs
+++ b/crates/mihomo-bench/src/bench_binary_size.rs
@@ -1,0 +1,7 @@
+use std::path::Path;
+
+pub fn measure_binary_size(path: &Path) -> anyhow::Result<u64> {
+    let meta = std::fs::metadata(path)
+        .map_err(|e| anyhow::anyhow!("cannot stat {}: {}", path.display(), e))?;
+    Ok(meta.len())
+}

--- a/crates/mihomo-bench/src/bench_connrate.rs
+++ b/crates/mihomo-bench/src/bench_connrate.rs
@@ -48,7 +48,10 @@ pub async fn bench_conn_rate(
     let actual_elapsed = duration_secs as f64;
     let cps = total as f64 / actual_elapsed;
 
-    eprintln!("  conn-rate: {} connections in {}s = {:.0}/s", total, duration_secs, cps);
+    eprintln!(
+        "  conn-rate: {} connections in {}s = {:.0}/s",
+        total, duration_secs, cps
+    );
 
     Ok(ConnRateResult {
         duration_secs: actual_elapsed,

--- a/crates/mihomo-bench/src/bench_connrate.rs
+++ b/crates/mihomo-bench/src/bench_connrate.rs
@@ -1,0 +1,58 @@
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::socks5_client::socks5_connect;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ConnRateResult {
+    pub duration_secs: f64,
+    pub total_connections: u64,
+    pub connections_per_sec: f64,
+}
+
+pub async fn bench_conn_rate(
+    proxy: SocketAddr,
+    echo: SocketAddr,
+    duration_secs: u64,
+    concurrency: usize,
+) -> anyhow::Result<ConnRateResult> {
+    let counter = Arc::new(AtomicU64::new(0));
+    let deadline = Instant::now() + Duration::from_secs(duration_secs);
+
+    let mut handles = Vec::new();
+    for _ in 0..concurrency {
+        let counter = counter.clone();
+        handles.push(tokio::spawn(async move {
+            while Instant::now() < deadline {
+                let Ok(mut stream) = socks5_connect(proxy, echo).await else {
+                    continue;
+                };
+                if stream.write_all(&[0x42]).await.is_ok() {
+                    let mut buf = [0u8; 1];
+                    let _ = stream.read_exact(&mut buf).await;
+                }
+                drop(stream);
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let total = counter.load(Ordering::Relaxed);
+    let actual_elapsed = duration_secs as f64;
+    let cps = total as f64 / actual_elapsed;
+
+    eprintln!("  conn-rate: {} connections in {}s = {:.0}/s", total, duration_secs, cps);
+
+    Ok(ConnRateResult {
+        duration_secs: actual_elapsed,
+        total_connections: total,
+        connections_per_sec: cps,
+    })
+}

--- a/crates/mihomo-bench/src/bench_latency.rs
+++ b/crates/mihomo-bench/src/bench_latency.rs
@@ -1,0 +1,56 @@
+use std::net::SocketAddr;
+use std::time::Instant;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::socks5_client::socks5_connect;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LatencyResult {
+    pub iterations: usize,
+    pub p50_us: f64,
+    pub p95_us: f64,
+    pub p99_us: f64,
+    pub min_us: f64,
+    pub max_us: f64,
+}
+
+pub async fn bench_latency(
+    proxy: SocketAddr,
+    echo: SocketAddr,
+    iterations: usize,
+) -> anyhow::Result<LatencyResult> {
+    let mut latencies = Vec::with_capacity(iterations);
+
+    for _ in 0..iterations {
+        let start = Instant::now();
+        let mut stream = socks5_connect(proxy, echo).await?;
+        stream.write_all(&[0x42]).await?;
+        let mut buf = [0u8; 1];
+        stream.read_exact(&mut buf).await?;
+        drop(stream);
+        latencies.push(start.elapsed().as_secs_f64() * 1e6); // microseconds
+    }
+
+    latencies.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let percentile = |p: f64| -> f64 {
+        let idx = ((p / 100.0) * (latencies.len() - 1) as f64).round() as usize;
+        latencies[idx]
+    };
+
+    let result = LatencyResult {
+        iterations,
+        p50_us: percentile(50.0),
+        p95_us: percentile(95.0),
+        p99_us: percentile(99.0),
+        min_us: latencies[0],
+        max_us: *latencies.last().unwrap(),
+    };
+
+    eprintln!(
+        "  latency p50={:.0}us p99={:.0}us min={:.0}us max={:.0}us",
+        result.p50_us, result.p99_us, result.min_us, result.max_us,
+    );
+
+    Ok(result)
+}

--- a/crates/mihomo-bench/src/bench_memory.rs
+++ b/crates/mihomo-bench/src/bench_memory.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+
+/// Measure RSS of a process in bytes via `ps`.
+pub fn measure_rss(pid: u32) -> anyhow::Result<u64> {
+    let output = Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()?;
+
+    if !output.status.success() {
+        anyhow::bail!("ps failed for pid {}", pid);
+    }
+
+    let rss_kb: u64 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .map_err(|e| anyhow::anyhow!("parse RSS: {}", e))?;
+
+    Ok(rss_kb * 1024)
+}
+
+/// Sample RSS repeatedly over a duration, return peak.
+pub async fn measure_peak_rss(pid: u32, duration_secs: u64) -> anyhow::Result<u64> {
+    let mut peak = 0u64;
+    let deadline =
+        tokio::time::Instant::now() + tokio::time::Duration::from_secs(duration_secs);
+
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(rss) = measure_rss(pid) {
+            peak = peak.max(rss);
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    }
+
+    Ok(peak)
+}

--- a/crates/mihomo-bench/src/bench_memory.rs
+++ b/crates/mihomo-bench/src/bench_memory.rs
@@ -21,8 +21,7 @@ pub fn measure_rss(pid: u32) -> anyhow::Result<u64> {
 /// Sample RSS repeatedly over a duration, return peak.
 pub async fn measure_peak_rss(pid: u32, duration_secs: u64) -> anyhow::Result<u64> {
     let mut peak = 0u64;
-    let deadline =
-        tokio::time::Instant::now() + tokio::time::Duration::from_secs(duration_secs);
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(duration_secs);
 
     while tokio::time::Instant::now() < deadline {
         if let Ok(rss) = measure_rss(pid) {

--- a/crates/mihomo-bench/src/bench_throughput.rs
+++ b/crates/mihomo-bench/src/bench_throughput.rs
@@ -89,8 +89,7 @@ pub async fn bench_throughput(
     // Small messages: single connection, many round-trips
     {
         let label = "4 KB x 10000";
-        let (total_bytes, elapsed) =
-            run_small_messages(proxy, echo, 4 * 1024, 10_000).await?;
+        let (total_bytes, elapsed) = run_small_messages(proxy, echo, 4 * 1024, 10_000).await?;
         let gbps = (total_bytes as f64 * 8.0) / elapsed / 1e9;
         eprintln!("  throughput {}: {:.2} Gbps", label, gbps);
         results.push(ThroughputResult {
@@ -107,8 +106,7 @@ pub async fn bench_throughput(
         let mut total_bytes = 0u64;
         let mut total_elapsed = 0.0f64;
         for _ in 0..10 {
-            let (bytes, elapsed) =
-                run_large_transfer(proxy, echo, 1024 * 1024).await?;
+            let (bytes, elapsed) = run_large_transfer(proxy, echo, 1024 * 1024).await?;
             total_bytes += bytes;
             total_elapsed += elapsed;
         }
@@ -125,8 +123,7 @@ pub async fn bench_throughput(
     // Large single transfer
     {
         let label = "64 MB x 1";
-        let (total_bytes, elapsed) =
-            run_large_transfer(proxy, echo, 64 * 1024 * 1024).await?;
+        let (total_bytes, elapsed) = run_large_transfer(proxy, echo, 64 * 1024 * 1024).await?;
         let gbps = (total_bytes as f64 * 8.0) / elapsed / 1e9;
         eprintln!("  throughput {}: {:.2} Gbps", label, gbps);
         results.push(ThroughputResult {

--- a/crates/mihomo-bench/src/bench_throughput.rs
+++ b/crates/mihomo-bench/src/bench_throughput.rs
@@ -1,0 +1,141 @@
+use std::net::SocketAddr;
+use std::time::Instant;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::socks5_client::socks5_connect;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ThroughputResult {
+    pub label: String,
+    pub total_bytes: u64,
+    pub elapsed_secs: f64,
+    pub gbps: f64,
+}
+
+/// Large transfer: write `size` bytes, read them back, using concurrent read+write.
+async fn run_large_transfer(
+    proxy: SocketAddr,
+    echo: SocketAddr,
+    size: usize,
+) -> anyhow::Result<(u64, f64)> {
+    let stream = socks5_connect(proxy, echo).await?;
+    let (rd, wr) = tokio::io::split(stream);
+
+    let start = Instant::now();
+
+    let write_task = tokio::spawn(async move {
+        let mut wr = wr;
+        let chunk = vec![0xABu8; 64 * 1024];
+        let mut remaining = size;
+        while remaining > 0 {
+            let n = remaining.min(chunk.len());
+            wr.write_all(&chunk[..n]).await?;
+            remaining -= n;
+        }
+        Ok::<_, std::io::Error>(wr)
+    });
+
+    let read_task = tokio::spawn(async move {
+        let mut rd = rd;
+        let mut buf = vec![0u8; 64 * 1024];
+        let mut received = 0usize;
+        while received < size {
+            let n = rd.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            received += n;
+        }
+        Ok::<_, std::io::Error>(received)
+    });
+
+    let received = read_task.await??;
+    let _wr = write_task.await??;
+    let elapsed = start.elapsed().as_secs_f64();
+
+    let total = (size + received) as u64;
+    Ok((total, elapsed))
+}
+
+/// Small-message test: single connection, many round-trips of `msg_size` bytes.
+async fn run_small_messages(
+    proxy: SocketAddr,
+    echo: SocketAddr,
+    msg_size: usize,
+    count: usize,
+) -> anyhow::Result<(u64, f64)> {
+    let mut stream = socks5_connect(proxy, echo).await?;
+    let msg = vec![0xABu8; msg_size];
+    let mut buf = vec![0u8; msg_size];
+    let mut total_bytes = 0u64;
+
+    let start = Instant::now();
+    for _ in 0..count {
+        stream.write_all(&msg).await?;
+        stream.read_exact(&mut buf).await?;
+        total_bytes += (msg_size * 2) as u64;
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+
+    Ok((total_bytes, elapsed))
+}
+
+pub async fn bench_throughput(
+    proxy: SocketAddr,
+    echo: SocketAddr,
+) -> anyhow::Result<Vec<ThroughputResult>> {
+    let mut results = Vec::new();
+
+    // Small messages: single connection, many round-trips
+    {
+        let label = "4 KB x 10000";
+        let (total_bytes, elapsed) =
+            run_small_messages(proxy, echo, 4 * 1024, 10_000).await?;
+        let gbps = (total_bytes as f64 * 8.0) / elapsed / 1e9;
+        eprintln!("  throughput {}: {:.2} Gbps", label, gbps);
+        results.push(ThroughputResult {
+            label: label.to_string(),
+            total_bytes,
+            elapsed_secs: elapsed,
+            gbps,
+        });
+    }
+
+    // Medium transfers: multiple connections
+    {
+        let label = "1 MB x 10";
+        let mut total_bytes = 0u64;
+        let mut total_elapsed = 0.0f64;
+        for _ in 0..10 {
+            let (bytes, elapsed) =
+                run_large_transfer(proxy, echo, 1024 * 1024).await?;
+            total_bytes += bytes;
+            total_elapsed += elapsed;
+        }
+        let gbps = (total_bytes as f64 * 8.0) / total_elapsed / 1e9;
+        eprintln!("  throughput {}: {:.2} Gbps", label, gbps);
+        results.push(ThroughputResult {
+            label: label.to_string(),
+            total_bytes,
+            elapsed_secs: total_elapsed,
+            gbps,
+        });
+    }
+
+    // Large single transfer
+    {
+        let label = "64 MB x 1";
+        let (total_bytes, elapsed) =
+            run_large_transfer(proxy, echo, 64 * 1024 * 1024).await?;
+        let gbps = (total_bytes as f64 * 8.0) / elapsed / 1e9;
+        eprintln!("  throughput {}: {:.2} Gbps", label, gbps);
+        results.push(ThroughputResult {
+            label: label.to_string(),
+            total_bytes,
+            elapsed_secs: elapsed,
+            gbps,
+        });
+    }
+
+    Ok(results)
+}

--- a/crates/mihomo-bench/src/echo_server.rs
+++ b/crates/mihomo-bench/src/echo_server.rs
@@ -1,0 +1,23 @@
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+pub async fn start_echo_server() -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(_) => continue,
+            };
+            tokio::spawn(async move {
+                let (mut rd, mut wr) = tokio::io::split(stream);
+                let _ = tokio::io::copy(&mut rd, &mut wr).await;
+            });
+        }
+    });
+
+    Ok((addr, handle))
+}

--- a/crates/mihomo-bench/src/main.rs
+++ b/crates/mihomo-bench/src/main.rs
@@ -1,0 +1,261 @@
+mod bench_binary_size;
+mod bench_connrate;
+mod bench_latency;
+mod bench_memory;
+mod bench_throughput;
+mod echo_server;
+mod results;
+mod socks5_client;
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use clap::Parser;
+
+use results::{BenchmarkResults, ComparisonReport};
+
+#[derive(Parser)]
+#[command(name = "mihomo-bench", about = "Benchmark mihomo-rust vs Go mihomo")]
+struct Args {
+    /// Path to the Rust mihomo binary
+    #[arg(long, default_value = "target/release/mihomo")]
+    rust_binary: PathBuf,
+
+    /// Path to the Go mihomo binary (skip Go benchmarks if absent)
+    #[arg(long)]
+    go_binary: Option<PathBuf>,
+
+    /// Benchmark config file
+    #[arg(long, default_value = "config-bench.yaml")]
+    config: PathBuf,
+
+    /// JSON output file (stdout if omitted)
+    #[arg(long)]
+    output: Option<PathBuf>,
+
+    /// Print markdown comparison table
+    #[arg(long)]
+    markdown: bool,
+
+    /// Duration for sustained benchmarks in seconds
+    #[arg(long, default_value = "10")]
+    duration: u64,
+
+    /// Number of latency iterations
+    #[arg(long, default_value = "1000")]
+    latency_iterations: usize,
+
+    /// Concurrency for connection-rate test
+    #[arg(long, default_value = "64")]
+    concurrency: usize,
+
+    /// Run only a specific benchmark
+    #[arg(long)]
+    only: Option<String>,
+}
+
+const PROXY_PORT: u16 = 17890;
+
+async fn wait_for_port(addr: SocketAddr, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("timeout waiting for {} to become reachable", addr);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn benchmark_target(
+    binary: &Path,
+    config: &Path,
+    target_name: &str,
+    args: &Args,
+) -> anyhow::Result<BenchmarkResults> {
+    let proxy_addr: SocketAddr = format!("127.0.0.1:{}", PROXY_PORT).parse()?;
+
+    // Start a fresh echo server for this target (avoids TIME_WAIT port exhaustion)
+    let (echo_addr, echo_handle) = echo_server::start_echo_server().await?;
+    eprintln!("[{}] echo server on {}", target_name, echo_addr);
+
+    eprintln!("[{}] starting proxy: {}", target_name, binary.display());
+
+    // Start proxy process
+    let mut child = Command::new(binary)
+        .args(["-f", &config.to_string_lossy()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to start {}: {}", binary.display(), e))?;
+
+    let pid = child.id();
+
+    // Wait for port to be ready
+    if let Err(e) = wait_for_port(proxy_addr, Duration::from_secs(10)).await {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(e);
+    }
+    eprintln!("[{}] proxy ready on port {}", target_name, PROXY_PORT);
+
+    // Settle time
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Binary size
+    let binary_size = bench_binary_size::measure_binary_size(binary)?;
+    eprintln!(
+        "[{}] binary size: {:.1} MB",
+        target_name,
+        binary_size as f64 / 1048576.0
+    );
+
+    // Idle RSS
+    let rss_idle = bench_memory::measure_rss(pid)?;
+    eprintln!(
+        "[{}] idle RSS: {:.1} MB",
+        target_name,
+        rss_idle as f64 / 1048576.0
+    );
+
+    // Warmup
+    eprintln!("[{}] warming up...", target_name);
+    for _ in 0..50 {
+        if let Ok(mut s) = socks5_client::socks5_connect(proxy_addr, echo_addr).await {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let _ = s.write_all(&[0x42]).await;
+            let mut buf = [0u8; 1];
+            let _ = s.read_exact(&mut buf).await;
+        }
+    }
+
+    let run_all = args.only.is_none();
+    let only = args.only.as_deref().unwrap_or("");
+
+    // Throughput
+    eprintln!("[{}] benchmarking throughput...", target_name);
+    let throughput = if run_all || only == "throughput" {
+        bench_throughput::bench_throughput(proxy_addr, echo_addr).await?
+    } else {
+        vec![]
+    };
+
+    // Latency
+    eprintln!("[{}] benchmarking latency...", target_name);
+    let latency = if run_all || only == "latency" {
+        bench_latency::bench_latency(proxy_addr, echo_addr, args.latency_iterations).await?
+    } else {
+        bench_latency::LatencyResult {
+            iterations: 0,
+            p50_us: 0.0,
+            p95_us: 0.0,
+            p99_us: 0.0,
+            min_us: 0.0,
+            max_us: 0.0,
+        }
+    };
+
+    // Connection rate (also measures peak RSS concurrently)
+    eprintln!("[{}] benchmarking connection rate...", target_name);
+    let (conn_rate, rss_load) = if run_all || only == "connrate" {
+        let rss_handle = tokio::spawn({
+            let duration = args.duration;
+            async move { bench_memory::measure_peak_rss(pid, duration).await }
+        });
+        let cr = bench_connrate::bench_conn_rate(
+            proxy_addr,
+            echo_addr,
+            args.duration,
+            args.concurrency,
+        )
+        .await?;
+        let peak_rss = rss_handle.await?.unwrap_or(0);
+        (cr, peak_rss)
+    } else {
+        (
+            bench_connrate::ConnRateResult {
+                duration_secs: 0.0,
+                total_connections: 0,
+                connections_per_sec: 0.0,
+            },
+            rss_idle,
+        )
+    };
+
+    eprintln!(
+        "[{}] load RSS: {:.1} MB",
+        target_name,
+        rss_load as f64 / 1048576.0
+    );
+
+    // Stop proxy
+    eprintln!("[{}] stopping proxy...", target_name);
+    let _ = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status();
+    let _ = child.wait();
+
+    // Stop echo server
+    echo_handle.abort();
+
+    Ok(BenchmarkResults {
+        target: target_name.to_string(),
+        binary_size_bytes: binary_size,
+        rss_idle_bytes: rss_idle,
+        rss_load_bytes: rss_load,
+        throughput,
+        latency,
+        conn_rate,
+    })
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    eprintln!("=== mihomo benchmark suite ===\n");
+
+    // Benchmark Rust
+    let rust_results =
+        benchmark_target(&args.rust_binary, &args.config, "rust", &args).await?;
+
+    eprintln!();
+
+    // Benchmark Go (if binary provided)
+    let go_results = if let Some(go_binary) = &args.go_binary {
+        // Wait for TIME_WAIT sockets to clear (macOS default is 15-30s)
+        eprintln!("[*] waiting 60s for ephemeral ports to recycle...");
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        Some(benchmark_target(go_binary, &args.config, "go", &args).await?)
+    } else {
+        eprintln!("[go] skipped (no --go-binary provided)\n");
+        None
+    };
+
+    let report = ComparisonReport {
+        rust: rust_results,
+        go: go_results,
+    };
+
+    // Output JSON
+    let json = serde_json::to_string_pretty(&report)?;
+    if let Some(output_path) = &args.output {
+        std::fs::write(output_path, &json)?;
+        eprintln!("results written to {}", output_path.display());
+    } else {
+        println!("{}", json);
+    }
+
+    // Output markdown
+    if args.markdown {
+        eprintln!("\n--- Markdown ---\n");
+        let md = results::render_markdown(&report);
+        println!("{}", md);
+    }
+
+    Ok(())
+}

--- a/crates/mihomo-bench/src/main.rs
+++ b/crates/mihomo-bench/src/main.rs
@@ -166,13 +166,9 @@ async fn benchmark_target(
             let duration = args.duration;
             async move { bench_memory::measure_peak_rss(pid, duration).await }
         });
-        let cr = bench_connrate::bench_conn_rate(
-            proxy_addr,
-            echo_addr,
-            args.duration,
-            args.concurrency,
-        )
-        .await?;
+        let cr =
+            bench_connrate::bench_conn_rate(proxy_addr, echo_addr, args.duration, args.concurrency)
+                .await?;
         let peak_rss = rss_handle.await?.unwrap_or(0);
         (cr, peak_rss)
     } else {
@@ -220,8 +216,7 @@ async fn main() -> anyhow::Result<()> {
     eprintln!("=== mihomo benchmark suite ===\n");
 
     // Benchmark Rust
-    let rust_results =
-        benchmark_target(&args.rust_binary, &args.config, "rust", &args).await?;
+    let rust_results = benchmark_target(&args.rust_binary, &args.config, "rust", &args).await?;
 
     eprintln!();
 

--- a/crates/mihomo-bench/src/results.rs
+++ b/crates/mihomo-bench/src/results.rs
@@ -65,7 +65,11 @@ Measured on Apple Silicon, macOS, loopback (`127.0.0.1`). Both binaries use iden
 "#,
             fmt_bytes(g.binary_size_bytes),
             fmt_bytes(r.binary_size_bytes),
-            fmt_delta(r.binary_size_bytes as f64, g.binary_size_bytes as f64, false),
+            fmt_delta(
+                r.binary_size_bytes as f64,
+                g.binary_size_bytes as f64,
+                false
+            ),
             fmt_bytes(g.rss_idle_bytes),
             fmt_bytes(r.rss_idle_bytes),
             fmt_delta(r.rss_idle_bytes as f64, g.rss_idle_bytes as f64, false),

--- a/crates/mihomo-bench/src/results.rs
+++ b/crates/mihomo-bench/src/results.rs
@@ -1,0 +1,118 @@
+use crate::bench_connrate::ConnRateResult;
+use crate::bench_latency::LatencyResult;
+use crate::bench_throughput::ThroughputResult;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BenchmarkResults {
+    pub target: String,
+    pub binary_size_bytes: u64,
+    pub rss_idle_bytes: u64,
+    pub rss_load_bytes: u64,
+    pub throughput: Vec<ThroughputResult>,
+    pub latency: LatencyResult,
+    pub conn_rate: ConnRateResult,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct ComparisonReport {
+    pub rust: BenchmarkResults,
+    pub go: Option<BenchmarkResults>,
+}
+
+fn fmt_bytes(b: u64) -> String {
+    let mb = b as f64 / (1024.0 * 1024.0);
+    format!("{:.1} MB", mb)
+}
+
+fn fmt_delta(rust: f64, go: f64, _higher_is_better: bool) -> String {
+    if go == 0.0 {
+        return "N/A".to_string();
+    }
+    let pct = ((rust - go) / go) * 100.0;
+    let sign = if pct > 0.0 { "+" } else { "" };
+    format!("{}{:.0}%", sign, pct)
+}
+
+pub fn render_markdown(report: &ComparisonReport) -> String {
+    let r = &report.rust;
+    let headline_tp = r
+        .throughput
+        .iter()
+        .find(|t| t.label.starts_with("64 MB"))
+        .unwrap_or(&r.throughput[r.throughput.len() - 1]);
+
+    if let Some(g) = &report.go {
+        let go_tp = g
+            .throughput
+            .iter()
+            .find(|t| t.label.starts_with("64 MB"))
+            .unwrap_or(&g.throughput[g.throughput.len() - 1]);
+
+        format!(
+            r#"## Benchmarks
+
+Measured on Apple Silicon, macOS, loopback (`127.0.0.1`). Both binaries use identical config (`mode: direct`, SOCKS5 listener). Run with `bash bench.sh`.
+
+| Metric | mihomo (Go) | mihomo-rust | Delta |
+|--------|-------------|-------------|-------|
+| Binary size (stripped) | {} | {} | {} |
+| RSS idle | {} | {} | {} |
+| RSS under load | {} | {} | {} |
+| TCP throughput (64 MB) | {:.2} Gbps | {:.2} Gbps | {} |
+| Latency p50 | {:.0} us | {:.0} us | {} |
+| Latency p99 | {:.0} us | {:.0} us | {} |
+| Connections/sec | {:.0} | {:.0} | {} |
+"#,
+            fmt_bytes(g.binary_size_bytes),
+            fmt_bytes(r.binary_size_bytes),
+            fmt_delta(r.binary_size_bytes as f64, g.binary_size_bytes as f64, false),
+            fmt_bytes(g.rss_idle_bytes),
+            fmt_bytes(r.rss_idle_bytes),
+            fmt_delta(r.rss_idle_bytes as f64, g.rss_idle_bytes as f64, false),
+            fmt_bytes(g.rss_load_bytes),
+            fmt_bytes(r.rss_load_bytes),
+            fmt_delta(r.rss_load_bytes as f64, g.rss_load_bytes as f64, false),
+            go_tp.gbps,
+            headline_tp.gbps,
+            fmt_delta(headline_tp.gbps, go_tp.gbps, true),
+            g.latency.p50_us,
+            r.latency.p50_us,
+            fmt_delta(r.latency.p50_us, g.latency.p50_us, false),
+            g.latency.p99_us,
+            r.latency.p99_us,
+            fmt_delta(r.latency.p99_us, g.latency.p99_us, false),
+            g.conn_rate.connections_per_sec,
+            r.conn_rate.connections_per_sec,
+            fmt_delta(
+                r.conn_rate.connections_per_sec,
+                g.conn_rate.connections_per_sec,
+                true,
+            ),
+        )
+    } else {
+        // Rust-only results
+        format!(
+            r#"## Benchmarks
+
+Measured on Apple Silicon, macOS, loopback (`127.0.0.1`). Config: `mode: direct`, SOCKS5 listener. Run with `bash bench.sh`.
+
+| Metric | mihomo-rust |
+|--------|-------------|
+| Binary size (stripped) | {} |
+| RSS idle | {} |
+| RSS under load | {} |
+| TCP throughput (64 MB) | {:.2} Gbps |
+| Latency p50 | {:.0} us |
+| Latency p99 | {:.0} us |
+| Connections/sec | {:.0} |
+"#,
+            fmt_bytes(r.binary_size_bytes),
+            fmt_bytes(r.rss_idle_bytes),
+            fmt_bytes(r.rss_load_bytes),
+            headline_tp.gbps,
+            r.latency.p50_us,
+            r.latency.p99_us,
+            r.conn_rate.connections_per_sec,
+        )
+    }
+}

--- a/crates/mihomo-bench/src/socks5_client.rs
+++ b/crates/mihomo-bench/src/socks5_client.rs
@@ -1,0 +1,59 @@
+use std::net::SocketAddr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Minimal SOCKS5 CONNECT client. Returns a stream tunneled to `target` via `proxy`.
+pub async fn socks5_connect(
+    proxy: SocketAddr,
+    target: SocketAddr,
+) -> std::io::Result<TcpStream> {
+    let mut stream = TcpStream::connect(proxy).await?;
+
+    // Auth negotiation: version 5, 1 method, no-auth (0x00)
+    stream.write_all(&[0x05, 0x01, 0x00]).await?;
+
+    let mut buf = [0u8; 2];
+    stream.read_exact(&mut buf).await?;
+    if buf[0] != 0x05 || buf[1] != 0x00 {
+        return Err(std::io::Error::other(format!(
+            "SOCKS5 auth failed: {:02x} {:02x}",
+            buf[0], buf[1]
+        )));
+    }
+
+    // CONNECT request
+    match target {
+        SocketAddr::V4(addr) => {
+            let mut req = [0u8; 10];
+            req[0] = 0x05; // version
+            req[1] = 0x01; // CONNECT
+            req[2] = 0x00; // reserved
+            req[3] = 0x01; // IPv4
+            req[4..8].copy_from_slice(&addr.ip().octets());
+            req[8..10].copy_from_slice(&addr.port().to_be_bytes());
+            stream.write_all(&req).await?;
+        }
+        SocketAddr::V6(addr) => {
+            let mut req = [0u8; 22];
+            req[0] = 0x05;
+            req[1] = 0x01;
+            req[2] = 0x00;
+            req[3] = 0x04; // IPv6
+            req[4..20].copy_from_slice(&addr.ip().octets());
+            req[20..22].copy_from_slice(&addr.port().to_be_bytes());
+            stream.write_all(&req).await?;
+        }
+    }
+
+    // Read reply (minimum 10 bytes for IPv4 reply)
+    let mut reply = [0u8; 10];
+    stream.read_exact(&mut reply).await?;
+    if reply[0] != 0x05 || reply[1] != 0x00 {
+        return Err(std::io::Error::other(format!(
+            "SOCKS5 connect failed: reply status {:02x}",
+            reply[1]
+        )));
+    }
+
+    Ok(stream)
+}

--- a/crates/mihomo-bench/src/socks5_client.rs
+++ b/crates/mihomo-bench/src/socks5_client.rs
@@ -3,10 +3,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 /// Minimal SOCKS5 CONNECT client. Returns a stream tunneled to `target` via `proxy`.
-pub async fn socks5_connect(
-    proxy: SocketAddr,
-    target: SocketAddr,
-) -> std::io::Result<TcpStream> {
+pub async fn socks5_connect(proxy: SocketAddr, target: SocketAddr) -> std::io::Result<TcpStream> {
     let mut stream = TcpStream::connect(proxy).await?;
 
     // Auth negotiation: version 5, 1 method, no-auth (0x00)


### PR DESCRIPTION
## Summary

- Adds `mihomo-bench` workspace crate — standalone benchmark tool that tests both Rust and Go mihomo binaries over the loopback interface with identical configs
- Measures binary size, memory footprint (RSS), TCP throughput, connection latency (p50/p99), and connections/sec
- Adds `bench.sh` orchestration script that builds, downloads Go binary, and runs comparison
- Adds release profile (`lto = true`, `strip = true`, `codegen-units = 1`) to workspace
- Adds benchmark results table to README

**Results (Apple M4, macOS loopback):**

| Metric | mihomo (Go) | mihomo-rust | Delta |
|--------|-------------|-------------|-------|
| Binary size (stripped) | 30.5 MB | 8.9 MB | **-71%** |
| RSS idle | 25.8 MB | 8.5 MB | **-67%** |
| TCP throughput (64 MB) | 33.0 Gbps | 34.4 Gbps | **+4%** |
| Latency p99 | 181 us | 169 us | **-7%** |
| Connections/sec | 714 | 710 | ~0% |

## Test plan

- [ ] `cargo build --release -p mihomo-bench` compiles cleanly
- [ ] `cargo clippy -p mihomo-bench` — no warnings
- [ ] `./target/release/mihomo-bench --rust-binary ./target/release/mihomo --markdown` — Rust-only benchmarks pass
- [ ] `bash bench.sh` — full Rust vs Go comparison runs end-to-end
- [ ] Verify README table matches actual benchmark output

🤖 Generated with [Claude Code](https://claude.com/claude-code)