### PR TITLE
chore(common): prune unimplemented AdapterType variants

### DIFF
--- a/crates/mihomo-common/src/adapter_type.rs
+++ b/crates/mihomo-common/src/adapter_type.rs
@@ -12,18 +12,11 @@ pub enum AdapterType {
     LoadBalance,
     Relay,
     Shadowsocks,
-    ShadowsocksR,
-    Snell,
     Socks5,
     Http,
-    Vmess,
     Vless,
     Trojan,
-    Hysteria,
     Hysteria2,
-    WireGuard,
-    Tuic,
-    Ssh,
 }
 
 impl fmt::Display for AdapterType {
@@ -38,18 +31,11 @@ impl fmt::Display for AdapterType {
             AdapterType::LoadBalance => write!(f, "LoadBalance"),
             AdapterType::Relay => write!(f, "Relay"),
             AdapterType::Shadowsocks => write!(f, "Shadowsocks"),
-            AdapterType::ShadowsocksR => write!(f, "ShadowsocksR"),
-            AdapterType::Snell => write!(f, "Snell"),
             AdapterType::Socks5 => write!(f, "Socks5"),
             AdapterType::Http => write!(f, "Http"),
-            AdapterType::Vmess => write!(f, "Vmess"),
             AdapterType::Vless => write!(f, "Vless"),
             AdapterType::Trojan => write!(f, "Trojan"),
-            AdapterType::Hysteria => write!(f, "Hysteria"),
             AdapterType::Hysteria2 => write!(f, "Hysteria2"),
-            AdapterType::WireGuard => write!(f, "WireGuard"),
-            AdapterType::Tuic => write!(f, "Tuic"),
-            AdapterType::Ssh => write!(f, "Ssh"),
         }
     }
 }

--- a/crates/mihomo-common/tests/common_test.rs
+++ b/crates/mihomo-common/tests/common_test.rs
@@ -15,18 +15,11 @@ fn test_adapter_type_display() {
         (AdapterType::Fallback, "Fallback"),
         (AdapterType::UrlTest, "URLTest"),
         (AdapterType::Shadowsocks, "Shadowsocks"),
-        (AdapterType::ShadowsocksR, "ShadowsocksR"),
-        (AdapterType::Snell, "Snell"),
         (AdapterType::Socks5, "Socks5"),
         (AdapterType::Http, "Http"),
-        (AdapterType::Vmess, "Vmess"),
         (AdapterType::Vless, "Vless"),
         (AdapterType::Trojan, "Trojan"),
-        (AdapterType::Hysteria, "Hysteria"),
         (AdapterType::Hysteria2, "Hysteria2"),
-        (AdapterType::WireGuard, "WireGuard"),
-        (AdapterType::Tuic, "Tuic"),
-        (AdapterType::Ssh, "Ssh"),
     ];
     for (variant, expected) in cases {
         assert_eq!(variant.to_string(), expected, "AdapterType::{:?}", variant);


### PR DESCRIPTION
## Summary
- Removes 7 `AdapterType` variants that have no proxy adapter implementations: `ShadowsocksR`, `Snell`, `Vmess`, `Hysteria`, `WireGuard`, `Tuic`, `Ssh`
- Eliminates dead_code noise and narrows the public API surface
- Updates `common_test.rs` display test to match the pruned enum

## Test plan
- [x] `cargo build` — clean, no errors
- [x] `cargo test --lib` — all 9 tests pass
- [x] `cargo clippy -p mihomo-common` — no dead_code warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)