### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-app"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-bench"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "dashmap",
  "futures",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-listener"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64",
  "libc",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
Bumps workspace version 0.6.2 → 0.7.0.

Gates:
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` (default / no-default / all-features) ✅
- `cargo test --lib` ✅ 451 passed

After merge, tag `v0.7.0` on main to trigger the release workflow (.github/workflows/release.yml builds musl artifacts + publishes GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)