### PR TITLE
chore(alloc): drop mimalloc, use system allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,16 +1599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libproc"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,7 +1760,6 @@ dependencies = [
  "mihomo-proxy",
  "mihomo-rules",
  "mihomo-tunnel",
- "mimalloc",
  "parking_lot",
  "rustls",
  "serde_yaml",
@@ -1995,15 +1984,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,9 +127,6 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # Parking lot for sync primitives
 parking_lot = "0.12"
 
-# Global allocator (ADR-0008 — M2 default for all targets)
-mimalloc = { version = "0.1", default-features = false }
-
 # Wait-free read / atomic swap for hot-path rule-set + proxy-provider refreshes
 arc-swap = "1"
 

--- a/crates/mihomo-app/Cargo.toml
+++ b/crates/mihomo-app/Cargo.toml
@@ -54,7 +54,6 @@ serde_yaml = { workspace = true }
 parking_lot = { workspace = true }
 dashmap = { workspace = true }
 rustls = { workspace = true }
-mimalloc = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/mihomo-app/src/main.rs
+++ b/crates/mihomo-app/src/main.rs
@@ -1,8 +1,3 @@
-use mimalloc::MiMalloc;
-
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use dashmap::DashMap;

--- a/crates/mihomo-common/src/adapter.rs
+++ b/crates/mihomo-common/src/adapter.rs
@@ -109,7 +109,7 @@ pub trait ProxyAdapter: Send + Sync {
     /// Default implementation returns `Err(NotSupported)`.  Override in
     /// adapters that support relay chaining (HTTP CONNECT, SOCKS5, …).
     ///
-    /// upstream: adapter/outbound/<proto>.go — `DialContextWithDialer`
+    /// upstream: `adapter/outbound/<proto>.go` — `DialContextWithDialer`
     async fn connect_over(
         &self,
         _stream: Box<dyn ProxyConn>,

--- a/crates/mihomo-proxy/src/group/relay.rs
+++ b/crates/mihomo-proxy/src/group/relay.rs
@@ -1,14 +1,14 @@
 //! Relay proxy group (M1.C-2) — chains multiple outbounds in sequence.
 //!
-//! Traffic flow: client → proxy[0] → proxy[1] → … → proxy[N-1] → target.
+//! Traffic flow: `client → proxy[0] → proxy[1] → … → proxy[N-1] → target`.
 //!
 //! # Dial algorithm
 //!
-//! - proxy[0]: `dial_tcp(meta_for_proxy[1])` — real TCP connect targeting the
+//! - `proxy[0]`: `dial_tcp(meta_for_proxy[1])` — real TCP connect targeting the
 //!   next hop's address.
-//! - proxy[1..N-2]: `connect_over(stream, meta_for_proxy[i+1])` — proxy-level
+//! - `proxy[1..N-2]`: `connect_over(stream, meta_for_proxy[i+1])` — proxy-level
 //!   CONNECT tunnel through the already-established stream.
-//! - proxy[N-1]: `connect_over(stream, final_target)` — final hop connects to
+//! - `proxy[N-1]`: `connect_over(stream, final_target)` — final hop connects to
 //!   the actual target.
 //!
 //! Nested relay-of-relay works transparently: `RelayGroup` implements


### PR DESCRIPTION
## Summary
- Remove `mimalloc::MiMalloc` `#[global_allocator]` wiring from `mihomo-app/src/main.rs`
- Drop `mimalloc` dependency from `crates/mihomo-app/Cargo.toml` and the workspace `Cargo.toml`
- Binary now uses the platform system allocator

## Heads-up
This reverses the **ADR-0008 (M2 default for all targets)** decision. The ADR document itself is not updated in this PR — if we keep this change, a superseding ADR should follow.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 418 passed across 11 crates
- [ ] Manual smoke run of `mihomo -f config.yaml` on target platform(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)