### PR TITLE
feat(trojan): UDP relay over TLS (CMD=0x03)

### DIFF
--- a/crates/mihomo-proxy/src/trojan.rs
+++ b/crates/mihomo-proxy/src/trojan.rs
@@ -3,6 +3,11 @@
 //! TLS is provided by `mihomo_transport::tls::TlsLayer` (M1.A-1 migration).
 //! Protocol logic — SHA-224 password hash, CRLF header, SOCKS5 address
 //! encoding — remains here unchanged.
+//!
+//! UDP relay (CMD=0x03 UDP_ASSOCIATE) tunnels packets over the same TLS
+//! stream as TCP.  Each datagram is framed as
+//! `ATYP | DST.ADDR | DST.PORT | LENGTH(u16 BE) | CRLF | PAYLOAD`,
+//! matching trojan-go / clash-meta upstream.
 
 use async_trait::async_trait;
 use mihomo_common::{
@@ -11,15 +16,26 @@ use mihomo_common::{
 };
 use mihomo_transport::{
     tls::{TlsConfig, TlsLayer},
-    Transport,
+    Stream as TransportStream, Transport,
 };
 use sha2::{Digest, Sha224};
-use tokio::io::AsyncWriteExt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::net::TcpStream;
+use tokio::sync::Mutex;
 use tracing::debug;
 
 use crate::stream_conn::StreamConn;
 use crate::transport_to_proxy_err;
+
+/// SOCKS5-style command bytes used inside the Trojan request header.
+const CMD_CONNECT: u8 = 0x01;
+const CMD_UDP_ASSOCIATE: u8 = 0x03;
+
+/// SOCKS5 address types.
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
 
 pub struct TrojanAdapter {
     name: String,
@@ -78,28 +94,242 @@ impl TrojanAdapter {
         // command byte
         buf.push(cmd);
         // SOCKS5 address format
-        if !metadata.host.is_empty() {
-            buf.push(0x03); // ATYP domain
-            let host_bytes = metadata.host.as_bytes();
-            buf.push(host_bytes.len() as u8);
-            buf.extend_from_slice(host_bytes);
-        } else if let Some(ip) = metadata.dst_ip {
-            match ip {
-                std::net::IpAddr::V4(v4) => {
-                    buf.push(0x01); // ATYP IPv4
-                    buf.extend_from_slice(&v4.octets());
-                }
-                std::net::IpAddr::V6(v6) => {
-                    buf.push(0x04); // ATYP IPv6
-                    buf.extend_from_slice(&v6.octets());
-                }
-            }
-        }
-        // Port (big-endian)
-        buf.extend_from_slice(&metadata.dst_port.to_be_bytes());
+        encode_socks5_addr_from_metadata(&mut buf, metadata);
         // CRLF
         buf.extend_from_slice(b"\r\n");
         buf
+    }
+
+    /// Open a TLS stream and write the Trojan request header.
+    async fn open_tls_with_header(
+        &self,
+        metadata: &Metadata,
+        cmd: u8,
+    ) -> Result<Box<dyn TransportStream>> {
+        let tcp = TcpStream::connect(&self.addr_str)
+            .await
+            .map_err(MihomoError::Io)?;
+
+        let mut stream = self
+            .tls_layer
+            .connect(Box::new(tcp))
+            .await
+            .map_err(transport_to_proxy_err)?;
+
+        let header = self.build_header(metadata, cmd);
+        stream.write_all(&header).await.map_err(MihomoError::Io)?;
+        Ok(stream)
+    }
+}
+
+/// Append a SOCKS5 address (ATYP + ADDR + PORT) drawn from `metadata` onto `buf`.
+///
+/// Used for both the request header and per-packet UDP frames.  Domain takes
+/// precedence over IP — same priority as `Metadata::remote_address`.
+fn encode_socks5_addr_from_metadata(buf: &mut Vec<u8>, metadata: &Metadata) {
+    if !metadata.host.is_empty() {
+        buf.push(ATYP_DOMAIN);
+        let host_bytes = metadata.host.as_bytes();
+        buf.push(host_bytes.len() as u8);
+        buf.extend_from_slice(host_bytes);
+    } else if let Some(ip) = metadata.dst_ip {
+        match ip {
+            IpAddr::V4(v4) => {
+                buf.push(ATYP_IPV4);
+                buf.extend_from_slice(&v4.octets());
+            }
+            IpAddr::V6(v6) => {
+                buf.push(ATYP_IPV6);
+                buf.extend_from_slice(&v6.octets());
+            }
+        }
+    } else {
+        // No address at all — encode 0.0.0.0 as a placeholder; the Trojan
+        // UDP_ASSOCIATE header destination is informational anyway.
+        buf.push(ATYP_IPV4);
+        buf.extend_from_slice(&[0, 0, 0, 0]);
+    }
+    buf.extend_from_slice(&metadata.dst_port.to_be_bytes());
+}
+
+/// Encode an explicit `SocketAddr` as a SOCKS5 address (used for per-packet
+/// UDP frames where each datagram targets an arbitrary peer).
+fn encode_socks5_addr_socket(buf: &mut Vec<u8>, addr: &SocketAddr) {
+    match addr.ip() {
+        IpAddr::V4(v4) => {
+            buf.push(ATYP_IPV4);
+            buf.extend_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            buf.push(ATYP_IPV6);
+            buf.extend_from_slice(&v6.octets());
+        }
+    }
+    buf.extend_from_slice(&addr.port().to_be_bytes());
+}
+
+/// Read a SOCKS5 address (ATYP + ADDR + PORT) and return it as a `SocketAddr`.
+///
+/// Domain-form replies are best-effort: if the domain parses as a literal IP
+/// it's returned as such, otherwise we synthesize `0.0.0.0:<port>` and let
+/// the caller log the original peer.  Trojan servers replying to client UDP
+/// almost always echo the IP form anyway.
+async fn read_socks5_addr<R: AsyncReadExt + Unpin>(reader: &mut R) -> Result<SocketAddr> {
+    let mut atyp = [0u8; 1];
+    reader
+        .read_exact(&mut atyp)
+        .await
+        .map_err(MihomoError::Io)?;
+    Ok(match atyp[0] {
+        ATYP_IPV4 => {
+            let mut ip = [0u8; 4];
+            reader.read_exact(&mut ip).await.map_err(MihomoError::Io)?;
+            let mut port = [0u8; 2];
+            reader
+                .read_exact(&mut port)
+                .await
+                .map_err(MihomoError::Io)?;
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::from(ip)), u16::from_be_bytes(port))
+        }
+        ATYP_IPV6 => {
+            let mut ip = [0u8; 16];
+            reader.read_exact(&mut ip).await.map_err(MihomoError::Io)?;
+            let mut port = [0u8; 2];
+            reader
+                .read_exact(&mut port)
+                .await
+                .map_err(MihomoError::Io)?;
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::from(ip)), u16::from_be_bytes(port))
+        }
+        ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            reader.read_exact(&mut len).await.map_err(MihomoError::Io)?;
+            let mut domain = vec![0u8; len[0] as usize];
+            reader
+                .read_exact(&mut domain)
+                .await
+                .map_err(MihomoError::Io)?;
+            let mut port = [0u8; 2];
+            reader
+                .read_exact(&mut port)
+                .await
+                .map_err(MihomoError::Io)?;
+            let port = u16::from_be_bytes(port);
+            let domain_str = std::str::from_utf8(&domain)
+                .map_err(|e| MihomoError::Proxy(format!("trojan udp: bad domain utf8: {}", e)))?;
+            // Try IP-literal first; otherwise fall back to UNSPECIFIED so the
+            // tunnel still has a usable SocketAddr without a DNS round-trip.
+            if let Ok(ip) = domain_str.parse::<IpAddr>() {
+                SocketAddr::new(ip, port)
+            } else {
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
+            }
+        }
+        other => {
+            return Err(MihomoError::Proxy(format!(
+                "trojan udp: unknown ATYP {:#x}",
+                other
+            )))
+        }
+    })
+}
+
+/// UDP-over-TLS packet connection.
+///
+/// The TLS stream is split into independent halves so `read_packet` and
+/// `write_packet` can run concurrently from `&self`.  Each half is guarded
+/// by its own `Mutex` because the trait exposes only `&self`, but in
+/// practice the tunnel calls each direction from a dedicated task.
+pub struct TrojanPacketConn {
+    reader: Mutex<ReadHalf<Box<dyn TransportStream>>>,
+    writer: Mutex<WriteHalf<Box<dyn TransportStream>>>,
+}
+
+impl TrojanPacketConn {
+    fn new(stream: Box<dyn TransportStream>) -> Self {
+        let (r, w) = tokio::io::split(stream);
+        Self {
+            reader: Mutex::new(r),
+            writer: Mutex::new(w),
+        }
+    }
+}
+
+#[async_trait]
+impl ProxyPacketConn for TrojanPacketConn {
+    async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        let mut reader = self.reader.lock().await;
+
+        let addr = read_socks5_addr(&mut *reader).await?;
+
+        let mut len_bytes = [0u8; 2];
+        reader
+            .read_exact(&mut len_bytes)
+            .await
+            .map_err(MihomoError::Io)?;
+        let length = u16::from_be_bytes(len_bytes) as usize;
+
+        let mut crlf = [0u8; 2];
+        reader
+            .read_exact(&mut crlf)
+            .await
+            .map_err(MihomoError::Io)?;
+        if &crlf != b"\r\n" {
+            return Err(MihomoError::Proxy(format!(
+                "trojan udp: expected CRLF, got {:?}",
+                crlf
+            )));
+        }
+
+        // Read the payload into the caller's buffer; if the frame is larger
+        // than `buf`, drain the remainder so the next frame stays aligned.
+        let to_copy = length.min(buf.len());
+        if to_copy > 0 {
+            reader
+                .read_exact(&mut buf[..to_copy])
+                .await
+                .map_err(MihomoError::Io)?;
+        }
+        if length > to_copy {
+            let mut sink = vec![0u8; length - to_copy];
+            reader
+                .read_exact(&mut sink)
+                .await
+                .map_err(MihomoError::Io)?;
+        }
+        Ok((to_copy, addr))
+    }
+
+    async fn write_packet(&self, buf: &[u8], addr: &SocketAddr) -> Result<usize> {
+        if buf.len() > u16::MAX as usize {
+            return Err(MihomoError::Proxy(format!(
+                "trojan udp: packet too large ({} > {})",
+                buf.len(),
+                u16::MAX
+            )));
+        }
+
+        // Pre-size: ATYP(1) + addr(≤16) + port(2) + len(2) + CRLF(2) + payload.
+        let mut frame = Vec::with_capacity(buf.len() + 23);
+        encode_socks5_addr_socket(&mut frame, addr);
+        frame.extend_from_slice(&(buf.len() as u16).to_be_bytes());
+        frame.extend_from_slice(b"\r\n");
+        frame.extend_from_slice(buf);
+
+        let mut writer = self.writer.lock().await;
+        writer.write_all(&frame).await.map_err(MihomoError::Io)?;
+        writer.flush().await.map_err(MihomoError::Io)?;
+        Ok(buf.len())
+    }
+
+    fn local_addr(&self) -> Result<SocketAddr> {
+        // The tunnel only reads this for diagnostics — we have no real local
+        // UDP socket bound, the datagrams ride on a TLS stream.
+        Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
+    }
+
+    fn close(&self) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -127,33 +357,64 @@ impl ProxyAdapter for TrojanAdapter {
             metadata.remote_address(),
             self.addr_str
         );
-
-        // TCP connect.
-        let tcp = TcpStream::connect(&self.addr_str)
-            .await
-            .map_err(MihomoError::Io)?;
-
-        // TLS handshake via the shared TlsLayer.
-        let mut stream = self
-            .tls_layer
-            .connect(Box::new(tcp))
-            .await
-            .map_err(transport_to_proxy_err)?;
-
-        // Send Trojan header (CMD_CONNECT = 0x01).
-        let header = self.build_header(metadata, 0x01);
-        stream.write_all(&header).await.map_err(MihomoError::Io)?;
-
+        let stream = self.open_tls_with_header(metadata, CMD_CONNECT).await?;
         Ok(Box::new(StreamConn(stream)))
     }
 
-    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        Err(MihomoError::NotSupported(
-            "Trojan UDP not yet implemented".into(),
-        ))
+    async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        if !self.support_udp {
+            return Err(MihomoError::NotSupported(
+                "Trojan UDP is disabled for this proxy (set `udp: true`)".into(),
+            ));
+        }
+        debug!(
+            "Trojan UDP-associating for {} via {}",
+            metadata.remote_address(),
+            self.addr_str
+        );
+        let stream = self
+            .open_tls_with_header(metadata, CMD_UDP_ASSOCIATE)
+            .await?;
+        Ok(Box::new(TrojanPacketConn::new(stream)))
     }
 
     fn health(&self) -> &ProxyHealth {
         &self.health
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_socket_v4() {
+        let mut buf = Vec::new();
+        encode_socks5_addr_socket(&mut buf, &"127.0.0.1:53".parse().unwrap());
+        assert_eq!(buf, vec![ATYP_IPV4, 127, 0, 0, 1, 0, 53]);
+    }
+
+    #[test]
+    fn encode_socket_v6() {
+        let mut buf = Vec::new();
+        encode_socks5_addr_socket(&mut buf, &"[::1]:1234".parse().unwrap());
+        assert_eq!(buf[0], ATYP_IPV6);
+        assert_eq!(buf.len(), 1 + 16 + 2);
+        assert_eq!(&buf[buf.len() - 2..], &1234u16.to_be_bytes());
+    }
+
+    #[test]
+    fn encode_metadata_domain_takes_precedence() {
+        let mut buf = Vec::new();
+        let md = Metadata {
+            host: "example.com".into(),
+            dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            dst_port: 443,
+            ..Default::default()
+        };
+        encode_socks5_addr_from_metadata(&mut buf, &md);
+        assert_eq!(buf[0], ATYP_DOMAIN);
+        assert_eq!(buf[1] as usize, "example.com".len());
+        assert_eq!(&buf[2..2 + "example.com".len()], b"example.com");
     }
 }

--- a/crates/mihomo-proxy/tests/trojan_integration.rs
+++ b/crates/mihomo-proxy/tests/trojan_integration.rs
@@ -3,12 +3,12 @@
 //! Uses an embedded mock Trojan server with a self-signed certificate.
 //! No external binaries required.
 
-use mihomo_common::{Metadata, Network, ProxyAdapter};
+use mihomo_common::{Metadata, MihomoError, Network, ProxyAdapter};
 use mihomo_proxy::TrojanAdapter;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::time::{timeout, Duration};
 
 const TROJAN_PASSWORD: &str = "test-trojan-password";
@@ -169,6 +169,13 @@ async fn start_mock_trojan_server(
                         let mut target = TcpStream::connect(target_addr).await.unwrap();
                         let _ = tokio::io::copy_bidirectional(&mut tls, &mut target).await;
                     }
+                    0x03 => {
+                        // UDP_ASSOCIATE: pump per-packet frames in both
+                        // directions over the TLS stream.  `target_addr` from
+                        // the request header is informational; each datagram
+                        // names its own destination.
+                        run_mock_udp_associate(tls).await;
+                    }
                     other => {
                         eprintln!("mock trojan: unsupported cmd: {}", other);
                     }
@@ -178,6 +185,140 @@ async fn start_mock_trojan_server(
     });
 
     (addr, handle)
+}
+
+/// Read one SOCKS5 address surfacing IO errors cleanly (the TCP-test
+/// `read_socks5_addr` helper above panics, which is fine inside a steady
+/// stream but noisy when the UDP-relay test tears down the TLS pipe).
+async fn try_read_socks5_addr<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<SocketAddr> {
+    let mut atyp = [0u8; 1];
+    reader.read_exact(&mut atyp).await?;
+    match atyp[0] {
+        0x01 => {
+            let mut ip = [0u8; 4];
+            reader.read_exact(&mut ip).await?;
+            let mut port = [0u8; 2];
+            reader.read_exact(&mut port).await?;
+            Ok(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(ip)),
+                u16::from_be_bytes(port),
+            ))
+        }
+        0x04 => {
+            let mut ip = [0u8; 16];
+            reader.read_exact(&mut ip).await?;
+            let mut port = [0u8; 2];
+            reader.read_exact(&mut port).await?;
+            Ok(SocketAddr::new(
+                IpAddr::V6(std::net::Ipv6Addr::from(ip)),
+                u16::from_be_bytes(port),
+            ))
+        }
+        0x03 => {
+            let mut len = [0u8; 1];
+            reader.read_exact(&mut len).await?;
+            let mut domain = vec![0u8; len[0] as usize];
+            reader.read_exact(&mut domain).await?;
+            let mut port = [0u8; 2];
+            reader.read_exact(&mut port).await?;
+            // Best-effort: parse domain as IP literal; otherwise use UNSPEC.
+            let s = String::from_utf8_lossy(&domain);
+            let ip: IpAddr = s.parse().unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+            Ok(SocketAddr::new(ip, u16::from_be_bytes(port)))
+        }
+        other => Err(std::io::Error::other(format!("unknown ATYP {:#x}", other))),
+    }
+}
+
+/// Read one Trojan UDP frame
+/// (`ATYP | ADDR | PORT | LEN(u16 BE) | CRLF | PAYLOAD`) from the TLS stream
+/// and return the decoded destination plus the payload bytes.
+async fn read_trojan_udp_frame<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<(SocketAddr, Vec<u8>)> {
+    let addr = try_read_socks5_addr(reader).await?;
+    let mut len_bytes = [0u8; 2];
+    reader.read_exact(&mut len_bytes).await?;
+    let length = u16::from_be_bytes(len_bytes) as usize;
+    let mut crlf = [0u8; 2];
+    reader.read_exact(&mut crlf).await?;
+    if &crlf != b"\r\n" {
+        return Err(std::io::Error::other("trojan udp: missing CRLF"));
+    }
+    let mut payload = vec![0u8; length];
+    reader.read_exact(&mut payload).await?;
+    Ok((addr, payload))
+}
+
+/// Write one Trojan UDP frame to the TLS stream.
+async fn write_trojan_udp_frame<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    addr: SocketAddr,
+    payload: &[u8],
+) -> std::io::Result<()> {
+    let mut frame = Vec::with_capacity(payload.len() + 23);
+    match addr.ip() {
+        IpAddr::V4(v4) => {
+            frame.push(0x01);
+            frame.extend_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            frame.push(0x04);
+            frame.extend_from_slice(&v6.octets());
+        }
+    }
+    frame.extend_from_slice(&addr.port().to_be_bytes());
+    frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    frame.extend_from_slice(b"\r\n");
+    frame.extend_from_slice(payload);
+    writer.write_all(&frame).await?;
+    writer.flush().await
+}
+
+/// Mock UDP_ASSOCIATE handler:
+///   * Reads framed UDP packets from the TLS stream.
+///   * Forwards each payload to the destination over a real UDP socket
+///     (single shared socket, like a Trojan server's "back end").
+///   * Echoes any inbound UDP datagrams back over the TLS stream framed with
+///     the source address.
+async fn run_mock_udp_associate<S>(tls: S)
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
+{
+    let (mut tls_r, mut tls_w) = tokio::io::split(tls);
+    let udp = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+
+    // tls -> udp: forward each frame to its named destination.
+    let udp_send = udp.clone();
+    let send_task = tokio::spawn(async move {
+        while let Ok((addr, payload)) = read_trojan_udp_frame(&mut tls_r).await {
+            if udp_send.send_to(&payload, addr).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // udp -> tls: every reply is wrapped back into a frame.
+    let recv_task = tokio::spawn(async move {
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let (n, peer) = match udp.recv_from(&mut buf).await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            if write_trojan_udp_frame(&mut tls_w, peer, &buf[..n])
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let _ = send_task.await;
+    recv_task.abort();
 }
 
 #[tokio::test]
@@ -279,4 +420,169 @@ async fn test_trojan_tcp_large_payload() {
         .await
         .expect("TCP read_exact failed");
     assert_eq!(buf, payload, "large payload echo mismatch");
+}
+
+// ─── UDP relay tests ─────────────────────────────────────────────────────────
+
+/// UDP echo server: every datagram bounces back to its sender.
+async fn start_udp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = socket.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let (n, peer) = match socket.recv_from(&mut buf).await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            if socket.send_to(&buf[..n], peer).await.is_err() {
+                break;
+            }
+        }
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn test_trojan_udp_echo() {
+    install_crypto_provider();
+
+    let (cert_der, key_der) = generate_self_signed_cert();
+    let (echo_addr, _echo_handle) = start_udp_echo_server().await;
+    let (trojan_addr, _trojan_handle) = start_mock_trojan_server(cert_der, key_der).await;
+
+    // udp=true so dial_udp succeeds.
+    let adapter = TrojanAdapter::new(
+        "test-trojan-udp",
+        "127.0.0.1",
+        trojan_addr.port(),
+        TROJAN_PASSWORD,
+        "localhost",
+        true,
+        true,
+    );
+
+    // The CMD=0x03 header carries a placeholder destination (the echo server),
+    // but every actual datagram below targets `echo_addr` independently.
+    let metadata = Metadata {
+        network: Network::Udp,
+        dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        dst_port: echo_addr.port(),
+        ..Default::default()
+    };
+
+    let pc = timeout(TIMEOUT, adapter.dial_udp(&metadata))
+        .await
+        .expect("UDP dial timed out")
+        .expect("UDP dial failed");
+
+    // Round-trip a few packets.
+    let payloads: [&[u8]; 3] = [
+        b"hello trojan udp",
+        b"second packet",
+        b"third packet with a slightly longer payload to test framing",
+    ];
+
+    for p in &payloads {
+        let n = timeout(TIMEOUT, pc.write_packet(p, &echo_addr))
+            .await
+            .expect("write_packet timed out")
+            .expect("write_packet failed");
+        assert_eq!(n, p.len());
+
+        let mut buf = vec![0u8; 4096];
+        let (n, from) = timeout(TIMEOUT, pc.read_packet(&mut buf))
+            .await
+            .expect("read_packet timed out")
+            .expect("read_packet failed");
+        assert_eq!(&buf[..n], *p, "UDP echo payload mismatch");
+        // The mock server echoes the *peer* address (the UDP echo server's
+        // local address), so the port must match.  IP may be 127.0.0.1 or
+        // the literal 0.0.0.0 placeholder on some platforms, so check port.
+        assert_eq!(from.port(), echo_addr.port(), "UDP echo source port");
+    }
+}
+
+#[tokio::test]
+async fn test_trojan_udp_multi_destination() {
+    install_crypto_provider();
+
+    let (cert_der, key_der) = generate_self_signed_cert();
+    let (echo_a, _ha) = start_udp_echo_server().await;
+    let (echo_b, _hb) = start_udp_echo_server().await;
+    let (trojan_addr, _trojan_handle) = start_mock_trojan_server(cert_der, key_der).await;
+
+    let adapter = TrojanAdapter::new(
+        "test-trojan-udp-multi",
+        "127.0.0.1",
+        trojan_addr.port(),
+        TROJAN_PASSWORD,
+        "localhost",
+        true,
+        true,
+    );
+
+    let metadata = Metadata {
+        network: Network::Udp,
+        dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        dst_port: echo_a.port(),
+        ..Default::default()
+    };
+
+    let pc = timeout(TIMEOUT, adapter.dial_udp(&metadata))
+        .await
+        .expect("UDP dial timed out")
+        .expect("UDP dial failed");
+
+    // Send to A and B over the same packet conn; the server must route each
+    // datagram to its individual destination.
+    pc.write_packet(b"to-a", &echo_a).await.unwrap();
+    pc.write_packet(b"to-b", &echo_b).await.unwrap();
+
+    // Both echoes should come back; order is not guaranteed.
+    let mut got = Vec::new();
+    for _ in 0..2 {
+        let mut buf = vec![0u8; 1024];
+        let (n, from) = timeout(TIMEOUT, pc.read_packet(&mut buf))
+            .await
+            .expect("read_packet timed out")
+            .expect("read_packet failed");
+        got.push((from.port(), buf[..n].to_vec()));
+    }
+    let expect_a = (echo_a.port(), b"to-a".to_vec());
+    let expect_b = (echo_b.port(), b"to-b".to_vec());
+    assert!(
+        got.contains(&expect_a) && got.contains(&expect_b),
+        "expected echoes from both servers, got {:?}",
+        got
+    );
+}
+
+#[tokio::test]
+async fn test_trojan_udp_disabled_returns_not_supported() {
+    install_crypto_provider();
+
+    // udp=false → dial_udp must reject without opening a TLS connection.
+    let adapter = TrojanAdapter::new(
+        "test-trojan-noudp",
+        "127.0.0.1",
+        1, // unreachable port — proves we never tried to dial
+        TROJAN_PASSWORD,
+        "localhost",
+        true,
+        false,
+    );
+
+    let metadata = Metadata {
+        network: Network::Udp,
+        dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        dst_port: 53,
+        ..Default::default()
+    };
+
+    match adapter.dial_udp(&metadata).await {
+        Ok(_) => panic!("dial_udp should fail when udp is disabled"),
+        Err(MihomoError::NotSupported(_)) => {}
+        Err(other) => panic!("expected NotSupported, got {:?}", other),
+    }
 }


### PR DESCRIPTION
## Summary
- Implements Trojan UDP relay (CMD=0x03 UDP_ASSOCIATE) over the same TLS stream used for TCP.
- Each datagram is framed as `ATYP | DST.ADDR | DST.PORT | LEN(u16 BE) | CRLF | PAYLOAD`, matching trojan-go / clash-meta upstream.
- `support_udp=false` short-circuits `dial_udp` with `NotSupported` before opening any TLS connection.

## Implementation
`crates/mihomo-proxy/src/trojan.rs`
- New `TrojanPacketConn` splits the TLS stream into read/write halves behind `tokio::sync::Mutex` so `&self` `ProxyPacketConn` methods work; oversized inbound frames are drained to keep alignment.
- TCP/UDP share `open_tls_with_header(metadata, cmd)`; SOCKS5 encode/decode is factored into helpers (`encode_socks5_addr_from_metadata`, `encode_socks5_addr_socket`, `read_socks5_addr`).
- Domain-form replies fall back to `0.0.0.0:port` when not parseable as an IP literal — Trojan servers almost always echo IP form, and we avoid a synchronous DNS round-trip in the hot path.

## Tests
`crates/mihomo-proxy/tests/trojan_integration.rs`
- Embedded mock server now handles `CMD=0x03` by pumping frames through a real `UdpSocket` and echoing replies back framed.
- `test_trojan_udp_echo` — multi-packet round-trip.
- `test_trojan_udp_multi_destination` — single conn fans out to two distinct UDP echo servers; verifies per-packet destination routing.
- `test_trojan_udp_disabled_returns_not_supported` — uses an unreachable port to prove no dial happens when `udp: false`.
- Three new unit tests cover SOCKS5 address encoding (v4, v6, domain priority over IP).

## Verification
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` ✅ (all crate suites)
- `cargo test --test trojan_integration` ✅ (5/5 passed: 2 existing TCP + 3 new UDP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)