### PR TITLE
fix(udp): evict idle UDP NAT sessions (60s idle, 15s sweep)

### DIFF
--- a/crates/mihomo-app/src/main.rs
+++ b/crates/mihomo-app/src/main.rs
@@ -431,6 +431,7 @@ async fn run(
     tunnel.set_mode(config.general.mode);
     tunnel.update_rules(config.rules);
     tunnel.update_proxies(config.proxies);
+    tunnel.spawn_background_tasks();
 
     // Start DNS server if configured
     if let Some(listen_addr) = config.dns.listen_addr {

--- a/crates/mihomo-tunnel/src/tunnel.rs
+++ b/crates/mihomo-tunnel/src/tunnel.rs
@@ -186,6 +186,16 @@ impl Tunnel {
         self.inner.proxies.read().clone()
     }
 
+    /// Spawn background tasks owned by the tunnel (currently just the UDP NAT
+    /// sweeper). Idempotent callers should only invoke this once per process.
+    pub fn spawn_background_tasks(&self) {
+        udp::spawn_nat_sweeper(
+            &self.inner.nat_table,
+            udp::DEFAULT_UDP_IDLE,
+            udp::DEFAULT_SWEEP_INTERVAL,
+        );
+    }
+
     pub fn rules_info(&self) -> Vec<(String, String, String)> {
         self.inner
             .rules

--- a/crates/mihomo-tunnel/src/udp.rs
+++ b/crates/mihomo-tunnel/src/udp.rs
@@ -2,13 +2,52 @@ use crate::tunnel::TunnelInner;
 use dashmap::DashMap;
 use mihomo_common::{Metadata, ProxyPacketConn};
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
+
+/// Idle timeout before a UDP NAT session is swept. Matches upstream mihomo-go.
+pub const DEFAULT_UDP_IDLE: Duration = Duration::from_secs(60);
+
+/// How often the sweeper scans for expired sessions.
+pub const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
 
 /// NAT table entry for UDP sessions
 pub struct UdpSession {
     pub conn: Box<dyn ProxyPacketConn>,
     pub proxy_name: String,
+    /// Monotonic millis since process start. Bumped on every fast-path forward
+    /// so idle sessions can be evicted by [`spawn_nat_sweeper`].
+    last_activity_ms: AtomicU64,
+}
+
+impl UdpSession {
+    pub fn new(conn: Box<dyn ProxyPacketConn>, proxy_name: String) -> Self {
+        Self {
+            conn,
+            proxy_name,
+            last_activity_ms: AtomicU64::new(monotonic_ms()),
+        }
+    }
+
+    fn touch(&self) {
+        self.last_activity_ms
+            .store(monotonic_ms(), Ordering::Relaxed);
+    }
+
+    fn idle_for(&self) -> Duration {
+        let now = monotonic_ms();
+        let last = self.last_activity_ms.load(Ordering::Relaxed);
+        Duration::from_millis(now.saturating_sub(last))
+    }
+}
+
+fn monotonic_ms() -> u64 {
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    let start = START.get_or_init(Instant::now);
+    start.elapsed().as_millis() as u64
 }
 
 // Direction A (ADR-0008 §6): key is a (src, dst) SocketAddr tuple — zero heap
@@ -18,6 +57,43 @@ pub type NatTable = Arc<DashMap<(SocketAddr, SocketAddr), Arc<UdpSession>>>;
 
 pub fn new_nat_table() -> NatTable {
     Arc::new(DashMap::new())
+}
+
+/// Spawn the background sweeper that evicts UDP NAT sessions idle for more
+/// than `idle`. Scans every `interval`. The task exits when the caller drops
+/// the returned `JoinHandle`'s aborter (or the last Arc to the table is
+/// dropped and the weak upgrade fails).
+pub fn spawn_nat_sweeper(
+    nat_table: &NatTable,
+    idle: Duration,
+    interval: Duration,
+) -> JoinHandle<()> {
+    let weak = Arc::downgrade(nat_table);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // First tick fires immediately; skip it.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let Some(table) = weak.upgrade() else {
+                debug!("UDP NAT sweeper: table dropped, exiting");
+                return;
+            };
+            let before = table.len();
+            if before == 0 {
+                continue;
+            }
+            table.retain(|_key, session| session.idle_for() < idle);
+            let evicted = before.saturating_sub(table.len());
+            if evicted > 0 {
+                debug!(
+                    "UDP NAT sweeper: evicted {evicted} idle sessions (remaining {})",
+                    table.len()
+                );
+            }
+        }
+    })
 }
 
 /// Handle a UDP packet: look up or create a NAT session.
@@ -49,6 +125,8 @@ pub async fn handle_udp(
         if let Err(e) = session.conn.write_packet(data, &dst_addr).await {
             debug!("UDP write error for {} -> {}: {}", src, dst_addr, e);
             tunnel.nat_table.remove(&key);
+        } else {
+            session.touch();
         }
         return;
     }
@@ -77,14 +155,93 @@ pub async fn handle_udp(
                 warn!("UDP initial write error for {} -> {}: {}", src, dst_addr, e);
                 return;
             }
-            let session = Arc::new(UdpSession {
-                conn,
-                proxy_name: proxy.name().to_string(),
-            });
+            let session = Arc::new(UdpSession::new(conn, proxy.name().to_string()));
             tunnel.nat_table.insert(key, session);
         }
         Err(e) => {
             warn!("UDP dial error for {} -> {}: {}", src, dst_addr, e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use mihomo_common::error::Result as MihomoResult;
+
+    struct NoopPacketConn;
+
+    #[async_trait]
+    impl ProxyPacketConn for NoopPacketConn {
+        async fn read_packet(&self, _buf: &mut [u8]) -> MihomoResult<(usize, SocketAddr)> {
+            Ok((0, "0.0.0.0:0".parse().unwrap()))
+        }
+        async fn write_packet(&self, buf: &[u8], _addr: &SocketAddr) -> MihomoResult<usize> {
+            Ok(buf.len())
+        }
+        fn local_addr(&self) -> MihomoResult<SocketAddr> {
+            Ok("0.0.0.0:0".parse().unwrap())
+        }
+        fn close(&self) -> MihomoResult<()> {
+            Ok(())
+        }
+    }
+
+    fn mk_session() -> Arc<UdpSession> {
+        Arc::new(UdpSession::new(Box::new(NoopPacketConn), "test".into()))
+    }
+
+    fn mk_key(port: u16) -> (SocketAddr, SocketAddr) {
+        (
+            SocketAddr::from(([127, 0, 0, 1], port)),
+            SocketAddr::from(([8, 8, 8, 8], 53)),
+        )
+    }
+
+    #[tokio::test(start_paused = false)]
+    async fn sweeper_evicts_idle_sessions() {
+        let table = new_nat_table();
+        table.insert(mk_key(1), mk_session());
+        table.insert(mk_key(2), mk_session());
+        assert_eq!(table.len(), 2);
+
+        let _handle =
+            spawn_nat_sweeper(&table, Duration::from_millis(50), Duration::from_millis(20));
+
+        // Wait past the idle threshold; sweeper runs every 20ms.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(table.len(), 0, "idle sessions should have been swept");
+    }
+
+    #[tokio::test(start_paused = false)]
+    async fn touched_sessions_are_kept() {
+        let table = new_nat_table();
+        let session = mk_session();
+        table.insert(mk_key(1), session.clone());
+
+        let _handle =
+            spawn_nat_sweeper(&table, Duration::from_millis(80), Duration::from_millis(20));
+
+        // Touch repeatedly so the session stays young.
+        for _ in 0..6 {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            session.touch();
+        }
+        assert_eq!(table.len(), 1, "active session must not be evicted");
+    }
+
+    #[tokio::test(start_paused = false)]
+    async fn sweeper_exits_when_table_dropped() {
+        let table = new_nat_table();
+        table.insert(mk_key(1), mk_session());
+        let handle = spawn_nat_sweeper(&table, Duration::from_secs(60), Duration::from_millis(20));
+        drop(table);
+        // Allow the next tick to observe the dropped table.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            handle.is_finished(),
+            "sweeper should exit once the table is dropped"
+        );
     }
 }


### PR DESCRIPTION
## Summary
UDP NAT sessions in `mihomo-tunnel` were only removed on write error. On iOS NE (50MB cap), DNS/QUIC/game traffic leaked sessions indefinitely — each holding a boxed `ProxyPacketConn` plus `proxy_name` String, KBs per entry.

- `UdpSession` now tracks `last_activity` via `AtomicU64` (monotonic ms since process start); bumped on every successful fast-path forward.
- `spawn_nat_sweeper` walks the `DashMap` on a ticker, `retain()`s entries with `idle_for() < idle`. Uses `Arc::downgrade` so the task exits once the table is dropped.
- `Tunnel::spawn_background_tasks` wires it in; `main.rs` calls it right after tunnel bootstrap.
- Defaults: **60s** idle (matches upstream mihomo-go), **15s** sweep interval.

## Memory impact
A leaked session previously lived until process exit. With this fix, idle DNS/QUIC flows are reclaimed within at most `idle + interval` (~75s). On a steady 50 QPS DNS load, table size stays bounded around the ~in-flight count instead of growing linearly with time.

## Test plan
- [x] Three new unit tests in `mihomo-tunnel::udp::tests`: eviction, keepalive-via-touch, clean exit when table dropped
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` → 421 passed (was 418)
- [ ] Soak test on iOS NE with DNS+QUIC mix to confirm table plateau

## Follow-ups (not in this PR)
From the memory audit, still open: unbounded connection-tracking `DashMap` in `statistics.rs` and `Vec<String>` chain duplication in `ConnectionInfo`. Revisit once listener-cleanup paths are audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)