### PR TITLE
docs: migration guide from Go mihomo

### DIFF
--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -1,20 +1,36 @@
 # Migration guide: Go mihomo → mihomo-rust
 
-Status: Spec-complete (2026-04-11) — protocol/group sections pre-populated from
-approved specs. "Known-broken" bullets filled in as M1.B/C code lands and soak
-testing runs. Known-good patterns updated after integration testing.
-Owner: pm
-Tracks roadmap item: **M1.H-3**
+Last updated: 2026-04-18. Tracks M1 feature state.
+Owner: pm. Tracks roadmap item: **M1.H-3**.
+Review cadence: updated at each milestone exit.
 
 This document is for operators migrating a working Go mihomo (Clash Meta)
 deployment to mihomo-rust. It covers:
 
-- What config surface is supported, partially supported, or not supported in M1.
-- Known-good patterns (tested, confirmed working).
-- Known-broken patterns (silently wrong or hard error).
+- What config surface is supported, partially supported, or not yet supported in M1.
+- Behavioral divergences and what to do about them.
+- Migration steps for common subscription types.
 - Feature flags equivalent to Go mihomo build tags.
 
 If you are starting fresh (not migrating), read the main README instead.
+
+**Scope note:** Features marked *M1.x*, *M2*, or *M3* are planned but not yet
+shipped. This guide is a snapshot of M1 at release, not a promise about future
+milestones.
+
+---
+
+## Quick compatibility check
+
+Run mihomo-rust with `-t` to validate your config without starting:
+
+```bash
+mihomo -f config.yaml -t
+```
+
+Hard errors (Class A divergences) print the upstream field name and the
+rejection reason. Warnings (Class B) print once at startup and the config
+loads. If `-t` exits 0, the config will load.
 
 ---
 
@@ -38,12 +54,12 @@ cause problems; items marked ~ work with caveats; items marked ✓ work.
 | `proxies:` — Direct, Reject | ✓ | Fully supported. |
 | `proxies:` — VMess | ✗ | Not implemented — use VLESS instead. |
 | `proxies:` — VLESS | ~ | M1.B-2 — see §Protocols. |
-| `proxies:` — HTTP CONNECT outbound | ~ | M1.B-3 — see §Protocols. |
-| `proxies:` — SOCKS5 outbound | ~ | M1.B-4 — see §Protocols. |
+| `proxies:` — HTTP CONNECT outbound | ✓ | Full parity (M1.B-3). |
+| `proxies:` — SOCKS5 outbound | ✓ | Full parity (M1.B-4). |
 | `proxies:` — Hysteria2 / TUIC / WireGuard | ✗ | Deferred to M1.5/M2. |
 | `proxy-groups:` — selector, url-test, fallback | ✓ | Fully supported. |
-| `proxy-groups:` — load-balance | ~ | M1.C-1 — see §Groups. |
-| `proxy-groups:` — relay | ~ | M1.C-2 — see §Groups. |
+| `proxy-groups:` — load-balance | ✓ | round-robin + consistent-hashing (M1.C-1). |
+| `proxy-groups:` — relay | ✓ | Chain multiple outbounds (M1.C-2). |
 | `rules:` — DOMAIN, DOMAIN-SUFFIX, DOMAIN-KEYWORD | ✓ | Fully supported. |
 | `rules:` — IP-CIDR, IP-CIDR6 | ✓ | Fully supported. |
 | `rules:` — GEOIP | ✓ | MaxMind MMDB. |
@@ -80,12 +96,23 @@ These fields parse without error but behave differently from Go mihomo:
 
 | Field | Go mihomo | mihomo-rust | Class |
 |-------|-----------|-------------|-------|
-| `secret` not set | API unprotected | API unprotected (but warns at startup) | Same |
-| `authentication: ["user:pass"]` | Accepted | Accepted; malformed entry (no colon) is hard error | A |
-| `skip-auth-prefixes` | Defaults to `[]` | Always includes `127.0.0.1/32` and `::1/128` even if not listed | A |
+| `secret` not set | API unprotected | API unprotected (warns at startup) | Same |
+| `authentication: ["user:pass"]` | Accepted | Malformed entry (no colon) is hard error | A |
+| `authentication: ["user:"]` (empty password) | Accepted silently | Accepted; warn-once | B |
+| `skip-auth-prefixes` | Defaults to `[]` | Always includes `127.0.0.1/32` + `::1/128` | A |
+| `skip-auth-prefixes` with invalid CIDR | Silently dropped | Hard parse error | A |
 | `dns.nameserver: quic://...` | Supported | Hard error with roadmap pointer | A |
-| `dns.nameserver: sdns://...` | Warn-drop | Hard error | A |
+| `dns.nameserver: sdns://...` | Warn-drop (silent) | Hard error | A |
 | `dns.default-nameserver: tls://...` | Allowed (bootstrap loop risk) | Hard error | A |
+| `dns.default-nameserver` absent with encrypted hostname upstream | Fails at first query | Hard error at load | A |
+| `nameserver-policy` entry with all URLs stripped | Runtime panic | Hard parse error at load | A |
+| `fallback-filter` GeoIP/CIDR gates | Only on primary failure | Also on poisoned responses (non-CN IP, bogon) | A |
+| `fallback-filter.geoip: true` with no MMDB | Startup error | Warn-once, gate disabled | B |
+| `nameserver-policy` key with `geosite:` prefix | Resolved via geosite DB | Warn-once, entry skipped | B |
+| `IN-TYPE` with unknown value (e.g. `IN-TYPE,QUIC`) | Silently no-match | Hard parse error | A |
+| `PUT /configs` in-flight connections | Graceful handover | Cold reload, connections dropped + logged | A |
+| `PUT /configs` payload with raw YAML (not base64) | Accepted in some versions | 400 with helpful message | B |
+| `GET /configs` response includes null Option fields | Full struct with nulls | Only non-null fields returned | B |
 | `geodata-mode`, `geodata-loader`, `geoip-matcher` | Valid fields | Ignored with warn-once (M2+) | B |
 
 ### Fields that are silently ignored in Go mihomo but error in mihomo-rust
@@ -96,14 +123,20 @@ security gaps and typo-likely mistakes become hard errors (Class A).
 
 | Mistake | Go mihomo | mihomo-rust |
 |---------|-----------|-------------|
-| Duplicate listener port | Silently overwrites | Hard parse error |
-| Duplicate listener name | Silently overwrites | Hard parse error |
-| Unknown listener type | Silently ignores | Hard parse error |
-| `authentication` entry with no `:` | Silently ignores | Hard parse error |
+| Duplicate listener port | Silently overwrites last | Hard parse error naming both conflicting listeners |
+| Duplicate listener name | Silently overwrites last | Hard parse error |
+| Unknown listener type (e.g. `type: redir`) | Silently ignored | Hard parse error |
+| Shorthand port + `listeners:` entry on same port | Both accepted | Hard parse error (same as duplicate port) |
+| `authentication` entry with no `:` | Silently stored with empty password | Hard parse error |
+| `authentication` entry with empty username (`:pass`) | Silently accepted | Hard parse error |
+| `skip-auth-prefixes` with invalid CIDR | Silently dropped | Hard parse error |
 | Malformed IP in `dns.hosts` | Silently skips | Hard parse error |
-| `.dat` geosite file in discovery path | Loads (protobuf) | Hard error + conversion hint |
+| `.dat` geosite file in discovery path | Loads (protobuf) | Hard error + conversion hint (`convert-geo`) |
 | `sub-rules:` cycle | May panic or loop | Hard parse error |
 | `sub-rules:` reference to undefined block | Runtime no-match | Hard parse error |
+| `nameserver-policy` entry with zero valid nameservers | Runtime panic at first query | Hard parse error at load |
+| `IN-TYPE` with unknown protocol name | Silently no-matches all traffic of that type | Hard parse error |
+| Base64 payload with URL-safe alphabet (`-`, `_`) | Accepted in some dashboard versions | 400 with decode-error message |
 
 ---
 
@@ -443,6 +476,23 @@ using them will produce a clear error at startup.
 
 ---
 
+## mihomo-rust-only features
+
+These exist in mihomo-rust but have no equivalent in Go mihomo. Dashboard
+tools built for Go mihomo will ignore them.
+
+| Feature | Path / Field | Notes |
+|---------|-------------|-------|
+| Prometheus metrics | `GET /metrics` | Native scrape endpoint; Go mihomo has no equivalent (M1.H-2) |
+| Subscription management API | `GET\|POST\|DELETE /api/subscriptions[/:name]` | mihomo-rust-specific |
+| Extended proxy group API | `GET\|POST\|PUT\|DELETE /api/proxy-groups[/:name]` | mihomo-rust-specific |
+| Rule CRUD API | `POST\|PUT\|DELETE /rules[/:index]` | Runtime rule editing |
+
+Keep these under the `/api/` prefix so they do not collide with
+Clash-compatible paths.
+
+---
+
 ## Feature flags (Cargo features)
 
 mihomo-rust uses Cargo feature flags where Go mihomo uses build tags:
@@ -463,6 +513,57 @@ cargo build --release --no-default-features -p mihomo-dns
 
 ---
 
+## Migration steps by subscription type
+
+### Type 1: Standard Clash Meta subscription (SS + VLESS/VMess, rule-set)
+
+Most common format from public providers. Typical issues:
+
+1. **VMess proxies** — replace with VLESS alternatives from your provider, or
+   remove them. mihomo-rust hard-errors on `type: vmess`.
+2. **`enhanced-mode: fake-ip`** — change to `redir-host` or remove the line
+   entirely (default is `redir-host`). Auto-fallback applies but logs a warn.
+3. **`fake-ip-range` / `fake-ip-filter`** — remove; silently ignored but creates
+   log noise.
+4. **GEOSITE rules with `.dat` files** — convert to mrs format:
+   ```bash
+   metacubex convert-geo geosite.dat -o geosite.mrs
+   ```
+5. **`quic://` nameservers** — replace with `tls://` or `https://` equivalents.
+   `quic://` is a hard parse error with a message pointing at the roadmap.
+6. Run `-t` to validate: `mihomo -f config.yaml -t`
+
+### Type 2: Enterprise split-tunnel (nameserver-policy, IN-NAME rules)
+
+1. **Named listeners** — `IN-NAME` / `IN-TYPE` rules require the `listeners:`
+   array (M1.F-1). Shorthand ports (`mixed-port`, `socks-port`) get auto-names
+   (`"mixed"`, `"socks"`) — `IN-NAME,mixed,...` works without changes.
+2. **`nameserver-policy` with `geosite:` keys** — entries like
+   `"geosite:cn": [...]` are skipped with a warn-once until geosite-in-policy
+   integration lands post-M1. Use exact domain or `+.` wildcard patterns instead.
+3. **`authentication:`** — ensure each entry has a colon separating username and
+   password. Entries without a colon are a hard parse error.
+4. **`skip-auth-prefixes:`** — loopback (`127.0.0.1/32`, `::1/128`) is always
+   skipped even if not listed. Invalid CIDRs are a hard parse error.
+
+### Type 3: Transparent proxy (tproxy, Linux)
+
+1. **TUN users** — switch to `tproxy-port`. TUN inbound is a non-goal. Use
+   nftables `TPROXY` target instead of `REDIRECT`.
+2. **`redir-port`** — not supported. Use `tproxy-port`.
+3. **PROCESS-NAME / PROCESS-PATH rules** — platform lookup wired (Linux netlink,
+   macOS libproc) via M1.D-1.
+
+### Type 4: Proxy provider subscription (`proxy-providers:`)
+
+1. **`proxy-providers:`** — supported in M1.H-1 (http + file sources, health-check,
+   `include-all` shorthand).
+2. **`interval:` refresh** — supported in M1.D-5. No config change needed.
+3. **`use:` in proxy groups** — wired in M1.H-1. Until that PR merges, list
+   proxies explicitly in the group's `proxies:` array.
+
+---
+
 ## Known-good patterns
 
 These have been tested against a real subscription and confirmed working:
@@ -478,11 +579,15 @@ These have been tested against a real subscription and confirmed working:
 
 ## Known-broken patterns
 
-*(Fill in as the team discovers them during soak testing.)*
+The following produce hard errors at load time (not silent failures):
 
-- DoQ upstreams — hard error; replace with DoH/DoT.
-- Hysteria2 proxies — hard error; no alternative in M1.
-- `fake-ip` DNS mode — removed; use `redir-host`.
+- **`quic://` nameservers** — hard error; replace with `tls://` or `https://`.
+- **Hysteria2 / TUIC proxies** — hard error (`type: hysteria2` / `type: tuic`); no alternative in M1.
+- **`fake-ip` DNS mode** — warn-once fallback to `redir-host`; see §Removed features.
+- **VMess proxies** — hard error; use `type: vless` instead.
+- **`vless` with `flow: xtls-rprx-direct`** — hard error; use `xtls-rprx-vision`.
+
+*(Additional patterns filled in after M1 soak testing against real subscriptions.)*
 
 ---
 

--- a/docs/specs/api-config-reload-test-plan.md
+++ b/docs/specs/api-config-reload-test-plan.md
@@ -1,0 +1,191 @@
+# Test Plan: Config reload API — PUT /configs and GET /configs (M1.G-10)
+
+Status: **draft** — owner: pm. Last updated: 2026-04-18.
+Tracks: task #23. Companion to `docs/specs/api-config-reload.md`.
+
+This is the QA-owned acceptance test plan. The spec's `§Test plan` section
+is the PM's starting point; this document is the final shape engineer should
+implement against. If the spec and this document disagree, **this document
+wins for test cases** — flag the discrepancy so the spec can be updated.
+
+Divergence-comment convention per memory (`feedback_spec_divergence_comments.md`):
+inline `Upstream: file::fn` + `NOT X` lines on bullets that exercise a
+divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
+
+## Scope and guardrails
+
+**In scope:**
+
+- `PUT /configs` — path-based reload, payload-based reload (base64 YAML),
+  `?force` semantics, auth enforcement, 400/204/401 response codes.
+- `GET /configs` — current config serialisation, `Option::None` field omission.
+- `AppState::reload()` — drain timeout, `connections_dropped` structured log,
+  listener teardown and restart.
+- `ArcSwap<Tunnel>` correctness — wait-free read path, atomic store on reload.
+- M1 scope boundary: cold reload only; hot-reload is M3.
+- All four divergences from upstream `hub/server.go::patchConfig`.
+
+**Out of scope (forbidden per spec §Out of scope):**
+
+- Hot-reload (no dropped connections) — M3.
+- PATCH partial config update — M1 replaces full config only.
+- Config version history / rollback — M3+.
+- Persisting PUT payload to disk — payload is memory-only unless engineer
+  explicitly implements optional persistence; not in M1 spec.
+- Dashboard UI compatibility testing — not our test surface.
+
+## File layout expected
+
+```
+crates/mihomo-api/src/
+  routes.rs            # MODIFIED: put_configs, get_configs handlers + routes
+  state.rs             # MODIFIED: ArcSwap<Tunnel>, reload() method
+Cargo.toml             # MODIFIED: arc-swap = "1", base64 = "0.22"
+crates/mihomo-api/tests/
+  config_reload_test.rs  # NEW: handler unit tests (axum test client)
+  config_reload_integration_test.rs  # NEW: full restart-reload integration test
+```
+
+## Divergence table
+
+Following ADR-0002 classification format:
+
+| # | Case | Class | Note |
+|---|------|:-----:|------|
+| 1 | `payload` field — upstream some dashboard versions send raw YAML string | B | We require base64. Raw YAML in payload field returns 400 with helpful message. Upstream: `hub/server.go::patchConfig` — raw string accepted. NOT silent corrupt decode. |
+| 2 | `?force=true` — upstream silently applies broken config, no prominent log | B | We log each validation error as `error!` before proceeding. Upstream: `patchConfig` force path — no prominent logging. Same end result, more observable. |
+| 3 | `GET /configs` — upstream returns full Go runtime struct including state | B | M1 returns `RawConfig` fields only (static config). Runtime state via /proxies, /rules, /connections. Upstream: `hub/server.go::getConfigs`. NOT null fields for absent Options. |
+| 4 | In-flight connections dropped on reload — upstream attempts graceful handover | A | Cold reload is intentional M1 simplification. Connections logged before force-close. Upstream: `hub/server.go` graceful tunnel swap. NOT silent drop — Class A per ADR-0002: operators must see what was dropped. |
+
+---
+
+## Case list
+
+### A. `PUT /configs` handler unit tests (`crates/mihomo-api/tests/config_reload_test.rs`)
+
+All cases use an axum test client with a mock `AppState` that records reload
+calls. No real listeners spawned. Use `#[tokio::test]`.
+
+| # | Case | Asserts |
+|---|------|---------|
+| A1 | `put_configs_path_valid_returns_204` | POST valid YAML path that exists on disk. Assert `204 No Content`. Assert `AppState::reload` called once. <br/> Upstream: `hub/server.go::patchConfig` — 204 on success. NOT 200. |
+| A2 | `put_configs_payload_base64_valid_returns_204` | `{"payload": "<base64 of valid YAML>"}`. Assert 204. Assert decoded YAML passed to reload. |
+| A3 | `put_configs_payload_base64_decoded_correctly` **[guard-rail]** | Encode `"port: 7890\n"` as base64. Assert the YAML string passed to `parse_raw_config` is exactly `"port: 7890\n"`. Guards that base64 decode is not double-decoded or truncated. |
+| A4 | `put_configs_invalid_yaml_syntax_returns_400` | `{"payload": "<base64 of 'port: {bad: yaml: ['>"}`. Assert `400`. Assert response body JSON `{"message": "config parse error: ..."}`. Assert `AppState::reload` NOT called. <br/> Upstream: `hub/server.go::patchConfig` — returns error on parse fail. NOT 500. NOT 204. |
+| A5 | `put_configs_invalid_yaml_error_body_is_json` **[guard-rail]** | Same bad YAML. Assert `Content-Type: application/json` header present on 400 response. Assert body parseable as `{"message": string}`. |
+| A6 | `put_configs_force_true_semantic_error_returns_204` | `?force=true`, valid YAML with semantic error (e.g., proxy group referencing non-existent proxy name). Assert 204. Assert `error!` log emitted with validation error text. Assert reload called. <br/> Upstream: `hub/server.go::patchConfig` force path — proceeds without logging. <br/> NOT 400 — force bypasses semantic validation. |
+| A7 | `put_configs_force_true_parse_error_still_400` | `?force=true`, malformed YAML syntax. Assert 400. Assert reload NOT called. <br/> Upstream: `patchConfig` — force flag applied to both parse and semantic errors (force can push a parse-broken config). <br/> NOT 204 — Class B per ADR-0002 §force semantics: we never apply parse-broken config even under force. |
+| A8 | `put_configs_no_auth_returns_401` | No `Authorization` header, `secret` configured. Assert 401. Assert reload NOT called. |
+| A9 | `put_configs_wrong_secret_returns_401` | Wrong Bearer token. Assert 401. |
+| A10 | `put_configs_body_neither_path_nor_payload_returns_400` | `{}` body. Assert 400 with message containing `"path"` and `"payload"`. |
+| A11 | `put_configs_body_both_path_and_payload_uses_path` **[guard-rail]** | Body with both `path` and `payload`. Assert 400 or that exactly one is used (per engineer's implementation choice — document which in PR). Guards against ambiguous-body silent behavior. |
+| A12 | `put_configs_payload_not_valid_base64_returns_400` | `{"payload": "not!!base64%%"}`. Assert 400 with message indicating decode failure. NOT panic. <br/> Upstream: Go `base64.StdEncoding.DecodeString` — returns error. We match but surface it as 400. |
+| A13 | `put_configs_path_nonexistent_file_returns_400` | `{"path": "/tmp/does_not_exist_abc123.yaml"}`. Assert 400 with file-not-found message. NOT 500. NOT panic. |
+| A14 | `put_configs_no_auth_configured_admits_without_token` **[guard-rail]** | `secret` not configured (empty). `PUT /configs` with no auth header. Assert 204 (no auth required). Guards that auth gate is absent when no secret set, matching behavior of all other endpoints. |
+
+### B. `GET /configs` handler unit tests
+
+| # | Case | Asserts |
+|---|------|---------|
+| B1 | `get_configs_returns_200_with_json` | `GET /configs`. Assert 200. Assert `Content-Type: application/json`. |
+| B2 | `get_configs_port_matches_configured_value` | App configured with `mixed-port: 7890`. Assert response JSON contains `"mixed-port": 7890`. |
+| B3 | `get_configs_absent_option_fields_omitted` | Config with no `socks-port`. Assert response JSON does NOT contain `"socks-port"` key (not `"socks-port": null`). <br/> Upstream: `hub/server.go::getConfigs` — includes null fields. <br/> NOT explicit null — Class B per ADR-0002: null Option fields are an internal implementation detail. |
+| B4 | `get_configs_requires_auth_when_secret_set` | `GET /configs` with no auth, secret configured. Assert 401. |
+| B5 | `get_configs_mode_field_reflects_current_mode` | Config with `mode: rule`. Assert `"mode": "rule"` in response. Regression guard that mode is serialised from active config, not a hardcoded default. |
+| B6 | `get_configs_after_reload_reflects_new_config` **[guard-rail]** | Start with `mixed-port: 7890`. Reload to `mixed-port: 7891`. `GET /configs`. Assert `"mixed-port": 7891`. Guards that GET reflects post-reload state, not stale pre-reload config. |
+
+### C. `AppState::reload()` unit tests
+
+These test the reload lifecycle in isolation with mock listeners and a
+controlled connection count.
+
+| # | Case | Asserts |
+|---|------|---------|
+| C1 | `reload_stops_old_listeners` | Mock listener tracking `is_stopped` flag. Call `reload()`. Assert all old mock listeners stopped. |
+| C2 | `reload_starts_new_listeners_with_new_config` | Reload with config changing port. Assert new listeners started on new port. Assert old port not re-opened. |
+| C3 | `reload_drains_connections_before_force_close` | Inject 3 mock connections with 100ms lifetime. Call `reload()`. Assert reload completes after connections finish (< 5s drain timeout). Assert `connections_dropped = 0` in log. |
+| C4 | `reload_force_closes_connections_after_drain_timeout` | Inject a mock connection that never closes. Call `reload()`. Assert force-close occurs after 5s. Assert structured log `connections_dropped = 1` at `warn!` level. <br/> Upstream: `hub/server.go` — no drain timeout; immediate swap. <br/> NOT silent close — Class A per ADR-0002: operators must see dropped count. |
+| C5 | `reload_connections_dropped_log_is_structured` **[guard-rail]** | Same as C4. Assert log contains field `connections_dropped` as a numeric key, NOT as part of an unstructured string like `"1 connections dropped"`. Engineers must use `warn!(connections_dropped = N, "...")` not `warn!("N connections dropped")`. |
+| C6 | `reload_swaps_arc_swap_atomically` | Assert that after `reload()`, `state.tunnel.load()` returns the new tunnel, not the old one. |
+| C7 | `reload_does_not_block_hot_path_reads` **[guard-rail]** | While reload is in progress (between drain and swap), assert `state.tunnel.load()` returns in O(1) without acquiring a lock. This is a structural test: verify `ArcSwap` is used (grep for `ArcSwap` in `state.rs`), not a `RwLock`. |
+
+### D. `ArcSwap` correctness tests
+
+| # | Case | Asserts |
+|---|------|---------|
+| D1 | `arc_swap_reader_sees_new_tunnel_after_store` | `ArcSwap::store(new_tunnel)` then `load()`. Assert `load()` returns the new tunnel. |
+| D2 | `arc_swap_concurrent_reads_during_store` **[guard-rail]** | Spawn 10 reader tasks, each calling `load()` in a tight loop. Concurrently call `store(new_tunnel)`. Assert no panic, no data race. All readers eventually see the new tunnel. This is a smoke test, not a formal proof — `tokio::test` with `#[should_not_panic]` semantics. |
+
+### E. M1 scope boundary tests
+
+| # | Case | Asserts |
+|---|------|---------|
+| E1 | `put_configs_drops_connections_not_hot_reload` | Start a long-lived proxied connection. Call `PUT /configs` with valid new config. Assert the existing connection is closed (receives EOF or RST within the drain window + 5s). Assert new connections work after reload. <br/> Upstream: `hub/server.go` — hot swap, connections not dropped. <br/> NOT hot-reload — Class A per ADR-0002: M1 intentionally drops connections; operators are warned in docs. |
+| E2 | `no_patch_endpoint_exists` **[guard-rail]** | `PATCH /configs`. Assert 405 Method Not Allowed (or 404). Partial config update is M3. |
+
+### F. Integration test — full restart-reload cycle (`config_reload_integration_test.rs`)
+
+`#[tokio::test]`, spawns a real mihomo-rust process in-process via
+`AppState` + real listeners on loopback. Linux and macOS.
+
+| # | Case | Asserts |
+|---|------|---------|
+| F1 | `config_reload_switches_listener_port` | Start with `mixed-port: 18090`. PUT new config with `mixed-port: 18091`. Assert port 18090 no longer accepts new connections (connection refused). Assert port 18091 accepts new connections. NOT both ports open simultaneously. |
+| F2 | `config_reload_updates_rules` | Start with rule `MATCH,Direct`. Reload config with rule `MATCH,Reject`. Connect via proxy after reload. Assert connection rejected. Guards that tunnel rule set is replaced, not merged. |
+| F3 | `config_reload_idempotent` **[guard-rail]** | Reload the same config twice in succession. Assert no panic, no port-already-in-use error, final state identical to a single reload. |
+
+### G. Base64 and payload edge cases
+
+| # | Case | Asserts |
+|---|------|---------|
+| G1 | `payload_standard_base64_alphabet` | YAML encoded with standard alphabet (`+`, `/`, `=` padding). Assert decoded correctly. |
+| G2 | `payload_url_safe_base64_rejected` **[guard-rail]** | YAML encoded with URL-safe alphabet (`-`, `_`). Assert 400 with decode-error message. We use standard alphabet only (matching MetaCubeXD / Yacd). Engineer must NOT silently accept URL-safe. |
+| G3 | `payload_with_line_breaks_rejected` **[guard-rail]** | Base64 string with `\n` line breaks (MIME-style). Assert 400. Standard encoding, no line breaks per spec. |
+| G4 | `payload_empty_base64_returns_400` | `{"payload": ""}`. Assert 400. Empty payload decodes to empty string, not valid YAML config. |
+
+---
+
+## Deferred / not tested here
+
+- Hot-reload (connection preservation across reload) — M3.
+- PATCH partial config update — M3.
+- Config rollback on reload failure — M3+.
+- Prometheus metric `config_reloads_total` counter — M1.H-2 (separate spec).
+- Throughput of reload path — not on the hot path; no benchmark needed.
+
+---
+
+## Exit criteria for this test plan
+
+- All §A–G cases pass on `ubuntu-latest` and `macos-latest` in CI.
+- `connections_dropped` structured log verified by §C5 (code review gate,
+  not regex-on-log-output — too brittle).
+- `GET /configs` never emits `null` values for absent fields (§B3 guard).
+- `ArcSwap` usage confirmed structurally in §C7 (not `RwLock`).
+- After reload, `cargo test --test config_reload_integration_test` green.
+
+## CI wiring required
+
+Add to `.github/workflows/test.yml`:
+
+1. `cargo test -p mihomo-api --test config_reload_test` — §A–D, §G cases.
+   Add to both `ubuntu-latest` and `macos-latest` jobs.
+2. `cargo test -p mihomo-api --test config_reload_integration_test` — §E–F
+   integration cases. Linux only for TProxy-adjacent cases; F1–F3 run on both.
+
+## Open questions for engineer
+
+1. **Both `path` and `payload` in body (§A11).** The spec doesn't specify
+   precedence. Recommend: return 400 for ambiguous body to force clients to
+   send exactly one. If the engineer instead picks `path`-first, document it
+   explicitly and update §A11 assertion.
+2. **Drain timeout configurability.** Spec fixes at 5s, not configurable in M1.
+   If engineer wants to make it configurable, it must be a `RawConfig` field
+   with a default of 5s — do not hard-code without a named constant.
+3. **`GET /configs` serialisation completeness.** Spec says "fields present in
+   `RawConfig` that are already serialisable." Confirm which fields in `RawConfig`
+   still lack `#[derive(Serialize)]` at implementation time. Missing fields are
+   acceptable for M1 — document them in a code comment so M2 can add them.
+4. **URL-safe base64 (§G2).** Confirm the `base64 = "0.22"` API used is
+   `STANDARD` (not `URL_SAFE`). This is a one-line choice at decode callsite
+   but must be explicit in the PR.

--- a/docs/specs/dns-nameserver-policy-test-plan.md
+++ b/docs/specs/dns-nameserver-policy-test-plan.md
@@ -1,0 +1,208 @@
+# Test Plan: DNS nameserver-policy and fallback-filter (M1.E-3, M1.E-4)
+
+Status: **draft** — owner: pm. Last updated: 2026-04-18.
+Tracks: task #22. Companion to `docs/specs/dns-nameserver-policy.md`.
+
+This is the QA-owned acceptance test plan. The spec's `§Test plan` section
+is the PM's starting point; this document is the final shape engineer should
+implement against. If the spec and this document disagree, **this document
+wins for test cases** — flag the discrepancy so the spec can be updated.
+
+Divergence-comment convention per memory (`feedback_spec_divergence_comments.md`):
+inline `Upstream: file::fn` + `NOT X` lines on bullets that exercise a
+divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
+
+## Scope and guardrails
+
+**In scope:**
+
+- `NameserverPolicy` struct and `lookup()` method (`crates/mihomo-dns/src/resolver.rs`)
+  — exact match, `+.` wildcard match, no-match fall-through.
+- `FallbackFilter` struct and `should_use_fallback()` method (same file)
+  — GeoIP gate, IP-CIDR gate, domain gate, disabled-gate pass-through.
+- Full resolver lookup flow: policy → global → fallback dispatch
+  (`Resolver::do_lookup()` or equivalent).
+- Config parser (`crates/mihomo-config/src/dns_parser.rs`) — YAML round-trip
+  for `nameserver-policy` and `fallback-filter` fields.
+- Divergences: `geosite:`/`rule-set:` prefix warn-and-skip, no-MMDB
+  startup warn, zero-valid-nameserver hard error.
+- Parallel nameserver dispatch (`futures::future::select_ok` semantics).
+
+**Out of scope (forbidden per spec §Out of scope):**
+
+- `geosite:` and `rule-set:` patterns resolving to actual geosite DBs —
+  M1.D-2 / M1.D-5. Warn-and-skip is the only behaviour tested here.
+- `dhcp://` nameserver — deferred.
+- Per-policy TLS config (all policies share global TLS from M1.E-1).
+- DoQ — M1.E-6.
+- Re-filtering of fallback results — spec §FallbackFilter explicitly
+  exempts fallback responses from re-filtering.
+- Throughput / latency benchmarks — M2.
+
+## File layout expected
+
+```
+crates/mihomo-dns/src/
+  resolver.rs          # MODIFIED: NameserverPolicy, FallbackFilter, lookup flow
+crates/mihomo-dns/tests/
+  nameserver_policy_integration.rs   # NEW: network-gated #[ignore] end-to-end tests
+crates/mihomo-config/src/
+  dns_parser.rs        # MODIFIED: nameserver_policy + fallback_filter fields
+crates/mihomo-config/tests/
+  config_test.rs       # MODIFIED: new dns_parser cases
+```
+
+## Divergence table
+
+Following ADR-0002 classification format:
+
+| # | Case | Class | Note |
+|---|------|:-----:|------|
+| 1 | `geosite:`/`rule-set:` prefix in nameserver-policy key — upstream supports | B | Warn-once at parse time, entry skipped. NOT hard error — real configs use these. |
+| 2 | `fallback-filter.geoip: true` with no MMDB — upstream errors at startup | B | We treat as `geoip: false` with `warn!`. Single-resolver configs need no GeoIP DB. NOT a startup error. |
+| 3 | Policy entry with zero valid nameservers (all URLs skipped) — upstream panics | A | Hard parse error: `"nameserver-policy entry 'KEY' has no valid nameservers"`. Silent routing to global = DNS leakage for internal domains. NOT silent fall-through. |
+| 4 | `fallback-filter` GeoIP/CIDR/domain gates — upstream only falls back on primary failure | A | We trigger fallback on GeoIP anomaly, bogon IP, or domain pattern match even when primary succeeds. Upstream: `dns/resolver.go::ipWithFallback` checks only SERVFAIL/timeout. NOT pass-through on poisoned responses. |
+| 5 | Fallback results not re-filtered — both upstream and mihomo-rust match | — | Consistent: fallback is the trusted alternate; re-filtering creates rejection loops. |
+
+---
+
+## Case list
+
+### A. `NameserverPolicy` unit tests (`crates/mihomo-dns/src/resolver.rs`)
+
+Pure in-process unit tests, no network. Mock policy nameservers that record
+whether they were called.
+
+| # | Case | Asserts |
+|---|------|---------|
+| A1 | `nameserver_policy_exact_match_routes_to_policy` | Policy entry `"example.com"` → mock policy server. Query `example.com A`. Assert policy mock called; global mock NOT called. <br/> Upstream: `dns/resolver.go::PolicyResolver` — policy takes precedence over global pool. NOT global nameservers when exact match exists. |
+| A2 | `nameserver_policy_exact_no_match_routes_to_global` | Policy entry `"example.com"` only. Query `other.com A`. Assert global mock called; policy mock NOT called. |
+| A3 | `nameserver_policy_wildcard_matches_subdomain` | Policy `"+.corp.internal"`. Query `foo.corp.internal`. Assert policy mock called; global mock NOT called. |
+| A4 | `nameserver_policy_wildcard_matches_root_domain` | Policy `"+.corp.internal"`. Query `corp.internal`. Assert policy mock called. <br/> Upstream: `dns/resolver.go` — `+.` prefix includes the root domain, not only subdomains. NOT global — `+.` is not sub-only. |
+| A5 | `nameserver_policy_wildcard_does_not_match_sibling` **[guard-rail]** | Policy `"+.corp.internal"`. Query `othercorp.internal`. Assert global mock called; policy mock NOT called. Guards trie boundary — `othercorp.internal` is a sibling, not a subdomain. |
+| A6 | `nameserver_policy_exact_takes_priority_over_wildcard` **[guard-rail]** | Two entries: exact `"api.corp.internal"` → mock-A; wildcard `"+.corp.internal"` → mock-B. Query `api.corp.internal`. Assert mock-A called; mock-B NOT called. Exact match wins per spec §Lookup flow step 3 (`exact` checked before `wildcard` in `NameserverPolicy::lookup`). |
+| A7 | `nameserver_policy_multiple_servers_parallel_dispatch` | Policy entry with two mock servers: slow-A (delays 50ms) and fast-B (responds immediately). Assert fast-B's response returned; total wall time < slow-A's delay. <br/> Upstream: `dns/resolver.go` uses goroutine fan-out. NOT sequential — `select_ok` returns first success. |
+| A8 | `nameserver_policy_geosite_prefix_warns_and_falls_through_to_global` | Policy key `"geosite:cn"`. At parse time assert one `warn!` log emitted. At lookup time query matching no plain-pattern policy → global mock called. <br/> Upstream: `dns/resolver.go` resolves `geosite:` patterns via the geosite DB (M1.D-2). <br/> NOT hard error — Class B per ADR-0002: too many real configs use this; defer geosite resolution to M1.D-2 integration. |
+| A9 | `nameserver_policy_zero_valid_nameservers_hard_errors_at_parse` | Config with policy entry whose only URL is `"quic://dns.example"` (unsupported scheme, stripped by M1.E-1). Assert `parse_dns` returns `Err` containing `"nameserver-policy entry"` and the key name. <br/> Upstream: `dns/resolver.go` — upstream would panic at lookup time with an empty client list. <br/> NOT silent fall-through to global — Class A per ADR-0002: silent routing of internal domain to global = DNS leakage. |
+
+### B. `FallbackFilter` unit tests (`crates/mihomo-dns/src/resolver.rs`)
+
+Pure unit tests on `FallbackFilter::should_use_fallback`. Use a stub MMDB
+that returns controlled country codes.
+
+| # | Case | Asserts |
+|---|------|---------|
+| B1 | `fallback_filter_geoip_triggers_on_non_matching_country` | GeoIP gate: `geoip: true`, `geoip-code: CN`. MMDB stub returns `"US"` for `8.8.8.8`. Query returns `8.8.8.8`. Assert `should_use_fallback` returns `true`. <br/> Upstream: `dns/resolver.go::ipWithFallback` — upstream only falls back on SERVFAIL/timeout. <br/> NOT pass-through — Class A per ADR-0002: censoring resolvers return valid-looking poisoned answers, not failures. |
+| B2 | `fallback_filter_geoip_passes_on_matching_country` | Same config. MMDB stub returns `"CN"`. Assert `should_use_fallback` returns `false`. |
+| B3 | `fallback_filter_ipcidr_triggers_on_bogon` | `ipcidr: ["240.0.0.0/4"]`. Primary returns `240.0.0.1`. Assert `should_use_fallback` returns `true`. |
+| B4 | `fallback_filter_ipcidr_passes_on_non_bogon` | Same config. Primary returns `1.1.1.1`. Assert `should_use_fallback` returns `false`. |
+| B5 | `fallback_filter_ipcidr_multiple_ranges` **[guard-rail]** | `ipcidr: ["240.0.0.0/4", "0.0.0.0/8"]`. Primary returns `0.0.0.1`. Assert `should_use_fallback` returns `true`. Guards that all ranges are checked, not only the first. |
+| B6 | `fallback_filter_domain_pattern_skips_primary` | `domain: ["+.google.cn"]`. Query `www.google.cn`. Assert `should_use_fallback` returns `true` **before** any IP address is available. <br/> Upstream: `dns/resolver.go` — no domain gate; upstream consults primary first. <br/> NOT primary-then-discard — domain gate short-circuits before primary query, per spec §FallbackFilter::should_use_fallback step 1. |
+| B7 | `fallback_filter_domain_wildcard_matches_root` | `domain: ["+.google.cn"]`. Query `google.cn`. Assert `should_use_fallback` returns `true`. (`+.` includes root.) |
+| B8 | `fallback_filter_domain_does_not_match_sibling` **[guard-rail]** | `domain: ["+.google.cn"]`. Query `notgoogle.cn`. Assert `should_use_fallback` returns `false`. |
+| B9 | `fallback_filter_all_disabled_never_triggers` | `geoip: false`, empty `ipcidr`, empty `domain`. Any primary IP. Assert `should_use_fallback` always returns `false`. |
+| B10 | `fallback_filter_geoip_no_mmdb_skips_gate_and_warns` | `geoip: true`, MMDB = `None`. Assert `should_use_fallback` returns `false` (gate skipped). Assert one `warn!` emitted at `Resolver::new()` time (NOT at query time — warn once at startup). <br/> Upstream: `dns/resolver.go` — Go mihomo errors at startup if MMDB is absent with geoip enabled. <br/> NOT a startup error — Class B per ADR-0002: single-resolver deployments without MMDB are valid. |
+| B11 | `fallback_filter_fallback_result_not_refiltered` | Fallback returns an IP that would itself trigger the GeoIP gate. Assert the result is returned as-is (filter not re-applied to fallback response). Per spec §Resolved questions item 3. |
+| B12 | `fallback_filter_geoip_multiple_ips_any_triggers` **[guard-rail]** | GeoIP gate active. Primary returns two IPs: `1.1.1.1` (CN, passes) and `8.8.8.8` (US, fails). Assert `should_use_fallback` returns `true`. Any non-matching IP is sufficient to trigger fallback — guards that the loop does not short-circuit on the first match. |
+
+### C. Resolver lookup flow integration tests (`crates/mihomo-dns/src/resolver.rs`)
+
+These require a tokio runtime (`#[tokio::test]`). Use mock nameservers that
+return controlled answers (no network).
+
+| # | Case | Asserts |
+|---|------|---------|
+| C1 | `lookup_flow_policy_match_uses_policy_not_global` | Full `Resolver` with policy `"example.com"` → policy-mock, global-mock also present. Query `example.com`. Assert answer from policy-mock returned; global-mock never called. |
+| C2 | `lookup_flow_no_policy_match_uses_global` | Full resolver, policy only covers `"example.com"`. Query `other.com`. Assert global-mock called. |
+| C3 | `lookup_flow_fallback_filter_triggers_fallback_on_poisoned_response` | GeoIP gate active. Global-mock returns `240.0.0.1` (in bogon ipcidr). Fallback-mock returns `1.2.3.4`. Assert `1.2.3.4` returned as final answer. Upstream: `dns/resolver.go::resolve` — no IP-CIDR gate applied to global result. NOT `240.0.0.1` passed through. Class A per ADR-0002. |
+| C4 | `lookup_flow_domain_gate_skips_global_queries_primary` | `fallback-filter.domain: ["+.blocked.cn"]`. Query `www.blocked.cn`. Assert global-mock NOT called; fallback-mock called directly. Verifies domain gate prevents primary query entirely. |
+| C5 | `lookup_flow_fallback_only_on_primary_failure_when_filter_disabled` | No fallback-filter. Global-mock succeeds. Assert fallback-mock never called. Regression: existing behaviour (fallback on failure only) must not regress. |
+| C6 | `lookup_flow_fallback_called_on_primary_failure` | No fallback-filter. Global-mock returns `SERVFAIL`. Fallback-mock returns valid answer. Assert fallback answer returned. |
+| C7 | `lookup_flow_policy_result_also_passes_through_fallback_filter` | Policy `"+.corp.internal"` → policy-mock returns `240.0.0.1` (bogon). `ipcidr: ["240.0.0.0/4"]` active. Assert fallback-mock called; `240.0.0.1` NOT returned. <br/> Upstream: `dns/resolver.go::PolicyResolver` does not apply fallback-filter to policy results. <br/> NOT pass-through — per spec §Lookup flow: filter applies to both policy and global results. |
+| C8 | `lookup_flow_error_when_both_global_and_fallback_fail` | Global-mock SERVFAIL, fallback-mock SERVFAIL. Assert resolver returns an `Err`. |
+| C9 | `lookup_flow_parallel_global_nameservers_fastest_wins` | Two global-mocks: slow-A (50ms), fast-B (0ms). Assert fast-B's answer returned; elapsed < slow-A's delay. Guards `select_ok` not sequential polling. |
+
+### D. Config parser unit tests (`crates/mihomo-config/tests/config_test.rs`)
+
+All new cases are `#[tokio::test]` to match the async DNS parser.
+
+| # | Case | Asserts |
+|---|------|---------|
+| D1 | `parse_nameserver_policy_exact_entry` | YAML with `nameserver-policy: {"example.com": ["1.2.3.4"]}`. Assert one exact entry in parsed `NameserverPolicy`. |
+| D2 | `parse_nameserver_policy_wildcard_entry` | YAML with `nameserver-policy: {"+.corp.internal": ["192.168.1.53"]}`. Assert one wildcard entry. |
+| D3 | `parse_nameserver_policy_string_value_normalized_to_list` | Value is a bare string `"192.168.1.53"` (not a list). Assert parsed as single-element `Vec`. <br/> Upstream: `config/config.go::parseNameserverPolicy` accepts both string and list. We match. |
+| D4 | `parse_nameserver_policy_geosite_prefix_warns_and_skips` | Key `"geosite:cn"`. Assert `warn!` logged; entry absent from parsed policy (not an error). Class B per ADR-0002. |
+| D5 | `parse_nameserver_policy_all_invalid_urls_hard_errors` | Entry with only `"quic://..."` URLs (all stripped by url-parser). Assert `parse_dns` returns `Err` containing the policy key. Class A per ADR-0002. |
+| D6 | `parse_fallback_filter_all_fields` | Full `fallback-filter` block: `geoip: true`, `geoip-code: CN`, `ipcidr: ["240.0.0.0/4"]`, `domain: ["+.google.cn"]`. Assert all fields parsed correctly. |
+| D7 | `parse_fallback_filter_defaults_when_absent` | No `fallback-filter` in YAML. Assert defaults: `geoip: true`, `geoip-code: "CN"`, `ipcidr: []`, `domain: []`. |
+| D8 | `parse_fallback_filter_geoip_false_disables_gate` | `fallback-filter: {geoip: false}`. Assert `geoip_enabled: false` in parsed struct. |
+| D9 | `parse_nameserver_policy_empty_block_is_valid` | `nameserver-policy: {}`. Assert `Ok` with empty policy (no entries). |
+| D10 | `parse_nameserver_policy_absent_is_valid` | No `nameserver-policy` key. Assert `Ok`, `policy: None` in resolver config. |
+| D11 | `parse_fallback_filter_invalid_cidr_errors` **[guard-rail]** | `ipcidr: ["not-a-cidr"]`. Assert `Err` at parse time, not at query time. Guards that CIDR parsing is eager. |
+| D12 | `parse_nameserver_policy_multiple_entries` | Three entries: one exact, two wildcard. Assert all three present in parsed policy. |
+
+### E. Network-dependent integration tests (`crates/mihomo-dns/tests/nameserver_policy_integration.rs`)
+
+All cases are `#[ignore]`. Run with:
+```
+cargo test -p mihomo-dns --test nameserver_policy_integration -- --ignored
+```
+Not wired into CI. Document in the PR description which resolvers were used.
+
+| # | Case | Asserts |
+|---|------|---------|
+| E1 | `nameserver_policy_routes_to_correct_server_live` | Policy `"+.cloudflare.com"` → `1.1.1.1:53`. Global `8.8.8.8:53`. Query `blog.cloudflare.com A`. Assert valid answer returned. (Not asserting which server — just that routing doesn't break live resolution.) |
+| E2 | `fallback_filter_geoip_live_with_mmdb` | Real MMDB from `geodata-subsection` test fixture. GeoIP gate `CN`. Query a known-clean domain. Assert result passes filter (no fallback triggered for a clean public domain). |
+
+### F. Async regression guard
+
+| # | Case | Asserts |
+|---|------|---------|
+| F1 | `resolver_do_lookup_is_async` **[guard-rail]** | Compile-time: assert the lookup entry point is `async fn`. Use a trivial `let _: Pin<Box<dyn Future<Output=_>>> = Box::pin(resolver.resolve(...))`. Fails to compile if someone de-async-ifies the lookup path. |
+
+---
+
+## Deferred / not tested here
+
+- `geosite:` / `rule-set:` patterns resolving to actual data — M1.D-2 / M1.D-5.
+- `dhcp://` nameserver — deferred per spec §Out of scope.
+- Hot-reload of policy entries without restart — M3.
+- Per-policy TLS client config — deferred per spec §Out of scope.
+- Throughput / latency benchmarks — M2.
+
+---
+
+## Exit criteria for this test plan
+
+- All §A–D cases pass on `ubuntu-latest` and `macos-latest` in CI.
+- §E network tests documented as manually run and passing at PR time;
+  not wired into CI.
+- §F compile guard passes.
+- `warn!` logs for `geosite:` and no-MMDB scenarios are emitted exactly
+  once (at parse/startup time), not once per query.
+- No regression in existing plain-UDP resolver tests.
+
+## CI wiring required
+
+Add `nameserver_policy_tests` (or the relevant test binary name for
+`crates/mihomo-dns/src/resolver.rs` unit tests and
+`crates/mihomo-config/tests/config_test.rs` new cases) to both the
+`ubuntu-latest` and `macos-latest` jobs in `.github/workflows/test.yml`.
+
+The §E integration tests are `#[ignore]` — no CI wiring needed.
+
+## Open questions for engineer
+
+1. **MMDB stub interface for §B tests.** `FallbackFilter::should_use_fallback`
+   accepts `Option<&MaxMindDB>`. For unit tests, confirm whether a test-only
+   stub MMDB can be constructed with a controlled `lookup_country` result, or
+   whether the method signature should accept a `trait GeoIpLookup` for
+   injectability. Either is fine — document the seam.
+2. **`select_ok` error semantics.** When all servers in a pool return `Err`,
+   `select_ok` returns the last error. Confirm the error returned to the caller
+   is wrapped with context identifying the pool (policy vs global vs fallback)
+   to aid debugging.
+3. **Warn-once implementation.** The spec requires warn-once at startup for
+   `geosite:` entries and no-MMDB. Confirm this uses a `std::sync::Once` or
+   equivalent, not a per-query guard, so the warn appears in startup logs
+   even before any query arrives.

--- a/docs/specs/inbound-auth-acl-test-plan.md
+++ b/docs/specs/inbound-auth-acl-test-plan.md
@@ -1,0 +1,220 @@
+# Test Plan: Inbound authentication and LAN ACLs (M1.F-3)
+
+Status: **draft** — owner: pm. Last updated: 2026-04-18.
+Tracks: task #21. Companion to `docs/specs/inbound-auth-acl.md`.
+
+This is the QA-owned acceptance test plan. The spec's `§Test plan` section
+is the PM's starting point; this document is the final shape engineer should
+implement against. If the spec and this document disagree, **this document
+wins for test cases** — flag the discrepancy so the spec can be updated.
+
+Divergence-comment convention per memory (`feedback_spec_divergence_comments.md`):
+inline `Upstream: file::fn` + `NOT X` lines on bullets that exercise a
+divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
+
+## Scope and guardrails
+
+**In scope:**
+
+- `Credentials` struct: `verify()` correctness and constant-time comparison.
+- `AuthConfig`: `should_skip()` CIDR matching, loopback always-skip invariant.
+- SOCKS5 listener auth: method negotiation (0x02 vs 0xFF), sub-negotiation
+  success/failure, `Metadata.in_user` population.
+- HTTP listener auth: `Proxy-Authorization: Basic` check on CONNECT and
+  forward-proxy requests, 407 responses, `Metadata.in_user` population.
+- Mixed listener: auth delegated to detected sub-protocol handler.
+- Config parser: `authentication:` and `skip-auth-prefixes:` YAML fields,
+  malformed entry detection, empty-password warn.
+- TProxy bypass: auth unconditionally skipped, `Metadata.in_user == None`.
+- Both Class A divergences (malformed entry hard error, invalid CIDR hard error)
+  and the Class B divergence (empty password warn-once).
+
+**Out of scope (forbidden per spec §Out of scope):**
+
+- Per-listener auth config — global auth list only in M1.
+- Digest / NTLM HTTP auth — Basic only.
+- RADIUS or external auth backends.
+- Rate limiting / brute-force protection — M2+.
+- `IN-USER` rule dispatch — spec only populates `Metadata.in_user`; rule
+  matching is M1.D-4 (requires both M1.F-1 and M1.F-3).
+- Password hashing (bcrypt/argon2) — plain text, matching upstream, M2+.
+- Throughput / latency benchmarks — M2.
+
+## File layout expected
+
+```
+crates/mihomo-config/src/
+  auth.rs              # NEW: Credentials, AuthConfig structs
+  raw.rs               # MODIFIED: authentication, skip_auth_prefixes fields
+  config_parser.rs     # MODIFIED: parse auth fields, build AuthConfig
+crates/mihomo-common/src/
+  metadata.rs          # MODIFIED: in_user: Option<String> field
+crates/mihomo-listener/src/
+  socks5.rs            # MODIFIED: auth check before handshake
+  http_proxy.rs        # MODIFIED: auth check after CONNECT line
+  mixed.rs             # MODIFIED: Arc<AuthConfig> plumbed through
+  tproxy/mod.rs        # MODIFIED: Arc<AuthConfig> accepted but not used (TProxy bypass)
+crates/mihomo-config/tests/
+  config_test.rs       # MODIFIED: auth config parse cases
+crates/mihomo-listener/tests/
+  auth_integration_test.rs  # NEW: listener auth integration tests
+```
+
+## Divergence table
+
+Following ADR-0002 classification format:
+
+| # | Case | Class | Note |
+|---|------|:-----:|------|
+| 1 | Malformed `user:pass` entry (no colon) — upstream silently ignores | A | Hard parse error. Upstream: `config/config.go::parseAuthentication` — entry with no `:` is appended as user=entry, pass="". NOT silent accept. |
+| 2 | Empty password (`user:`) — upstream accepts without warning | B | Warn-once at parse time. NOT hard error — empty passwords are valid but likely a typo. |
+| 3 | Invalid CIDR in `skip-auth-prefixes` — upstream silently ignores | A | Hard parse error. An invalid CIDR produces a skip-list that is smaller than the operator intended, potentially exposing auth-required endpoints. NOT silent ignore. |
+| 4 | Loopback removal from skip-list — upstream allows `allow-lan: true` without preserving loopback bypass | A | `127.0.0.1/32` and `::1/128` always in skip-list, even when `skip-auth-prefixes: []` explicitly. NOT removable. |
+
+---
+
+## Case list
+
+### A. `Credentials` unit tests (`crates/mihomo-config/src/auth.rs`)
+
+Pure unit tests, no network, no tokio.
+
+| # | Case | Asserts |
+|---|------|---------|
+| A1 | `credentials_verify_correct_password` | Store `alice:hunter2`. `verify("alice", "hunter2")` → `true`. |
+| A2 | `credentials_verify_wrong_password` | `verify("alice", "wrongpass")` → `false`. NOT panic. |
+| A3 | `credentials_verify_unknown_user` | `verify("nobody", "anything")` → `false`. NOT panic. |
+| A4 | `credentials_verify_empty_username` | `verify("", "pass")` → `false`. NOT panic or index error. |
+| A5 | `credentials_verify_empty_password_stored` | Store `bob:` (empty password). `verify("bob", "")` → `true`. `verify("bob", "x")` → `false`. Empty password is valid once stored. |
+| A6 | `credentials_is_empty_true_when_no_entries` | `Credentials` constructed from `[]` → `is_empty()` returns `true`. |
+| A7 | `credentials_is_empty_false_with_entries` | One entry → `is_empty()` returns `false`. |
+| A8 | `credentials_verify_uses_constant_time_comparison` **[guard-rail]** | Structural test: grep the implementation of `verify()` for `subtle::ConstantTimeEq` or equivalent. Assert it is NOT a bare `==` or `!=` comparison on `String`/`&str`. This is a code-review gate, not a timing test. Document the grep pattern in the PR checklist. |
+| A9 | `credentials_multiple_users_independent` **[guard-rail]** | Store `alice:pass1`, `bob:pass2`. `verify("alice", "pass2")` → `false`. `verify("bob", "pass1")` → `false`. Guards that credential pairs are not cross-matched. |
+
+### B. `AuthConfig::should_skip` unit tests (`crates/mihomo-config/src/auth.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| B1 | `should_skip_loopback_ipv4_always` | `AuthConfig` built with empty `skip-auth-prefixes`. `should_skip("127.0.0.1")` → `true`. <br/> Upstream: `config/config.go::parseAuthentication` — loopback is not automatically added; operator must include it. <br/> NOT requires explicit config — Class A per ADR-0002: missing loopback bypass breaks local tooling. |
+| B2 | `should_skip_loopback_ipv6_always` | `should_skip("::1")` → `true` with empty prefix list. |
+| B3 | `should_skip_configured_subnet` | `skip-auth-prefixes: ["192.168.0.0/24"]`. `should_skip("192.168.0.1")` → `true`. |
+| B4 | `should_skip_outside_subnet` | Same config. `should_skip("10.0.0.1")` → `false`. |
+| B5 | `should_skip_subnet_boundary` **[guard-rail]** | `skip-auth-prefixes: ["192.168.0.0/24"]`. `should_skip("192.168.0.255")` → `true`; `should_skip("192.168.1.0")` → `false`. Guards CIDR boundary arithmetic. |
+| B6 | `should_skip_ipv6_configured_prefix` | `skip-auth-prefixes: ["fd00::/8"]`. `should_skip("fd00::1")` → `true`. |
+| B7 | `should_skip_explicit_empty_list_still_skips_loopback` | `skip-auth-prefixes: []` explicitly. `should_skip("127.0.0.1")` → `true`. Loopback is unconditional regardless of explicit empty. |
+| B8 | `should_skip_false_for_public_ip` | No `skip-auth-prefixes`. `should_skip("8.8.8.8")` → `false`. |
+
+### C. SOCKS5 listener auth integration tests (`crates/mihomo-listener/tests/auth_integration_test.rs`)
+
+All `#[tokio::test]`, loopback connections only.
+
+| # | Case | Asserts |
+|---|------|---------|
+| C1 | `socks5_no_auth_config_admits_all` | No `authentication:` config. Client connects with no auth. Assert connection admitted. `Metadata.in_user == None`. Regression guard: existing no-auth behavior unchanged. |
+| C2 | `socks5_correct_credentials_admitted` | `authentication: [alice:hunter2]`. Client negotiates method `0x02`, sends `alice` / `hunter2`. Assert admitted. `Metadata.in_user == Some("alice")`. <br/> Upstream: `listener/socks5/tcp.go::handleConn` — credentials checked here. |
+| C3 | `socks5_wrong_password_rejected` | Same config. Client sends correct user, wrong password. Assert server sends `[0x01, 0x01]` (auth failure per RFC 1929 §3). Assert connection closed. <br/> Upstream: `listener/socks5/tcp.go` — sends auth failure response. NOT left open. |
+| C4 | `socks5_unknown_user_rejected` | Client sends user not in store. Assert `[0x01, 0x01]` and close. |
+| C5 | `socks5_client_offers_only_no_auth_method_rejected` | Client hello: methods `[0x00]` only (no auth offered). Server replies `[0x05, 0xFF]` (no acceptable methods). Assert connection closed. |
+| C6 | `socks5_client_offers_both_methods_server_selects_userpass` **[guard-rail]** | Client hello: methods `[0x00, 0x02]`. Assert server selects `0x02`, not `0x00`. Guards that server does not accept no-auth when credentials are configured. |
+| C7 | `socks5_skip_prefix_bypasses_auth` | `authentication: [alice:hunter2]`, `skip-auth-prefixes: ["127.0.0.1/32"]`. Client from `127.0.0.1` connects with no auth. Assert admitted (method `0x00`). `Metadata.in_user == None`. |
+| C8 | `socks5_non_skip_ip_must_authenticate` **[guard-rail]** | Same config. Client from `127.0.0.2` (not loopback, not in skip list) offers no auth. Assert `[0x05, 0xFF]` and close. Guards that skip-prefix check is IP-specific, not global. |
+| C9 | `socks5_in_user_populated_on_success` | Verify `Metadata.in_user` contains the exact username string from the credential that authenticated. Assert case-sensitive match. |
+| C10 | `socks5_in_user_none_on_skip_prefix` | Connection from skip-prefix IP. Assert `Metadata.in_user == None` (not `Some("")`). |
+
+### D. HTTP listener auth integration tests (`crates/mihomo-listener/tests/auth_integration_test.rs`)
+
+All `#[tokio::test]`, loopback, real HTTP framing.
+
+| # | Case | Asserts |
+|---|------|---------|
+| D1 | `http_no_auth_config_admits_all` | No `authentication:`. CONNECT request with no `Proxy-Authorization`. Assert `200 Connection established`. Regression guard. |
+| D2 | `http_connect_correct_basic_auth_admitted` | `authentication: [alice:hunter2]`. CONNECT with `Proxy-Authorization: Basic YWxpY2U6aHVudGVyMg==` (base64 of `alice:hunter2`). Assert `200`. `Metadata.in_user == Some("alice")`. <br/> Upstream: `listener/http/proxy.go::handleConn` — Basic auth checked here. |
+| D3 | `http_connect_no_auth_header_returns_407` | Auth configured. CONNECT with no `Proxy-Authorization`. Assert `407 Proxy Authentication Required`. Assert response includes `Proxy-Authenticate: Basic realm="mihomo"`. <br/> Upstream: `listener/http/proxy.go` — returns 407. NOT 401 (Proxy auth uses 407, not 401). |
+| D4 | `http_connect_wrong_password_returns_407` | CONNECT with `Proxy-Authorization: Basic` containing wrong password. Assert `407`. |
+| D5 | `http_connect_unknown_user_returns_407` | User not in store. Assert `407`. |
+| D6 | `http_connect_malformed_base64_returns_407` **[guard-rail]** | `Proxy-Authorization: Basic not-valid-base64!!!`. Assert `407`. NOT panic or 500. |
+| D7 | `http_connect_no_colon_in_decoded_credentials_returns_407` **[guard-rail]** | `Proxy-Authorization: Basic` with valid base64 that decodes to `alicehunter2` (no colon). Assert `407`. NOT split at wrong position. |
+| D8 | `http_forward_proxy_request_requires_auth` | Non-CONNECT forward proxy `GET http://example.com/ HTTP/1.1`. Auth configured, no header. Assert `407`. <br/> Upstream: `listener/http/proxy.go` — both CONNECT and forward proxy checked. We match. |
+| D9 | `http_skip_prefix_bypasses_auth` | Auth configured, `skip-auth-prefixes: ["127.0.0.1/32"]`. CONNECT from `127.0.0.1` with no auth. Assert `200`. `Metadata.in_user == None`. |
+| D10 | `http_407_closes_connection_after_failure` **[guard-rail]** | After a `407` response, assert the server does not leave the connection open for re-use. Prevents auth bypass via persistent connection reuse. |
+| D11 | `http_in_user_populated_correct_username` | Verify `Metadata.in_user == Some("alice")` not `Some("alice:hunter2")` (password not leaked into in_user). |
+
+### E. TProxy bypass tests (`crates/mihomo-listener/tests/auth_integration_test.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| E1 | `tproxy_auth_never_applied` | TProxy listener constructed with `authentication: [alice:hunter2]`. Accept a transparent connection. Assert connection proceeds without auth challenge. `Metadata.in_user == None`. <br/> Upstream: `listener/tproxy/` — no auth in TProxy path. We match by explicit design (§TProxy connections bypass auth unconditionally). |
+| E2 | `tproxy_in_user_always_none` | Any TProxy connection regardless of source IP. Assert `Metadata.in_user == None`, not `Some(...)`. |
+
+### F. Config parser tests (`crates/mihomo-config/tests/config_test.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| F1 | `parse_authentication_single_entry` | `authentication: ["alice:hunter2"]`. Assert `Credentials` contains `alice → hunter2`. |
+| F2 | `parse_authentication_multiple_entries` | Three entries. Assert all three stored. |
+| F3 | `parse_authentication_absent_means_no_auth` | No `authentication:` key. Assert `credentials.is_empty() == true`. |
+| F4 | `parse_authentication_empty_list_means_no_auth` | `authentication: []`. Assert `is_empty() == true`. |
+| F5 | `parse_authentication_malformed_no_colon_hard_errors` | `authentication: ["alicehunter2"]` (no colon). Assert `Err` at parse. <br/> Upstream: `config/config.go::parseAuthentication` — entry stored with empty password (silent). <br/> NOT silent — Class A per ADR-0002: almost certainly a config typo. |
+| F6 | `parse_authentication_empty_password_warns` | `authentication: ["alice:"]`. Assert `Ok`. Assert one `warn!` log emitted at parse time. NOT error. Class B per ADR-0002. |
+| F7 | `parse_authentication_empty_username_hard_errors` **[guard-rail]** | `authentication: [":hunter2"]`. Assert `Err`. A credential with an empty username can never match. Upstream: silently accepts. NOT silent — same rationale as F5. |
+| F8 | `parse_skip_auth_prefixes_valid_cidrs` | Two valid CIDRs. Assert both parsed into `skip_prefixes`. |
+| F9 | `parse_skip_auth_prefixes_invalid_cidr_hard_errors` | `skip-auth-prefixes: ["not-a-cidr"]`. Assert `Err`. <br/> Upstream: `config/config.go` — invalid CIDR silently dropped. <br/> NOT silent — Class A per ADR-0002: a smaller-than-intended skip list exposes auth-required endpoints. |
+| F10 | `parse_skip_auth_prefixes_absent_defaults_to_loopback_only` | No `skip-auth-prefixes:` key. Assert `skip_prefixes` contains `127.0.0.1/32` and `::1/128` and nothing else. |
+| F11 | `parse_skip_auth_prefixes_explicit_empty_still_has_loopback` | `skip-auth-prefixes: []`. Assert `skip_prefixes` still contains `127.0.0.1/32` and `::1/128`. Loopback cannot be removed. |
+| F12 | `parse_authentication_colon_in_password` **[guard-rail]** | `authentication: ["alice:pass:with:colons"]`. Assert username `alice`, password `pass:with:colons` (split on first colon only). |
+
+### G. `Metadata.in_user` field regression guard
+
+| # | Case | Asserts |
+|---|------|---------|
+| G1 | `metadata_in_user_defaults_to_none` **[guard-rail]** | `Metadata::default()` → `in_user == None`. Guards that the new field doesn't break any code that constructs `Metadata` without setting `in_user`. |
+| G2 | `metadata_in_user_does_not_leak_password` **[guard-rail]** | After successful auth, assert `in_user` contains only the username, not the password or the `user:pass` pair. Structural test: assert `in_user` value does not contain `":"`. |
+
+---
+
+## Deferred / not tested here
+
+- `IN-USER` rule matching dispatch — M1.D-4 (requires both F-1 and F-3).
+- Per-listener auth config — M2+.
+- Digest / NTLM HTTP auth — deferred per spec §Out of scope.
+- Password hashing — M2+.
+- Rate limiting on auth failure — M2+.
+- Throughput — M2 benchmark harness.
+
+---
+
+## Exit criteria for this test plan
+
+- All §A–G cases pass on `ubuntu-latest` and `macos-latest` in CI.
+- §A8 constant-time comparison guard documented in PR checklist (code review,
+  not a timing test).
+- No regression in existing SOCKS5 and HTTP integration tests.
+- `Metadata.in_user` field present in `mihomo-common` before any listener
+  changes land — field addition is a separate, additive commit.
+
+## CI wiring required
+
+Add to `.github/workflows/test.yml`:
+
+1. `cargo test -p mihomo-config --test config_test` — picks up §F cases.
+2. `cargo test -p mihomo-listener --test auth_integration_test` — new binary for
+   §C–E cases. Add to both `ubuntu-latest` and `macos-latest` jobs.
+3. `cargo test -p mihomo-common --lib` — picks up §G1 regression guard
+   (already wired if common lib tests run; new field addition is additive).
+
+## Open questions for engineer
+
+1. **`subtle` crate placement.** The spec recommends adding `subtle` to the
+   workspace. Confirm whether it should be a direct dependency of
+   `mihomo-config` (where `Credentials` lives) or `mihomo-common`. Add to
+   `Cargo.toml` workspace members only, not re-exported.
+2. **407 connection handling.** After sending a 407, confirm whether the
+   server closes the TCP connection immediately or leaves it open for a retry
+   with credentials. HTTP/1.1 allows a retry on the same connection for
+   `407`, but many clients open a new connection. The spec says "close" — if
+   the engineer chooses keep-alive retry, update §D10 accordingly before merging.
+3. **Mixed listener auth delegation.** When the mixed listener detects HTTP
+   (vs SOCKS5) and hands off to the HTTP sub-handler, confirm `Arc<AuthConfig>`
+   is passed through and the IP used for `should_skip()` is the original TCP
+   `src_addr`, not a proxy-forwarded header value. Proxy-forwarded IPs are
+   trivially spoofable and must not affect auth decisions.

--- a/docs/specs/listeners-unified-test-plan.md
+++ b/docs/specs/listeners-unified-test-plan.md
@@ -1,0 +1,207 @@
+# Test Plan: Unified named listeners (M1.F-1)
+
+Status: **draft** — owner: pm. Last updated: 2026-04-18.
+Tracks: task #19. Companion to `docs/specs/listeners-unified.md`.
+
+This is the QA-owned acceptance test plan. The spec's `§Test plan` section
+is the PM's starting point; this document is the final shape engineer should
+implement against. If the spec and this document disagree, **this document
+wins for test cases** — flag the discrepancy so the spec can be updated.
+
+Divergence-comment convention per memory (`feedback_spec_divergence_comments.md`):
+inline `Upstream: file::fn` + `NOT X` lines on bullets that exercise a
+divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
+
+## Scope and guardrails
+
+**In scope:**
+
+- Config parser (`crates/mihomo-config/src/`) — `listeners:` array parsing,
+  shorthand field auto-naming, duplicate port/name detection.
+- Listener construction — `name: String` stored at construction time in all
+  four listener types (mixed, http, socks5, tproxy).
+- `Metadata.in_name` and `Metadata.in_port` population on each accepted
+  connection in all four listener implementations.
+- `IN-NAME`, `IN-PORT`, `IN-TYPE` rule matching against populated Metadata.
+- `GET /listeners` REST endpoint (list only, no mutation).
+- All four Class A divergences: duplicate port, duplicate name, unknown type,
+  shorthand+named port collision.
+
+**Out of scope (forbidden per spec §Out of scope):**
+
+- `IN-USER` rule — requires M1.F-3 auth; `Metadata.in_user` is not
+  populated here.
+- Redir and tunnel listener types — deferred to M1.F-4/F-5.
+- Per-listener proxy overrides — M3.
+- Hot-adding/removing listeners at runtime — M3.
+- Auth/ACL on listeners — M1.F-3 spec.
+- TProxy correctness (SO_ORIGINAL_DST, nftables) — covered by existing
+  tproxy integration tests; not repeated here.
+
+## File layout expected
+
+```
+crates/mihomo-config/src/
+  raw.rs               # MODIFIED: RawListener struct, listeners field on RawConfig
+  config_parser.rs     # MODIFIED: parse listeners:, merge shorthand, dedup checks
+crates/mihomo-listener/src/
+  mixed.rs             # MODIFIED: name field, Metadata.in_name/in_port population
+  http_proxy.rs        # MODIFIED: same
+  socks5.rs            # MODIFIED: same
+  tproxy/mod.rs        # MODIFIED: same
+crates/mihomo-rules/src/
+  parser.rs            # MODIFIED: IN-TYPE dispatch added
+crates/mihomo-api/src/
+  routes.rs            # MODIFIED: GET /listeners handler + route
+crates/mihomo-config/tests/
+  config_test.rs       # MODIFIED: new listeners-related cases
+crates/mihomo-listener/tests/
+  listener_metadata_test.rs  # NEW: in_name/in_port population tests
+```
+
+## Divergence table
+
+Following ADR-0002 classification format:
+
+| # | Case | Class | Note |
+|---|------|:-----:|------|
+| 1 | Duplicate listener port — upstream silently overwrites last | A | Hard parse error: `"port N already used by listener 'M'"`. Upstream: `config/config.go::parseListeners` — last entry wins, no warning. NOT silent overwrite. |
+| 2 | Duplicate listener name — upstream silently overwrites last | A | Hard parse error: `"listener name 'X' already defined"`. Same upstream behavior. NOT silent overwrite. |
+| 3 | Unknown listener type — upstream ignores the entry | A | Hard parse error. Upstream: `listener/listener.go` — unknown type logged and skipped. NOT silent ignore: a misconfigured listener type means no proxy for that port. |
+| 4 | Shorthand port + `listeners:` entry on same port — upstream accepts | A | Hard parse error. Same dedup rule as duplicate `listeners:` entries. NOT accepted. |
+| 5 | Unknown `IN-TYPE` value — upstream silently no-match | A | Hard parse error at rule-load time. Upstream: `rules/parser.go` — unknown IN-TYPE returns false. NOT silent no-match: a typo in `IN-TYPE,QUIC` would silently never route, which is worse than a startup error. |
+
+---
+
+## Case list
+
+### A. Config parser unit tests (`crates/mihomo-config/tests/config_test.rs`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| A1 | `parse_named_listener_socks5_all_fields` | YAML `listeners: [{name: corp-socks, type: socks5, port: 7891, listen: 0.0.0.0}]`. Assert `NamedListener { name: "corp-socks", listener_type: Socks5, port: 7891, listen: 0.0.0.0:7891 }`. |
+| A2 | `parse_named_listener_mixed` | `type: mixed`. Assert `ListenerType::Mixed`. |
+| A3 | `parse_named_listener_http` | `type: http`. Assert `ListenerType::Http`. |
+| A4 | `parse_named_listener_tproxy` | `type: tproxy`. Assert `ListenerType::TProxy`. |
+| A5 | `parse_named_listener_listen_defaults_to_global_bind` | Entry with no `listen` field. Assert `listen` address matches global `bind-address` (or `127.0.0.1` if not set). |
+| A6 | `parse_named_listener_listen_overrides_global` | Global `bind-address: 127.0.0.1`, listener `listen: 0.0.0.0`. Assert listener's resolved `listen` is `0.0.0.0`, not `127.0.0.1`. |
+| A7 | `parse_shorthand_mixed_port_auto_names` | `mixed-port: 7890`, no `listeners:` block. Assert resulting listener list contains `NamedListener { name: "mixed", type: Mixed, port: 7890 }`. |
+| A8 | `parse_shorthand_http_port_auto_names` | `http-port: 7891`. Assert name `"http"`. |
+| A9 | `parse_shorthand_socks_port_auto_names` | `socks-port: 1080`. Assert name `"socks"`. |
+| A10 | `parse_shorthand_tproxy_port_auto_names` | `tproxy-port: 7892`. Assert name `"tproxy"`. |
+| A11 | `parse_shorthand_and_named_listeners_coexist` | `mixed-port: 7890` plus `listeners: [{name: corp-socks, type: socks5, port: 7891}]`. Assert both present in the merged listener list. |
+| A12 | `parse_duplicate_port_in_named_listeners_hard_errors` | Two `listeners:` entries both on port 7891. Assert `Err` containing `"port"` and `"7891"`. <br/> Upstream: `config/config.go::parseListeners` — last entry silently overwrites. <br/> NOT silent overwrite — Class A per ADR-0002. |
+| A13 | `parse_duplicate_name_in_named_listeners_hard_errors` | Two `listeners:` entries both named `"corp-socks"`. Assert `Err` containing `"corp-socks"`. <br/> Upstream: same silent-overwrite behavior. <br/> NOT silent overwrite — Class A per ADR-0002. |
+| A14 | `parse_shorthand_and_named_same_port_hard_errors` | `mixed-port: 7890` and `listeners: [{name: foo, type: socks5, port: 7890}]`. Assert `Err`. <br/> Upstream: `config/config.go` accepts this (two listeners on same port, both spawn). <br/> NOT accepted — Class A per ADR-0002: two listeners on the same port is a bind-failure at runtime; fail loudly at parse. |
+| A15 | `parse_unknown_listener_type_hard_errors` | `type: redir`. Assert `Err` containing `"redir"` and the listener name. <br/> Upstream: `listener/listener.go` — unknown type logged and skipped. <br/> NOT silent ignore — Class A per ADR-0002. |
+| A16 | `parse_listeners_empty_array_is_valid` | `listeners: []`. Assert `Ok`, empty listener list from `listeners:` block (shorthand still applies). |
+| A17 | `parse_listeners_absent_is_valid` | No `listeners:` key. Assert `Ok`. Shorthand ports work as before. |
+| A18 | `parse_tproxy_sni_field_forwarded` **[guard-rail]** | `type: tproxy, tproxy-sni: true`. Assert `tproxy_sni: true` in parsed struct. Non-tproxy entry with `tproxy-sni` → warn-once and ignore (not a parse error). |
+
+### B. Listener Metadata population tests (`crates/mihomo-listener/tests/listener_metadata_test.rs`)
+
+All require a tokio runtime (`#[tokio::test]`). Use loopback connections, no
+external network. Assert fields on the `Metadata` passed to the tunnel
+callback.
+
+| # | Case | Asserts |
+|---|------|---------|
+| B1 | `mixed_listener_populates_in_name` | Construct `MixedListener` with `name = "my-mixed"`. Accept a connection. Assert `metadata.in_name == "my-mixed"`. <br/> Upstream: `listener/listener.go` — `inbound.NewMixed` does not set `in_name`; Metadata's `SpecialProxy` field is used loosely. <br/> NOT zero-value `in_name` — spec §Metadata population: every listener stores its name and stamps every Metadata. |
+| B2 | `mixed_listener_populates_in_port` | Same listener on port 7890. Assert `metadata.in_port == 7890`. |
+| B3 | `http_listener_populates_in_name_and_port` | `HttpListener { name: "corp-http", port: 7891 }`. Assert `metadata.in_name == "corp-http"` and `metadata.in_port == 7891`. |
+| B4 | `socks5_listener_populates_in_name_and_port` | `Socks5Listener { name: "corp-socks", port: 1080 }`. Assert both fields. |
+| B5 | `tproxy_listener_populates_in_name_and_port` | `TProxyListener { name: "transparent", port: 7892 }`. Assert both fields. |
+| B6 | `mixed_listener_http_conn_type` | CONNECT-via-HTTP connection through mixed listener. Assert `metadata.conn_type == ConnType::Http` (or `Https` for CONNECT). |
+| B7 | `socks5_listener_sets_socks5_conn_type` | SOCKS5 connection. Assert `metadata.conn_type == ConnType::Socks5`. |
+| B8 | `two_listeners_different_names_stamp_correctly` **[guard-rail]** | Two listeners spawned simultaneously: `"corp"` on port 7891, `"personal"` on port 7892. Connect to each. Assert each connection's Metadata carries its own listener's name and port, not the other's. Guards against shared/static name state. |
+| B9 | `shorthand_listener_in_name_is_auto_name` | Listener spawned from `mixed-port: 7890` shorthand (auto-name `"mixed"`). Assert `metadata.in_name == "mixed"`. |
+
+### C. IN-NAME / IN-PORT / IN-TYPE rule matching unit tests (`crates/mihomo-rules/`)
+
+Pure unit tests on the rule matching logic. No network, no listener required.
+
+| # | Case | Asserts |
+|---|------|---------|
+| C1 | `in_name_rule_matches_exact_name` | `Metadata { in_name: "corp-socks", .. }`. Rule `IN-NAME,corp-socks,Target`. Assert match. |
+| C2 | `in_name_rule_no_match_different_name` | `in_name: "personal"`. Rule `IN-NAME,corp-socks,Target`. Assert no match. |
+| C3 | `in_name_rule_no_match_empty_in_name` | `in_name: ""` (zero value, pre-M1.F-1 behavior). Rule `IN-NAME,corp-socks,Target`. Assert no match. NOT panic. |
+| C4 | `in_port_rule_matches_configured_port` | `Metadata { in_port: 7891, .. }`. Rule `IN-PORT,7891,Target`. Assert match. |
+| C5 | `in_port_rule_no_match_different_port` | `in_port: 7892`. Rule `IN-PORT,7891,Target`. Assert no match. |
+| C6 | `in_type_http_matches_http_conn_type` | `Metadata { conn_type: ConnType::Http }`. Rule `IN-TYPE,HTTP`. Assert match. |
+| C7 | `in_type_http_matches_https_conn_type` | `Metadata { conn_type: ConnType::Https }`. Rule `IN-TYPE,HTTP`. Assert match. `IN-TYPE,HTTP` is a superset of HTTP+HTTPS per spec §IN-TYPE rule mapping. |
+| C8 | `in_type_https_matches_only_https` | `ConnType::Http`. Rule `IN-TYPE,HTTPS`. Assert no match. `IN-TYPE,HTTPS` is HTTPS-only. |
+| C9 | `in_type_socks5_matches_socks5` | `ConnType::Socks5`. Rule `IN-TYPE,SOCKS5`. Assert match. |
+| C10 | `in_type_tproxy_matches_tproxy` | `ConnType::TProxy`. Rule `IN-TYPE,TPROXY`. Assert match. |
+| C11 | `in_type_inner_matches_inner` | `ConnType::Inner`. Rule `IN-TYPE,INNER`. Assert match. |
+| C12 | `in_type_cross_type_no_match` **[guard-rail]** | `ConnType::Socks5`. Rule `IN-TYPE,HTTP`. Assert no match. Guards that conn_type dispatch doesn't cross-match. |
+| C13 | `in_type_unknown_value_hard_errors_at_parse` | Rule string `"IN-TYPE,QUIC,Target"`. Assert parse returns `Err`. <br/> Upstream: `rules/parser.go` — unknown IN-TYPE silently returns false at match time. <br/> NOT silent no-match — Class A per ADR-0002: a typo would silently never route all traffic of that type. |
+| C14 | `in_name_rule_case_sensitive` **[guard-rail]** | `in_name: "Corp-Socks"`. Rule `IN-NAME,corp-socks,Target`. Assert no match. Rule matching is case-sensitive — listener names are exact strings, not normalized. |
+
+### D. GET /listeners API endpoint tests (`crates/mihomo-api/`)
+
+| # | Case | Asserts |
+|---|------|---------|
+| D1 | `get_listeners_returns_all_running_listeners` | App started with `mixed-port: 7890` and `listeners: [{name: corp-socks, type: socks5, port: 7891}]`. `GET /listeners`. Assert 200, JSON array with two objects: `{name: "mixed", type: "mixed", port: 7890}` and `{name: "corp-socks", type: "socks5", port: 7891}`. |
+| D2 | `get_listeners_empty_when_none_configured` | No ports configured. `GET /listeners`. Assert 200, empty JSON array `[]`. |
+| D3 | `get_listeners_listen_address_included` | Listener with explicit `listen: 0.0.0.0`. Assert response object includes `"listen": "0.0.0.0"`. |
+| D4 | `get_listeners_requires_bearer_auth` | `GET /listeners` with no `Authorization` header when `secret` is set. Assert 401. |
+| D5 | `get_listeners_no_mutation_endpoint` **[guard-rail]** | `POST /listeners`, `DELETE /listeners/corp-socks`. Assert 405 Method Not Allowed (or 404). Hot-add/remove is M3. |
+
+### E. Integration test (end-to-end rule routing via named listener)
+
+`#[tokio::test]`, loopback only. Starts a real listener, connects, asserts
+the rule fires correctly.
+
+| # | Case | Asserts |
+|---|------|---------|
+| E1 | `in_name_rule_routes_connection_to_correct_proxy` | Two SOCKS5 listeners: `"corp"` on port 18001, `"personal"` on port 18002. Rules: `IN-NAME,corp,Direct` first, `IN-NAME,personal,Reject` second. Connect via `"corp"` listener → Direct. Connect via `"personal"` listener → Reject (connection refused). |
+| E2 | `in_type_rule_routes_by_listener_type` | Mixed listener (HTTP + SOCKS5 on same port). HTTP request → `IN-TYPE,HTTP,Direct` rule fires. SOCKS5 request → `IN-TYPE,SOCKS5,Reject` rule fires. |
+
+---
+
+## Deferred / not tested here
+
+- `IN-USER` rule — requires M1.F-3 auth, `Metadata.in_user` not populated here.
+- Redir / tunnel listener types — M1.F-4/F-5.
+- Per-listener proxy override — M3.
+- Hot reload of listener list — M3.
+- TProxy correctness (SO_ORIGINAL_DST, nftables rules) — existing tproxy
+  integration tests cover this.
+
+---
+
+## Exit criteria for this test plan
+
+- All §A–D cases pass on `ubuntu-latest` and `macos-latest` in CI.
+- §E integration tests pass on `ubuntu-latest`; `tproxy` cases Linux-only
+  (skip on macOS with `#[cfg(target_os = "linux")]`).
+- `Metadata.in_name` is never `""` for any connection accepted by a named
+  listener — assert via §B8 that the zero-value cannot appear from a running
+  listener.
+- `cargo test --lib -p mihomo-rules` includes the new IN-TYPE parser cases.
+
+## CI wiring required
+
+Add to `.github/workflows/test.yml`:
+
+1. `cargo test -p mihomo-config --test config_test` — picks up §A cases (already
+   in CI if config_test.rs is wired; new cases are additive).
+2. `cargo test -p mihomo-listener --test listener_metadata_test` — new test
+   binary for §B cases.
+3. §E integration tests: add to the existing `rules_test` or a new
+   `listener_integration` binary in the `ubuntu-latest` job.
+
+## Open questions for engineer
+
+1. **`ConnType` for HTTPS through mixed listener.** The mixed listener receives
+   both plain HTTP and CONNECT (tunnel) requests. Confirm whether `ConnType::Https`
+   is set for the CONNECT tunnel case or only after TLS is detected by the sniffer
+   (M1.F-2). If it's always `Http` at the mixed-listener boundary, `IN-TYPE,HTTPS`
+   may not be testable until M1.F-2 lands — flag in the PR.
+2. **`in_port` source.** Spec says `metadata.in_port = self.listen.port()`. Confirm
+   this is the listener's configured port (e.g. 7891), not the ephemeral source port
+   of the client connection. The `IN-PORT` rule matches on the listener's port, not
+   the client's.
+3. **`GET /listeners` auth.** Confirm whether the endpoint follows the same Bearer
+   auth pattern as other `GET` endpoints (required when `secret` is set). If there
+   is a global auth middleware, no per-route work is needed — just register the route.


### PR DESCRIPTION
## Summary

- Adds/updates `docs/migration-from-go-mihomo.md` — M1.H-3 deliverable
- Covers: supported config fields, intentionally-unsupported fields with rationale, all M1 Class A/B behavioral divergences per ADR-0002, migration steps for 4 subscription types, mihomo-rust-only features

## Key content

- Quick compatibility check (`-t` flag) at top
- Migration steps by subscription type: standard Clash Meta, enterprise split-tunnel, tproxy, proxy provider
- All new M1 Class A hard-error cases documented (duplicate port/name, empty credentials, invalid CIDR, zero-valid-nameserver, unknown IN-TYPE, URL-safe base64)
- Class B warn-once cases: alterId coerce, unknown cipher fallback, base64 raw YAML
- mihomo-rust-only: `GET /metrics` (Prometheus), `/api/*` endpoint prefix

## Test plan
- [ ] QA review: verify all Class A/B entries match spec §Divergence tables
- [ ] Team-lead review before M1 exit tag

/cc @qa