### PR TITLE
chore: bump workspace version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-app"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-bench"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-listener"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1961,14 +1961,14 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ panic = "abort"
 opt-level = "z"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
- Bump workspace `version` from `0.4.0` → `0.5.0` (all 12 crates inherit)
- Refresh `Cargo.lock` via `cargo update --workspace`

Minor bump justified by the ECH (Encrypted Client Hello) feature shipped since 0.4.0 (commits `dab0ab7` DNS-sourced ECH + retry self-heal).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 432 tests pass across 11 crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)