### PR TITLE
docs(test-plans): seed M1 test plans for E-3/E-4, F-1, F-3, G-10

### DIFF
--- a/docs/specs/dns-nameserver-policy-test-plan.md
+++ b/docs/specs/dns-nameserver-policy-test-plan.md
@@ -1,0 +1,208 @@
+# Test Plan: DNS nameserver-policy and fallback-filter (M1.E-3, M1.E-4)
+
+Status: **draft** — owner: pm. Last updated: 2026-04-18.
+Tracks: task #22. Companion to `docs/specs/dns-nameserver-policy.md`.
+
+This is the QA-owned acceptance test plan. The spec's `§Test plan` section
+is the PM's starting point; this document is the final shape engineer should
+implement against. If the spec and this document disagree, **this document
+wins for test cases** — flag the discrepancy so the spec can be updated.
+
+Divergence-comment convention per memory (`feedback_spec_divergence_comments.md`):
+inline `Upstream: file::fn` + `NOT X` lines on bullets that exercise a
+divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
+
+## Scope and guardrails
+
+**In scope:**
+
+- `NameserverPolicy` struct and `lookup()` method (`crates/mihomo-dns/src/resolver.rs`)
+  — exact match, `+.` wildcard match, no-match fall-through.
+- `FallbackFilter` struct and `should_use_fallback()` method (same file)
+  — GeoIP gate, IP-CIDR gate, domain gate, disabled-gate pass-through.
+- Full resolver lookup flow: policy → global → fallback dispatch
+  (`Resolver::do_lookup()` or equivalent).
+- Config parser (`crates/mihomo-config/src/dns_parser.rs`) — YAML round-trip
+  for `nameserver-policy` and `fallback-filter` fields.
+- Divergences: `geosite:`/`rule-set:` prefix warn-and-skip, no-MMDB
+  startup warn, zero-valid-nameserver hard error.
+- Parallel nameserver dispatch (`futures::future::select_ok` semantics).
+
+**Out of scope (forbidden per spec §Out of scope):**
+
+- `geosite:` and `rule-set:` patterns resolving to actual geosite DBs —
+  M1.D-2 / M1.D-5. Warn-and-skip is the only behaviour tested here.
+- `dhcp://` nameserver — deferred.
+- Per-policy TLS config (all policies share global TLS from M1.E-1).
+- DoQ — M1.E-6.
+- Re-filtering of fallback results — spec §FallbackFilter explicitly
+  exempts fallback responses from re-filtering.
+- Throughput / latency benchmarks — M2.
+
+## File layout expected
+
+```
+crates/mihomo-dns/src/
+  resolver.rs          # MODIFIED: NameserverPolicy, FallbackFilter, lookup flow
+crates/mihomo-dns/tests/
+  nameserver_policy_integration.rs   # NEW: network-gated #[ignore] end-to-end tests
+crates/mihomo-config/src/
+  dns_parser.rs        # MODIFIED: nameserver_policy + fallback_filter fields
+crates/mihomo-config/tests/
+  config_test.rs       # MODIFIED: new dns_parser cases
+```
+
+## Divergence table
+
+Following ADR-0002 classification format:
+
+| # | Case | Class | Note |
+|---|------|:-----:|------|
+| 1 | `geosite:`/`rule-set:` prefix in nameserver-policy key — upstream supports | B | Warn-once at parse time, entry skipped. NOT hard error — real configs use these. |
+| 2 | `fallback-filter.geoip: true` with no MMDB — upstream errors at startup | B | We treat as `geoip: false` with `warn!`. Single-resolver configs need no GeoIP DB. NOT a startup error. |
+| 3 | Policy entry with zero valid nameservers (all URLs skipped) — upstream panics | A | Hard parse error: `"nameserver-policy entry 'KEY' has no valid nameservers"`. Silent routing to global = DNS leakage for internal domains. NOT silent fall-through. |
+| 4 | `fallback-filter` GeoIP/CIDR/domain gates — upstream only falls back on primary failure | A | We trigger fallback on GeoIP anomaly, bogon IP, or domain pattern match even when primary succeeds. Upstream: `dns/resolver.go::ipWithFallback` checks only SERVFAIL/timeout. NOT pass-through on poisoned responses. |
+| 5 | Fallback results not re-filtered — both upstream and mihomo-rust match | — | Consistent: fallback is the trusted alternate; re-filtering creates rejection loops. |
+
+---
+
+## Case list
+
+### A. `NameserverPolicy` unit tests (`crates/mihomo-dns/src/resolver.rs`)
+
+Pure in-process unit tests, no network. Mock policy nameservers that record
+whether they were called.
+
+| # | Case | Asserts |
+|---|------|---------|
+| A1 | `nameserver_policy_exact_match_routes_to_policy` | Policy entry `"example.com"` → mock policy server. Query `example.com A`. Assert policy mock called; global mock NOT called. <br/> Upstream: `dns/resolver.go::PolicyResolver` — policy takes precedence over global pool. NOT global nameservers when exact match exists. |
+| A2 | `nameserver_policy_exact_no_match_routes_to_global` | Policy entry `"example.com"` only. Query `other.com A`. Assert global mock called; policy mock NOT called. |
+| A3 | `nameserver_policy_wildcard_matches_subdomain` | Policy `"+.corp.internal"`. Query `foo.corp.internal`. Assert policy mock called; global mock NOT called. |
+| A4 | `nameserver_policy_wildcard_matches_root_domain` | Policy `"+.corp.internal"`. Query `corp.internal`. Assert policy mock called. <br/> Upstream: `dns/resolver.go` — `+.` prefix includes the root domain, not only subdomains. NOT global — `+.` is not sub-only. |
+| A5 | `nameserver_policy_wildcard_does_not_match_sibling` **[guard-rail]** | Policy `"+.corp.internal"`. Query `othercorp.internal`. Assert global mock called; policy mock NOT called. Guards trie boundary — `othercorp.internal` is a sibling, not a subdomain. |
+| A6 | `nameserver_policy_exact_takes_priority_over_wildcard` **[guard-rail]** | Two entries: exact `"api.corp.internal"` → mock-A; wildcard `"+.corp.internal"` → mock-B. Query `api.corp.internal`. Assert mock-A called; mock-B NOT called. Exact match wins per spec §Lookup flow step 3 (`exact` checked before `wildcard` in `NameserverPolicy::lookup`). |
+| A7 | `nameserver_policy_multiple_servers_parallel_dispatch` | Policy entry with two mock servers: slow-A (delays 50ms) and fast-B (responds immediately). Assert fast-B's response returned; total wall time < slow-A's delay. <br/> Upstream: `dns/resolver.go` uses goroutine fan-out. NOT sequential — `select_ok` returns first success. |
+| A8 | `nameserver_policy_geosite_prefix_warns_and_falls_through_to_global` | Policy key `"geosite:cn"`. At parse time assert one `warn!` log emitted. At lookup time query matching no plain-pattern policy → global mock called. <br/> Upstream: `dns/resolver.go` resolves `geosite:` patterns via the geosite DB (M1.D-2). <br/> NOT hard error — Class B per ADR-0002: too many real configs use this; defer geosite resolution to M1.D-2 integration. |
+| A9 | `nameserver_policy_zero_valid_nameservers_hard_errors_at_parse` | Config with policy entry whose only URL is `"quic://dns.example"` (unsupported scheme, stripped by M1.E-1). Assert `parse_dns` returns `Err` containing `"nameserver-policy entry"` and the key name. <br/> Upstream: `dns/resolver.go` — upstream would panic at lookup time with an empty client list. <br/> NOT silent fall-through to global — Class A per ADR-0002: silent routing of internal domain to global = DNS leakage. |
+
+### B. `FallbackFilter` unit tests (`crates/mihomo-dns/src/resolver.rs`)
+
+Pure unit tests on `FallbackFilter::should_use_fallback`. Use a stub MMDB
+that returns controlled country codes.
+
+| # | Case | Asserts |
+|---|------|---------|
+| B1 | `fallback_filter_geoip_triggers_on_non_matching_country` | GeoIP gate: `geoip: true`, `geoip-code: CN`. MMDB stub returns `"US"` for `8.8.8.8`. Query returns `8.8.8.8`. Assert `should_use_fallback` returns `true`. <br/> Upstream: `dns/resolver.go::ipWithFallback` — upstream only falls back on SERVFAIL/timeout. <br/> NOT pass-through — Class A per ADR-0002: censoring resolvers return valid-looking poisoned answers, not failures. |
+| B2 | `fallback_filter_geoip_passes_on_matching_country` | Same config. MMDB stub returns `"CN"`. Assert `should_use_fallback` returns `false`. |
+| B3 | `fallback_filter_ipcidr_triggers_on_bogon` | `ipcidr: ["240.0.0.0/4"]`. Primary returns `240.0.0.1`. Assert `should_use_fallback` returns `true`. |
+| B4 | `fallback_filter_ipcidr_passes_on_non_bogon` | Same config. Primary returns `1.1.1.1`. Assert `should_use_fallback` returns `false`. |
+| B5 | `fallback_filter_ipcidr_multiple_ranges` **[guard-rail]** | `ipcidr: ["240.0.0.0/4", "0.0.0.0/8"]`. Primary returns `0.0.0.1`. Assert `should_use_fallback` returns `true`. Guards that all ranges are checked, not only the first. |
+| B6 | `fallback_filter_domain_pattern_skips_primary` | `domain: ["+.google.cn"]`. Query `www.google.cn`. Assert `should_use_fallback` returns `true` **before** any IP address is available. <br/> Upstream: `dns/resolver.go` — no domain gate; upstream consults primary first. <br/> NOT primary-then-discard — domain gate short-circuits before primary query, per spec §FallbackFilter::should_use_fallback step 1. |
+| B7 | `fallback_filter_domain_wildcard_matches_root` | `domain: ["+.google.cn"]`. Query `google.cn`. Assert `should_use_fallback` returns `true`. (`+.` includes root.) |
+| B8 | `fallback_filter_domain_does_not_match_sibling` **[guard-rail]** | `domain: ["+.google.cn"]`. Query `notgoogle.cn`. Assert `should_use_fallback` returns `false`. |
+| B9 | `fallback_filter_all_disabled_never_triggers` | `geoip: false`, empty `ipcidr`, empty `domain`. Any primary IP. Assert `should_use_fallback` always returns `false`. |
+| B10 | `fallback_filter_geoip_no_mmdb_skips_gate_and_warns` | `geoip: true`, MMDB = `None`. Assert `should_use_fallback` returns `false` (gate skipped). Assert one `warn!` emitted at `Resolver::new()` time (NOT at query time — warn once at startup). <br/> Upstream: `dns/resolver.go` — Go mihomo errors at startup if MMDB is absent with geoip enabled. <br/> NOT a startup error — Class B per ADR-0002: single-resolver deployments without MMDB are valid. |
+| B11 | `fallback_filter_fallback_result_not_refiltered` | Fallback returns an IP that would itself trigger the GeoIP gate. Assert the result is returned as-is (filter not re-applied to fallback response). Per spec §Resolved questions item 3. |
+| B12 | `fallback_filter_geoip_multiple_ips_any_triggers` **[guard-rail]** | GeoIP gate active. Primary returns two IPs: `1.1.1.1` (CN, passes) and `8.8.8.8` (US, fails). Assert `should_use_fallback` returns `true`. Any non-matching IP is sufficient to trigger fallback — guards that the loop does not short-circuit on the first match. |
+
+### C. Resolver lookup flow integration tests (`crates/mihomo-dns/src/resolver.rs`)
+
+These require a tokio runtime (`#[tokio::test]`). Use mock nameservers that
+return controlled answers (no network).
+
+| # | Case | Asserts |
+|---|------|---------|
+| C1 | `lookup_flow_policy_match_uses_policy_not_global` | Full `Resolver` with policy `"example.com"` → policy-mock, global-mock also present. Query `example.com`. Assert answer from policy-mock returned; global-mock never called. |
+| C2 | `lookup_flow_no_policy_match_uses_global` | Full resolver, policy only covers `"example.com"`. Query `other.com`. Assert global-mock called. |
+| C3 | `lookup_flow_fallback_filter_triggers_fallback_on_poisoned_response` | GeoIP gate active. Global-mock returns `240.0.0.1` (in bogon ipcidr). Fallback-mock returns `1.2.3.4`. Assert `1.2.3.4` returned as final answer. Upstream: `dns/resolver.go::resolve` — no IP-CIDR gate applied to global result. NOT `240.0.0.1` passed through. Class A per ADR-0002. |
+| C4 | `lookup_flow_domain_gate_skips_global_queries_primary` | `fallback-filter.domain: ["+.blocked.cn"]`. Query `www.blocked.cn`. Assert global-mock NOT called; fallback-mock called directly. Verifies domain gate prevents primary query entirely. |
+| C5 | `lookup_flow_fallback_only_on_primary_failure_when_filter_disabled` | No fallback-filter. Global-mock succeeds. Assert fallback-mock never called. Regression: existing behaviour (fallback on failure only) must not regress. |
+| C6 | `lookup_flow_fallback_called_on_primary_failure` | No fallback-filter. Global-mock returns `SERVFAIL`. Fallback-mock returns valid answer. Assert fallback answer returned. |
+| C7 | `lookup_flow_policy_result_also_passes_through_fallback_filter` | Policy `"+.corp.internal"` → policy-mock returns `240.0.0.1` (bogon). `ipcidr: ["240.0.0.0/4"]` active. Assert fallback-mock called; `240.0.0.1` NOT returned. <br/> Upstream: `dns/resolver.go::PolicyResolver` does not apply fallback-filter to policy results. <br/> NOT pass-through — per spec §Lookup flow: filter applies to both policy and global results. |
+| C8 | `lookup_flow_error_when_both_global_and_fallback_fail` | Global-mock SERVFAIL, fallback-mock SERVFAIL. Assert resolver returns an `Err`. |
+| C9 | `lookup_flow_parallel_global_nameservers_fastest_wins` | Two global-mocks: slow-A (50ms), fast-B (0ms). Assert fast-B's answer returned; elapsed < slow-A's delay. Guards `select_ok` not sequential polling. |
+
+### D. Config parser unit tests (`crates/mihomo-config/tests/config_test.rs`)
+
+All new cases are `#[tokio::test]` to match the async DNS parser.
+
+| # | Case | Asserts |
+|---|------|---------|
+| D1 | `parse_nameserver_policy_exact_entry` | YAML with `nameserver-policy: {"example.com": ["1.2.3.4"]}`. Assert one exact entry in parsed `NameserverPolicy`. |
+| D2 | `parse_nameserver_policy_wildcard_entry` | YAML with `nameserver-policy: {"+.corp.internal": ["192.168.1.53"]}`. Assert one wildcard entry. |
+| D3 | `parse_nameserver_policy_string_value_normalized_to_list` | Value is a bare string `"192.168.1.53"` (not a list). Assert parsed as single-element `Vec`. <br/> Upstream: `config/config.go::parseNameserverPolicy` accepts both string and list. We match. |
+| D4 | `parse_nameserver_policy_geosite_prefix_warns_and_skips` | Key `"geosite:cn"`. Assert `warn!` logged; entry absent from parsed policy (not an error). Class B per ADR-0002. |
+| D5 | `parse_nameserver_policy_all_invalid_urls_hard_errors` | Entry with only `"quic://..."` URLs (all stripped by url-parser). Assert `parse_dns` returns `Err` containing the policy key. Class A per ADR-0002. |
+| D6 | `parse_fallback_filter_all_fields` | Full `fallback-filter` block: `geoip: true`, `geoip-code: CN`, `ipcidr: ["240.0.0.0/4"]`, `domain: ["+.google.cn"]`. Assert all fields parsed correctly. |
+| D7 | `parse_fallback_filter_defaults_when_absent` | No `fallback-filter` in YAML. Assert defaults: `geoip: true`, `geoip-code: "CN"`, `ipcidr: []`, `domain: []`. |
+| D8 | `parse_fallback_filter_geoip_false_disables_gate` | `fallback-filter: {geoip: false}`. Assert `geoip_enabled: false` in parsed struct. |
+| D9 | `parse_nameserver_policy_empty_block_is_valid` | `nameserver-policy: {}`. Assert `Ok` with empty policy (no entries). |
+| D10 | `parse_nameserver_policy_absent_is_valid` | No `nameserver-policy` key. Assert `Ok`, `policy: None` in resolver config. |
+| D11 | `parse_fallback_filter_invalid_cidr_errors` **[guard-rail]** | `ipcidr: ["not-a-cidr"]`. Assert `Err` at parse time, not at query time. Guards that CIDR parsing is eager. |
+| D12 | `parse_nameserver_policy_multiple_entries` | Three entries: one exact, two wildcard. Assert all three present in parsed policy. |
+
+### E. Network-dependent integration tests (`crates/mihomo-dns/tests/nameserver_policy_integration.rs`)
+
+All cases are `#[ignore]`. Run with:
+```
+cargo test -p mihomo-dns --test nameserver_policy_integration -- --ignored
+```
+Not wired into CI. Document in the PR description which resolvers were used.
+
+| # | Case | Asserts |
+|---|------|---------|
+| E1 | `nameserver_policy_routes_to_correct_server_live` | Policy `"+.cloudflare.com"` → `1.1.1.1:53`. Global `8.8.8.8:53`. Query `blog.cloudflare.com A`. Assert valid answer returned. (Not asserting which server — just that routing doesn't break live resolution.) |
+| E2 | `fallback_filter_geoip_live_with_mmdb` | Real MMDB from `geodata-subsection` test fixture. GeoIP gate `CN`. Query a known-clean domain. Assert result passes filter (no fallback triggered for a clean public domain). |
+
+### F. Async regression guard
+
+| # | Case | Asserts |
+|---|------|---------|
+| F1 | `resolver_do_lookup_is_async` **[guard-rail]** | Compile-time: assert the lookup entry point is `async fn`. Use a trivial `let _: Pin<Box<dyn Future<Output=_>>> = Box::pin(resolver.resolve(...))`. Fails to compile if someone de-async-ifies the lookup path. |
+
+---
+
+## Deferred / not tested here
+
+- `geosite:` / `rule-set:` patterns resolving to actual data — M1.D-2 / M1.D-5.
+- `dhcp://` nameserver — deferred per spec §Out of scope.
+- Hot-reload of policy entries without restart — M3.
+- Per-policy TLS client config — deferred per spec §Out of scope.
+- Throughput / latency benchmarks — M2.
+
+---
+
+## Exit criteria for this test plan
+
+- All §A–D cases pass on `ubuntu-latest` and `macos-latest` in CI.
+- §E network tests documented as manually run and passing at PR time;
+  not wired into CI.
+- §F compile guard passes.
+- `warn!` logs for `geosite:` and no-MMDB scenarios are emitted exactly
+  once (at parse/startup time), not once per query.
+- No regression in existing plain-UDP resolver tests.
+
+## CI wiring required
+
+Add `nameserver_policy_tests` (or the relevant test binary name for
+`crates/mihomo-dns/src/resolver.rs` unit tests and
+`crates/mihomo-config/tests/config_test.rs` new cases) to both the
+`ubuntu-latest` and `macos-latest` jobs in `.github/workflows/test.yml`.
+
+The §E integration tests are `#[ignore]` — no CI wiring needed.
+
+## Open questions for engineer
+
+1. **MMDB stub interface for §B tests.** `FallbackFilter::should_use_fallback`
+   accepts `Option<&MaxMindDB>`. For unit tests, confirm whether a test-only
+   stub MMDB can be constructed with a controlled `lookup_country` result, or
+   whether the method signature should accept a `trait GeoIpLookup` for
+   injectability. Either is fine — document the seam.
+2. **`select_ok` error semantics.** When all servers in a pool return `Err`,
+   `select_ok` returns the last error. Confirm the error returned to the caller
+   is wrapped with context identifying the pool (policy vs global vs fallback)
+   to aid debugging.
+3. **Warn-once implementation.** The spec requires warn-once at startup for
+   `geosite:` entries and no-MMDB. Confirm this uses a `std::sync::Once` or
+   equivalent, not a per-query guard, so the warn appears in startup logs
+   even before any query arrives.

--- a/docs/specs/inbound-auth-acl-test-plan.md
+++ b/docs/specs/inbound-auth-acl-test-plan.md
@@ -1,0 +1,220 @@
+# Test Plan: Inbound authentication and LAN ACLs (M1.F-3)
+
+Status: **draft** — owner: pm. Last updated: 2026-04-18.
+Tracks: task #21. Companion to `docs/specs/inbound-auth-acl.md`.
+
+This is the QA-owned acceptance test plan. The spec's `§Test plan` section
+is the PM's starting point; this document is the final shape engineer should
+implement against. If the spec and this document disagree, **this document
+wins for test cases** — flag the discrepancy so the spec can be updated.
+
+Divergence-comment convention per memory (`feedback_spec_divergence_comments.md`):
+inline `Upstream: file::fn` + `NOT X` lines on bullets that exercise a
+divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
+
+## Scope and guardrails
+
+**In scope:**
+
+- `Credentials` struct: `verify()` correctness and constant-time comparison.
+- `AuthConfig`: `should_skip()` CIDR matching, loopback always-skip invariant.
+- SOCKS5 listener auth: method negotiation (0x02 vs 0xFF), sub-negotiation
+  success/failure, `Metadata.in_user` population.
+- HTTP listener auth: `Proxy-Authorization: Basic` check on CONNECT and
+  forward-proxy requests, 407 responses, `Metadata.in_user` population.
+- Mixed listener: auth delegated to detected sub-protocol handler.
+- Config parser: `authentication:` and `skip-auth-prefixes:` YAML fields,
+  malformed entry detection, empty-password warn.
+- TProxy bypass: auth unconditionally skipped, `Metadata.in_user == None`.
+- Both Class A divergences (malformed entry hard error, invalid CIDR hard error)
+  and the Class B divergence (empty password warn-once).
+
+**Out of scope (forbidden per spec §Out of scope):**
+
+- Per-listener auth config — global auth list only in M1.
+- Digest / NTLM HTTP auth — Basic only.
+- RADIUS or external auth backends.
+- Rate limiting / brute-force protection — M2+.
+- `IN-USER` rule dispatch — spec only populates `Metadata.in_user`; rule
+  matching is M1.D-4 (requires both M1.F-1 and M1.F-3).
+- Password hashing (bcrypt/argon2) — plain text, matching upstream, M2+.
+- Throughput / latency benchmarks — M2.
+
+## File layout expected
+
+```
+crates/mihomo-config/src/
+  auth.rs              # NEW: Credentials, AuthConfig structs
+  raw.rs               # MODIFIED: authentication, skip_auth_prefixes fields
+  config_parser.rs     # MODIFIED: parse auth fields, build AuthConfig
+crates/mihomo-common/src/
+  metadata.rs          # MODIFIED: in_user: Option<String> field
+crates/mihomo-listener/src/
+  socks5.rs            # MODIFIED: auth check before handshake
+  http_proxy.rs        # MODIFIED: auth check after CONNECT line
+  mixed.rs             # MODIFIED: Arc<AuthConfig> plumbed through
+  tproxy/mod.rs        # MODIFIED: Arc<AuthConfig> accepted but not used (TProxy bypass)
+crates/mihomo-config/tests/
+  config_test.rs       # MODIFIED: auth config parse cases
+crates/mihomo-listener/tests/
+  auth_integration_test.rs  # NEW: listener auth integration tests
+```
+
+## Divergence table
+
+Following ADR-0002 classification format:
+
+| # | Case | Class | Note |
+|---|------|:-----:|------|
+| 1 | Malformed `user:pass` entry (no colon) — upstream silently ignores | A | Hard parse error. Upstream: `config/config.go::parseAuthentication` — entry with no `:` is appended as user=entry, pass="". NOT silent accept. |
+| 2 | Empty password (`user:`) — upstream accepts without warning | B | Warn-once at parse time. NOT hard error — empty passwords are valid but likely a typo. |
+| 3 | Invalid CIDR in `skip-auth-prefixes` — upstream silently ignores | A | Hard parse error. An invalid CIDR produces a skip-list that is smaller than the operator intended, potentially exposing auth-required endpoints. NOT silent ignore. |
+| 4 | Loopback removal from skip-list — upstream allows `allow-lan: true` without preserving loopback bypass | A | `127.0.0.1/32` and `::1/128` always in skip-list, even when `skip-auth-prefixes: []` explicitly. NOT removable. |
+
+---
+
+## Case list
+
+### A. `Credentials` unit tests (`crates/mihomo-config/src/auth.rs`)
+
+Pure unit tests, no network, no tokio.
+
+| # | Case | Asserts |
+|---|------|---------|
+| A1 | `credentials_verify_correct_password` | Store `alice:hunter2`. `verify("alice", "hunter2")` → `true`. |
+| A2 | `credentials_verify_wrong_password` | `verify("alice", "wrongpass")` → `false`. NOT panic. |
+| A3 | `credentials_verify_unknown_user` | `verify("nobody", "anything")` → `false`. NOT panic. |
+| A4 | `credentials_verify_empty_username` | `verify("", "pass")` → `false`. NOT panic or index error. |
+| A5 | `credentials_verify_empty_password_stored` | Store `bob:` (empty password). `verify("bob", "")` → `true`. `verify("bob", "x")` → `false`. Empty password is valid once stored. |
+| A6 | `credentials_is_empty_true_when_no_entries` | `Credentials` constructed from `[]` → `is_empty()` returns `true`. |
+| A7 | `credentials_is_empty_false_with_entries` | One entry → `is_empty()` returns `false`. |
+| A8 | `credentials_verify_uses_constant_time_comparison` **[guard-rail]** | Structural test: grep the implementation of `verify()` for `subtle::ConstantTimeEq` or equivalent. Assert it is NOT a bare `==` or `!=` comparison on `String`/`&str`. This is a code-review gate, not a timing test. Document the grep pattern in the PR checklist. |
+| A9 | `credentials_multiple_users_independent` **[guard-rail]** | Store `alice:pass1`, `bob:pass2`. `verify("alice", "pass2")` → `false`. `verify("bob", "pass1")` → `false`. Guards that credential pairs are not cross-matched. |
+
+### B. `AuthConfig::should_skip` unit tests (`crates/mihomo-config/src/auth.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| B1 | `should_skip_loopback_ipv4_always` | `AuthConfig` built with empty `skip-auth-prefixes`. `should_skip("127.0.0.1")` → `true`. <br/> Upstream: `config/config.go::parseAuthentication` — loopback is not automatically added; operator must include it. <br/> NOT requires explicit config — Class A per ADR-0002: missing loopback bypass breaks local tooling. |
+| B2 | `should_skip_loopback_ipv6_always` | `should_skip("::1")` → `true` with empty prefix list. |
+| B3 | `should_skip_configured_subnet` | `skip-auth-prefixes: ["192.168.0.0/24"]`. `should_skip("192.168.0.1")` → `true`. |
+| B4 | `should_skip_outside_subnet` | Same config. `should_skip("10.0.0.1")` → `false`. |
+| B5 | `should_skip_subnet_boundary` **[guard-rail]** | `skip-auth-prefixes: ["192.168.0.0/24"]`. `should_skip("192.168.0.255")` → `true`; `should_skip("192.168.1.0")` → `false`. Guards CIDR boundary arithmetic. |
+| B6 | `should_skip_ipv6_configured_prefix` | `skip-auth-prefixes: ["fd00::/8"]`. `should_skip("fd00::1")` → `true`. |
+| B7 | `should_skip_explicit_empty_list_still_skips_loopback` | `skip-auth-prefixes: []` explicitly. `should_skip("127.0.0.1")` → `true`. Loopback is unconditional regardless of explicit empty. |
+| B8 | `should_skip_false_for_public_ip` | No `skip-auth-prefixes`. `should_skip("8.8.8.8")` → `false`. |
+
+### C. SOCKS5 listener auth integration tests (`crates/mihomo-listener/tests/auth_integration_test.rs`)
+
+All `#[tokio::test]`, loopback connections only.
+
+| # | Case | Asserts |
+|---|------|---------|
+| C1 | `socks5_no_auth_config_admits_all` | No `authentication:` config. Client connects with no auth. Assert connection admitted. `Metadata.in_user == None`. Regression guard: existing no-auth behavior unchanged. |
+| C2 | `socks5_correct_credentials_admitted` | `authentication: [alice:hunter2]`. Client negotiates method `0x02`, sends `alice` / `hunter2`. Assert admitted. `Metadata.in_user == Some("alice")`. <br/> Upstream: `listener/socks5/tcp.go::handleConn` — credentials checked here. |
+| C3 | `socks5_wrong_password_rejected` | Same config. Client sends correct user, wrong password. Assert server sends `[0x01, 0x01]` (auth failure per RFC 1929 §3). Assert connection closed. <br/> Upstream: `listener/socks5/tcp.go` — sends auth failure response. NOT left open. |
+| C4 | `socks5_unknown_user_rejected` | Client sends user not in store. Assert `[0x01, 0x01]` and close. |
+| C5 | `socks5_client_offers_only_no_auth_method_rejected` | Client hello: methods `[0x00]` only (no auth offered). Server replies `[0x05, 0xFF]` (no acceptable methods). Assert connection closed. |
+| C6 | `socks5_client_offers_both_methods_server_selects_userpass` **[guard-rail]** | Client hello: methods `[0x00, 0x02]`. Assert server selects `0x02`, not `0x00`. Guards that server does not accept no-auth when credentials are configured. |
+| C7 | `socks5_skip_prefix_bypasses_auth` | `authentication: [alice:hunter2]`, `skip-auth-prefixes: ["127.0.0.1/32"]`. Client from `127.0.0.1` connects with no auth. Assert admitted (method `0x00`). `Metadata.in_user == None`. |
+| C8 | `socks5_non_skip_ip_must_authenticate` **[guard-rail]** | Same config. Client from `127.0.0.2` (not loopback, not in skip list) offers no auth. Assert `[0x05, 0xFF]` and close. Guards that skip-prefix check is IP-specific, not global. |
+| C9 | `socks5_in_user_populated_on_success` | Verify `Metadata.in_user` contains the exact username string from the credential that authenticated. Assert case-sensitive match. |
+| C10 | `socks5_in_user_none_on_skip_prefix` | Connection from skip-prefix IP. Assert `Metadata.in_user == None` (not `Some("")`). |
+
+### D. HTTP listener auth integration tests (`crates/mihomo-listener/tests/auth_integration_test.rs`)
+
+All `#[tokio::test]`, loopback, real HTTP framing.
+
+| # | Case | Asserts |
+|---|------|---------|
+| D1 | `http_no_auth_config_admits_all` | No `authentication:`. CONNECT request with no `Proxy-Authorization`. Assert `200 Connection established`. Regression guard. |
+| D2 | `http_connect_correct_basic_auth_admitted` | `authentication: [alice:hunter2]`. CONNECT with `Proxy-Authorization: Basic YWxpY2U6aHVudGVyMg==` (base64 of `alice:hunter2`). Assert `200`. `Metadata.in_user == Some("alice")`. <br/> Upstream: `listener/http/proxy.go::handleConn` — Basic auth checked here. |
+| D3 | `http_connect_no_auth_header_returns_407` | Auth configured. CONNECT with no `Proxy-Authorization`. Assert `407 Proxy Authentication Required`. Assert response includes `Proxy-Authenticate: Basic realm="mihomo"`. <br/> Upstream: `listener/http/proxy.go` — returns 407. NOT 401 (Proxy auth uses 407, not 401). |
+| D4 | `http_connect_wrong_password_returns_407` | CONNECT with `Proxy-Authorization: Basic` containing wrong password. Assert `407`. |
+| D5 | `http_connect_unknown_user_returns_407` | User not in store. Assert `407`. |
+| D6 | `http_connect_malformed_base64_returns_407` **[guard-rail]** | `Proxy-Authorization: Basic not-valid-base64!!!`. Assert `407`. NOT panic or 500. |
+| D7 | `http_connect_no_colon_in_decoded_credentials_returns_407` **[guard-rail]** | `Proxy-Authorization: Basic` with valid base64 that decodes to `alicehunter2` (no colon). Assert `407`. NOT split at wrong position. |
+| D8 | `http_forward_proxy_request_requires_auth` | Non-CONNECT forward proxy `GET http://example.com/ HTTP/1.1`. Auth configured, no header. Assert `407`. <br/> Upstream: `listener/http/proxy.go` — both CONNECT and forward proxy checked. We match. |
+| D9 | `http_skip_prefix_bypasses_auth` | Auth configured, `skip-auth-prefixes: ["127.0.0.1/32"]`. CONNECT from `127.0.0.1` with no auth. Assert `200`. `Metadata.in_user == None`. |
+| D10 | `http_407_closes_connection_after_failure` **[guard-rail]** | After a `407` response, assert the server does not leave the connection open for re-use. Prevents auth bypass via persistent connection reuse. |
+| D11 | `http_in_user_populated_correct_username` | Verify `Metadata.in_user == Some("alice")` not `Some("alice:hunter2")` (password not leaked into in_user). |
+
+### E. TProxy bypass tests (`crates/mihomo-listener/tests/auth_integration_test.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| E1 | `tproxy_auth_never_applied` | TProxy listener constructed with `authentication: [alice:hunter2]`. Accept a transparent connection. Assert connection proceeds without auth challenge. `Metadata.in_user == None`. <br/> Upstream: `listener/tproxy/` — no auth in TProxy path. We match by explicit design (§TProxy connections bypass auth unconditionally). |
+| E2 | `tproxy_in_user_always_none` | Any TProxy connection regardless of source IP. Assert `Metadata.in_user == None`, not `Some(...)`. |
+
+### F. Config parser tests (`crates/mihomo-config/tests/config_test.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| F1 | `parse_authentication_single_entry` | `authentication: ["alice:hunter2"]`. Assert `Credentials` contains `alice → hunter2`. |
+| F2 | `parse_authentication_multiple_entries` | Three entries. Assert all three stored. |
+| F3 | `parse_authentication_absent_means_no_auth` | No `authentication:` key. Assert `credentials.is_empty() == true`. |
+| F4 | `parse_authentication_empty_list_means_no_auth` | `authentication: []`. Assert `is_empty() == true`. |
+| F5 | `parse_authentication_malformed_no_colon_hard_errors` | `authentication: ["alicehunter2"]` (no colon). Assert `Err` at parse. <br/> Upstream: `config/config.go::parseAuthentication` — entry stored with empty password (silent). <br/> NOT silent — Class A per ADR-0002: almost certainly a config typo. |
+| F6 | `parse_authentication_empty_password_warns` | `authentication: ["alice:"]`. Assert `Ok`. Assert one `warn!` log emitted at parse time. NOT error. Class B per ADR-0002. |
+| F7 | `parse_authentication_empty_username_hard_errors` **[guard-rail]** | `authentication: [":hunter2"]`. Assert `Err`. A credential with an empty username can never match. Upstream: silently accepts. NOT silent — same rationale as F5. |
+| F8 | `parse_skip_auth_prefixes_valid_cidrs` | Two valid CIDRs. Assert both parsed into `skip_prefixes`. |
+| F9 | `parse_skip_auth_prefixes_invalid_cidr_hard_errors` | `skip-auth-prefixes: ["not-a-cidr"]`. Assert `Err`. <br/> Upstream: `config/config.go` — invalid CIDR silently dropped. <br/> NOT silent — Class A per ADR-0002: a smaller-than-intended skip list exposes auth-required endpoints. |
+| F10 | `parse_skip_auth_prefixes_absent_defaults_to_loopback_only` | No `skip-auth-prefixes:` key. Assert `skip_prefixes` contains `127.0.0.1/32` and `::1/128` and nothing else. |
+| F11 | `parse_skip_auth_prefixes_explicit_empty_still_has_loopback` | `skip-auth-prefixes: []`. Assert `skip_prefixes` still contains `127.0.0.1/32` and `::1/128`. Loopback cannot be removed. |
+| F12 | `parse_authentication_colon_in_password` **[guard-rail]** | `authentication: ["alice:pass:with:colons"]`. Assert username `alice`, password `pass:with:colons` (split on first colon only). |
+
+### G. `Metadata.in_user` field regression guard
+
+| # | Case | Asserts |
+|---|------|---------|
+| G1 | `metadata_in_user_defaults_to_none` **[guard-rail]** | `Metadata::default()` → `in_user == None`. Guards that the new field doesn't break any code that constructs `Metadata` without setting `in_user`. |
+| G2 | `metadata_in_user_does_not_leak_password` **[guard-rail]** | After successful auth, assert `in_user` contains only the username, not the password or the `user:pass` pair. Structural test: assert `in_user` value does not contain `":"`. |
+
+---
+
+## Deferred / not tested here
+
+- `IN-USER` rule matching dispatch — M1.D-4 (requires both F-1 and F-3).
+- Per-listener auth config — M2+.
+- Digest / NTLM HTTP auth — deferred per spec §Out of scope.
+- Password hashing — M2+.
+- Rate limiting on auth failure — M2+.
+- Throughput — M2 benchmark harness.
+
+---
+
+## Exit criteria for this test plan
+
+- All §A–G cases pass on `ubuntu-latest` and `macos-latest` in CI.
+- §A8 constant-time comparison guard documented in PR checklist (code review,
+  not a timing test).
+- No regression in existing SOCKS5 and HTTP integration tests.
+- `Metadata.in_user` field present in `mihomo-common` before any listener
+  changes land — field addition is a separate, additive commit.
+
+## CI wiring required
+
+Add to `.github/workflows/test.yml`:
+
+1. `cargo test -p mihomo-config --test config_test` — picks up §F cases.
+2. `cargo test -p mihomo-listener --test auth_integration_test` — new binary for
+   §C–E cases. Add to both `ubuntu-latest` and `macos-latest` jobs.
+3. `cargo test -p mihomo-common --lib` — picks up §G1 regression guard
+   (already wired if common lib tests run; new field addition is additive).
+
+## Open questions for engineer
+
+1. **`subtle` crate placement.** The spec recommends adding `subtle` to the
+   workspace. Confirm whether it should be a direct dependency of
+   `mihomo-config` (where `Credentials` lives) or `mihomo-common`. Add to
+   `Cargo.toml` workspace members only, not re-exported.
+2. **407 connection handling.** After sending a 407, confirm whether the
+   server closes the TCP connection immediately or leaves it open for a retry
+   with credentials. HTTP/1.1 allows a retry on the same connection for
+   `407`, but many clients open a new connection. The spec says "close" — if
+   the engineer chooses keep-alive retry, update §D10 accordingly before merging.
+3. **Mixed listener auth delegation.** When the mixed listener detects HTTP
+   (vs SOCKS5) and hands off to the HTTP sub-handler, confirm `Arc<AuthConfig>`
+   is passed through and the IP used for `should_skip()` is the original TCP
+   `src_addr`, not a proxy-forwarded header value. Proxy-forwarded IPs are
+   trivially spoofable and must not affect auth decisions.

--- a/docs/specs/listeners-unified-test-plan.md
+++ b/docs/specs/listeners-unified-test-plan.md
@@ -1,0 +1,207 @@
+# Test Plan: Unified named listeners (M1.F-1)
+
+Status: **draft** — owner: pm. Last updated: 2026-04-18.
+Tracks: task #19. Companion to `docs/specs/listeners-unified.md`.
+
+This is the QA-owned acceptance test plan. The spec's `§Test plan` section
+is the PM's starting point; this document is the final shape engineer should
+implement against. If the spec and this document disagree, **this document
+wins for test cases** — flag the discrepancy so the spec can be updated.
+
+Divergence-comment convention per memory (`feedback_spec_divergence_comments.md`):
+inline `Upstream: file::fn` + `NOT X` lines on bullets that exercise a
+divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
+
+## Scope and guardrails
+
+**In scope:**
+
+- Config parser (`crates/mihomo-config/src/`) — `listeners:` array parsing,
+  shorthand field auto-naming, duplicate port/name detection.
+- Listener construction — `name: String` stored at construction time in all
+  four listener types (mixed, http, socks5, tproxy).
+- `Metadata.in_name` and `Metadata.in_port` population on each accepted
+  connection in all four listener implementations.
+- `IN-NAME`, `IN-PORT`, `IN-TYPE` rule matching against populated Metadata.
+- `GET /listeners` REST endpoint (list only, no mutation).
+- All four Class A divergences: duplicate port, duplicate name, unknown type,
+  shorthand+named port collision.
+
+**Out of scope (forbidden per spec §Out of scope):**
+
+- `IN-USER` rule — requires M1.F-3 auth; `Metadata.in_user` is not
+  populated here.
+- Redir and tunnel listener types — deferred to M1.F-4/F-5.
+- Per-listener proxy overrides — M3.
+- Hot-adding/removing listeners at runtime — M3.
+- Auth/ACL on listeners — M1.F-3 spec.
+- TProxy correctness (SO_ORIGINAL_DST, nftables) — covered by existing
+  tproxy integration tests; not repeated here.
+
+## File layout expected
+
+```
+crates/mihomo-config/src/
+  raw.rs               # MODIFIED: RawListener struct, listeners field on RawConfig
+  config_parser.rs     # MODIFIED: parse listeners:, merge shorthand, dedup checks
+crates/mihomo-listener/src/
+  mixed.rs             # MODIFIED: name field, Metadata.in_name/in_port population
+  http_proxy.rs        # MODIFIED: same
+  socks5.rs            # MODIFIED: same
+  tproxy/mod.rs        # MODIFIED: same
+crates/mihomo-rules/src/
+  parser.rs            # MODIFIED: IN-TYPE dispatch added
+crates/mihomo-api/src/
+  routes.rs            # MODIFIED: GET /listeners handler + route
+crates/mihomo-config/tests/
+  config_test.rs       # MODIFIED: new listeners-related cases
+crates/mihomo-listener/tests/
+  listener_metadata_test.rs  # NEW: in_name/in_port population tests
+```
+
+## Divergence table
+
+Following ADR-0002 classification format:
+
+| # | Case | Class | Note |
+|---|------|:-----:|------|
+| 1 | Duplicate listener port — upstream silently overwrites last | A | Hard parse error: `"port N already used by listener 'M'"`. Upstream: `config/config.go::parseListeners` — last entry wins, no warning. NOT silent overwrite. |
+| 2 | Duplicate listener name — upstream silently overwrites last | A | Hard parse error: `"listener name 'X' already defined"`. Same upstream behavior. NOT silent overwrite. |
+| 3 | Unknown listener type — upstream ignores the entry | A | Hard parse error. Upstream: `listener/listener.go` — unknown type logged and skipped. NOT silent ignore: a misconfigured listener type means no proxy for that port. |
+| 4 | Shorthand port + `listeners:` entry on same port — upstream accepts | A | Hard parse error. Same dedup rule as duplicate `listeners:` entries. NOT accepted. |
+| 5 | Unknown `IN-TYPE` value — upstream silently no-match | A | Hard parse error at rule-load time. Upstream: `rules/parser.go` — unknown IN-TYPE returns false. NOT silent no-match: a typo in `IN-TYPE,QUIC` would silently never route, which is worse than a startup error. |
+
+---
+
+## Case list
+
+### A. Config parser unit tests (`crates/mihomo-config/tests/config_test.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| A1 | `parse_named_listener_socks5_all_fields` | YAML `listeners: [{name: corp-socks, type: socks5, port: 7891, listen: 0.0.0.0}]`. Assert `NamedListener { name: "corp-socks", listener_type: Socks5, port: 7891, listen: 0.0.0.0:7891 }`. |
+| A2 | `parse_named_listener_mixed` | `type: mixed`. Assert `ListenerType::Mixed`. |
+| A3 | `parse_named_listener_http` | `type: http`. Assert `ListenerType::Http`. |
+| A4 | `parse_named_listener_tproxy` | `type: tproxy`. Assert `ListenerType::TProxy`. |
+| A5 | `parse_named_listener_listen_defaults_to_global_bind` | Entry with no `listen` field. Assert `listen` address matches global `bind-address` (or `127.0.0.1` if not set). |
+| A6 | `parse_named_listener_listen_overrides_global` | Global `bind-address: 127.0.0.1`, listener `listen: 0.0.0.0`. Assert listener's resolved `listen` is `0.0.0.0`, not `127.0.0.1`. |
+| A7 | `parse_shorthand_mixed_port_auto_names` | `mixed-port: 7890`, no `listeners:` block. Assert resulting listener list contains `NamedListener { name: "mixed", type: Mixed, port: 7890 }`. |
+| A8 | `parse_shorthand_http_port_auto_names` | `http-port: 7891`. Assert name `"http"`. |
+| A9 | `parse_shorthand_socks_port_auto_names` | `socks-port: 1080`. Assert name `"socks"`. |
+| A10 | `parse_shorthand_tproxy_port_auto_names` | `tproxy-port: 7892`. Assert name `"tproxy"`. |
+| A11 | `parse_shorthand_and_named_listeners_coexist` | `mixed-port: 7890` plus `listeners: [{name: corp-socks, type: socks5, port: 7891}]`. Assert both present in the merged listener list. |
+| A12 | `parse_duplicate_port_in_named_listeners_hard_errors` | Two `listeners:` entries both on port 7891. Assert `Err` containing `"port"` and `"7891"`. <br/> Upstream: `config/config.go::parseListeners` — last entry silently overwrites. <br/> NOT silent overwrite — Class A per ADR-0002. |
+| A13 | `parse_duplicate_name_in_named_listeners_hard_errors` | Two `listeners:` entries both named `"corp-socks"`. Assert `Err` containing `"corp-socks"`. <br/> Upstream: same silent-overwrite behavior. <br/> NOT silent overwrite — Class A per ADR-0002. |
+| A14 | `parse_shorthand_and_named_same_port_hard_errors` | `mixed-port: 7890` and `listeners: [{name: foo, type: socks5, port: 7890}]`. Assert `Err`. <br/> Upstream: `config/config.go` accepts this (two listeners on same port, both spawn). <br/> NOT accepted — Class A per ADR-0002: two listeners on the same port is a bind-failure at runtime; fail loudly at parse. |
+| A15 | `parse_unknown_listener_type_hard_errors` | `type: redir`. Assert `Err` containing `"redir"` and the listener name. <br/> Upstream: `listener/listener.go` — unknown type logged and skipped. <br/> NOT silent ignore — Class A per ADR-0002. |
+| A16 | `parse_listeners_empty_array_is_valid` | `listeners: []`. Assert `Ok`, empty listener list from `listeners:` block (shorthand still applies). |
+| A17 | `parse_listeners_absent_is_valid` | No `listeners:` key. Assert `Ok`. Shorthand ports work as before. |
+| A18 | `parse_tproxy_sni_field_forwarded` **[guard-rail]** | `type: tproxy, tproxy-sni: true`. Assert `tproxy_sni: true` in parsed struct. Non-tproxy entry with `tproxy-sni` → warn-once and ignore (not a parse error). |
+
+### B. Listener Metadata population tests (`crates/mihomo-listener/tests/listener_metadata_test.rs`)
+
+All require a tokio runtime (`#[tokio::test]`). Use loopback connections, no
+external network. Assert fields on the `Metadata` passed to the tunnel
+callback.
+
+| # | Case | Asserts |
+|---|------|---------|
+| B1 | `mixed_listener_populates_in_name` | Construct `MixedListener` with `name = "my-mixed"`. Accept a connection. Assert `metadata.in_name == "my-mixed"`. <br/> Upstream: `listener/listener.go` — `inbound.NewMixed` does not set `in_name`; Metadata's `SpecialProxy` field is used loosely. <br/> NOT zero-value `in_name` — spec §Metadata population: every listener stores its name and stamps every Metadata. |
+| B2 | `mixed_listener_populates_in_port` | Same listener on port 7890. Assert `metadata.in_port == 7890`. |
+| B3 | `http_listener_populates_in_name_and_port` | `HttpListener { name: "corp-http", port: 7891 }`. Assert `metadata.in_name == "corp-http"` and `metadata.in_port == 7891`. |
+| B4 | `socks5_listener_populates_in_name_and_port` | `Socks5Listener { name: "corp-socks", port: 1080 }`. Assert both fields. |
+| B5 | `tproxy_listener_populates_in_name_and_port` | `TProxyListener { name: "transparent", port: 7892 }`. Assert both fields. |
+| B6 | `mixed_listener_http_conn_type` | CONNECT-via-HTTP connection through mixed listener. Assert `metadata.conn_type == ConnType::Http` (or `Https` for CONNECT). |
+| B7 | `socks5_listener_sets_socks5_conn_type` | SOCKS5 connection. Assert `metadata.conn_type == ConnType::Socks5`. |
+| B8 | `two_listeners_different_names_stamp_correctly` **[guard-rail]** | Two listeners spawned simultaneously: `"corp"` on port 7891, `"personal"` on port 7892. Connect to each. Assert each connection's Metadata carries its own listener's name and port, not the other's. Guards against shared/static name state. |
+| B9 | `shorthand_listener_in_name_is_auto_name` | Listener spawned from `mixed-port: 7890` shorthand (auto-name `"mixed"`). Assert `metadata.in_name == "mixed"`. |
+
+### C. IN-NAME / IN-PORT / IN-TYPE rule matching unit tests (`crates/mihomo-rules/`)
+
+Pure unit tests on the rule matching logic. No network, no listener required.
+
+| # | Case | Asserts |
+|---|------|---------|
+| C1 | `in_name_rule_matches_exact_name` | `Metadata { in_name: "corp-socks", .. }`. Rule `IN-NAME,corp-socks,Target`. Assert match. |
+| C2 | `in_name_rule_no_match_different_name` | `in_name: "personal"`. Rule `IN-NAME,corp-socks,Target`. Assert no match. |
+| C3 | `in_name_rule_no_match_empty_in_name` | `in_name: ""` (zero value, pre-M1.F-1 behavior). Rule `IN-NAME,corp-socks,Target`. Assert no match. NOT panic. |
+| C4 | `in_port_rule_matches_configured_port` | `Metadata { in_port: 7891, .. }`. Rule `IN-PORT,7891,Target`. Assert match. |
+| C5 | `in_port_rule_no_match_different_port` | `in_port: 7892`. Rule `IN-PORT,7891,Target`. Assert no match. |
+| C6 | `in_type_http_matches_http_conn_type` | `Metadata { conn_type: ConnType::Http }`. Rule `IN-TYPE,HTTP`. Assert match. |
+| C7 | `in_type_http_matches_https_conn_type` | `Metadata { conn_type: ConnType::Https }`. Rule `IN-TYPE,HTTP`. Assert match. `IN-TYPE,HTTP` is a superset of HTTP+HTTPS per spec §IN-TYPE rule mapping. |
+| C8 | `in_type_https_matches_only_https` | `ConnType::Http`. Rule `IN-TYPE,HTTPS`. Assert no match. `IN-TYPE,HTTPS` is HTTPS-only. |
+| C9 | `in_type_socks5_matches_socks5` | `ConnType::Socks5`. Rule `IN-TYPE,SOCKS5`. Assert match. |
+| C10 | `in_type_tproxy_matches_tproxy` | `ConnType::TProxy`. Rule `IN-TYPE,TPROXY`. Assert match. |
+| C11 | `in_type_inner_matches_inner` | `ConnType::Inner`. Rule `IN-TYPE,INNER`. Assert match. |
+| C12 | `in_type_cross_type_no_match` **[guard-rail]** | `ConnType::Socks5`. Rule `IN-TYPE,HTTP`. Assert no match. Guards that conn_type dispatch doesn't cross-match. |
+| C13 | `in_type_unknown_value_hard_errors_at_parse` | Rule string `"IN-TYPE,QUIC,Target"`. Assert parse returns `Err`. <br/> Upstream: `rules/parser.go` — unknown IN-TYPE silently returns false at match time. <br/> NOT silent no-match — Class A per ADR-0002: a typo would silently never route all traffic of that type. |
+| C14 | `in_name_rule_case_sensitive` **[guard-rail]** | `in_name: "Corp-Socks"`. Rule `IN-NAME,corp-socks,Target`. Assert no match. Rule matching is case-sensitive — listener names are exact strings, not normalized. |
+
+### D. GET /listeners API endpoint tests (`crates/mihomo-api/`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| D1 | `get_listeners_returns_all_running_listeners` | App started with `mixed-port: 7890` and `listeners: [{name: corp-socks, type: socks5, port: 7891}]`. `GET /listeners`. Assert 200, JSON array with two objects: `{name: "mixed", type: "mixed", port: 7890}` and `{name: "corp-socks", type: "socks5", port: 7891}`. |
+| D2 | `get_listeners_empty_when_none_configured` | No ports configured. `GET /listeners`. Assert 200, empty JSON array `[]`. |
+| D3 | `get_listeners_listen_address_included` | Listener with explicit `listen: 0.0.0.0`. Assert response object includes `"listen": "0.0.0.0"`. |
+| D4 | `get_listeners_requires_bearer_auth` | `GET /listeners` with no `Authorization` header when `secret` is set. Assert 401. |
+| D5 | `get_listeners_no_mutation_endpoint` **[guard-rail]** | `POST /listeners`, `DELETE /listeners/corp-socks`. Assert 405 Method Not Allowed (or 404). Hot-add/remove is M3. |
+
+### E. Integration test (end-to-end rule routing via named listener)
+
+`#[tokio::test]`, loopback only. Starts a real listener, connects, asserts
+the rule fires correctly.
+
+| # | Case | Asserts |
+|---|------|---------|
+| E1 | `in_name_rule_routes_connection_to_correct_proxy` | Two SOCKS5 listeners: `"corp"` on port 18001, `"personal"` on port 18002. Rules: `IN-NAME,corp,Direct` first, `IN-NAME,personal,Reject` second. Connect via `"corp"` listener → Direct. Connect via `"personal"` listener → Reject (connection refused). |
+| E2 | `in_type_rule_routes_by_listener_type` | Mixed listener (HTTP + SOCKS5 on same port). HTTP request → `IN-TYPE,HTTP,Direct` rule fires. SOCKS5 request → `IN-TYPE,SOCKS5,Reject` rule fires. |
+
+---
+
+## Deferred / not tested here
+
+- `IN-USER` rule — requires M1.F-3 auth, `Metadata.in_user` not populated here.
+- Redir / tunnel listener types — M1.F-4/F-5.
+- Per-listener proxy override — M3.
+- Hot reload of listener list — M3.
+- TProxy correctness (SO_ORIGINAL_DST, nftables rules) — existing tproxy
+  integration tests cover this.
+
+---
+
+## Exit criteria for this test plan
+
+- All §A–D cases pass on `ubuntu-latest` and `macos-latest` in CI.
+- §E integration tests pass on `ubuntu-latest`; `tproxy` cases Linux-only
+  (skip on macOS with `#[cfg(target_os = "linux")]`).
+- `Metadata.in_name` is never `""` for any connection accepted by a named
+  listener — assert via §B8 that the zero-value cannot appear from a running
+  listener.
+- `cargo test --lib -p mihomo-rules` includes the new IN-TYPE parser cases.
+
+## CI wiring required
+
+Add to `.github/workflows/test.yml`:
+
+1. `cargo test -p mihomo-config --test config_test` — picks up §A cases (already
+   in CI if config_test.rs is wired; new cases are additive).
+2. `cargo test -p mihomo-listener --test listener_metadata_test` — new test
+   binary for §B cases.
+3. §E integration tests: add to the existing `rules_test` or a new
+   `listener_integration` binary in the `ubuntu-latest` job.
+
+## Open questions for engineer
+
+1. **`ConnType` for HTTPS through mixed listener.** The mixed listener receives
+   both plain HTTP and CONNECT (tunnel) requests. Confirm whether `ConnType::Https`
+   is set for the CONNECT tunnel case or only after TLS is detected by the sniffer
+   (M1.F-2). If it's always `Http` at the mixed-listener boundary, `IN-TYPE,HTTPS`
+   may not be testable until M1.F-2 lands — flag in the PR.
+2. **`in_port` source.** Spec says `metadata.in_port = self.listen.port()`. Confirm
+   this is the listener's configured port (e.g. 7891), not the ephemeral source port
+   of the client connection. The `IN-PORT` rule matches on the listener's port, not
+   the client's.
+3. **`GET /listeners` auth.** Confirm whether the endpoint follows the same Bearer
+   auth pattern as other `GET` endpoints (required when `secret` is set). If there
+   is a global auth middleware, no per-route work is needed — just register the route.


### PR DESCRIPTION
## Summary

- Adds test plans for four M1 spec items authored by PM:
  - `docs/specs/dns-nameserver-policy-test-plan.md` — M1.E-3/E-4 nameserver-policy + fallback-filter (45 cases)
  - `docs/specs/listeners-unified-test-plan.md` — M1.F-1 named listeners (48 cases)
  - `docs/specs/inbound-auth-acl-test-plan.md` — M1.F-3 inbound auth + ACL (54 cases)
  - `docs/specs/api-config-reload-test-plan.md` — M1.G-10 PUT /configs reload (38 cases)

## Divergence citations

All Class A/B divergences cited per ADR-0002. Key Class A cases:
- dns-nameserver-policy: fallback-filter GeoIP gate applies even when primary succeeds (upstream `dns/resolver.go::ipWithFallback` — Class A)
- listeners-unified: duplicate port/name hard error (upstream `config/config.go::parseListeners` silently overwrites — Class A)
- inbound-auth-acl: empty-username hard error; no-colon hard error (upstream silently stores — Class A); `subtle::ConstantTimeEq` structural guard
- api-config-reload: force-close after drain timeout logs `connections_dropped=N` at `warn!`; `?force=true` still 400 on parse error (upstream pushes broken config — Class B); ArcSwap structural guard

## Test plan
- [ ] QA review: verify divergence bullets have upstream `file::fn` + `NOT X` + ADR-0002 Class cite
- [ ] Unblocks engineer tasks: #19 (M1.F-1), #21 (M1.F-3), #22 (M1.E-3/E-4), #23 (M1.G-10)

/cc @qa