### PR TITLE
perf(tls): cap rustls send buffer at 16 KB per connection

### DIFF
--- a/crates/mihomo-transport/src/tls.rs
+++ b/crates/mihomo-transport/src/tls.rs
@@ -391,14 +391,28 @@ impl RustlsInner {
     }
 
     async fn connect(&self, inner: Box<dyn Stream>) -> Result<Box<dyn Stream>> {
-        let tls_stream = self
+        let mut tls_stream = self
             .connector
             .connect(self.server_name.clone(), inner)
             .await
             .map_err(|e| TransportError::Tls(e.to_string()))?;
+        // Cap the per-connection ciphertext send queue (rustls default is 64 KB
+        // per `DEFAULT_BUFFER_LIMIT` in common_state.rs). 64 KB × thousands of
+        // idle-but-alive flows is the worst-case tail that blows iOS NE's
+        // 50 MB cap under write backpressure; 16 KB is still larger than a
+        // typical TLS record (~16 KB max) so steady-state throughput is
+        // unaffected while backpressure stalls the reader earlier.
+        tls_stream
+            .get_mut()
+            .1
+            .set_buffer_limit(Some(RUSTLS_SEND_BUFFER_LIMIT));
         Ok(Box::new(tls_stream))
     }
 }
+
+/// Cap on the rustls `sendable_tls` ciphertext queue per connection.
+/// See `RustlsInner::connect` for rationale.
+const RUSTLS_SEND_BUFFER_LIMIT: usize = 16 * 1024;
 
 // ─── BoringSSL backend ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
rustls's `ClientConnection` defaults `sendable_tls` (the outgoing ciphertext queue) to [`DEFAULT_BUFFER_LIMIT = 64 KB`](https://docs.rs/rustls/0.23.37/src/rustls/common_state.rs.html#1056). Under write backpressure — slow remote, congested path, lots of idle-but-alive flows — that 64 KB × thousands of connections is the worst-case tail that blows iOS NE's 50 MB cap.

This PR calls `ClientConnection::set_buffer_limit(Some(16 * 1024))` right after the handshake completes, inside `RustlsInner::connect`.

## Impact
- **Worst-case per connection:** 64 KB → 16 KB (ciphertext send queue)
- **Savings under backpressure:** up to **48 KB/conn** (~240 MB avoided at 5k concurrent flows in the degenerate case)
- **Steady-state throughput:** unaffected. 16 KB fits one full TLS record (max payload 16 KB + overhead), so a normal flowing connection buffers ≤ 1 record at a time.

## Why it's safe
- The cap is an *upper bound*; buffers still grow on-demand from 0.
- When the limit is reached, `write()` returns `WouldBlock` — this is already how rustls signals pressure; consumers (tokio-rustls → `copy_bidirectional`) handle it correctly.
- Applied only on the rustls backend. BoringSSL backend (feature `boring-tls`) has separate buffer management and is untouched.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 418 passed
- [x] `cargo test -p mihomo-transport --test tls_test` — 13 passed (full loopback handshake + I/O)
- [ ] Soak test on iOS NE at high concurrency with a slow remote — confirm RSS stays bounded

## Related
Companion to #41 (copy_bidirectional 8KB→4KB). Together they reduce per-connection memory from 16 KB + up-to-64 KB = up-to-80 KB to 8 KB + up-to-16 KB = up-to-24 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)