### PR TITLE
perf(tcp-relay): shrink copy_bidirectional buffers 8KB → 4KB

### DIFF
--- a/crates/mihomo-tunnel/src/tcp.rs
+++ b/crates/mihomo-tunnel/src/tcp.rs
@@ -3,6 +3,11 @@ use mihomo_common::{Metadata, ProxyConn};
 use tokio::io;
 use tracing::{debug, info, warn};
 
+/// Per-direction relay buffer for `copy_bidirectional_with_sizes`. Two of these
+/// live for the full connection lifetime, so on an iOS NE 50MB cap halving
+/// the tokio default (8 KB → 4 KB) saves 8 KB/conn — ~40 MB at 5k conns.
+const RELAY_BUF_SIZE: usize = 4 * 1024;
+
 pub async fn handle_tcp(
     tunnel: &TunnelInner,
     mut conn: Box<dyn ProxyConn>,
@@ -41,7 +46,14 @@ pub async fn handle_tcp(
     match proxy.dial_tcp(&metadata).await {
         Ok(mut remote) => {
             // Bidirectional copy
-            match io::copy_bidirectional(&mut conn, &mut remote).await {
+            match io::copy_bidirectional_with_sizes(
+                &mut conn,
+                &mut remote,
+                RELAY_BUF_SIZE,
+                RELAY_BUF_SIZE,
+            )
+            .await
+            {
                 Ok((up, down)) => {
                     tunnel.stats.add_upload(up as i64);
                     tunnel.stats.add_download(down as i64);


### PR DESCRIPTION
## Summary
`tokio::io::copy_bidirectional` uses `DEFAULT_BUF_SIZE = 8 KB` per direction ([`tokio-1.49/src/io/util/mod.rs:88`](https://docs.rs/tokio/1.49.0/src/tokio/io/util/mod.rs.html)), so every TCP flow holds **2× 8 KB = 16 KB** of boxed slices for its full lifetime.

Swap to `copy_bidirectional_with_sizes(&mut a, &mut b, 4096, 4096)` — saves **8 KB per connection**, **~40 MB at 5k concurrent flows**.

## Why this is safe
- Interactive proxy traffic (HTTP requests, RPC, TLS handshakes) is dominated by packets well under 4 KB.
- Bulk transfer throughput is MTU-bound (~1.5 KB per segment), not relay-buffer-bound.
- The buffer is only a staging area between `read()` and `write()`; smaller means more loop iterations but the same bytes/sec through the kernel.
- No behavioral change — same API, same error semantics.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 418 passed (no new tests; this is a buffer-size tune)
- [ ] Throughput sanity (if someone has a running setup): `iperf3` or large-file download through a Trojan proxy — expect no measurable regression

## Scope
Only changes `crates/mihomo-tunnel/src/tcp.rs`. UDP path is unaffected (different buffers on per-packet read). Follow-up PR will cap the rustls ciphertext queue, which is the other memory lever on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)