### PR TITLE
ci(coverage): skip outbound-internet DoH/DoT tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,8 +47,18 @@ jobs:
         env:
           MIHOMO_REQUIRE_INTEGRATION_BINS: "1"
         run: |
+          # `--include-ignored` runs local-process integration tests (ssserver,
+          # simple-obfs, embedded mock servers). Tests in
+          # crates/mihomo-dns/tests/doh_dot_integration.rs require outbound
+          # internet (Cloudflare/Google DoH/DoT) and are not reachable from
+          # GitHub-hosted runners — skip them by name.
           cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info \
-            -- --include-ignored
+            -- --include-ignored \
+               --skip dot_resolves_example_com \
+               --skip doh_resolves_example_com \
+               --skip dot_bogus_sni_fails_cert_validation \
+               --skip doh_bogus_sni_fails_cert_validation \
+               --skip dot_hostname_with_bootstrap_resolves
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary
- Coverage workflow has been red on the last 4 of 5 nightly runs (e.g. [25089357903](https://github.com/madeye/mihomo-rust/actions/runs/25089357903)) because `--include-ignored` picks up the network-only tests in `crates/mihomo-dns/tests/doh_dot_integration.rs`, which dial Cloudflare/Google DoH/DoT — unreachable from GitHub-hosted runners.
- Skip those five tests by name. Local-process integration tests (ssserver, simple-obfs, embedded mock servers) still run via `--include-ignored`.
- The skipped tests remain runnable locally with `cargo test -p mihomo-dns --test doh_dot_integration -- --ignored`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (432 passed)
- [ ] Trigger Coverage workflow via `workflow_dispatch` after merge and confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)