### PR TITLE
test(sniffer): repair config-test compile + 11 new unit tests + roadmap audit

### DIFF
--- a/crates/mihomo-common/src/sniffer/http.rs
+++ b/crates/mihomo-common/src/sniffer/http.rs
@@ -75,4 +75,26 @@ mod tests {
         let buf = b"GET / HTTP/1.1\r\nHost: [::1]:8080\r\n\r\n";
         assert_eq!(sniff_http(buf), Some("::1".to_string()));
     }
+
+    #[test]
+    fn sniff_http_ipv6_host_no_port() {
+        // Bracketed IPv6 host without a `:port` suffix is still recognised.
+        let buf = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]\r\n\r\n";
+        assert_eq!(sniff_http(buf), Some("2001:db8::1".to_string()));
+    }
+
+    #[test]
+    fn sniff_http_empty_host_value_returns_none() {
+        // RFC 7230 §5.4 forbids an empty Host value; we drop it rather than
+        // returning an empty `sniff_host`.
+        let buf = b"GET / HTTP/1.1\r\nHost: \r\n\r\n";
+        assert_eq!(sniff_http(buf), None);
+    }
+
+    #[test]
+    fn sniff_http_host_with_surrounding_whitespace() {
+        // Field-value LWS must be trimmed.
+        let buf = b"GET / HTTP/1.1\r\nHost:    example.com   \r\n\r\n";
+        assert_eq!(sniff_http(buf), Some("example.com".to_string()));
+    }
 }

--- a/crates/mihomo-common/src/sniffer/tls.rs
+++ b/crates/mihomo-common/src/sniffer/tls.rs
@@ -185,4 +185,101 @@ mod tests {
         let header = [0x16u8, 0x03, 0x01, 0x00, 0x05];
         assert_eq!(sniff_tls(&header), None);
     }
+
+    /// Build a ClientHello whose only extension is a non-SNI extension
+    /// (extended_master_secret, type 0x0017, empty data). Sniffing should
+    /// return `None` rather than panicking on the missing SNI.
+    fn build_client_hello_without_sni() -> Vec<u8> {
+        let mut other_ext = Vec::new();
+        other_ext.extend_from_slice(&[0x00, 0x17]);
+        other_ext.extend_from_slice(&[0x00, 0x00]);
+
+        let extensions_len = other_ext.len();
+
+        let mut hello = Vec::new();
+        hello.extend_from_slice(&[0x03, 0x03]);
+        hello.extend_from_slice(&[0u8; 32]);
+        hello.push(0x00);
+        hello.extend_from_slice(&[0x00, 0x02, 0x00, 0x2f]);
+        hello.extend_from_slice(&[0x01, 0x00]);
+        hello.extend_from_slice(&(extensions_len as u16).to_be_bytes());
+        hello.extend_from_slice(&other_ext);
+
+        let handshake_len = hello.len();
+        let mut handshake = vec![
+            0x01,
+            ((handshake_len >> 16) & 0xff) as u8,
+            ((handshake_len >> 8) & 0xff) as u8,
+            (handshake_len & 0xff) as u8,
+        ];
+        handshake.extend_from_slice(&hello);
+
+        let record_len = handshake.len();
+        let mut record = Vec::new();
+        record.push(0x16);
+        record.extend_from_slice(&[0x03, 0x01]);
+        record.extend_from_slice(&(record_len as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+        record
+    }
+
+    #[test]
+    fn sniff_tls_no_sni_extension_returns_none() {
+        let data = build_client_hello_without_sni();
+        assert_eq!(sniff_tls(&data), None);
+    }
+
+    #[test]
+    fn sniff_tls_skips_non_host_name_entries() {
+        // SNI extension with a non-zero name_type entry first, then a host_name
+        // entry. Per RFC 6066 §3 only name_type=0 (host_name) is currently
+        // defined, so the parser must skip the unknown entry rather than
+        // misinterpreting it as the hostname.
+        let host = b"target.example.com";
+        // Entry 1: name_type=0x99 (unknown), name="ignored"
+        let unknown = b"ignored";
+        // Entry 2: name_type=0x00 (host_name), name=host
+        let mut list = Vec::new();
+        list.push(0x99);
+        list.extend_from_slice(&(unknown.len() as u16).to_be_bytes());
+        list.extend_from_slice(unknown);
+        list.push(0x00);
+        list.extend_from_slice(&(host.len() as u16).to_be_bytes());
+        list.extend_from_slice(host);
+
+        let mut sni_ext = Vec::new();
+        sni_ext.extend_from_slice(&[0x00, 0x00]);
+        let ext_data_len = (2 + list.len()) as u16;
+        sni_ext.extend_from_slice(&ext_data_len.to_be_bytes());
+        sni_ext.extend_from_slice(&(list.len() as u16).to_be_bytes());
+        sni_ext.extend_from_slice(&list);
+
+        let extensions_len = sni_ext.len();
+        let mut hello = Vec::new();
+        hello.extend_from_slice(&[0x03, 0x03]);
+        hello.extend_from_slice(&[0u8; 32]);
+        hello.push(0x00);
+        hello.extend_from_slice(&[0x00, 0x02, 0x00, 0x2f]);
+        hello.extend_from_slice(&[0x01, 0x00]);
+        hello.extend_from_slice(&(extensions_len as u16).to_be_bytes());
+        hello.extend_from_slice(&sni_ext);
+
+        let handshake_len = hello.len();
+        let mut handshake = vec![
+            0x01,
+            ((handshake_len >> 16) & 0xff) as u8,
+            ((handshake_len >> 8) & 0xff) as u8,
+            (handshake_len & 0xff) as u8,
+        ];
+        handshake.extend_from_slice(&hello);
+
+        let record_len = handshake.len();
+        let mut record = Vec::new();
+        record.push(0x16);
+        record.extend_from_slice(&[0x03, 0x01]);
+        record.extend_from_slice(&(record_len as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+
+        assert_eq!(sniff_tls(&record), Some("target.example.com".to_string()));
+    }
 }

--- a/crates/mihomo-config/tests/sniffer_config_test.rs
+++ b/crates/mihomo-config/tests/sniffer_config_test.rs
@@ -1,0 +1,357 @@
+//! Config-parser tests for the `sniffer:` YAML block.
+//!
+//! These exercise [`mihomo_config::load_config_from_str`] end-to-end and
+//! assert on the resulting `Config.sniffer` (a [`SnifferConfig`]) — the
+//! parser itself (`parse_sniffer_config`) is private.
+//!
+//! # Test plan coverage (S-series)
+//!
+//! | ID  | Description                                                            |
+//! |-----|------------------------------------------------------------------------|
+//! | S1  | absent `sniffer:` + absent `tproxy_sni:` → default (disabled)          |
+//! | S2  | `enable: true` + no `sniff:` map at all → hard error                   |
+//! | S3  | `enable: true` + `sniff:` map with no recognised protocols → hard err  |
+//! | S4  | `enable: true` + `sniff.TLS.ports: [443]` → loaded, tls_ports=[443]    |
+//! | S5  | `enable: true` + `sniff.HTTP.ports: [80]` → loaded, http_ports=[80]    |
+//! | S6  | `enable: true` + both TLS and HTTP populated → both lists set          |
+//! | S7  | Protocol keys are case-insensitive (`tls:`, `Tls:`, `TLS:` all work)   |
+//! | S8  | `sniff.QUIC` is parsed but ignored (warn-only)                         |
+//! | S9  | Unknown protocol key is parsed but ignored (warn-only)                 |
+//! | S10 | `enable: false` + empty `sniff:` → loads (no port-presence check)      |
+//! | S11 | `timeout: 0` → hard error (out of range)                               |
+//! | S12 | `timeout: 60001` → hard error (out of range)                           |
+//! | S13 | `timeout: 250` → loaded, Duration::from_millis(250)                    |
+//! | S14 | `skip-domain` and `force-domain` lists pass through verbatim           |
+//! | S15 | deprecated `tproxy_sni: true` alone → enable=true, tls=[443]           |
+//! | S16 | `sniffer:` + `tproxy_sni: true` → sniffer wins; tproxy_sni ignored     |
+//! | S17 | `force-dns-mapping: true` → warns and accepted; rest of config loads   |
+//! | S18 | `parse-pure-ip` / `override-destination` overrides apply               |
+
+use mihomo_config::load_config_from_str;
+
+// `Config` doesn't implement `Debug`, so `Result::expect_err` is unusable.
+// This helper unwraps the `Err` arm or panics with a useful message.
+async fn expect_load_err(yaml: &str) -> String {
+    match load_config_from_str(yaml).await {
+        Ok(_) => panic!("expected load_config_from_str to fail, but it succeeded"),
+        Err(e) => e.to_string(),
+    }
+}
+
+// ─── S1: defaults — neither sniffer: nor tproxy_sni: set ─────────────────
+
+#[tokio::test]
+async fn s1_no_sniffer_block_yields_default_disabled() {
+    let cfg = load_config_from_str("port: 7890\n")
+        .await
+        .expect("config must load");
+    assert!(!cfg.sniffer.enable, "default sniffer must be disabled");
+    // When disabled, port lists carry the `SnifferConfig::default()` values
+    // and are inert at runtime — we only assert the disable flag.
+    assert!(!cfg.sniffer.override_destination);
+}
+
+// ─── S2: enable: true with no `sniff:` map at all ────────────────────────
+
+#[tokio::test]
+async fn s2_enable_true_without_sniff_map_errors() {
+    let yaml = r#"
+sniffer:
+  enable: true
+"#;
+    let err = expect_load_err(yaml).await;
+    assert!(
+        err.contains("sniff"),
+        "error must mention `sniff`: got {}",
+        err
+    );
+}
+
+// ─── S3: enable: true with sniff: map that has no recognised protos ──────
+
+#[tokio::test]
+async fn s3_enable_true_with_only_unknown_protocols_errors() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    QUIC:
+      ports: [443]
+    SOMETHING:
+      ports: [9999]
+"#;
+    let err = expect_load_err(yaml).await;
+    assert!(
+        err.contains("no ports"),
+        "error must mention 'no ports': got {}",
+        err
+    );
+}
+
+// ─── S4: TLS ports only ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn s4_tls_only_loads() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    TLS:
+      ports: [443, 8443]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert!(cfg.sniffer.enable);
+    assert_eq!(cfg.sniffer.tls_ports, vec![443, 8443]);
+    assert_eq!(cfg.sniffer.http_ports, Vec::<u16>::new());
+}
+
+// ─── S5: HTTP ports only ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn s5_http_only_loads() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80, 8080]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert!(cfg.sniffer.enable);
+    assert_eq!(cfg.sniffer.http_ports, vec![80, 8080]);
+    assert_eq!(cfg.sniffer.tls_ports, Vec::<u16>::new());
+}
+
+// ─── S6: both TLS and HTTP ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn s6_both_protocols_loads() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    TLS:
+      ports: [443]
+    HTTP:
+      ports: [80]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert_eq!(cfg.sniffer.tls_ports, vec![443]);
+    assert_eq!(cfg.sniffer.http_ports, vec![80]);
+}
+
+// ─── S7: case-insensitive protocol keys ──────────────────────────────────
+
+#[tokio::test]
+async fn s7_lowercase_protocol_keys_accepted() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    tls:
+      ports: [443]
+    http:
+      ports: [80]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert_eq!(cfg.sniffer.tls_ports, vec![443]);
+    assert_eq!(cfg.sniffer.http_ports, vec![80]);
+}
+
+// ─── S8: QUIC is ignored (warn-only) ─────────────────────────────────────
+
+#[tokio::test]
+async fn s8_quic_protocol_ignored_with_other_proto_present() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    TLS:
+      ports: [443]
+    QUIC:
+      ports: [443]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    // QUIC entry is silently dropped — we don't synthesise a quic_ports field.
+    assert_eq!(cfg.sniffer.tls_ports, vec![443]);
+    assert_eq!(cfg.sniffer.http_ports, Vec::<u16>::new());
+}
+
+// ─── S9: unknown protocol key is ignored ─────────────────────────────────
+
+#[tokio::test]
+async fn s9_unknown_protocol_ignored_with_known_proto_present() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80]
+    PIRATE-PROTOCOL:
+      ports: [1337]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert_eq!(cfg.sniffer.http_ports, vec![80]);
+    assert_eq!(cfg.sniffer.tls_ports, Vec::<u16>::new());
+}
+
+// ─── S10: enable: false + empty sniff is OK ──────────────────────────────
+
+#[tokio::test]
+async fn s10_disabled_with_empty_sniff_loads() {
+    // No `sniff:` key at all, no error because enable is false.
+    let yaml = r#"
+sniffer:
+  enable: false
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert!(!cfg.sniffer.enable);
+}
+
+// ─── S11/S12: timeout out of range ───────────────────────────────────────
+
+#[tokio::test]
+async fn s11_timeout_zero_errors() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  timeout: 0
+  sniff:
+    TLS:
+      ports: [443]
+"#;
+    let err = expect_load_err(yaml).await;
+    assert!(err.contains("timeout"), "got: {}", err);
+}
+
+#[tokio::test]
+async fn s12_timeout_above_max_errors() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  timeout: 60001
+  sniff:
+    TLS:
+      ports: [443]
+"#;
+    let err = expect_load_err(yaml).await;
+    assert!(err.contains("timeout"), "got: {}", err);
+}
+
+// ─── S13: custom timeout in range ────────────────────────────────────────
+
+#[tokio::test]
+async fn s13_timeout_custom_value_applied() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  timeout: 250
+  sniff:
+    TLS:
+      ports: [443]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert_eq!(cfg.sniffer.timeout, std::time::Duration::from_millis(250));
+}
+
+// ─── S14: skip-domain / force-domain pass-through ────────────────────────
+
+#[tokio::test]
+async fn s14_skip_and_force_domain_passthrough() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  sniff:
+    TLS:
+      ports: [443]
+  skip-domain:
+    - "*.ads.example.com"
+    - tracker.evil.test
+  force-domain:
+    - "+.cdn.example.com"
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert_eq!(
+        cfg.sniffer.skip_domain,
+        vec![
+            "*.ads.example.com".to_string(),
+            "tracker.evil.test".to_string()
+        ]
+    );
+    assert_eq!(
+        cfg.sniffer.force_domain,
+        vec!["+.cdn.example.com".to_string()]
+    );
+}
+
+// ─── S15: deprecated `tproxy_sni: true` alone ────────────────────────────
+
+#[tokio::test]
+async fn s15_deprecated_tproxy_sni_alone_synthesises_minimal_config() {
+    // RawConfig is `kebab-case` — the YAML key is `tproxy-sni`, mapping to
+    // the `tproxy_sni` field in Rust.
+    let yaml = r#"
+tproxy-sni: true
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert!(cfg.sniffer.enable);
+    assert_eq!(cfg.sniffer.tls_ports, vec![443]);
+    assert_eq!(cfg.sniffer.http_ports, Vec::<u16>::new());
+    assert!(cfg.sniffer.parse_pure_ip);
+    assert!(!cfg.sniffer.override_destination);
+}
+
+// ─── S16: sniffer + tproxy_sni → sniffer wins ────────────────────────────
+
+#[tokio::test]
+async fn s16_sniffer_block_wins_when_both_present() {
+    let yaml = r#"
+tproxy-sni: true
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    // sniffer block dictates: HTTP-only, no TLS — tproxy_sni's "TLS:443" is ignored.
+    assert_eq!(cfg.sniffer.http_ports, vec![80]);
+    assert_eq!(cfg.sniffer.tls_ports, Vec::<u16>::new());
+}
+
+// ─── S17: force-dns-mapping accepted (warn-only) ─────────────────────────
+
+#[tokio::test]
+async fn s17_force_dns_mapping_accepted_with_warn() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  sniff:
+    TLS:
+      ports: [443]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert!(cfg.sniffer.enable);
+    assert_eq!(cfg.sniffer.tls_ports, vec![443]);
+    // No assertion on the warn line — `tracing` capture would couple us to
+    // the global subscriber. The intent is "no hard error".
+}
+
+// ─── S18: parse-pure-ip and override-destination overrides ───────────────
+
+#[tokio::test]
+async fn s18_parse_pure_ip_and_override_destination_apply() {
+    let yaml = r#"
+sniffer:
+  enable: true
+  parse-pure-ip: false
+  override-destination: true
+  sniff:
+    TLS:
+      ports: [443]
+"#;
+    let cfg = load_config_from_str(yaml).await.expect("must load");
+    assert!(!cfg.sniffer.parse_pure_ip);
+    assert!(cfg.sniffer.override_destination);
+}

--- a/crates/mihomo-listener/src/sniffer.rs
+++ b/crates/mihomo-listener/src/sniffer.rs
@@ -350,6 +350,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sniffer_parse_pure_ip_runs_on_ip_host() {
+        // host is a literal IP → parse_pure_ip lets sniff proceed even with the
+        // gate enabled.
+        let cfg = SnifferConfig {
+            enable: true,
+            parse_pure_ip: true,
+            tls_ports: vec![443],
+            ..Default::default()
+        };
+        let rt = make_runtime(cfg);
+        let (mut client, server) = make_stream_pair().await;
+        let hello = build_client_hello("example.com");
+        client.write_all(&hello).await.unwrap();
+
+        let mut meta = make_metadata("93.184.216.34", 443);
+        rt.sniff(&server, &mut meta).await;
+        assert_eq!(meta.sniff_host, "example.com");
+    }
+
+    #[tokio::test]
+    async fn sniffer_parse_pure_ip_disabled_runs_on_domain_host() {
+        // parse_pure_ip = false → the host-already-a-domain short-circuit is
+        // skipped and sniffing runs normally.
+        let cfg = SnifferConfig {
+            enable: true,
+            parse_pure_ip: false,
+            tls_ports: vec![443],
+            ..Default::default()
+        };
+        let rt = make_runtime(cfg);
+        let (mut client, server) = make_stream_pair().await;
+        let hello = build_client_hello("real-sni.example.com");
+        client.write_all(&hello).await.unwrap();
+
+        let mut meta = make_metadata("placeholder.example.com", 443);
+        rt.sniff(&server, &mut meta).await;
+        assert_eq!(meta.sniff_host, "real-sni.example.com");
+    }
+
+    #[test]
+    fn maybe_apply_sniff_disabled_is_noop() {
+        let cfg = SnifferConfig {
+            enable: false,
+            override_destination: true,
+            ..Default::default()
+        };
+        let rt = make_runtime(cfg);
+        let mut meta = make_metadata("1.2.3.4", 443);
+        rt.maybe_apply_sniff("example.com", &mut meta);
+        assert_eq!(meta.sniff_host, "");
+        assert_eq!(meta.host, "1.2.3.4");
+    }
+
+    #[test]
+    fn maybe_apply_sniff_skip_domain_drops_host() {
+        let cfg = SnifferConfig {
+            enable: true,
+            override_destination: true,
+            skip_domain: vec!["+.ads.example.com".to_string()],
+            ..Default::default()
+        };
+        let rt = make_runtime(cfg);
+        let mut meta = make_metadata("1.2.3.4", 80);
+        rt.maybe_apply_sniff("tracker.ads.example.com", &mut meta);
+        assert_eq!(meta.sniff_host, "");
+        assert_eq!(meta.host, "1.2.3.4");
+    }
+
+    #[test]
+    fn maybe_apply_sniff_override_destination_mutates_host() {
+        let cfg = SnifferConfig {
+            enable: true,
+            override_destination: true,
+            ..Default::default()
+        };
+        let rt = make_runtime(cfg);
+        let mut meta = make_metadata("1.2.3.4", 80);
+        rt.maybe_apply_sniff("example.com", &mut meta);
+        assert_eq!(meta.sniff_host, "example.com");
+        assert_eq!(meta.host, "example.com");
+    }
+
+    #[test]
+    fn maybe_apply_sniff_override_false_keeps_host() {
+        let cfg = SnifferConfig {
+            enable: true,
+            override_destination: false,
+            ..Default::default()
+        };
+        let rt = make_runtime(cfg);
+        let mut meta = make_metadata("1.2.3.4", 80);
+        rt.maybe_apply_sniff("example.com", &mut meta);
+        assert_eq!(meta.sniff_host, "example.com");
+        assert_eq!(meta.host, "1.2.3.4");
+    }
+
+    #[tokio::test]
     async fn sniffer_http_port_dispatches_to_http_parser() {
         let cfg = SnifferConfig {
             enable: true,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # mihomo-rust Roadmap
 
 Owner: pm
-Last updated: 2026-04-18 (M1 audit — struck through merged items, task refs added)
+Last updated: 2026-04-25 (audit — strike merged M0/M1/M2 items; only M1.E-6, M1.F-4/5, and M3 remain open)
 Source inputs: `docs/vision.md`, `docs/gap-analysis.md`, `docs/ci-status.md`.
 
 This roadmap translates the architect's gap analysis into an ordered work
@@ -28,11 +28,11 @@ pick these up as "fix-it Fridays" while larger M1 specs are drafted.
 | # | Item | Value | Risk | Notes |
 |---|------|:-----:|:----:|-------|
 | ~~M0-1~~ | ~~Enforce REST API `secret` (Bearer auth)~~ | H | L | ~~`AppState.secret` is `#[allow(dead_code)]`; unauth API is a security gap~~ *(merged [178c30f](../../../commit/178c30f))* |
-| M0-2 | Replace `eprintln!` debug in `routes.rs:115` with `tracing::debug!` | L | L | Hot-path log spam |
+| ~~M0-2~~ | ~~Replace `eprintln!` debug in `routes.rs:115` with `tracing::debug!`~~ | L | L | ~~Hot-path log spam~~ *(closed: no `eprintln!` left in `mihomo-api`; routes.rs has been rewritten)* |
 | ~~M0-3~~ | ~~Wire `PROCESS-NAME` lookup (netlink on Linux, `libproc` on macOS)~~ | M | M | ~~Currently a no-op `Box<dyn Fn()>`; rules silently never match~~ *(merged [d89e5fd](../../../commit/d89e5fd))* |
 | ~~M0-4~~ | ~~GEOIP parser + shared `Arc<MaxMindDB>` plumbing~~ | H | M | ~~Today `parse_rule` rejects `GEOIP`; YAML with GEOIP fails to load~~ *(merged [d89e5fd](../../../commit/d89e5fd))* |
 | ~~M0-5~~ | ~~Populate `Resolver` hosts trie from `dns.hosts` config~~ | M | L | ~~Trie allocated, never filled~~ *(merged [d89e5fd](../../../commit/d89e5fd); superseded by M1.E-5 for remaining gaps)* |
-| M0-6 | Wire DNS in-flight dedup (`inflight: DashMap`) | M | L | Allocated but `#[allow(dead_code)]` |
+| ~~M0-6~~ | ~~Wire DNS in-flight dedup (`inflight: DashMap`)~~ | M | L | ~~Allocated but `#[allow(dead_code)]`~~ *(closed: `Resolver::lookup` now uses the inflight map; covered by `inflight_entry_cleared_after_lookup_miss` in `mihomo-dns/src/resolver.rs`)* |
 | ~~M0-7~~ | ~~Verify `AND/OR/NOT` logic rules reachable from top-level parser~~ | M | L | ~~`logic.rs` exists; confirm dispatch, add tests~~ *(confirmed + tested in [8924d49](../../../commit/8924d49))* |
 | ~~M0-8~~ | ~~Prune dead `AdapterType` variants (or mark `#[doc(hidden)]`)~~ | L | L | ~~`RejectDrop`, `Compatible`, `Pass`, `Dns`, `Relay`, `LoadBalance`, unimplemented protos~~ *(merged [3599bdb](../../../commit/3599bdb))* |
 | ~~M0-9~~ | ~~Drop or implement `rule-providers.interval` periodic refresh~~ | M | L | ~~Field accepted and ignored today~~ *(superseded by M1.D-5)* |
@@ -128,8 +128,8 @@ has its own `connect_over` override in 334d55c. All B items are on main.
 | ~~M1.D-1~~ | ~~Finish parser for already-enum'd rule types: `IN-PORT`, `DSCP`, `UID`, `SRC-GEOIP`, `PROCESS-PATH`~~ | M | L | ~~[`docs/specs/rules-parser-completion.md`](specs/rules-parser-completion.md)~~ *(merged [8924d49](../../../commit/8924d49))* | ~~engineer~~ |
 | ~~M1.D-2~~ | ~~`GEOSITE` rule + geosite DB loader (**`mrs` only**, per architect 2026-04-11)~~ | H | M | ~~[`docs/specs/rule-geosite.md`](specs/rule-geosite.md)~~ *(merged [1567670](../../../commit/1567670))* | ~~engineer~~ |
 | ~~M1.D-3~~ | ~~`IP-SUFFIX`, `IP-ASN` (requires ASN MMDB)~~ | M | M | ~~bundled into M1.D-1 spec~~ *(merged [8924d49](../../../commit/8924d49))* | ~~engineer~~ |
-| M1.D-4 | `IN-TYPE`, `IN-NAME`, `IN-USER` (depends on named listeners — see M1.F) | M | M | covered by M1.F-1 (IN-TYPE/IN-NAME) + M1.F-3 (IN-USER); no separate spec | engineer-b (task #16, blocked by #13) |
-| M1.D-5 | Rule provider `inline` type, `mrs` binary format, periodic `interval` refresh | M | M | [`docs/specs/rule-provider-upgrade.md`](specs/rule-provider-upgrade.md) *(draft)* — supersedes M0-9 | engineer-b (task #10) |
+| ~~M1.D-4~~ | ~~`IN-TYPE`, `IN-NAME`, `IN-USER` (depends on named listeners — see M1.F)~~ | M | M | ~~covered by M1.F-1 (IN-TYPE/IN-NAME) + M1.F-3 (IN-USER); no separate spec~~ *(merged [33aeeb4](../../../commit/33aeeb4) IN-TYPE/IN-NAME, [0f315ff](../../../commit/0f315ff) IN-USER)* | ~~engineer-b~~ |
+| ~~M1.D-5~~ | ~~Rule provider `inline` type, `mrs` binary format, periodic `interval` refresh~~ | M | M | ~~[`docs/specs/rule-provider-upgrade.md`](specs/rule-provider-upgrade.md)~~ *(merged [7d32518](../../../commit/7d32518); supersedes M0-9)* | ~~engineer-b~~ |
 | ~~M1.D-6~~ | ~~`DOMAIN-WILDCARD`~~ | L | L | ~~bundled into M1.D-1 spec~~ *(merged [8924d49](../../../commit/8924d49))* | ~~engineer~~ |
 | ~~M1.D-7~~ | ~~`SUB-RULE` (named rule subsets)~~ | M | M | ~~[`docs/specs/sub-rules.md`](specs/sub-rules.md)~~ *(merged [663cf0e](../../../commit/663cf0e))* | ~~engineer~~ |
 
@@ -139,18 +139,18 @@ has its own `connect_over` override in 334d55c. All B items are on main.
 |---|------|:-----:|:----:|------|-------|
 | ~~M1.E-1~~ | ~~DoH and DoT upstream clients (hickory supports both)~~ | H | M | ~~[`docs/specs/dns-doh-dot.md`](specs/dns-doh-dot.md)~~ *(merged [daf53a5](../../../commit/daf53a5))* | ~~engineer~~ |
 | ~~M1.E-2~~ | ~~`default-nameserver` (bootstrap)~~ | H | L | ~~bundled into M1.E-1 spec~~ *(merged [daf53a5](../../../commit/daf53a5))* | ~~engineer~~ |
-| M1.E-3 | `nameserver-policy` (per-domain routing) | H | M | [`docs/specs/dns-nameserver-policy.md`](specs/dns-nameserver-policy.md) *(draft)* | engineer-b (task #11) |
-| M1.E-4 | `fallback-filter` (GeoIP / IP-CIDR / domain gating) | M | M | bundled into M1.E-3 spec | engineer-b (task #11) |
-| M1.E-5 | `hosts` + `use-system-hosts` | M | L | [`docs/specs/dns-hosts.md`](specs/dns-hosts.md) *(draft)* — supersedes M0-5 | engineer-b (task #12) |
+| ~~M1.E-3~~ | ~~`nameserver-policy` (per-domain routing)~~ | H | M | ~~[`docs/specs/dns-nameserver-policy.md`](specs/dns-nameserver-policy.md)~~ *(merged [6b32f04](../../../commit/6b32f04))* | ~~engineer-b~~ |
+| ~~M1.E-4~~ | ~~`fallback-filter` (GeoIP / IP-CIDR / domain gating)~~ | M | M | ~~bundled into M1.E-3 spec~~ *(merged [6b32f04](../../../commit/6b32f04))* | ~~engineer-b~~ |
+| ~~M1.E-5~~ | ~~`hosts` + `use-system-hosts`~~ | M | L | ~~[`docs/specs/dns-hosts.md`](specs/dns-hosts.md); supersedes M0-5~~ *(merged [6b32f04](../../../commit/6b32f04))* | ~~engineer-b~~ |
 | M1.E-6 | DoQ upstream | L | M | defer to M2 unless a user asks | — |
 
 ### M1.F — Inbounds & sniffer
 
 | # | Item | Value | Risk | Spec | Owner |
 |---|------|:-----:|:----:|------|-------|
-| M1.F-1 | Generic `listeners:` named-listener config (prereq for IN-NAME / IN-TYPE) | M | M | [`docs/specs/listeners-unified.md`](specs/listeners-unified.md) *(draft)* | engineer-b (task #13) |
-| M1.F-2 | TLS SNI + HTTP Host sniffer (enables rule matching on port-only flows) | H | M | [`docs/specs/sniffer.md`](specs/sniffer.md) *(draft)* | engineer-b (task #14) |
-| M1.F-3 | `authentication` + `skip-auth-prefixes` + LAN ACLs | M | L | [`docs/specs/inbound-auth-acl.md`](specs/inbound-auth-acl.md) *(draft)* | engineer-b (task #15) |
+| ~~M1.F-1~~ | ~~Generic `listeners:` named-listener config (prereq for IN-NAME / IN-TYPE)~~ | M | M | ~~[`docs/specs/listeners-unified.md`](specs/listeners-unified.md)~~ *(merged [33aeeb4](../../../commit/33aeeb4))* | ~~engineer-b~~ |
+| ~~M1.F-2~~ | ~~TLS SNI + HTTP Host sniffer (enables rule matching on port-only flows)~~ | H | M | ~~[`docs/specs/sniffer.md`](specs/sniffer.md)~~ *(merged [a02943a](../../../commit/a02943a))* | ~~engineer-b~~ |
+| ~~M1.F-3~~ | ~~`authentication` + `skip-auth-prefixes` + LAN ACLs~~ | M | L | ~~[`docs/specs/inbound-auth-acl.md`](specs/inbound-auth-acl.md)~~ *(merged [9b00bff](../../../commit/9b00bff))* | ~~engineer-b~~ |
 | M1.F-4 | Linux `redir` listener (SO_ORIGINAL_DST) | L | M | defer to M1.x or M2 | — |
 | M1.F-5 | Static `tunnel` listener (SS-style port→target) | L | L | defer | — |
 
@@ -160,21 +160,21 @@ has its own `connect_over` override in 334d55c. All B items are on main.
 |---|------|:-----:|:----:|------|-------|
 | ~~M1.G-1~~ | ~~Bearer `secret` auth enforcement (= M0-1, tracked here too)~~ | H | L | ~~trivial, fold into M0-1~~ *(merged [178c30f](../../../commit/178c30f))* | ~~engineer~~ |
 | ~~M1.G-2~~ | ~~`GET /proxies/:name/delay` and `GET /group/:name/delay`~~ | H | L | ~~[`docs/specs/api-delay-endpoints.md`](specs/api-delay-endpoints.md)~~ *(merged [eab429f](../../../commit/eab429f))* | ~~engineer~~ |
-| M1.G-3 | `GET /logs` websocket stream | H | M | [`docs/specs/api-logs-websocket.md`](specs/api-logs-websocket.md) *(draft)* | engineer-a (task #19) |
-| M1.G-4 | `GET /memory` websocket (runtime RSS stream) | M | L | bundled into M1.G-3 spec | engineer-a (task #19) |
-| M1.G-5 | `GET/PUT /providers/rules[/:name]` | M | L | bundled into M1.D-5 spec | engineer-b (task #10) |
-| M1.G-6 | `GET/PUT /providers/proxies[/:name]` + proxy providers impl | H | M | depends on M1.H-1 | engineer-b (task #18, blocked by #17) |
-| M1.G-7 | `DELETE /connections` (bulk) | L | L | bundled into M1.G-3 spec | engineer-a (task #19) |
-| M1.G-8 | `GET /dns/query` (align with upstream; current is POST) | L | L | bundled into M1.G-3 spec | engineer-a (task #19) |
-| M1.G-9 | `POST /cache/dns/flush` | L | L | bundled into M1.G-3 spec | engineer-a (task #19) |
-| M1.G-10 | `PUT /configs` (reload from path/body) | M | M | [`docs/specs/api-config-reload.md`](specs/api-config-reload.md) *(draft)*; M3 = hot-reload | engineer-a (task #20) |
+| ~~M1.G-3~~ | ~~`GET /logs` websocket stream~~ | H | M | ~~[`docs/specs/api-logs-websocket.md`](specs/api-logs-websocket.md)~~ *(merged [413a6f8](../../../commit/413a6f8); WS routed at `routes.rs:137`)* | ~~engineer-a~~ |
+| ~~M1.G-4~~ | ~~`GET /memory` websocket (runtime RSS stream)~~ | M | L | ~~bundled into M1.G-3 spec~~ *(merged [413a6f8](../../../commit/413a6f8); routed at `routes.rs:138`)* | ~~engineer-a~~ |
+| ~~M1.G-5~~ | ~~`GET/PUT /providers/rules[/:name]`~~ | M | L | ~~bundled into M1.D-5 spec~~ *(merged [7d32518](../../../commit/7d32518); routed at `routes.rs:205`)* | ~~engineer-b~~ |
+| ~~M1.G-6~~ | ~~`GET/PUT /providers/proxies[/:name]` + proxy providers impl~~ | H | M | ~~depends on M1.H-1~~ *(merged [a0e4e26](../../../commit/a0e4e26); routed at `routes.rs:195` with `/healthcheck`)* | ~~engineer-b~~ |
+| ~~M1.G-7~~ | ~~`DELETE /connections` (bulk)~~ | L | L | ~~bundled into M1.G-3 spec~~ *(merged [413a6f8](../../../commit/413a6f8))* | ~~engineer-a~~ |
+| ~~M1.G-8~~ | ~~`GET /dns/query` (align with upstream; current is POST)~~ | L | L | ~~bundled into M1.G-3 spec~~ *(merged [413a6f8](../../../commit/413a6f8))* | ~~engineer-a~~ |
+| ~~M1.G-9~~ | ~~`POST /cache/dns/flush`~~ | L | L | ~~bundled into M1.G-3 spec~~ *(merged [413a6f8](../../../commit/413a6f8))* | ~~engineer-a~~ |
+| ~~M1.G-10~~ | ~~`PUT /configs` (reload from path/body)~~ | M | M | ~~[`docs/specs/api-config-reload.md`](specs/api-config-reload.md); M3 = hot-reload~~ *(merged [9ca423e](../../../commit/9ca423e))* | ~~engineer-a~~ |
 
 ### M1.H — Providers & observability
 
 | # | Item | Value | Risk | Spec | Owner |
 |---|------|:-----:|:----:|------|-------|
-| M1.H-1 | `proxy-providers` (http/file, health-check, include-all) | H | M | [`docs/specs/proxy-providers.md`](specs/proxy-providers.md) *(draft)* | engineer-b (task #17) |
-| M1.H-2 | Prometheus `/metrics` (traffic, conns, rule-match counters, proxy health) | H | L | [`docs/specs/metrics-prometheus.md`](specs/metrics-prometheus.md) *(draft)* | engineer-a (task #21) |
+| ~~M1.H-1~~ | ~~`proxy-providers` (http/file, health-check, include-all)~~ | H | M | ~~[`docs/specs/proxy-providers.md`](specs/proxy-providers.md)~~ *(merged [a0e4e26](../../../commit/a0e4e26))* | ~~engineer-b~~ |
+| ~~M1.H-2~~ | ~~Prometheus `/metrics` (traffic, conns, rule-match counters, proxy health)~~ | H | L | ~~[`docs/specs/metrics-prometheus.md`](specs/metrics-prometheus.md)~~ *(merged [9ca423e](../../../commit/9ca423e))* | ~~engineer-a~~ |
 | ~~M1.H-3~~ | ~~Migration guide from Go mihomo (supported vs intentionally-not fields)~~ | M | L | ~~`docs/migration-from-go-mihomo.md`~~ *(merged [e3e1a50](../../../commit/e3e1a50))* | ~~pm~~ |
 
 ### M1 exit criteria (revised 2026-04-11)
@@ -196,22 +196,23 @@ slow-leak detection moves to M2 profiling if ever needed.
 
 ## M2 — Performance and footprint
 
-Scope frozen after M1 lands. Placeholder order (all items from `vision.md`
-§M2):
+Scope frozen after M1 lands. Status as of 2026-04-25:
 
-1. `geodata:` YAML subsection (`mmdb-path`, `asn-path`, `geosite-path`, `auto-update`, `url.*`) — [`docs/specs/geodata-subsection.md`](specs/geodata-subsection.md) *(design sketch)*.
-2. Benchmark harness vs Go mihomo on identical hardware — `docs/benchmarks/`.
-2. Allocator audit of TCP relay and UDP NAT hot paths.
-3. Cargo feature flags for every optional protocol/transport; minimal-build
-   size budget for `aarch64-musl` and `mipsel-musl`.
-4. Rule-engine micro-optimizations (trie layout, IP-CIDR structure).
-5. Release CI — prebuilt static binaries per `ci-status.md` P1 item 5.
-6. M2 also absorbs: MSRV pin, macOS CI job, `cargo audit` cron, `cargo doc`
-   check, `cargo hack --feature-powerset`, coverage upload (`ci-status.md`
-   §P1/P2).
+1. ~~`geodata:` YAML subsection (`mmdb-path`, `asn-path`, `geosite-path`, `auto-update`, `url.*`) — [`docs/specs/geodata-subsection.md`](specs/geodata-subsection.md).~~ *(merged [db5228f](../../../commit/db5228f) — M2.A)*
+2. ~~Benchmark harness vs Go mihomo on identical hardware — `docs/benchmarks/`.~~ *(merged [9754bdc](../../../commit/9754bdc) criterion harness; [3d3b179](../../../commit/3d3b179) DNS QPS + 10k-rule extension — M2.B)*
+3. ~~Allocator audit of TCP relay and UDP NAT hot paths.~~ *(merged [a4058af](../../../commit/a4058af) zero-alloc UDP NAT; [f191272](../../../commit/f191272) trie early-exit + skip-domain scan — M2.D; [2ceebeb](../../../commit/2ceebeb) reverted mimalloc back to system allocator)*
+4. ~~Cargo feature flags for every optional protocol/transport; minimal-build size budget for `aarch64-musl` and `mipsel-musl`.~~ *(merged [f249a56](../../../commit/f249a56) feature flags + size budget; [10e570c](../../../commit/10e570c) `panic=abort`; [b377939](../../../commit/b377939) `opt-level=z` — M2.E; aarch64 minimal 9.5 → 5.x MB)*
+5. ~~Rule-engine micro-optimizations (trie layout, IP-CIDR structure).~~ *(merged with M2.D in [f191272](../../../commit/f191272))*
+6. Release CI — prebuilt static binaries per `ci-status.md` P1 item 5. *(open)*
+7. ~~MSRV pin, `cargo audit` cron, `cargo doc` check, `cargo hack --feature-powerset`, coverage upload.~~ *(merged [9dd952f](../../../commit/9dd952f) / [280876f](../../../commit/280876f) — M2.F; macOS CI was already on)*
 
 Exit criteria: measurably lower CPU and RSS than Go mihomo on a shared
-benchmark, minimal-build binary under stated size budget.
+benchmark, minimal-build binary under stated size budget. **Bench numbers
+are now produced by the criterion harness; an exit comparison vs Go mihomo
+on shared hardware still needs to be published before declaring M2 done.**
+
+**Still open in M2:** release-CI prebuilt binaries (item 6) and the
+published Go-vs-Rust benchmark comparison.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Sniffer config tests**: \`crates/mihomo-config/tests/sniffer_config_test.rs\` was untracked and didn't compile (missing helper, \`Result::expect_err\` on a non-\`Debug\` \`Config\`). Added \`expect_load_err\` helper, corrected S1's assertion (defaults are non-empty but inert), switched S15/S16 YAML to kebab-case \`tproxy-sni:\` to match \`RawConfig\`'s serde rename. 18/18 pass.
- **New sniffer unit tests (11)**: TLS no-SNI / non-host_name entries; HTTP bracketed-IPv6-no-port / empty Host / LWS trim; \`SnifferRuntime\` parse_pure_ip on IP host / domain host with gate off; four \`maybe_apply_sniff\` direct-path cases (disabled, skip-domain drop, override on/off).
- **Orphan removal**: deleted \`crates/mihomo-listener/src/tproxy/sni.rs\` (never declared in any \`mod\`; superseded by \`mihomo-listener/src/sniffer.rs\` + \`mihomo-common/src/sniffer/\`).
- **Roadmap audit**: \`docs/roadmap.md\` last-updated bumped to 2026-04-25. Struck merged M0-2, M0-6, M1.D-4/5, M1.E-3/4/5, M1.F-1/2/3, M1.G-3..G-10, M1.H-1/2 with commit links. Rewrote M2 placeholder to reflect M2.A/B/D/E/F merged; only release-CI prebuilt binaries and the published Go-vs-Rust benchmark comparison remain open. Three legitimately-deferred items (M1.E-6 DoQ, M1.F-4 redir, M1.F-5 static tunnel) left untouched per the doc's maintenance rule. **PM may want to reconcile with their in-flight \`docs/drop-deferred-outbounds\` branch.**

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` — 429 pass
- [x] \`cargo test --test sniffer_config_test -p mihomo-config\` — 18 pass
- [ ] CI green on Ubuntu + macOS
- [ ] Optional: PM ack on the \`docs/roadmap.md\` audit before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)