### PR TITLE
fix(transport): drop unmaintained rustls-pemfile (RUSTSEC-2025-0134)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,6 @@ dependencies = [
  "rcgen",
  "regex",
  "rustls",
- "rustls-pemfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-boring",
@@ -2829,15 +2828,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/mihomo-transport/Cargo.toml
+++ b/crates/mihomo-transport/Cargo.toml
@@ -16,7 +16,6 @@ tls = [
     "dep:tokio-rustls",
     "dep:rustls",
     "dep:webpki-roots",
-    "dep:rustls-pemfile",
 ]
 # boring-tls: enables BoringSSL-backed TLS for ECH and uTLS fingerprinting.
 # Requires cmake 3.14+ and a C++ compiler at build time (boring-sys vendors BoringSSL).
@@ -59,7 +58,6 @@ bytes = { workspace = true }
 tokio-rustls    = { workspace = true, optional = true }
 rustls          = { workspace = true, optional = true }
 webpki-roots    = { workspace = true, optional = true }
-rustls-pemfile  = { version = "2", optional = true }
 
 # ws feature
 tokio-tungstenite = { workspace = true, optional = true }
@@ -83,7 +81,6 @@ boring-sys   = { version = "5.0.2", optional = true }
 tokio        = { workspace = true }
 tokio-rustls = { workspace = true }
 rustls       = { workspace = true }
-rustls-pemfile = "2"
 rcgen        = "0.13"
 md5          = "0.8"
 # Log-capture strategy: home-rolled MakeWriter in tests/support/log_capture.rs using

--- a/crates/mihomo-transport/src/tls.rs
+++ b/crates/mihomo-transport/src/tls.rs
@@ -357,19 +357,21 @@ impl RustlsInner {
         // --- Client-auth half ---
         let mut tls_config = match &config.client_cert {
             Some(cc) => {
-                let cert_chain = rustls_pemfile::certs(&mut cc.cert_pem.as_slice())
+                // rustls-pemfile is unmaintained (RUSTSEC-2025-0134); use the
+                // PemObject trait from rustls-pki-types, which is the same parser
+                // re-exposed without the wrapper crate.
+                use rustls::pki_types::pem::PemObject;
+                use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+                let cert_chain = CertificateDer::pem_slice_iter(cc.cert_pem.as_slice())
                     .collect::<std::result::Result<Vec<_>, _>>()
                     .map_err(|e| {
                         TransportError::Config(format!(
                             "client_cert.cert_pem: PEM parse error: {e}"
                         ))
                     })?;
-                let private_key = rustls_pemfile::private_key(&mut cc.key_pem.as_slice())
-                    .map_err(|e| {
+                let private_key =
+                    PrivateKeyDer::from_pem_slice(cc.key_pem.as_slice()).map_err(|e| {
                         TransportError::Config(format!("client_cert.key_pem: PEM parse error: {e}"))
-                    })?
-                    .ok_or_else(|| {
-                        TransportError::Config("client_cert.key_pem: no private key found".into())
                     })?;
                 builder
                     .with_client_auth_cert(cert_chain, private_key)


### PR DESCRIPTION
## Summary

`rustls-pemfile` has been unmaintained and archived since August 2025
(RUSTSEC-2025-0134). The advisory recommends migrating to
`rustls-pki-types`'s `PemObject` trait — the same parser, exposed
without the wrapper crate. `rustls-pki-types` is already in the graph
via `rustls 0.23`, so this is a zero-new-dep migration.

## Changes

- `mihomo-transport/src/tls.rs`: client-cert PEM parsing now uses
  `CertificateDer::pem_slice_iter` and `PrivateKeyDer::from_pem_slice`.
  The "no private key found" `Option` branch collapses into
  `PemObject`'s `NoItemsFound` error variant.
- `mihomo-transport/Cargo.toml`: removed `rustls-pemfile` from both
  `[dependencies]` and `[dev-dependencies]`, and dropped
  `dep:rustls-pemfile` from the `tls` feature.

`rustls-pemfile` no longer appears in `Cargo.lock` after this change.

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo clippy --all-targets --no-default-features -- -D warnings` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --lib` → 468 passed ✅

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)