### PR TITLE
M2 specs: punch list + roadmap table + geodata tightenings

### DIFF
--- a/docs/benchmarks/hardware.md
+++ b/docs/benchmarks/hardware.md
@@ -1,0 +1,54 @@
+# Benchmark Hardware Record
+
+This file documents the reference machine used for M2 benchmark runs.
+Engineer-b (or whoever runs the bench) fills in actual values before
+committing the first baseline JSON. See ADR-0006 for the rationale on
+why hardware documentation is mandatory for reproducible comparison.
+
+## Reference machine
+
+| Field | Value |
+|-------|-------|
+| CPU model | *(e.g., Apple M3 Pro, AMD EPYC 7763, Intel Core i9-13900K)* |
+| Core count (physical / logical) | *(e.g., 11P + 2E / 14)* |
+| RAM | *(e.g., 18 GB LPDDR5)* |
+| OS / distro | *(e.g., macOS 15.4, Ubuntu 24.04 LTS)* |
+| Kernel version | *(e.g., Darwin 25.4.0, Linux 6.8.0)* |
+| CPU governor | *(e.g., performance, powersave, N/A on Apple Silicon)* |
+| NUMA topology | *(e.g., single-node, or NUMA node assignments if pinned)* |
+| Storage | *(e.g., NVMe SSD — not relevant to network benchmarks but useful context)* |
+
+## Build environment
+
+| Field | Value |
+|-------|-------|
+| Rust toolchain | *(e.g., stable 1.88.0 x86_64-unknown-linux-gnu)* |
+| zig version | *(e.g., 0.13.0 — used by cargo-zigbuild for musl targets)* |
+| mihomo-rust commit SHA | *(filled in per-run; also captured in results JSON)* |
+| mihomo-rust build flags | `cargo build --release --locked` |
+| Go mihomo version | *(e.g., v1.19.2)* |
+| Go mihomo download | `gh release download` from MetaCubeX/mihomo |
+
+## Allocator
+
+| Implementation | Allocator |
+|----------------|-----------|
+| mihomo-rust | system allocator (default; no jemalloc/mimalloc unless changed) |
+| Go mihomo | Go runtime GC allocator |
+
+Document any change to the Rust allocator (e.g., switching to `tikv-jemallocator`)
+in the commit that changes it, and record the new allocator here.
+
+## Run conditions
+
+- Both implementations run as foreground processes; no other significant workloads.
+- CPU frequency scaling: note governor setting above.
+- Warmup: `bench.sh` runs a 5-second warmup before measurement (if applicable).
+- Repetitions: single run per baseline commit; use `--duration` env var to extend.
+- Network: loopback only (both upstream proxy and load generator on same host).
+
+## Per-run fields (captured in baseline JSON, not this file)
+
+The baseline JSON (`baseline-YYYY-MM-DD.json`) includes `machine` as a string
+summary (e.g., `"aarch64, 11 cores, 18 GB, macOS 25.4"`). This file provides
+the full human-readable record. Both must be committed together.

--- a/docs/specs/allocator-audit.md
+++ b/docs/specs/allocator-audit.md
@@ -1,80 +1,104 @@
 # Spec: Allocator audit — zero per-packet allocations (M2)
 
-Status: Draft (2026-04-18)
+Status: Draft (2026-04-18, revised with engineer-a prep findings)
 Owner: engineer-a
 Tracks roadmap item: **M2** (allocator audit)
 Lane: engineer-a (perf measurement chain)
-Blocked by: benchmark-harness.md (need baseline RSS before claiming wins)
-Upstream reference: Go mihomo allocates per-packet buffers in relay loops;
-not a divergence issue — we are optimizing our own path.
+Blocked by: M2.B-2 — criterion microbenchmarks must exist first (see benchmark-harness.md)
+Upstream reference: Go mihomo allocates per-packet buffers; we are optimizing our own path.
 
-## Motivation
+## Confirmed findings (engineer-a pre-audit)
 
-The single-sentence M2 footprint goal is "zero heap allocations per forwarded
-packet on the steady state." TCP relay and UDP NAT are the hot paths:
-any `Box`/`Vec`/`Arc`-clone per packet shows up as GC pressure in Go and as
-allocator churn in Rust. The allocator audit identifies and removes these.
+### TCP relay — already zero-copy
 
-The benchmark harness (benchmark-harness.md) provides before/after RSS and
-CPU numbers. Without the baseline first, we cannot measure the win.
+`mihomo-tunnel/src/tunnel.rs` uses `tokio::io::copy_bidirectional`, which copies
+directly between reader and writer buffers with no heap allocation per forwarded byte.
+Per-connection allocations (rule_name/payload `format!`, `track_connection` boxing)
+are one-time setup costs, not per-packet. **TCP relay hot path is already clean.**
+
+Remaining allocator work is per-connection setup and UDP NAT.
+
+### UDP NAT — confirmed hot-path allocation
+
+`crates/mihomo-tunnel/src/udp.rs:30`:
+
+```rust
+let key = format!("{}:{}", src, metadata.remote_address());
+```
+
+This `String` allocation runs on **every incoming UDP packet**, including the fast
+path (existing session lookup at line 33). Because the allocation precedes the
+session check, even cache-hit packets pay the heap cost on every call to
+`handle_udp`. This is the highest-value first fix.
+
+**Proposed fix:** replace the `String` key with a structured type that implements
+`Hash + Eq` without allocating:
+
+```rust
+// Option A — if remote_address() always parses as SocketAddr:
+type NatKey = (SocketAddr, SocketAddr);
+
+// Option B — SmolStr (stack-allocated for strings ≤ 23 bytes; most SocketAddr
+// strings fit):
+type NatKey = (SocketAddr, smol_str::SmolStr);
+```
+
+Engineer-a should verify which option is safe given `remote_address()` format
+(domain names vs IP:port) and choose accordingly. Document the decision.
 
 ## Scope
 
 In scope:
 
-1. Instrument the hot path (TCP relay loop in `mihomo-tunnel/src/tunnel.rs`,
-   UDP NAT in `mihomo-tunnel/src/udp.rs`) with `dhat` or `stats_alloc` to
-   count and locate per-packet allocations.
-2. Replace identified allocations with one of:
-   - Stack-allocated fixed-size buffers (`[u8; N]` or `MaybeUninit`).
-   - A `bytes::BytesMut` pool or `tokio::io::copy_buf` with a caller-supplied
-     buffer, eliminating the per-call `Vec::new()`.
-   - Pre-allocated `Arc` clones moved outside the per-packet hot path.
-3. Re-run the benchmark harness after each change and record the delta.
-4. Document findings in `docs/benchmarks/allocator-audit-findings.md`.
+1. Fix the `format!` NAT key allocation in `udp.rs:30` (highest-value item).
+2. Audit remaining `handle_udp` path for any other per-packet allocations
+   (e.g., `DashMap` key interning, `Box<dyn ProxyPacketConn>` per new session
+   is acceptable — one-time cost).
+3. Audit per-connection setup in TCP path: `rule_name`/`payload` `format!` strings
+   and `track_connection` boxing. These are one-time per connection; fix only if
+   the connection-setup rate is high enough to show up in profiling.
+4. Re-run the criterion UDP fast-path benchmark (M2.B-2) before and after fix #1;
+   record the delta.
+5. Document findings in `docs/benchmarks/allocator-audit-findings.md`.
 
 Out of scope:
 
-- DNS resolver allocations (separate profiling concern — latency not throughput).
+- DNS resolver allocations (separate profiling concern).
 - Rule matching allocations — covered by rule-engine-micro-opt.md.
-- `unsafe` custom allocators (only if a safe rewrite is impossible and the win
-  justifies it — requires architect sign-off).
+- `unsafe` custom allocators unless a safe rewrite is impossible (requires
+  architect-2 sign-off).
 
 ## Measurement protocol
 
 ```
-# Before patch:
-cargo build --release --features dhat-heap
-DHAT_PROFILING=1 ./target/release/mihomo -f bench/config-mihomo-rust.yaml &
-# run bench/run.sh mihomo-rust for 30 s
-# save dhat output, count allocations on TCP relay path
+# Before fix:
+cargo bench -p mihomo-tunnel --bench udp_bench -- --save-baseline pre-alloc-fix
 
-# After patch:
-# same, verify zero allocs on hot path for steady-state forwarding
+# After fix:
+cargo bench -p mihomo-tunnel --bench udp_bench -- --baseline pre-alloc-fix
 ```
 
-Primary metric: allocations per packet on TCP relay (target: 0).
-Secondary metrics: RSS steady-state from benchmark harness (target: ≤ M1 baseline).
+Primary metric: allocations per fast-path UDP packet (target: 0).
+Secondary: benchmark throughput delta (p50 latency on `udp_fastpath` bench).
 
 ## Acceptance criteria
 
-1. Profiling shows zero heap allocations per forwarded packet in TCP relay
-   steady state (after the connection is established).
-2. UDP NAT allocation count per datagram ≤ 1 (one `Bytes` clone per outbound
-   datagram is acceptable; `Vec::new()` per packet is not).
-3. `cargo test --lib` still passes after all changes.
-4. RSS steady-state in the benchmark harness improves or does not regress
-   vs the pre-audit baseline.
-5. Findings (what was found, what was changed, what was deferred) documented
-   in `docs/benchmarks/allocator-audit-findings.md`.
+1. The `format!` NAT key allocation at `udp.rs:30` is eliminated for the fast
+   path (existing session lookup).
+2. The criterion `udp_fastpath` benchmark shows a measurable throughput improvement
+   vs the pre-fix baseline.
+3. UDP NAT new-session path allocates at most once per session (the `DashMap`
+   insert + proxy connection setup), not per packet.
+4. `cargo test --lib` passes after all changes.
+5. `docs/benchmarks/allocator-audit-findings.md` documents: what was found, what
+   was fixed, what was deferred, and the before/after benchmark numbers.
 
 ## Implementation checklist (engineer-a handoff)
 
-- [ ] Add `dhat` (or `stats_alloc`) dev-dependency behind a `dhat-heap` feature flag.
-- [ ] Run profiling pass on TCP relay path; record allocation sites.
-- [ ] Run profiling pass on UDP NAT path; record allocation sites.
-- [ ] For each identified allocation site: decide fix vs defer; implement fixes.
-- [ ] Re-run benchmark harness after fixes; record before/after delta.
+- [ ] Inspect `metadata.remote_address()` return type — confirm whether it's always
+      a parseable `SocketAddr` or can be a domain:port string.
+- [ ] Implement the NatKey fix (Option A or B above); run `cargo test --lib`.
+- [ ] Run criterion `udp_fastpath` bench before and after; record delta.
+- [ ] Scan remaining `handle_udp` call sites for any other per-packet allocations.
+- [ ] Audit per-connection setup in TCP path (lower priority — one-time cost).
 - [ ] Write `docs/benchmarks/allocator-audit-findings.md`.
-- [ ] Remove `dhat` profiling feature (or leave it as an optional dev feature
-      with a doc comment — engineer's call).

--- a/docs/specs/allocator-audit.md
+++ b/docs/specs/allocator-audit.md
@@ -1,0 +1,80 @@
+# Spec: Allocator audit — zero per-packet allocations (M2)
+
+Status: Draft (2026-04-18)
+Owner: engineer-a
+Tracks roadmap item: **M2** (allocator audit)
+Lane: engineer-a (perf measurement chain)
+Blocked by: benchmark-harness.md (need baseline RSS before claiming wins)
+Upstream reference: Go mihomo allocates per-packet buffers in relay loops;
+not a divergence issue — we are optimizing our own path.
+
+## Motivation
+
+The single-sentence M2 footprint goal is "zero heap allocations per forwarded
+packet on the steady state." TCP relay and UDP NAT are the hot paths:
+any `Box`/`Vec`/`Arc`-clone per packet shows up as GC pressure in Go and as
+allocator churn in Rust. The allocator audit identifies and removes these.
+
+The benchmark harness (benchmark-harness.md) provides before/after RSS and
+CPU numbers. Without the baseline first, we cannot measure the win.
+
+## Scope
+
+In scope:
+
+1. Instrument the hot path (TCP relay loop in `mihomo-tunnel/src/tunnel.rs`,
+   UDP NAT in `mihomo-tunnel/src/udp.rs`) with `dhat` or `stats_alloc` to
+   count and locate per-packet allocations.
+2. Replace identified allocations with one of:
+   - Stack-allocated fixed-size buffers (`[u8; N]` or `MaybeUninit`).
+   - A `bytes::BytesMut` pool or `tokio::io::copy_buf` with a caller-supplied
+     buffer, eliminating the per-call `Vec::new()`.
+   - Pre-allocated `Arc` clones moved outside the per-packet hot path.
+3. Re-run the benchmark harness after each change and record the delta.
+4. Document findings in `docs/benchmarks/allocator-audit-findings.md`.
+
+Out of scope:
+
+- DNS resolver allocations (separate profiling concern — latency not throughput).
+- Rule matching allocations — covered by rule-engine-micro-opt.md.
+- `unsafe` custom allocators (only if a safe rewrite is impossible and the win
+  justifies it — requires architect sign-off).
+
+## Measurement protocol
+
+```
+# Before patch:
+cargo build --release --features dhat-heap
+DHAT_PROFILING=1 ./target/release/mihomo -f bench/config-mihomo-rust.yaml &
+# run bench/run.sh mihomo-rust for 30 s
+# save dhat output, count allocations on TCP relay path
+
+# After patch:
+# same, verify zero allocs on hot path for steady-state forwarding
+```
+
+Primary metric: allocations per packet on TCP relay (target: 0).
+Secondary metrics: RSS steady-state from benchmark harness (target: ≤ M1 baseline).
+
+## Acceptance criteria
+
+1. Profiling shows zero heap allocations per forwarded packet in TCP relay
+   steady state (after the connection is established).
+2. UDP NAT allocation count per datagram ≤ 1 (one `Bytes` clone per outbound
+   datagram is acceptable; `Vec::new()` per packet is not).
+3. `cargo test --lib` still passes after all changes.
+4. RSS steady-state in the benchmark harness improves or does not regress
+   vs the pre-audit baseline.
+5. Findings (what was found, what was changed, what was deferred) documented
+   in `docs/benchmarks/allocator-audit-findings.md`.
+
+## Implementation checklist (engineer-a handoff)
+
+- [ ] Add `dhat` (or `stats_alloc`) dev-dependency behind a `dhat-heap` feature flag.
+- [ ] Run profiling pass on TCP relay path; record allocation sites.
+- [ ] Run profiling pass on UDP NAT path; record allocation sites.
+- [ ] For each identified allocation site: decide fix vs defer; implement fixes.
+- [ ] Re-run benchmark harness after fixes; record before/after delta.
+- [ ] Write `docs/benchmarks/allocator-audit-findings.md`.
+- [ ] Remove `dhat` profiling feature (or leave it as an optional dev feature
+      with a doc comment — engineer's call).

--- a/docs/specs/allocator-audit.md
+++ b/docs/specs/allocator-audit.md
@@ -1,24 +1,69 @@
 # Spec: Allocator audit — zero per-packet allocations (M2)
 
-Status: Draft (2026-04-18, revised with engineer-a prep findings)
+Status: Draft (2026-04-18, updated with ADR-0008 decisions)
 Owner: engineer-a
 Tracks roadmap item: **M2** (allocator audit)
 Lane: engineer-a (perf measurement chain)
+ADR: [`docs/adr/0008-m2-allocator-audit.md`](../adr/0008-m2-allocator-audit.md) — HP-1/2/3 scope, 0.5 alloc/iter threshold, Phase A/B methodology
 Blocked by: M2.B-2 — criterion microbenchmarks must exist first (see benchmark-harness.md)
 Upstream reference: Go mihomo allocates per-packet buffers; we are optimizing our own path.
 
+## ADR-0008 scope: hot paths HP-1, HP-2, HP-3
+
+ADR-0008 classifies three hot paths for this audit:
+
+- **HP-1: UDP NAT fast path** — existing-session lookup in `handle_udp`. Primary target.
+- **HP-2: TCP per-connection setup** — rule matching + connection boxing. One-time cost
+  per connection; secondary target, fix only if connection-setup rate shows up in profiling.
+- **HP-3: Rule matching overhead** — allocations inside `match_engine` per connection.
+  Covered primarily by rule-engine-micro-opt.md; any allocation fix that surfaces here
+  during the audit is fair game to fix in this task.
+
+ADR-0008 **threshold: ≤ 0.5 allocations per criterion iteration** on the fast-path
+benchmarks (HP-1). This is not a "zero" hard requirement — it acknowledges that
+criterion's internal measurement overhead produces a small fractional count. The
+practical target is zero allocations on the hot path; 0.5 alloc/iter is the
+measurable signal to aim for in the bench output.
+
+## Two-phase methodology (ADR-0008)
+
+### Phase A — dhat profiling
+
+Use `dhat` (via the `dhat-heap` feature flag) to locate all heap allocation sites
+under load. Run `bench.sh` (the end-to-end harness) for 30 seconds with `dhat` enabled,
+inspect the flamegraph, and identify allocations on HP-1 and HP-2 paths.
+
+```bash
+cargo build --release --features dhat-heap
+DHAT_PROFILING=1 ./target/release/mihomo -f bench/config-mihomo-rust.yaml &
+# run load for 30s, then kill, inspect dhat output
+```
+
+### Phase B — audit-alloc verification
+
+After Phase A fixes, verify with `--features audit-alloc` (a counting-allocator
+wrapper) that the criterion `udp_fastpath` benchmark reaches the ≤ 0.5 alloc/iter
+threshold. This confirms the dhat fix actually removed the allocation and didn't
+just move it out of the profiled window.
+
+```bash
+cargo bench -p mihomo-tunnel --bench udp_bench --features audit-alloc \
+  -- --save-baseline post-fix
+```
+
 ## Confirmed findings (engineer-a pre-audit)
 
-### TCP relay — already zero-copy
+### TCP relay — already zero-copy (HP-2 reduced scope)
 
 `mihomo-tunnel/src/tunnel.rs` uses `tokio::io::copy_bidirectional`, which copies
 directly between reader and writer buffers with no heap allocation per forwarded byte.
 Per-connection allocations (rule_name/payload `format!`, `track_connection` boxing)
 are one-time setup costs, not per-packet. **TCP relay hot path is already clean.**
 
-Remaining allocator work is per-connection setup and UDP NAT.
+HP-2 scope is reduced: only the per-connection setup allocations need auditing,
+and only if the connection-setup rate shows up in profiling.
 
-### UDP NAT — confirmed hot-path allocation
+### HP-1 confirmed: UDP NAT hot-path allocation
 
 `crates/mihomo-tunnel/src/udp.rs:30`:
 
@@ -31,74 +76,76 @@ path (existing session lookup at line 33). Because the allocation precedes the
 session check, even cache-hit packets pay the heap cost on every call to
 `handle_udp`. This is the highest-value first fix.
 
-**Proposed fix:** replace the `String` key with a structured type that implements
-`Hash + Eq` without allocating:
+**ADR-0008 confirmed fix: Option A — `(SocketAddr, SocketAddr)` NatKey.**
 
 ```rust
-// Option A — if remote_address() always parses as SocketAddr:
 type NatKey = (SocketAddr, SocketAddr);
-
-// Option B — SmolStr (stack-allocated for strings ≤ 23 bytes; most SocketAddr
-// strings fit):
-type NatKey = (SocketAddr, smol_str::SmolStr);
 ```
 
-Engineer-a should verify which option is safe given `remote_address()` format
-(domain names vs IP:port) and choose accordingly. Document the decision.
+`metadata.remote_address()` is always a parsed `SocketAddr` at this point in the
+tunnel (pre-resolution happens at `pre_resolve` above). Engineer-a confirmed this
+is safe. Option B (SmolStr) is withdrawn — domain names are resolved before
+`handle_udp` is called.
+
+The `NatTable` type alias changes from `Arc<DashMap<String, ...>>` to
+`Arc<DashMap<(SocketAddr, SocketAddr), ...>>`. Update all call sites.
 
 ## Scope
 
 In scope:
 
-1. Fix the `format!` NAT key allocation in `udp.rs:30` (highest-value item).
-2. Audit remaining `handle_udp` path for any other per-packet allocations
-   (e.g., `DashMap` key interning, `Box<dyn ProxyPacketConn>` per new session
-   is acceptable — one-time cost).
-3. Audit per-connection setup in TCP path: `rule_name`/`payload` `format!` strings
-   and `track_connection` boxing. These are one-time per connection; fix only if
-   the connection-setup rate is high enough to show up in profiling.
-4. Re-run the criterion UDP fast-path benchmark (M2.B-2) before and after fix #1;
-   record the delta.
-5. Document findings in `docs/benchmarks/allocator-audit-findings.md`.
+1. **HP-1**: Fix the `format!` NAT key allocation in `udp.rs:30` with `(SocketAddr, SocketAddr)` key.
+2. Phase A dhat profiling to find any additional HP-1/HP-2 allocations missed by visual inspection.
+3. Phase B `audit-alloc` verification that HP-1 bench reaches ≤ 0.5 alloc/iter.
+4. **HP-2**: Audit per-connection setup in TCP path; fix if connection-setup rate is
+   significant (defer if one-time cost is below noise floor in profiling).
+5. Document all findings in `docs/benchmarks/allocator-audit-findings.md`.
 
 Out of scope:
 
 - DNS resolver allocations (separate profiling concern).
-- Rule matching allocations — covered by rule-engine-micro-opt.md.
+- Rule matching allocations — covered by rule-engine-micro-opt.md (HP-3 overlap
+  goes to that task; surface here only if it blocks the HP-1 fix).
 - `unsafe` custom allocators unless a safe rewrite is impossible (requires
   architect-2 sign-off).
 
 ## Measurement protocol
 
-```
-# Before fix:
-cargo bench -p mihomo-tunnel --bench udp_bench -- --save-baseline pre-alloc-fix
+```bash
+# Before fix — save baseline:
+cargo bench -p mihomo-tunnel --bench udp_bench -- --save-baseline pre-hp1-fix
 
-# After fix:
-cargo bench -p mihomo-tunnel --bench udp_bench -- --baseline pre-alloc-fix
-```
+# After fix — compare:
+cargo bench -p mihomo-tunnel --bench udp_bench -- --baseline pre-hp1-fix
 
-Primary metric: allocations per fast-path UDP packet (target: 0).
-Secondary: benchmark throughput delta (p50 latency on `udp_fastpath` bench).
+# Phase B — verify alloc count:
+cargo bench -p mihomo-tunnel --bench udp_bench --features audit-alloc \
+  -- --save-baseline post-hp1-fix
+# Target: ≤ 0.5 alloc/iter on udp_fastpath bench
+```
 
 ## Acceptance criteria
 
-1. The `format!` NAT key allocation at `udp.rs:30` is eliminated for the fast
-   path (existing session lookup).
-2. The criterion `udp_fastpath` benchmark shows a measurable throughput improvement
-   vs the pre-fix baseline.
-3. UDP NAT new-session path allocates at most once per session (the `DashMap`
+1. The `format!` NAT key allocation at `udp.rs:30` is eliminated; `NatTable`
+   uses `(SocketAddr, SocketAddr)` as the key type.
+2. Phase B `audit-alloc` bench shows ≤ 0.5 alloc/iter on `udp_fastpath` (ADR-0008 threshold).
+3. The criterion `udp_fastpath` benchmark shows measurable throughput improvement
+   vs the pre-fix baseline (Phase A→B delta recorded).
+4. UDP NAT new-session path allocates at most once per session (the `DashMap`
    insert + proxy connection setup), not per packet.
-4. `cargo test --lib` passes after all changes.
-5. `docs/benchmarks/allocator-audit-findings.md` documents: what was found, what
-   was fixed, what was deferred, and the before/after benchmark numbers.
+5. `cargo test --lib` passes after all changes.
+6. `docs/benchmarks/allocator-audit-findings.md` documents: what was found (Phase A),
+   what was fixed (HP-1 NatKey change), what was deferred (HP-2 if below noise floor),
+   and before/after benchmark numbers.
 
 ## Implementation checklist (engineer-a handoff)
 
-- [ ] Inspect `metadata.remote_address()` return type — confirm whether it's always
-      a parseable `SocketAddr` or can be a domain:port string.
-- [ ] Implement the NatKey fix (Option A or B above); run `cargo test --lib`.
-- [ ] Run criterion `udp_fastpath` bench before and after; record delta.
-- [ ] Scan remaining `handle_udp` call sites for any other per-packet allocations.
-- [ ] Audit per-connection setup in TCP path (lower priority — one-time cost).
+- [ ] Add `dhat` dev-dependency behind `dhat-heap` feature flag; add counting-allocator
+      wrapper behind `audit-alloc` feature flag.
+- [ ] Change `NatTable` key from `String` to `(SocketAddr, SocketAddr)`; update all
+      call sites; run `cargo test --lib`.
+- [ ] Run criterion `udp_fastpath` bench before fix (save baseline) and after (compare).
+- [ ] Run Phase B `audit-alloc` bench; confirm ≤ 0.5 alloc/iter.
+- [ ] Run Phase A dhat profiling for 30s; inspect output for additional HP-1/HP-2 sites.
+- [ ] Audit per-connection setup in TCP path (HP-2); decide fix vs defer.
 - [ ] Write `docs/benchmarks/allocator-audit-findings.md`.

--- a/docs/specs/benchmark-harness.md
+++ b/docs/specs/benchmark-harness.md
@@ -1,0 +1,111 @@
+# Spec: Benchmark harness vs Go mihomo (M2)
+
+Status: Draft (2026-04-18)
+Owner: engineer-a
+Tracks roadmap item: **M2** (benchmark harness)
+Lane: engineer-a (perf measurement chain)
+Blocks: allocator-audit.md, rule-engine-micro-opt.md
+Upstream reference: none — this is a mihomo-rust capability, not a parity feature.
+
+## Motivation
+
+The M2 exit criterion ("measurably lower CPU and RSS than Go mihomo on a shared
+benchmark") requires a reproducible, machine-readable harness that runs both
+implementations under identical load and captures throughput, latency percentiles,
+CPU time, and RSS. Without a baseline run there is nothing to optimize against
+and no way to declare M2 done.
+
+The harness also serves as a long-term regression guardrail: any future change that
+regresses CPU or RSS beyond a configured threshold fails CI.
+
+## Scope
+
+In scope:
+
+1. Benchmark driver script at `bench/run.sh` orchestrating both sides.
+2. A shared workload definition: rule-based tunnel config (`bench/config-mihomo-rust.yaml`,
+   `bench/config-go-mihomo.yaml`) and synthetic traffic generator using `wrk2` or
+   `iperf3` for throughput + `wrk` for HTTP latency.
+3. Metric capture: `perf stat` (or `/usr/bin/time -v`) for CPU, `smem`/`/proc/<pid>/status`
+   for RSS peak and steady-state, `wrk`/`wrk2` JSON output for req/s and latency
+   percentiles (p50, p95, p99).
+4. Machine-readable result output: `bench/results/` directory with one JSON file per
+   run, keyed by `{impl, version, date, target}`.
+5. `bench/compare.py` — diff two JSON result files and emit a human-readable table
+   and an exit code 1 if mihomo-rust is worse than Go mihomo on any primary metric
+   by more than the configured threshold (default 5%).
+6. A `bench` CI job (manual `workflow_dispatch` only, not on every PR — benchmark
+   runs are slow and require a dedicated runner or a quiet window).
+
+Out of scope:
+
+- Automated CI gating on every PR (reserved for M2 regression check after baseline
+  is established).
+- Protocol-level micro-benchmarks (`cargo bench`) — those belong to the individual
+  crates. This harness measures end-to-end tunnel throughput.
+- Hardware specification enforcement — the harness documents the test machine and
+  warns if metrics are collected on a machine that doesn't match the baseline.
+
+## Workload definition
+
+### Tunnel config (both sides)
+
+- 5 rule entries (DOMAIN-SUFFIX, IP-CIDR, GEOIP, RULE-SET, MATCH) to exercise
+  realistic rule-matching.
+- One `DIRECT` outbound, one `REJECT` outbound, one upstream proxy (Shadowsocks or
+  Trojan over loopback).
+- Snooping DNS mode (mihomo-rust) vs default DNS (Go mihomo) — document the
+  difference in `docs/benchmarks/methodology.md`.
+
+### Traffic scenarios
+
+| Scenario | Tool | Duration | Connections | Metric |
+|----------|------|----------|-------------|--------|
+| TCP throughput | iperf3 | 30 s | 1 | Gbps (relay overhead) |
+| HTTP requests | wrk | 60 s | 50 | req/s, p99 latency |
+| Concurrent conns | wrk2 | 60 s | 500 | RSS under load |
+
+## Result format
+
+```json
+{
+  "impl": "mihomo-rust",
+  "version": "0.4.0",
+  "date": "2026-04-18",
+  "machine": "aarch64, 4 cores, 4 GB RAM",
+  "scenarios": {
+    "tcp_throughput_gbps": 9.3,
+    "http_rps": 42000,
+    "http_p99_ms": 3.2,
+    "rss_peak_mb": 28,
+    "rss_steady_mb": 22,
+    "cpu_user_s": 11.4,
+    "cpu_sys_s": 2.1
+  }
+}
+```
+
+## Acceptance criteria
+
+1. `bench/run.sh mihomo-rust` and `bench/run.sh go-mihomo` both complete without
+   error and produce valid JSON in `bench/results/`.
+2. `bench/compare.py` correctly identifies regressions and exits non-zero.
+3. A committed baseline run exists at `docs/benchmarks/baseline-2026-XXXX.json`
+   showing mihomo-rust CPU and RSS ≤ Go mihomo (if it doesn't, the baseline is
+   the starting point and the delta is recorded as the M2 improvement target).
+4. `docs/benchmarks/methodology.md` documents the test machine spec, OS, kernel
+   version, and any tuning (CPU governor, NUMA pinning) needed for reproducible
+   results.
+5. The `bench` GitHub Actions job runs successfully on `workflow_dispatch`.
+
+## Implementation checklist (engineer-a handoff)
+
+- [ ] Create `bench/` directory structure: `run.sh`, `config-mihomo-rust.yaml`,
+      `config-go-mihomo.yaml`, `compare.py`, `results/.gitkeep`.
+- [ ] Create `docs/benchmarks/methodology.md`.
+- [ ] Add `.github/workflows/bench.yml` with `workflow_dispatch` trigger, `bench`
+      job that installs wrk/wrk2/iperf3, builds both binaries, runs the harness,
+      uploads `bench/results/` as an artifact.
+- [ ] Record and commit the first baseline run.
+- [ ] Add `bench/compare.py` threshold check to the `bench` CI job (exit 1 if
+      mihomo-rust regresses vs the committed baseline by > 5% on primary metrics).

--- a/docs/specs/benchmark-harness.md
+++ b/docs/specs/benchmark-harness.md
@@ -1,111 +1,107 @@
 # Spec: Benchmark harness vs Go mihomo (M2)
 
-Status: Draft (2026-04-18)
+Status: Draft (2026-04-18, revised with engineer-a prep findings)
 Owner: engineer-a
 Tracks roadmap item: **M2** (benchmark harness)
 Lane: engineer-a (perf measurement chain)
-Blocks: allocator-audit.md, rule-engine-micro-opt.md
-Upstream reference: none — this is a mihomo-rust capability, not a parity feature.
+Blocks: allocator-audit.md (M2.B-2), rule-engine-micro-opt.md (M2.B-2)
+Upstream reference: none — mihomo-rust capability, not a parity feature.
 
-## Motivation
+## Current state
 
-The M2 exit criterion ("measurably lower CPU and RSS than Go mihomo on a shared
-benchmark") requires a reproducible, machine-readable harness that runs both
-implementations under identical load and captures throughput, latency percentiles,
-CPU time, and RSS. Without a baseline run there is nothing to optimize against
-and no way to declare M2 done.
+The bench infrastructure is partially implemented:
+- `crates/mihomo-bench/` — standalone binary that runs both implementations
+- `bench.sh` — orchestration script: builds both binaries, downloads Go mihomo via
+  `gh release download`, runs `mihomo-bench`, writes `target/bench/results.json`
+- `config-bench.yaml` — shared workload config
 
-The harness also serves as a long-term regression guardrail: any future change that
-regresses CPU or RSS beyond a configured threshold fails CI.
+**What is missing:**
+1. No published numbers in `docs/benchmarks/` — results live only in `target/` (gitignored).
+2. No `criterion` microbenchmarks for rule-engine and allocator work — those require
+   in-process benchmarks at the crate level, not the end-to-end harness.
 
-## Scope
+This spec covers both gaps as two sequential sub-items.
 
-In scope:
+## M2.B-1 — Publish benchmark numbers
 
-1. Benchmark driver script at `bench/run.sh` orchestrating both sides.
-2. A shared workload definition: rule-based tunnel config (`bench/config-mihomo-rust.yaml`,
-   `bench/config-go-mihomo.yaml`) and synthetic traffic generator using `wrk2` or
-   `iperf3` for throughput + `wrk` for HTTP latency.
-3. Metric capture: `perf stat` (or `/usr/bin/time -v`) for CPU, `smem`/`/proc/<pid>/status`
-   for RSS peak and steady-state, `wrk`/`wrk2` JSON output for req/s and latency
-   percentiles (p50, p95, p99).
-4. Machine-readable result output: `bench/results/` directory with one JSON file per
-   run, keyed by `{impl, version, date, target}`.
-5. `bench/compare.py` — diff two JSON result files and emit a human-readable table
-   and an exit code 1 if mihomo-rust is worse than Go mihomo on any primary metric
-   by more than the configured threshold (default 5%).
-6. A `bench` CI job (manual `workflow_dispatch` only, not on every PR — benchmark
-   runs are slow and require a dedicated runner or a quiet window).
+Run the existing `bench.sh` on the agreed reference machine, capture the JSON output,
+and commit a snapshot to `docs/benchmarks/`.
 
-Out of scope:
+Deliverables:
+1. `docs/benchmarks/methodology.md` — document the test machine (arch, cores, RAM, OS,
+   kernel version, CPU governor, any NUMA tuning), the Go mihomo version compared
+   against, and the workload (duration, concurrency, scenario descriptions from
+   `config-bench.yaml`).
+2. `docs/benchmarks/baseline-YYYY-MM-DD.json` — the results JSON from one clean run
+   on the reference machine.
+3. A `bench` GitHub Actions job (`workflow_dispatch` only) that:
+   - Builds both binaries
+   - Runs `bench.sh`
+   - Uploads `target/bench/results.json` as a workflow artifact
 
-- Automated CI gating on every PR (reserved for M2 regression check after baseline
-  is established).
-- Protocol-level micro-benchmarks (`cargo bench`) — those belong to the individual
-  crates. This harness measures end-to-end tunnel throughput.
-- Hardware specification enforcement — the harness documents the test machine and
-  warns if metrics are collected on a machine that doesn't match the baseline.
+The baseline numbers are the M2 starting point. If mihomo-rust is already faster, record
+it and note the delta. If Go mihomo is faster, record it as the target.
 
-## Workload definition
+## M2.B-2 — Criterion microbenchmarks
 
-### Tunnel config (both sides)
+Add `criterion` microbenchmarks to the crates that M2.C and M2.D will optimize.
+These are the measurement tool for in-process work; they must exist before the
+optimization passes can claim a quantified win.
 
-- 5 rule entries (DOMAIN-SUFFIX, IP-CIDR, GEOIP, RULE-SET, MATCH) to exercise
-  realistic rule-matching.
-- One `DIRECT` outbound, one `REJECT` outbound, one upstream proxy (Shadowsocks or
-  Trojan over loopback).
-- Snooping DNS mode (mihomo-rust) vs default DNS (Go mihomo) — document the
-  difference in `docs/benchmarks/methodology.md`.
+### mihomo-trie benchmarks (`crates/mihomo-trie/benches/trie_bench.rs`)
 
-### Traffic scenarios
+```rust
+// Measure lookup throughput at N = {100, 1000, 10_000} entries
+criterion_group!(benches, lookup_100, lookup_1000, lookup_10000);
+```
 
-| Scenario | Tool | Duration | Connections | Metric |
-|----------|------|----------|-------------|--------|
-| TCP throughput | iperf3 | 30 s | 1 | Gbps (relay overhead) |
-| HTTP requests | wrk | 60 s | 50 | req/s, p99 latency |
-| Concurrent conns | wrk2 | 60 s | 500 | RSS under load |
+Domains sampled from a realistic distribution (mix of TLDs, subdomains, wildcards).
 
-## Result format
+### mihomo-rules benchmarks (`crates/mihomo-rules/benches/rules_bench.rs`)
 
-```json
-{
-  "impl": "mihomo-rust",
-  "version": "0.4.0",
-  "date": "2026-04-18",
-  "machine": "aarch64, 4 cores, 4 GB RAM",
-  "scenarios": {
-    "tcp_throughput_gbps": 9.3,
-    "http_rps": 42000,
-    "http_p99_ms": 3.2,
-    "rss_peak_mb": 28,
-    "rss_steady_mb": 22,
-    "cpu_user_s": 11.4,
-    "cpu_sys_s": 2.1
-  }
-}
+```rust
+// Measure rule-list scan at N = {50, 200, 500} rules
+// Current: linear scan over Vec<Box<dyn Rule>>
+criterion_group!(benches, rule_scan_50, rule_scan_200, rule_scan_500);
+```
+
+Include both domain-heavy and IP-CIDR-heavy workload mixes.
+
+### mihomo-tunnel UDP benchmarks (`crates/mihomo-tunnel/benches/udp_bench.rs`)
+
+```rust
+// Measure handle_udp fast-path (existing session) throughput
+// Primary target: the format!() key allocation at udp.rs:30
+criterion_group!(benches, udp_fastpath);
 ```
 
 ## Acceptance criteria
 
-1. `bench/run.sh mihomo-rust` and `bench/run.sh go-mihomo` both complete without
-   error and produce valid JSON in `bench/results/`.
-2. `bench/compare.py` correctly identifies regressions and exits non-zero.
-3. A committed baseline run exists at `docs/benchmarks/baseline-2026-XXXX.json`
-   showing mihomo-rust CPU and RSS ≤ Go mihomo (if it doesn't, the baseline is
-   the starting point and the delta is recorded as the M2 improvement target).
-4. `docs/benchmarks/methodology.md` documents the test machine spec, OS, kernel
-   version, and any tuning (CPU governor, NUMA pinning) needed for reproducible
-   results.
-5. The `bench` GitHub Actions job runs successfully on `workflow_dispatch`.
+### M2.B-1
+1. `docs/benchmarks/methodology.md` exists and documents machine + workload.
+2. `docs/benchmarks/baseline-YYYY-MM-DD.json` committed (valid JSON, all scenario keys present).
+3. `bench` CI job runs successfully on `workflow_dispatch` and uploads results artifact.
+
+### M2.B-2
+1. `cargo bench -p mihomo-trie`, `cargo bench -p mihomo-rules`, and
+   `cargo bench -p mihomo-tunnel` all run without error.
+2. Baseline numbers are printed to stdout and can be used as `--save-baseline` reference.
+3. `cargo test --lib` still passes after adding benches.
 
 ## Implementation checklist (engineer-a handoff)
 
-- [ ] Create `bench/` directory structure: `run.sh`, `config-mihomo-rust.yaml`,
-      `config-go-mihomo.yaml`, `compare.py`, `results/.gitkeep`.
+### M2.B-1
 - [ ] Create `docs/benchmarks/methodology.md`.
-- [ ] Add `.github/workflows/bench.yml` with `workflow_dispatch` trigger, `bench`
-      job that installs wrk/wrk2/iperf3, builds both binaries, runs the harness,
-      uploads `bench/results/` as an artifact.
-- [ ] Record and commit the first baseline run.
-- [ ] Add `bench/compare.py` threshold check to the `bench` CI job (exit 1 if
-      mihomo-rust regresses vs the committed baseline by > 5% on primary metrics).
+- [ ] Run `bench.sh` on reference machine; save output to `docs/benchmarks/baseline-YYYY-MM-DD.json`.
+- [ ] Add `.github/workflows/bench.yml` (workflow_dispatch, bench job, artifact upload).
+- [ ] Commit both files.
+
+### M2.B-2
+- [ ] Add `criterion` dev-dependency to `mihomo-trie/Cargo.toml` with `[[bench]]`.
+- [ ] Write `crates/mihomo-trie/benches/trie_bench.rs` with lookup benchmarks.
+- [ ] Add `criterion` dev-dependency to `mihomo-rules/Cargo.toml`.
+- [ ] Write `crates/mihomo-rules/benches/rules_bench.rs` with rule-scan benchmarks.
+- [ ] Add `criterion` dev-dependency to `mihomo-tunnel/Cargo.toml`.
+- [ ] Write `crates/mihomo-tunnel/benches/udp_bench.rs` with UDP fast-path benchmark
+      (isolating the `format!` allocation at `udp.rs:30`).
+- [ ] Run all benches, save baselines as `--save-baseline m2-start`.

--- a/docs/specs/benchmark-harness.md
+++ b/docs/specs/benchmark-harness.md
@@ -1,9 +1,10 @@
 # Spec: Benchmark harness vs Go mihomo (M2)
 
-Status: Draft (2026-04-18, revised with engineer-a prep findings)
+Status: Draft (2026-04-18, revised with engineer-a prep findings + ADR-0006)
 Owner: engineer-a
 Tracks roadmap item: **M2** (benchmark harness)
 Lane: engineer-a (perf measurement chain)
+ADR: [`docs/adr/0006-m2-benchmark-workloads.md`](../adr/0006-m2-benchmark-workloads.md) — workload definitions, hardware record format, comparison thresholds
 Blocks: allocator-audit.md (M2.B-2), rule-engine-micro-opt.md (M2.B-2)
 Upstream reference: none — mihomo-rust capability, not a parity feature.
 

--- a/docs/specs/cargo-feature-flags.md
+++ b/docs/specs/cargo-feature-flags.md
@@ -1,0 +1,110 @@
+# Spec: Cargo feature flags + minimal-build size budget (M2)
+
+Status: Draft (2026-04-18)
+Owner: engineer-b
+Tracks roadmap item: **M2** (Cargo feature flags, minimal-build)
+Lane: engineer-b (footprint + infra chain)
+Upstream reference: Go mihomo uses build tags; not directly applicable to Rust.
+This is a mihomo-rust capability, not a parity feature.
+
+## Motivation
+
+`vision.md` §Goals item 3: "Single static binary, minimal runtime allocations on
+the hot path, aggressive feature-gating so builds for embedded targets (mipsel,
+aarch64 musl) stay small." Today every optional protocol and transport compiles
+into the default build. Disabling unused protocols via Cargo features lets an
+operator targeting a low-flash router cut the binary size significantly.
+
+The M2 exit criterion requires a minimal-build binary under the stated size budget
+for `aarch64-unknown-linux-musl` and `mipsel-unknown-linux-musl`.
+
+## Feature flag taxonomy
+
+### Protocol features (default: all on in the default profile)
+
+| Feature | Crate | What it gates |
+|---------|-------|---------------|
+| `ss` | `mihomo-proxy` | Shadowsocks adapter + `shadowsocks` crate dep |
+| `trojan` | `mihomo-proxy` | Trojan adapter + `tokio-rustls` dep |
+| `vless` | `mihomo-proxy` | VLESS adapter (M1.B-2) |
+| `http-outbound` | `mihomo-proxy` | HTTP CONNECT adapter |
+| `socks5-outbound` | `mihomo-proxy` | SOCKS5 outbound adapter |
+| `load-balance` | `mihomo-proxy` | Load-balance group |
+| `relay` | `mihomo-proxy` | Relay group |
+
+### Transport features
+
+| Feature | Crate | What it gates |
+|---------|-------|---------------|
+| `transport-tls` | `mihomo-transport` | TLS layer |
+| `transport-ws` | `mihomo-transport` | WebSocket layer |
+| `transport-grpc` | `mihomo-transport` | gRPC/gun layer |
+| `transport-h2` | `mihomo-transport` | H2 + HTTP-upgrade layers |
+
+### Inbound features
+
+| Feature | Crate | What it gates |
+|---------|-------|---------------|
+| `listener-http` | `mihomo-listener` | HTTP proxy inbound |
+| `listener-socks5` | `mihomo-listener` | SOCKS5 inbound |
+| `listener-tproxy` | `mihomo-listener` | TProxy (nftables/pf) — Linux/macOS only |
+| `listener-mixed` | `mihomo-listener` | Mixed (HTTP+SOCKS5) inbound |
+
+### Convenience bundles
+
+| Feature | Includes |
+|---------|---------|
+| `full` (default) | all of the above |
+| `minimal` | `ss`, `transport-tls`, `listener-mixed` |
+
+## Size budget
+
+Target (strip + UPX is NOT used — reproducible, no upx dependency):
+
+| Target | Full build | Minimal build |
+|--------|-----------|---------------|
+| `aarch64-unknown-linux-musl` | ≤ 12 MB | ≤ 5 MB |
+| `mipsel-unknown-linux-musl` | ≤ 14 MB | ≤ 6 MB |
+
+Measure with: `ls -lh target/<target>/release/mihomo` on the stripped binary
+(`cargo zigbuild --release ... && llvm-strip` or `strip`).
+
+If the first run misses the budget, use `cargo bloat --release --crates` to
+identify the largest contributors and iterate. Document the final sizes in
+`docs/benchmarks/binary-size.md`.
+
+## Release CI integration
+
+- The existing `release.yml` builds `x86_64` and `aarch64` musl. Add `mipsel-unknown-linux-musl`
+  to the matrix (see ci-quality-gates.md for the CI change).
+- Add a `minimal-size-check` step: build the `minimal` feature set, measure stripped
+  size, fail the job if over budget.
+
+## Divergences from upstream
+
+None — this is a new capability. No upstream `geodata:` / Go-build-tag divergence
+to classify.
+
+## Acceptance criteria
+
+1. `cargo build --no-default-features --features minimal --target aarch64-unknown-linux-musl`
+   compiles without errors.
+2. Stripped minimal binary for `aarch64-musl` is ≤ 5 MB; for `mipsel-musl` ≤ 6 MB.
+3. Full-feature build for both targets is within the full budget above.
+4. `cargo test --lib` passes for both default and minimal feature sets.
+5. `cargo hack --feature-powerset check` passes for `mihomo-proxy`,
+   `mihomo-transport`, and `mihomo-listener` (wired in ci-quality-gates.md).
+6. Binary sizes documented in `docs/benchmarks/binary-size.md`.
+
+## Implementation checklist (engineer-b handoff)
+
+- [ ] Audit all optional deps in `mihomo-proxy/Cargo.toml` and add feature gates.
+- [ ] Audit `mihomo-transport/Cargo.toml` and add `transport-*` feature gates.
+- [ ] Audit `mihomo-listener/Cargo.toml` and add `listener-*` feature gates.
+- [ ] Define `full` (default) and `minimal` bundle features at the workspace root.
+- [ ] Update `mihomo-app/src/main.rs` to conditionally register only the enabled
+      adapters and listeners (using `#[cfg(feature = "...")]`).
+- [ ] Add `minimal-size-check` step to `release.yml`.
+- [ ] Add `mipsel-unknown-linux-musl` to the `release.yml` build matrix
+      (see ci-quality-gates.md §Release matrix expansion).
+- [ ] Measure and document final sizes in `docs/benchmarks/binary-size.md`.

--- a/docs/specs/cargo-feature-flags.md
+++ b/docs/specs/cargo-feature-flags.md
@@ -1,9 +1,10 @@
 # Spec: Cargo feature flags + minimal-build size budget (M2)
 
-Status: Draft (2026-04-18, revised with engineer-b prep findings)
+Status: Draft (2026-04-18, updated with ADR-0007 decisions)
 Owner: engineer-b
 Tracks roadmap item: **M2** (Cargo feature flags, minimal-build)
 Lane: engineer-b (footprint + infra chain)
+ADR: [`docs/adr/0007-m2-footprint-budget.md`](../adr/0007-m2-footprint-budget.md)
 Upstream reference: Go mihomo uses build tags; not directly applicable to Rust.
 This is a mihomo-rust capability, not a parity feature.
 
@@ -61,7 +62,13 @@ exist yet.
 | Bundle | Includes |
 |--------|---------|
 | `full` (default) | all features above |
-| `minimal` | `ss`, `transport-tls`, `listener-mixed`, `dns-server` |
+| `minimal` | `ss`, `trojan`, `transport-tls`, `transport-ws`, `listener-mixed`, `dns-server` — REST API always included (not optional) |
+
+**ADR-0007 §1 defines `minimal` as `tls,ws,ss,trojan,api`** — the "minimum useful set
+for a router operator." Dropping TLS would exclude SS+v2ray-plugin+TLS+ws, the
+dominant modern transport pairing for ~95% of router users. Do NOT remove `transport-tls`
+or `transport-ws` from the minimal bundle to chase a smaller binary; revisit in M3
+after profiling real operator usage.
 
 ## Load-bearing deps that must become conditional
 
@@ -79,17 +86,31 @@ overhead for them.
 
 ## Size budget
 
-Target (stripped binary; no UPX):
+Per ADR-0007 §2 (confirmed). Target = stripped binary, no UPX, `minimal` feature set:
 
-| Target | Full build | Minimal build |
-|--------|-----------|---------------|
-| `aarch64-unknown-linux-musl` | no regression vs baseline | ≤ 5 MB (TBD — architect-2 to confirm) |
-| `mipsel-unknown-linux-musl` | no regression vs baseline | ≤ 6 MB (TBD — architect-2 to confirm) |
+| Target | Default build | Minimal build | Gate |
+|--------|--------------|---------------|------|
+| `aarch64-unknown-linux-musl` | ≤ 20 MiB | ≤ 8 MiB | **hard** — release fails if exceeded |
+| `mipsel-unknown-linux-musl` | ≤ 20 MiB | ≤ 7 MiB | **soft** — release emits warning, does not fail |
+| `x86_64-unknown-linux-musl` | ≤ 20 MiB | not gated | informational only |
 
-**Note:** exact budget numbers are pending architect-2 sign-off (Task #25).
-This spec uses placeholder figures; engineer-b should not hard-code them in CI
-until Task #25 closes. The `ci-quality-gates.md §minimal-size-check` step will
-be parameterized once the numbers are confirmed.
+**Budget rationale (ADR-0007 §2):**
+- mipsel 7 MiB: common legacy mipsel router flash is 16 MiB with ~6–8 MiB free
+  after OpenWRT base; 7 MiB fits with overlayfs + config + logs.
+- aarch64 8 MiB: ~8% codegen headroom vs mipsel; aarch64 routers have ≥ 64 MiB
+  storage, leaving room for one additional small-protocol addition before amendment.
+- Default 16–20 MiB: no hard cap on full builds today; track via informational step.
+
+**Step 0 prerequisite (ADR-0007 §Migration step 0):** these budgets are only
+meaningful after engineer-b completes the feature-gating work that makes `ss`,
+`trojan`, `transport-tls`, `transport-ws`, `hickory-server` conditional. Do NOT
+add the CI size-check step until the gating compiles without errors — a 11 MiB
+"minimal" build that ignores features is a false gate.
+
+**Downward amendments** are welcome: if the real post-gating measurement on the
+reference host is below budget (e.g., 6.2 MiB mipsel), open a one-paragraph
+amendment PR to tighten the cap. We commit to the upper bound now; tightening
+costs nothing.
 
 Measure with:
 
@@ -119,12 +140,14 @@ None — new capability.
 
 1. `cargo build --no-default-features --features minimal --target aarch64-unknown-linux-musl`
    compiles without errors.
-2. Stripped minimal binary for `aarch64-musl` meets the architect-confirmed budget.
-3. Stripped minimal binary for `mipsel-musl` meets the architect-confirmed budget.
+2. Stripped minimal binary for `aarch64-musl` is ≤ 8 MiB (hard gate — CI fails if exceeded).
+3. Stripped minimal binary for `mipsel-musl` is ≤ 7 MiB (soft gate — CI emits warning, does not fail).
 4. `cargo test --lib` passes for both `full` (default) and `minimal` feature sets.
 5. `cargo hack --feature-powerset check` passes for `mihomo-proxy`,
    `mihomo-transport`, `mihomo-listener`, and `mihomo-dns` (wired in ci-quality-gates.md).
 6. Binary sizes documented in `docs/benchmarks/binary-size.md`.
+7. Step 0 prerequisite satisfied: `--no-default-features --features minimal` produces a
+   meaningfully smaller binary than default before any CI gate is added.
 
 ## Implementation checklist (engineer-b handoff)
 

--- a/docs/specs/cargo-feature-flags.md
+++ b/docs/specs/cargo-feature-flags.md
@@ -1,6 +1,6 @@
 # Spec: Cargo feature flags + minimal-build size budget (M2)
 
-Status: Draft (2026-04-18)
+Status: Draft (2026-04-18, revised with engineer-b prep findings)
 Owner: engineer-b
 Tracks roadmap item: **M2** (Cargo feature flags, minimal-build)
 Lane: engineer-b (footprint + infra chain)
@@ -9,26 +9,26 @@ This is a mihomo-rust capability, not a parity feature.
 
 ## Motivation
 
-`vision.md` §Goals item 3: "Single static binary, minimal runtime allocations on
-the hot path, aggressive feature-gating so builds for embedded targets (mipsel,
-aarch64 musl) stay small." Today every optional protocol and transport compiles
-into the default build. Disabling unused protocols via Cargo features lets an
-operator targeting a low-flash router cut the binary size significantly.
+`vision.md` §Goals item 3: "aggressive feature-gating so builds for embedded
+targets (mipsel, aarch64 musl) stay small."
 
-The M2 exit criterion requires a minimal-build binary under the stated size budget
-for `aarch64-unknown-linux-musl` and `mipsel-unknown-linux-musl`.
+**Engineer-b finding:** `cargo build --no-default-features` currently produces
+the same ~11 MB binary as the default build because SS, Direct, Reject, and
+`hickory-server` are unconditionally compiled in (not behind any feature gate).
+The actual work in M2.E is making these optional — the feature flag infra doesn't
+exist yet.
 
 ## Feature flag taxonomy
 
-### Protocol features (default: all on in the default profile)
+### Protocol features (proposed; all default-on in the `full` bundle)
 
 | Feature | Crate | What it gates |
 |---------|-------|---------------|
 | `ss` | `mihomo-proxy` | Shadowsocks adapter + `shadowsocks` crate dep |
 | `trojan` | `mihomo-proxy` | Trojan adapter + `tokio-rustls` dep |
 | `vless` | `mihomo-proxy` | VLESS adapter (M1.B-2) |
-| `http-outbound` | `mihomo-proxy` | HTTP CONNECT adapter |
-| `socks5-outbound` | `mihomo-proxy` | SOCKS5 outbound adapter |
+| `http-outbound` | `mihomo-proxy` | HTTP CONNECT outbound |
+| `socks5-outbound` | `mihomo-proxy` | SOCKS5 outbound |
 | `load-balance` | `mihomo-proxy` | Load-balance group |
 | `relay` | `mihomo-proxy` | Relay group |
 
@@ -36,7 +36,7 @@ for `aarch64-unknown-linux-musl` and `mipsel-unknown-linux-musl`.
 
 | Feature | Crate | What it gates |
 |---------|-------|---------------|
-| `transport-tls` | `mihomo-transport` | TLS layer |
+| `transport-tls` | `mihomo-transport` | TLS layer + `rustls`/`tokio-rustls` deps |
 | `transport-ws` | `mihomo-transport` | WebSocket layer |
 | `transport-grpc` | `mihomo-transport` | gRPC/gun layer |
 | `transport-h2` | `mihomo-transport` | H2 + HTTP-upgrade layers |
@@ -47,64 +47,97 @@ for `aarch64-unknown-linux-musl` and `mipsel-unknown-linux-musl`.
 |---------|-------|---------------|
 | `listener-http` | `mihomo-listener` | HTTP proxy inbound |
 | `listener-socks5` | `mihomo-listener` | SOCKS5 inbound |
-| `listener-tproxy` | `mihomo-listener` | TProxy (nftables/pf) — Linux/macOS only |
+| `listener-tproxy` | `mihomo-listener` | TProxy (nftables/pf); Linux/macOS only |
 | `listener-mixed` | `mihomo-listener` | Mixed (HTTP+SOCKS5) inbound |
 
-### Convenience bundles
+### DNS features
 
-| Feature | Includes |
-|---------|---------|
-| `full` (default) | all of the above |
-| `minimal` | `ss`, `transport-tls`, `listener-mixed` |
+| Feature | Crate | What it gates |
+|---------|-------|---------------|
+| `dns-server` | `mihomo-dns` | `hickory-server` DNS server dep (currently unconditional) |
+
+### Convenience bundles (workspace root)
+
+| Bundle | Includes |
+|--------|---------|
+| `full` (default) | all features above |
+| `minimal` | `ss`, `transport-tls`, `listener-mixed`, `dns-server` |
+
+## Load-bearing deps that must become conditional
+
+Engineer-b found these are currently unconditional but must be feature-gated to
+achieve the size budget:
+
+| Dep | Currently in | Proposal |
+|-----|-------------|---------|
+| `shadowsocks` crate | `mihomo-proxy/Cargo.toml` unconditional | gate on `ss` feature |
+| `hickory-server` | `mihomo-dns/Cargo.toml` unconditional | gate on `dns-server` feature; `minimal` includes it |
+| Direct + Reject adapters | compiled unconditionally | leave unconditional — they are load-bearing stubs with near-zero size |
+
+Direct and Reject have negligible binary contribution; do not add feature-gating
+overhead for them.
 
 ## Size budget
 
-Target (strip + UPX is NOT used — reproducible, no upx dependency):
+Target (stripped binary; no UPX):
 
 | Target | Full build | Minimal build |
 |--------|-----------|---------------|
-| `aarch64-unknown-linux-musl` | ≤ 12 MB | ≤ 5 MB |
-| `mipsel-unknown-linux-musl` | ≤ 14 MB | ≤ 6 MB |
+| `aarch64-unknown-linux-musl` | no regression vs baseline | ≤ 5 MB (TBD — architect-2 to confirm) |
+| `mipsel-unknown-linux-musl` | no regression vs baseline | ≤ 6 MB (TBD — architect-2 to confirm) |
 
-Measure with: `ls -lh target/<target>/release/mihomo` on the stripped binary
-(`cargo zigbuild --release ... && llvm-strip` or `strip`).
+**Note:** exact budget numbers are pending architect-2 sign-off (Task #25).
+This spec uses placeholder figures; engineer-b should not hard-code them in CI
+until Task #25 closes. The `ci-quality-gates.md §minimal-size-check` step will
+be parameterized once the numbers are confirmed.
 
-If the first run misses the budget, use `cargo bloat --release --crates` to
-identify the largest contributors and iterate. Document the final sizes in
-`docs/benchmarks/binary-size.md`.
+Measure with:
+
+```bash
+cargo zigbuild --release --no-default-features --features minimal \
+  --target aarch64-unknown-linux-musl --bin mihomo
+llvm-strip target/aarch64-unknown-linux-musl/release/mihomo
+ls -lh target/aarch64-unknown-linux-musl/release/mihomo
+```
+
+Use `cargo bloat --release --crates` to identify the largest contributors if the
+budget is missed.
 
 ## Release CI integration
 
-- The existing `release.yml` builds `x86_64` and `aarch64` musl. Add `mipsel-unknown-linux-musl`
-  to the matrix (see ci-quality-gates.md for the CI change).
-- Add a `minimal-size-check` step: build the `minimal` feature set, measure stripped
-  size, fail the job if over budget.
+- Add a `minimal-size-check` step to `release.yml` after the existing build step:
+  build with `--no-default-features --features minimal`, strip, measure size, fail
+  if over budget.
+- See `ci-quality-gates.md` §Release matrix expansion for the mipsel-musl target
+  addition.
 
 ## Divergences from upstream
 
-None — this is a new capability. No upstream `geodata:` / Go-build-tag divergence
-to classify.
+None — new capability.
 
 ## Acceptance criteria
 
 1. `cargo build --no-default-features --features minimal --target aarch64-unknown-linux-musl`
    compiles without errors.
-2. Stripped minimal binary for `aarch64-musl` is ≤ 5 MB; for `mipsel-musl` ≤ 6 MB.
-3. Full-feature build for both targets is within the full budget above.
-4. `cargo test --lib` passes for both default and minimal feature sets.
+2. Stripped minimal binary for `aarch64-musl` meets the architect-confirmed budget.
+3. Stripped minimal binary for `mipsel-musl` meets the architect-confirmed budget.
+4. `cargo test --lib` passes for both `full` (default) and `minimal` feature sets.
 5. `cargo hack --feature-powerset check` passes for `mihomo-proxy`,
-   `mihomo-transport`, and `mihomo-listener` (wired in ci-quality-gates.md).
+   `mihomo-transport`, `mihomo-listener`, and `mihomo-dns` (wired in ci-quality-gates.md).
 6. Binary sizes documented in `docs/benchmarks/binary-size.md`.
 
 ## Implementation checklist (engineer-b handoff)
 
-- [ ] Audit all optional deps in `mihomo-proxy/Cargo.toml` and add feature gates.
-- [ ] Audit `mihomo-transport/Cargo.toml` and add `transport-*` feature gates.
-- [ ] Audit `mihomo-listener/Cargo.toml` and add `listener-*` feature gates.
-- [ ] Define `full` (default) and `minimal` bundle features at the workspace root.
-- [ ] Update `mihomo-app/src/main.rs` to conditionally register only the enabled
-      adapters and listeners (using `#[cfg(feature = "...")]`).
-- [ ] Add `minimal-size-check` step to `release.yml`.
-- [ ] Add `mipsel-unknown-linux-musl` to the `release.yml` build matrix
-      (see ci-quality-gates.md §Release matrix expansion).
-- [ ] Measure and document final sizes in `docs/benchmarks/binary-size.md`.
+- [ ] Audit `mihomo-proxy/Cargo.toml`: add feature gates for `ss`, `trojan`, `vless`,
+      `http-outbound`, `socks5-outbound`, `load-balance`, `relay`.
+- [ ] Audit `mihomo-transport/Cargo.toml`: add `transport-*` feature gates.
+- [ ] Audit `mihomo-listener/Cargo.toml`: add `listener-*` feature gates.
+- [ ] Audit `mihomo-dns/Cargo.toml`: gate `hickory-server` dep on `dns-server` feature.
+- [ ] Define `full` (default) and `minimal` bundle features at workspace root
+      (`Cargo.toml` `[features]` table).
+- [ ] Update `mihomo-app/src/main.rs`: conditionally register only enabled adapters
+      and listeners using `#[cfg(feature = "...")]`.
+- [ ] Add `minimal-size-check` step to `release.yml` (parameterize budget from
+      env var so architect-2's numbers can be dropped in without spec edit).
+- [ ] Measure stripped sizes for both targets; document in `docs/benchmarks/binary-size.md`.
+- [ ] **Wait for architect-2 Task #25** before hard-coding size thresholds in CI.

--- a/docs/specs/ci-quality-gates.md
+++ b/docs/specs/ci-quality-gates.md
@@ -1,0 +1,130 @@
+# Spec: CI quality gates (M2 absorbed items)
+
+Status: Draft (2026-04-18)
+Owner: engineer-b
+Tracks roadmap item: **M2** (absorbed CI items from ci-status.md §P1/P2)
+Lane: engineer-b (footprint + infra chain)
+See also: ci-status.md §Gaps (P1 item 5, P2 items 6/8/9);
+          cargo-feature-flags.md §Release CI integration.
+
+## Motivation
+
+`ci-status.md` §P2 lists three quality signals that are not yet wired:
+code coverage (P2-6), `cargo doc` check (P2-8), and `cargo hack --feature-powerset`
+(P2-9). The release matrix also needs `mipsel-unknown-linux-musl` to complete
+the M2 footprint deliverable. All four are small CI additions that can be done
+in one task.
+
+**Already resolved (do NOT re-do):** MSRV pin (P1-3), macOS CI job (P1-4),
+cargo audit cron (P2-7), x86_64 + aarch64 release artifacts (P1-5).
+
+## Changes
+
+### 1. `cargo doc` check — add to `test.yml` lint job
+
+Add to the existing `lint` job after `cargo clippy`:
+
+```yaml
+- name: cargo doc
+  run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+  env:
+    RUSTDOCFLAGS: "-D warnings"
+```
+
+This catches broken intra-doc links and missing doc on public items at lint time,
+not separately. No new job needed.
+
+### 2. `cargo hack --feature-powerset check` — new `features` job in `test.yml`
+
+```yaml
+features:
+  name: Feature powerset check
+  runs-on: ubuntu-latest
+  needs: lint
+  steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo install cargo-hack --locked
+    - name: feature powerset
+      run: |
+        cargo hack --feature-powerset check \
+          -p mihomo-proxy \
+          -p mihomo-transport \
+          -p mihomo-listener
+```
+
+Scope: only `mihomo-proxy`, `mihomo-transport`, and `mihomo-listener` — the crates
+that gain feature flags from cargo-feature-flags.md. Full-workspace powerset is
+too slow and targets crates with no features.
+
+### 3. Coverage upload — new `coverage` job in `test.yml` (nightly, scheduled)
+
+Add a separate `coverage.yml` workflow on a nightly schedule (Mon–Fri 04:00 UTC),
+not gating PRs (coverage is informational, not a blocker):
+
+```yaml
+name: Coverage
+on:
+  schedule:
+    - cron: "0 4 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-llvm-cov --locked
+      - name: Install ssserver (for SS integration tests)
+        run: |
+          cargo install shadowsocks-rust \
+            --features "stream-cipher aead-cipher-2022" --locked
+      - name: Collect coverage
+        run: |
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+```
+
+`fail_ci_if_error: false` — Codecov outages should not block the team.
+
+### 4. `mipsel-unknown-linux-musl` release target
+
+Add to the matrix in `release.yml`:
+
+```yaml
+- target: mipsel-unknown-linux-musl
+```
+
+`cargo-zigbuild` with zig 0.13 already supports this target; no additional
+tooling changes required. The existing `minimal-size-check` step from
+cargo-feature-flags.md applies to this target too.
+
+## Acceptance criteria
+
+1. `lint` job fails if any `cargo doc --workspace --no-deps` warning is raised
+   (confirmed by breaking a doc link and seeing a red lint job).
+2. `features` job runs and passes on a PR that adds a new feature flag in
+   `mihomo-proxy`.
+3. `coverage.yml` runs on schedule, produces `lcov.info`, and uploads to
+   Codecov successfully (or exits cleanly with `fail_ci_if_error: false`).
+4. `release.yml` produces a `mihomo-*-mipsel-unknown-linux-musl.tar.gz` artifact
+   on `v*` tag push.
+5. `cargo test --lib` is not changed or broken.
+
+## Implementation checklist (engineer-b handoff)
+
+- [ ] Add `cargo doc` step to the `lint` job in `.github/workflows/test.yml`.
+- [ ] Add `features` job to `.github/workflows/test.yml` with
+      `cargo hack --feature-powerset check` for the three crates.
+- [ ] Create `.github/workflows/coverage.yml` (nightly schedule + dispatch).
+- [ ] Add `mipsel-unknown-linux-musl` entry to the `release.yml` build matrix.
+- [ ] Verify all four changes pass on a test branch before merging.

--- a/docs/specs/ci-quality-gates.md
+++ b/docs/specs/ci-quality-gates.md
@@ -1,9 +1,10 @@
 # Spec: CI quality gates (M2 absorbed items)
 
-Status: Draft (2026-04-18)
+Status: Draft (2026-04-18, updated with ADR-0007 mipsel soft-gate decision)
 Owner: engineer-b
 Tracks roadmap item: **M2** (absorbed CI items from ci-status.md §P1/P2)
 Lane: engineer-b (footprint + infra chain)
+ADR: [`docs/adr/0007-m2-footprint-budget.md`](../adr/0007-m2-footprint-budget.md) §1 — mipsel soft-gate classification
 See also: ci-status.md §Gaps (P1 item 5, P2 items 6/8/9);
           cargo-feature-flags.md §Release CI integration.
 
@@ -105,8 +106,24 @@ Add to the matrix in `release.yml`:
 ```
 
 `cargo-zigbuild` with zig 0.13 already supports this target; no additional
-tooling changes required. The existing `minimal-size-check` step from
-cargo-feature-flags.md applies to this target too.
+tooling changes required.
+
+**Soft-gate behavior (ADR-0007 §1):** mipsel is a **soft target** in M2. The
+`minimal-size-check` step for mipsel MUST emit a warning and continue — it must
+NOT fail the release job. Use `|| true` or a conditional exit code check:
+
+```bash
+# mipsel size check — soft gate (warning only, per ADR-0007 §1)
+SIZE=$(stat -c%s target/mipsel-unknown-linux-musl/release/mihomo)
+BUDGET_BYTES=$((7 * 1024 * 1024))   # 7 MiB
+if [ "$SIZE" -gt "$BUDGET_BYTES" ]; then
+  echo "::warning::mipsel minimal binary ${SIZE} bytes exceeds soft budget ${BUDGET_BYTES}"
+fi
+# Note: no exit 1 — soft gate
+```
+
+aarch64 and x86_64 remain **hard-gated** (release fails if exceeded).
+No functional validation (no QEMU runner) for mipsel regardless of budget pass/fail.
 
 ## Acceptance criteria
 
@@ -117,7 +134,8 @@ cargo-feature-flags.md applies to this target too.
 3. `coverage.yml` runs on schedule, produces `lcov.info`, and uploads to
    Codecov successfully (or exits cleanly with `fail_ci_if_error: false`).
 4. `release.yml` produces a `mihomo-*-mipsel-unknown-linux-musl.tar.gz` artifact
-   on `v*` tag push.
+   on `v*` tag push; mipsel size overrun emits `::warning::` but does NOT fail
+   the release job (soft gate, ADR-0007 §1).
 5. `cargo test --lib` is not changed or broken.
 
 ## Implementation checklist (engineer-b handoff)

--- a/docs/specs/geodata-subsection.md
+++ b/docs/specs/geodata-subsection.md
@@ -101,8 +101,23 @@ is a runtime error, not a parse-time error.
 ### Auto-update task
 
 Spawned once at startup when `auto-update: true`. Wakes every
-`auto-update-interval` hours, downloads each configured URL, writes
-to a temp file, and atomically replaces the live file via `rename(2)`.
+`auto-update-interval` hours. On each tick:
+
+1. **Check in-flight guard.** If a download for this DB is already in progress
+   from a previous tick (slow network, large `geosite.mrs`), skip this tick with
+   `debug!("auto-update: {db} refresh already in flight, skipping")`. Do NOT
+   start a second concurrent download — overlapping writes to the temp file can
+   corrupt it. Use a per-DB `AtomicBool` flag set before the request and cleared
+   on completion or error.
+
+2. **Conditional GET.** Before downloading the body, issue a `HEAD` request or
+   a `GET` with `If-Modified-Since: <file mtime>`. If the server returns `304 Not
+   Modified` (or identical `Content-Length` + `Last-Modified`), skip the download.
+   This avoids hammering GitHub's release CDN rate limit (5000 req/h per IP) on
+   short intervals and wastes no bandwidth when files are unchanged.
+
+3. **Download, write temp, rename.** Write the body to a temp file in the same
+   directory as the target, then atomically replace via `rename(2)`.
 
 **Important:** `rename(2)` updates the file on disk but NOT the in-memory DB.
 After each successful file swap, the task MUST explicitly reload the DB into
@@ -145,6 +160,12 @@ Class A or B divergence — it is a feature interaction, not a correctness trade
 7. Upstream-only fields (`geodata-mode`, `geodata-loader`) → parsed without
    error, `warn!` logged once per field.
 8. `auto-update-interval: 0` → hard parse error ("minimum is 1 hour").
+9. Conditional GET: with `auto-update: true`, if the remote file is unchanged
+   (server returns `304` or matching `Content-Length` + `Last-Modified`), no
+   body is downloaded and the existing file is left untouched.
+10. Single in-flight guard: if a download for a given DB is already in progress
+    when the next tick fires, the new tick logs `debug!` and returns without
+    starting a second download.
 
 ## Implementation checklist (engineer handoff — M2)
 
@@ -153,6 +174,9 @@ Class A or B divergence — it is a feature interaction, not a correctness trade
       optional explicit path before discovery chain.
 - [ ] Spawn auto-update task in `main.rs` when `auto-update: true`; wrap each
       DB in `Arc<RwLock<_>>` if not already.
+- [ ] Add per-DB `AtomicBool` in-flight guard; skip tick with `debug!` if set.
+- [ ] Implement conditional GET (`If-Modified-Since` or HEAD + compare headers);
+      skip body download on 304 / unchanged.
 - [ ] Implement atomic file replace (`tempfile` + `rename`).
 - [ ] Warn-once on unrecognised `geodata.*` fields.
 

--- a/docs/specs/rule-engine-micro-opt.md
+++ b/docs/specs/rule-engine-micro-opt.md
@@ -1,83 +1,99 @@
 # Spec: Rule-engine micro-optimizations (M2)
 
-Status: Draft (2026-04-18)
+Status: Draft (2026-04-18, revised with engineer-a prep findings)
 Owner: engineer-a
 Tracks roadmap item: **M2** (rule-engine micro-optimizations)
 Lane: engineer-a (perf measurement chain)
-Blocked by: benchmark-harness.md (need latency baseline)
-Depends on: allocator-audit.md (hot-path allocations should be fixed first
-            to isolate rule-matching costs from allocator noise)
+Blocked by: M2.B-2 — criterion microbenchmarks must exist first (see benchmark-harness.md)
 Upstream reference: Go mihomo uses a linear scan over the rule list.
 We already have a domain trie; this spec adds targeted improvements.
 
-## Motivation
+## Confirmed findings (engineer-a pre-audit)
 
-Rule matching is in the critical path of every connection. For a config with
-hundreds of rules, a linear scan is measurable latency. The roadmap scopes
-three sub-areas: domain trie layout, IP-CIDR matching structure, and
-rule-provider refresh cost.
+The rule engine in `mihomo-tunnel/src/match_engine.rs` (or `mihomo-rules/src/`) performs
+a **linear scan over `Vec<Box<dyn Rule>>`** for every connection. For configs with
+many rules, this is measurable latency. The obvious first improvement is an
+early-exit DOMAIN trie: domain rules are the most common rule type in real
+subscription configs, and the existing `mihomo-trie` can short-circuit the
+linear scan for domain lookups before checking IP/geo/logic rules.
 
-## Scope
+## Sub-area 0 — Early-exit DOMAIN trie (primary target)
 
-### Sub-area 1 — Domain trie layout
+### Problem
+
+Every connection currently scans the full rule list until a match is found.
+Domain rules (DOMAIN, DOMAIN-SUFFIX, DOMAIN-KEYWORD) are often the first
+match and appear early in the list, but their lookup is dispatched via
+`Box<dyn Rule>::matches()` with no opportunity for the engine to batch them.
+
+### Proposed fix
+
+Pre-partition rules at config-load time:
+1. Extract all `DOMAIN` / `DOMAIN-SUFFIX` rules into the existing trie.
+2. For a new connection, probe the trie first. On hit: return immediately without
+   scanning the remaining rules.
+3. On miss: fall through to the remaining ordered rule list (IP-CIDR, GEOIP, etc.).
+4. DOMAIN-KEYWORD rules (substring match, not prefix match) remain in the linear
+   scan — the trie cannot represent them.
+
+This preserves rule ordering semantics as long as DOMAIN/DOMAIN-SUFFIX rules in
+the config are always intended to fire before any non-domain rule. If a user has
+interleaved non-domain rules between domain rules (unusual but valid), this
+optimization changes semantics. Document this constraint clearly, and add a config
+validation warning if such interleaving is detected.
+
+## Sub-area 1 — Domain trie layout
 
 The current trie in `mihomo-trie` is a HashMap-per-node tree. On a lookup-heavy
 workload this generates pointer chasing. Investigate:
 
 1. Replace `HashMap<char, Node>` per-node with a compact sorted `Vec<(char, Node)>`
    + binary search for small branching-factor nodes (most nodes have ≤ 5 children).
-2. Alternatively, evaluate `AhoCorasick` for DOMAIN-KEYWORD rules (these currently
-   fall through to a linear scan).
-3. Measure lookup throughput before/after using `criterion` benchmarks in the
-   `mihomo-trie` crate.
+2. Measure lookup throughput before/after using the M2.B-2 criterion benchmarks.
 
-Ship the change with the better benchmark result; discard the other.
+Ship the change only if it yields a measurable improvement; document the result
+either way.
 
-### Sub-area 2 — IP-CIDR matching structure
+## Sub-area 2 — IP-CIDR matching structure
 
-IP-CIDR rules use a `Vec<(IpNetwork, action)>` with linear scan in
-`mihomo-rules/src/ip_cidr.rs`. For configs with many IP rules:
+IP-CIDR rules use a linear scan. For configs with many IP rules:
 
-1. Evaluate building a prefix-length–bucketed lookup (`[Vec<_>; 128]` for v6,
-   `[Vec<_>; 32]` for v4) so only the matching prefix-length bucket is scanned.
-2. Alternatively, evaluate `IpLookupTable` from the `ip_network_table` crate.
-3. Benchmark with a synthetic rule set of 500 CIDR entries.
+1. Evaluate building a prefix-length–bucketed lookup so only the matching
+   prefix-length bucket is scanned.
+2. Benchmark with a synthetic rule set of 500 CIDR entries (M2.B-2 criterion bench).
 
-Ship the option that yields ≥ 15% improvement on the benchmark; otherwise keep
-the current code and document the finding.
+Ship only if ≥ 15% improvement on the benchmark; otherwise keep current code
+and document the finding.
 
-### Sub-area 3 — Rule-provider refresh cost
+## Sub-area 3 — Rule-provider async reload
 
-When a rule-provider reloads, the current implementation rebuilds the entire
-rule set. For large `.mrs` files this can introduce a hiccup. Investigate:
+When a rule-provider reloads, the current implementation rebuilds the entire rule
+set on the reload path. Move to `tokio::spawn_blocking` + atomic `Arc<RuleSet>` swap
+so reload does not block rule-matching on the hot path.
 
-1. Move `RuleSet::load()` off the hot path — run it in a `tokio::spawn_blocking`
-   task, swap the `Arc<RuleSet>` atomically after load.
-2. Confirm that readers holding the old `Arc<RuleSet>` are not interrupted (they
-   complete against the old set; new connections see the new set after the swap).
-3. Measure: time to reload a 50k-rule `.mrs` file before/after.
+This is a correctness/latency improvement even if it shows no throughput delta.
 
 ## Acceptance criteria
 
-1. `criterion` benchmarks for trie lookup and IP-CIDR lookup exist in the
-   respective crates and pass.
-2. At least one of the three sub-areas yields a measurable improvement
-   (≥ 10% on the relevant micro-benchmark), and that improvement is committed.
-3. Rule-provider reload does not block the rule-matching hot path (tested by
-   a unit test that fires a reload while a stream of rule-match calls is in
-   flight).
-4. `cargo test --lib` passes after all changes.
-5. Benchmark harness HTTP p99 latency does not regress vs the allocator-audit
-   baseline.
+1. Early-exit DOMAIN trie (sub-area 0) is implemented; `cargo test --lib` passes;
+   a new test verifies that a domain-rule match short-circuits before IP rules are
+   evaluated.
+2. Criterion rule-scan benchmark (`mihomo-rules`) shows improved p50 for
+   domain-heavy workloads after sub-area 0.
+3. At least one of sub-areas 1 or 2 is investigated; findings documented
+   (`docs/benchmarks/rule-engine-findings.md`) even if no code change is made.
+4. Rule-provider async reload (sub-area 3) is implemented; no blocking on
+   hot path during reload; unit test confirms concurrent reload + match works.
+5. HTTP p99 latency in the end-to-end benchmark harness does not regress vs
+   the M2.B-1 baseline.
 
 ## Implementation checklist (engineer-a handoff)
 
-- [ ] Add `criterion` benchmarks to `mihomo-trie`: `lookup_bench` measuring
-      `N = {100, 1000, 10000}` lookups on a realistic domain set.
-- [ ] Prototype trie sub-area 1 (or 2) on a branch; run benchmark; decide.
-- [ ] Add `criterion` benchmarks to `mihomo-rules`: `ip_cidr_bench` with
-      synthetic 500-entry rule set.
-- [ ] Prototype IP-CIDR sub-area 1 (or 2) on a branch; run benchmark; decide.
-- [ ] Implement rule-provider async-reload in `mihomo-rules/src/rule_set.rs`;
-      add unit test for concurrent reload.
-- [ ] Update `docs/benchmarks/rule-engine-findings.md` with before/after numbers.
+- [ ] Implement early-exit DOMAIN trie partition in the rule match engine
+      (sub-area 0); add unit test for short-circuit behavior.
+- [ ] Run criterion `rule_scan` bench before and after sub-area 0; record delta.
+- [ ] Prototype trie node compaction (sub-area 1); run `trie_bench`; decide and document.
+- [ ] Prototype IP-CIDR bucketing (sub-area 2); run `rules_bench`; decide and document.
+- [ ] Implement rule-provider async reload (sub-area 3); add concurrency unit test.
+- [ ] Write `docs/benchmarks/rule-engine-findings.md` with before/after numbers for
+      all sub-areas attempted.

--- a/docs/specs/rule-engine-micro-opt.md
+++ b/docs/specs/rule-engine-micro-opt.md
@@ -1,0 +1,83 @@
+# Spec: Rule-engine micro-optimizations (M2)
+
+Status: Draft (2026-04-18)
+Owner: engineer-a
+Tracks roadmap item: **M2** (rule-engine micro-optimizations)
+Lane: engineer-a (perf measurement chain)
+Blocked by: benchmark-harness.md (need latency baseline)
+Depends on: allocator-audit.md (hot-path allocations should be fixed first
+            to isolate rule-matching costs from allocator noise)
+Upstream reference: Go mihomo uses a linear scan over the rule list.
+We already have a domain trie; this spec adds targeted improvements.
+
+## Motivation
+
+Rule matching is in the critical path of every connection. For a config with
+hundreds of rules, a linear scan is measurable latency. The roadmap scopes
+three sub-areas: domain trie layout, IP-CIDR matching structure, and
+rule-provider refresh cost.
+
+## Scope
+
+### Sub-area 1 — Domain trie layout
+
+The current trie in `mihomo-trie` is a HashMap-per-node tree. On a lookup-heavy
+workload this generates pointer chasing. Investigate:
+
+1. Replace `HashMap<char, Node>` per-node with a compact sorted `Vec<(char, Node)>`
+   + binary search for small branching-factor nodes (most nodes have ≤ 5 children).
+2. Alternatively, evaluate `AhoCorasick` for DOMAIN-KEYWORD rules (these currently
+   fall through to a linear scan).
+3. Measure lookup throughput before/after using `criterion` benchmarks in the
+   `mihomo-trie` crate.
+
+Ship the change with the better benchmark result; discard the other.
+
+### Sub-area 2 — IP-CIDR matching structure
+
+IP-CIDR rules use a `Vec<(IpNetwork, action)>` with linear scan in
+`mihomo-rules/src/ip_cidr.rs`. For configs with many IP rules:
+
+1. Evaluate building a prefix-length–bucketed lookup (`[Vec<_>; 128]` for v6,
+   `[Vec<_>; 32]` for v4) so only the matching prefix-length bucket is scanned.
+2. Alternatively, evaluate `IpLookupTable` from the `ip_network_table` crate.
+3. Benchmark with a synthetic rule set of 500 CIDR entries.
+
+Ship the option that yields ≥ 15% improvement on the benchmark; otherwise keep
+the current code and document the finding.
+
+### Sub-area 3 — Rule-provider refresh cost
+
+When a rule-provider reloads, the current implementation rebuilds the entire
+rule set. For large `.mrs` files this can introduce a hiccup. Investigate:
+
+1. Move `RuleSet::load()` off the hot path — run it in a `tokio::spawn_blocking`
+   task, swap the `Arc<RuleSet>` atomically after load.
+2. Confirm that readers holding the old `Arc<RuleSet>` are not interrupted (they
+   complete against the old set; new connections see the new set after the swap).
+3. Measure: time to reload a 50k-rule `.mrs` file before/after.
+
+## Acceptance criteria
+
+1. `criterion` benchmarks for trie lookup and IP-CIDR lookup exist in the
+   respective crates and pass.
+2. At least one of the three sub-areas yields a measurable improvement
+   (≥ 10% on the relevant micro-benchmark), and that improvement is committed.
+3. Rule-provider reload does not block the rule-matching hot path (tested by
+   a unit test that fires a reload while a stream of rule-match calls is in
+   flight).
+4. `cargo test --lib` passes after all changes.
+5. Benchmark harness HTTP p99 latency does not regress vs the allocator-audit
+   baseline.
+
+## Implementation checklist (engineer-a handoff)
+
+- [ ] Add `criterion` benchmarks to `mihomo-trie`: `lookup_bench` measuring
+      `N = {100, 1000, 10000}` lookups on a realistic domain set.
+- [ ] Prototype trie sub-area 1 (or 2) on a branch; run benchmark; decide.
+- [ ] Add `criterion` benchmarks to `mihomo-rules`: `ip_cidr_bench` with
+      synthetic 500-entry rule set.
+- [ ] Prototype IP-CIDR sub-area 1 (or 2) on a branch; run benchmark; decide.
+- [ ] Implement rule-provider async-reload in `mihomo-rules/src/rule_set.rs`;
+      add unit test for concurrent reload.
+- [ ] Update `docs/benchmarks/rule-engine-findings.md` with before/after numbers.


### PR DESCRIPTION
## Summary

- Drafts 5 new M2 specs: `benchmark-harness.md`, `allocator-audit.md`, `rule-engine-micro-opt.md`, `cargo-feature-flags.md`, `ci-quality-gates.md`
- Updates `roadmap.md §M2` from a bullet list to a full table with spec links, lane assignments, and dependency notes
- Tightens `geodata-subsection.md`: adds conditional-GET staleness check + single in-flight refresh guard per DB (Task #35)
- Adds `docs/benchmarks/hardware.md` template for ADR-0006 reference machine documentation

## Spec status

| Spec | Status |
|------|--------|
| `geodata-subsection.md` | Architect-approved (ADR-0006); two tightenings folded |
| `benchmark-harness.md` | Draft — split M2.B into B-1 (publish numbers) and B-2 (criterion microbenchmarks) |
| `allocator-audit.md` | Draft — cites confirmed `udp.rs:30` target; TCP relay already zero-copy |
| `rule-engine-micro-opt.md` | Draft — early-exit DOMAIN trie as primary sub-area 0 |
| `cargo-feature-flags.md` | Draft — size budget pending architect-2 Task #25 confirmation |
| `ci-quality-gates.md` | Draft — mipsel-musl scope pending architect-2 confirmation |

## Test plan

- [ ] Docs-only change: no code modified. `cargo fmt --all -- --check` passes. `cargo test --lib` passes.
- [ ] Engineers can view specs at correct paths in this PR before merging to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)