### PR TITLE
fix(ci): unbreak release workflow for v0.x tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
             # aarch64: hard gate — release fails if minimal binary exceeds 8 MiB
             minimal_budget_bytes: 8388608
             minimal_soft_gate: false
-          - target: mipsel-unknown-linux-musl
-            # mipsel: soft gate — emit warning only, per ADR-0007 §1
-            minimal_budget_bytes: 7340032
-            minimal_soft_gate: true
+          # mipsel-unknown-linux-musl: temporarily disabled — `rust-std` is no
+          # longer published for this target on stable. Re-enable when stable
+          # ships the component again, or when ADR-0007 §1 promotes it to a
+          # nightly/build-std path. Tracked separately from ADR-0007.
     steps:
       - uses: actions/checkout@v4
 
@@ -62,11 +62,12 @@ jobs:
             --no-default-features --features minimal \
             --target ${{ matrix.target }} \
             --bin mihomo
-          # Copy minimal binary aside before default binary overwrites artifact
+          # Copy minimal binary aside before default binary overwrites artifact.
+          # Binary is already stripped via [profile.release] strip = true in
+          # the workspace Cargo.toml — no post-build strip needed (and the
+          # host `strip` cannot read aarch64 ELF anyway).
           cp "target/${{ matrix.target }}/release/mihomo" \
              "target/${{ matrix.target }}/release/mihomo-minimal"
-          llvm-strip "target/${{ matrix.target }}/release/mihomo-minimal" \
-            2>/dev/null || strip "target/${{ matrix.target }}/release/mihomo-minimal"
 
       - name: Minimal binary size check
         if: matrix.minimal_budget_bytes != 0


### PR DESCRIPTION
## Summary
The v0.6.0 tag push exposed two unrelated pre-existing failures in `Release`:

- **mipsel-unknown-linux-musl**: `rust-std` is no longer published for this target on stable, so `dtolnay/rust-toolchain@stable` fails before any build runs. ADR-0007 §1 already classifies mipsel as soft-gated with no QEMU smoke-test infra; drop it from the matrix until stable ships the component again or we move it to a nightly/build-std path. Tracked separately from ADR-0007.
- **aarch64-unknown-linux-musl**: build succeeded; the post-build `llvm-strip || strip` fell through to the host (x86_64) strip, which cannot read aarch64 ELF, so the job failed at the strip step. The workspace already sets `[profile.release] strip = true`, so the binary is already stripped at link time — drop the redundant post-build strip.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --lib (442 tests pass)
- [ ] On merge: re-run `Release` against `v0.6.0` via `workflow_dispatch` (or a fresh tag) and confirm both `x86_64-musl` and `aarch64-musl` artifacts upload to the v0.6.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)