### PR TITLE
fix(test/tproxy + rustdoc): unblock CI — tproxy_ready grep + HTML-tag escapes

### DIFF
--- a/tests/tproxy-qemu/guest-init.sh
+++ b/tests/tproxy-qemu/guest-init.sh
@@ -30,7 +30,9 @@ echo "mihomo started (PID $MIHOMO_PID)"
 # --- Wait for TProxy listener to be ready (up to 10s) ---
 READY=0
 for i in $(seq 1 20); do
-    if grep -q "TProxy listener started" /tmp/mihomo.log 2>/dev/null; then
+    # Match both legacy "TProxy listener started" and current
+    # "TProxy listener '<name>' started on <addr>" formats.
+    if grep -qE "TProxy listener( '[^']*')? started" /tmp/mihomo.log 2>/dev/null; then
         READY=1
         echo "TProxy listener ready after $((i * 500))ms"
         break


### PR DESCRIPTION
## Summary

Two CI-hygiene fixes that together unblock everything else. They were originally separate (rustdoc bug was on #37); cherry-picked together here because each one is needed to surface the other (lint blocks tproxy → tproxy blocks merge → can't fix lint).

### 1. `tproxy_ready` readiness probe (test bug)

`tests/tproxy-qemu/guest-init.sh` greps `/tmp/mihomo.log` for the literal substring `"TProxy listener started"`. mihomo now logs:

```
TProxy listener '<name>' started on <addr>
```

(`crates/mihomo-listener/src/tproxy/mod.rs:72` — listener name was inserted between `"listener"` and `"started"` in a multi-listener refactor). Substring no longer appears, probe times out at 10 s.

**This is a test bug, not a product regression.** Every failing run had `mihomo_alive`, `tproxy_listening`, `tproxy_intercept`, `tproxy_relay`, `tproxy_sni_extract`, `firewall_teardown` PASS — only the readiness probe was wrong.

Fix: regex that matches both formats — `grep -qE "TProxy listener( '[^']*')? started"`. Verified locally against new format, legacy format, and a noise line.

### 2. Rustdoc HTML-tag / intra-doc-link escapes

`RUSTDOCFLAGS="-D warnings" cargo doc` was failing on:

- `crates/mihomo-common/src/adapter.rs:112` — `<proto>` parsed as unclosed HTML tag
- `crates/mihomo-proxy/src/group/relay.rs:3,7` — `proxy[0]`/`meta_for_proxy[1]` parsed as intra-doc links

Wrap in backticks so rustdoc treats them as code spans.

## History

- `2026-04-18 08:22` main run 24600688958 — tproxy ✅
- `2026-04-18 11:39` main run **24603815078** — tproxy ❌ (readiness probe regression landed)
- `2026-04-19 → 2026-04-21` — masked by lint failure causing tproxy to be SKIPPED

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (workspace, zero warnings)
- [x] `cargo test --lib`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` (now passes locally)
- [x] Regex match verified locally against both log formats
- [ ] Confirm CI: `lint` → PASS, `tproxy` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)