### PR TITLE
fix(deps): bump hickory to 0.26 and adapt to API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,13 +388,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -505,6 +516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +536,16 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -998,6 +1029,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1099,32 +1131,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "hickory-proto 0.26.1",
+ "http",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "rustls",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2",
- "http",
  "idna",
  "ipnet",
  "once_cell",
  "rand 0.9.2",
  "ring",
- "rustls",
- "serde",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
  "tracing",
  "url",
 ]
@@ -1137,15 +1213,41 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
  "parking_lot",
  "rand 0.9.2",
  "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
  "rustls",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -1154,17 +1256,17 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-util",
- "hickory-proto",
+ "hickory-net",
+ "hickory-proto 0.26.1",
  "ipnet",
  "prefix-trie",
  "serde",
@@ -1538,6 +1640,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,7 +1935,7 @@ version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap",
- "hickory-proto",
+ "hickory-proto 0.26.1",
  "serde",
  "serde_json",
  "tokio",
@@ -1817,8 +1968,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-proto 0.26.1",
+ "hickory-resolver 0.26.1",
  "ipnet",
  "maxminddb",
  "mihomo-common",
@@ -1849,8 +2000,8 @@ dependencies = [
  "async-trait",
  "dashmap",
  "futures",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-proto 0.26.1",
+ "hickory-resolver 0.26.1",
  "hickory-server",
  "ipnet",
  "lru",
@@ -2038,6 +2189,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -2312,10 +2469,11 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
 dependencies = [
+ "either",
  "ipnet",
  "num-traits",
 ]
@@ -2460,6 +2618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2665,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2644,6 +2819,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2873,7 +3057,7 @@ dependencies = [
  "cfg-if",
  "dynosaur",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libc",
  "log",
  "lru_time_cache",
@@ -2909,7 +3093,7 @@ dependencies = [
  "bytes",
  "camellia",
  "cfg-if",
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "ctr",
  "hkdf",
@@ -2949,6 +3133,22 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -3062,6 +3262,27 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 webpki-roots = "0.26"
 
 # DNS
-hickory-resolver = "0.25"
-hickory-server = "0.25"
-hickory-proto = "0.25"
+hickory-resolver = "0.26"
+hickory-server = "0.26"
+hickory-proto = "0.26"
 
 # Web framework
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/mihomo-bench/src/bench_dns.rs
+++ b/crates/mihomo-bench/src/bench_dns.rs
@@ -18,11 +18,8 @@ pub struct DnsResult {
 }
 
 fn build_query(name: &str, id: u16) -> anyhow::Result<Vec<u8>> {
-    let mut msg = Message::new();
-    msg.set_id(id);
-    msg.set_message_type(MessageType::Query);
-    msg.set_op_code(OpCode::Query);
-    msg.set_recursion_desired(true);
+    let mut msg = Message::new(id, MessageType::Query, OpCode::Query);
+    msg.metadata.recursion_desired = true;
 
     let name: Name = name.parse()?;
     let query = Query::query(name, RecordType::A);

--- a/crates/mihomo-bench/src/main.rs
+++ b/crates/mihomo-bench/src/main.rs
@@ -89,11 +89,8 @@ async fn wait_for_udp_port(addr: SocketAddr, timeout: Duration) -> anyhow::Resul
     let deadline = tokio::time::Instant::now() + timeout;
     let sock = UdpSocket::bind("127.0.0.1:0").await?;
 
-    let mut msg = Message::new();
-    msg.set_id(0);
-    msg.set_message_type(MessageType::Query);
-    msg.set_op_code(OpCode::Query);
-    msg.set_recursion_desired(true);
+    let mut msg = Message::new(0, MessageType::Query, OpCode::Query);
+    msg.metadata.recursion_desired = true;
     let name: Name = "ping.invalid.".parse()?;
     msg.add_query(Query::query(name, RecordType::A));
     let probe = msg.to_bytes()?;

--- a/crates/mihomo-config/src/ech_dns.rs
+++ b/crates/mihomo-config/src/ech_dns.rs
@@ -30,18 +30,19 @@ use std::collections::HashMap;
 pub(crate) async fn fetch_ech_from_dns(name: &str) -> Result<Vec<u8>, String> {
     let resolver = Resolver::builder_tokio()
         .map_err(|e| format!("ech-dns: build system resolver: {}", e))?
-        .build();
+        .build()
+        .map_err(|e| format!("ech-dns: build system resolver: {}", e))?;
     let lookup = resolver
         .lookup(name, RecordType::HTTPS)
         .await
         .map_err(|e| format!("ech-dns: HTTPS lookup for {}: {}", name, e))?;
 
-    for record in lookup.record_iter() {
-        let svcb = match record.data() {
+    for record in lookup.answers() {
+        let svcb = match &record.data {
             RData::HTTPS(https) => &https.0,
             _ => continue,
         };
-        for (_, value) in svcb.svc_params() {
+        for (_, value) in &svcb.svc_params {
             if let SvcParamValue::EchConfigList(list) = value {
                 if !list.0.is_empty() {
                     return Ok(list.0.clone());

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -1,9 +1,8 @@
 use crate::cache::DnsCache;
 use crate::upstream::{HostOrIp, NameServerUrl};
 use dashmap::DashMap;
-use hickory_proto::xfer::Protocol;
-use hickory_resolver::config::{NameServerConfig, ResolverConfig};
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::config::{ConnectionConfig, NameServerConfig, ResolverConfig};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 use ipnet::IpNet;
 use mihomo_common::DnsMode;
@@ -269,18 +268,23 @@ impl Resolver {
     }
 
     fn build_resolver(servers: &[SocketAddr]) -> TokioResolver {
-        let mut config = ResolverConfig::new();
+        let mut config = ResolverConfig::from_parts(None, vec![], vec![]);
         for &addr in servers {
-            config.add_name_server(NameServerConfig::new(addr, Protocol::Udp));
-            config.add_name_server(NameServerConfig::new(addr, Protocol::Tcp));
+            let mut udp = ConnectionConfig::udp();
+            udp.port = addr.port();
+            let mut tcp = ConnectionConfig::tcp();
+            tcp.port = addr.port();
+            config.add_name_server(NameServerConfig::new(addr.ip(), true, vec![udp, tcp]));
         }
         let mut builder =
-            TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
+            TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
         let opts = builder.options_mut();
         opts.timeout = Duration::from_secs(5);
         opts.attempts = 2;
         opts.cache_size = 0;
-        builder.build()
+        builder
+            .build()
+            .expect("TokioResolver build is infallible for the static configuration above")
     }
 
     /// Build a `Resolver` from structured `NameServerUrl` lists, running a
@@ -321,61 +325,64 @@ impl Resolver {
         }
 
         // Step 3: Short-circuit if no bootstrap needed.
-        let resolved_map: HashMap<String, IpAddr> = if hostnames_needing_bootstrap.is_empty() {
-            HashMap::new()
-        } else {
-            if default_ns.is_empty() {
-                return Err(BootstrapError::DefaultNameserverMissing {
-                    first_encrypted: first_encrypted_with_hostname.unwrap_or_default(),
-                });
-            }
-
-            // Step 4: Build throwaway bootstrap resolver.
-            let bootstrap_resolver = {
-                let mut config = ResolverConfig::new();
-                for ns in &default_ns {
-                    let addr = url_to_plain_socketaddr(ns);
-                    let protocol = if matches!(ns, NameServerUrl::Tcp { .. }) {
-                        Protocol::Tcp
-                    } else {
-                        Protocol::Udp
-                    };
-                    config.add_name_server(NameServerConfig::new(addr, protocol));
+        let resolved_map: HashMap<String, IpAddr> =
+            if hostnames_needing_bootstrap.is_empty() {
+                HashMap::new()
+            } else {
+                if default_ns.is_empty() {
+                    return Err(BootstrapError::DefaultNameserverMissing {
+                        first_encrypted: first_encrypted_with_hostname.unwrap_or_default(),
+                    });
                 }
-                let mut builder =
-                    TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
-                let opts = builder.options_mut();
-                opts.timeout = Duration::from_secs(3);
-                opts.attempts = 2;
-                opts.cache_size = 0;
-                builder.build()
-            };
 
-            // Resolve sequentially — fail-fast on first failure.
-            let mut map = HashMap::new();
-            for host in &hostnames_needing_bootstrap {
-                match bootstrap_resolver.lookup_ip(host.as_str()).await {
-                    Ok(lookup) => {
-                        let ip =
-                            lookup
-                                .iter()
-                                .next()
-                                .ok_or_else(|| BootstrapError::CannotResolve {
+                // Step 4: Build throwaway bootstrap resolver.
+                let bootstrap_resolver = {
+                    let mut config = ResolverConfig::from_parts(None, vec![], vec![]);
+                    for ns in &default_ns {
+                        let addr = url_to_plain_socketaddr(ns);
+                        let mut cc = if matches!(ns, NameServerUrl::Tcp { .. }) {
+                            ConnectionConfig::tcp()
+                        } else {
+                            ConnectionConfig::udp()
+                        };
+                        cc.port = addr.port();
+                        config.add_name_server(NameServerConfig::new(addr.ip(), true, vec![cc]));
+                    }
+                    let mut builder =
+                        TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
+                    let opts = builder.options_mut();
+                    opts.timeout = Duration::from_secs(3);
+                    opts.attempts = 2;
+                    opts.cache_size = 0;
+                    builder.build().map_err(|e| BootstrapError::CannotResolve {
+                        host: "<bootstrap>".to_string(),
+                        source: Box::new(e),
+                    })?
+                };
+
+                // Resolve sequentially — fail-fast on first failure.
+                let mut map = HashMap::new();
+                for host in &hostnames_needing_bootstrap {
+                    match bootstrap_resolver.lookup_ip(host.as_str()).await {
+                        Ok(lookup) => {
+                            let ip = lookup.iter().next().ok_or_else(|| {
+                                BootstrapError::CannotResolve {
                                     host: host.clone(),
                                     source: "no addresses returned".into(),
-                                })?;
-                        map.insert(host.clone(), ip);
-                    }
-                    Err(e) => {
-                        return Err(BootstrapError::CannotResolve {
-                            host: host.clone(),
-                            source: Box::new(e),
-                        });
+                                }
+                            })?;
+                            map.insert(host.clone(), ip);
+                        }
+                        Err(e) => {
+                            return Err(BootstrapError::CannotResolve {
+                                host: host.clone(),
+                                source: Box::new(e),
+                            });
+                        }
                     }
                 }
-            }
-            map
-        };
+                map
+            };
 
         // Steps 5 & 6: Build main + fallback — one resolver per URL for parallel dispatch.
         let main = main_urls
@@ -421,15 +428,25 @@ impl Resolver {
                 SocketAddr::new(host_or_ip_to_addr(addr, resolved), *port)
             }
         };
+        let port = socket_addr.port();
+        let ip = socket_addr.ip();
         let ns_cfg = match url {
-            NameServerUrl::Udp { .. } => NameServerConfig::new(socket_addr, Protocol::Udp),
-            NameServerUrl::Tcp { .. } => NameServerConfig::new(socket_addr, Protocol::Tcp),
+            NameServerUrl::Udp { .. } => {
+                let mut cc = ConnectionConfig::udp();
+                cc.port = port;
+                NameServerConfig::new(ip, true, vec![cc])
+            }
+            NameServerUrl::Tcp { .. } => {
+                let mut cc = ConnectionConfig::tcp();
+                cc.port = port;
+                NameServerConfig::new(ip, true, vec![cc])
+            }
             NameServerUrl::Tls { sni, .. } => {
                 #[cfg(feature = "encrypted")]
                 {
-                    let mut cfg = NameServerConfig::new(socket_addr, Protocol::Tls);
-                    cfg.tls_dns_name = Some(sni.clone());
-                    cfg
+                    let mut cc = ConnectionConfig::tls(Arc::from(sni.as_str()));
+                    cc.port = port;
+                    NameServerConfig::new(ip, true, vec![cc])
                 }
                 #[cfg(not(feature = "encrypted"))]
                 {
@@ -443,10 +460,12 @@ impl Resolver {
             NameServerUrl::Https { sni, path, .. } => {
                 #[cfg(feature = "encrypted")]
                 {
-                    let mut cfg = NameServerConfig::new(socket_addr, Protocol::Https);
-                    cfg.tls_dns_name = Some(sni.clone());
-                    cfg.http_endpoint = Some(path.clone());
-                    cfg
+                    let mut cc = ConnectionConfig::https(
+                        Arc::from(sni.as_str()),
+                        Some(Arc::from(path.as_str())),
+                    );
+                    cc.port = port;
+                    NameServerConfig::new(ip, true, vec![cc])
                 }
                 #[cfg(not(feature = "encrypted"))]
                 {
@@ -458,15 +477,17 @@ impl Resolver {
                 }
             }
         };
-        let mut config = ResolverConfig::new();
+        let mut config = ResolverConfig::from_parts(None, vec![], vec![]);
         config.add_name_server(ns_cfg);
         let mut builder =
-            TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
+            TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
         let opts = builder.options_mut();
         opts.timeout = Duration::from_secs(5);
         opts.attempts = 2;
         opts.cache_size = 0;
-        builder.build()
+        builder
+            .build()
+            .expect("TokioResolver build is infallible for the static configuration above")
     }
 
     pub async fn resolve_ip(&self, host: &str) -> Option<IpAddr> {


### PR DESCRIPTION
Bumps `hickory-resolver`, `hickory-server`, and `hickory-proto` from 0.25 to 0.26 and ports our DNS code to the reshaped APIs.

### API changes adapted

- `ResolverConfig::new()` + `add_name_server(NameServerConfig::new(SocketAddr, Protocol))` → `from_parts` plus per-protocol `ConnectionConfig` with explicit port (`NameServerConfig::new(IpAddr, trust_negative_responses, Vec<ConnectionConfig>)`). TLS/HTTPS SNI + DoH path now belong to `ConnectionConfig::tls/https`.
- `TokioConnectionProvider` → `hickory_resolver::net::runtime::TokioRuntimeProvider` (the old module is now private).
- `ResolverBuilder::build()` now returns `Result<_, NetError>`. Static configs unwrap with an explanatory `expect()`; the bootstrap resolver propagates the error via `BootstrapError::CannotResolve`.
- `hickory_proto::xfer::Protocol` removed — protocol is implicit in `ConnectionConfig::{udp,tcp,tls,https}`.
- `Message::new()` now takes `(id, MessageType, OpCode)` and the `set_id/set_message_type/set_op_code/set_recursion_desired` setters are gone. Bench code now constructs with the new ctor and writes `metadata.recursion_desired` directly.
- `Lookup::record_iter()` removed → use `answers()`. `Record::data()` is now a public field. `SVCB::svc_params` is a public field, not a method.

### Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings   # clean
cargo test --lib                            # 448 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)