### PR TITLE
chore: bump workspace version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-app"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-bench"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-listener"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1971,14 +1971,14 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ panic = "abort"
 opt-level = "z"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
- Bump workspace version 0.5.0 → 0.6.0 across all 12 crates.
- Reflects the GeoIP MMDB removal and per-country IpRange parse-time build (#48 et al.) since 0.5.0.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --lib (442 tests, 11 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)