### PR TITLE
feat(dns): forward non-A/AAAA queries through nameserver pipeline

### DIFF
--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -3,7 +3,9 @@ use crate::fakeip::{Pool, Skipper};
 use crate::upstream::{HostOrIp, NameServerUrl};
 use dashmap::DashMap;
 use hickory_resolver::config::{ConnectionConfig, NameServerConfig, ResolverConfig};
+use hickory_resolver::lookup::Lookup;
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::RecordType;
 use hickory_resolver::TokioResolver;
 use ipnet::IpNet;
 use mihomo_common::DnsMode;
@@ -254,6 +256,35 @@ async fn query_pool(resolvers: &[TokioResolver], host: &str) -> Option<(Vec<IpAd
         Ok(((ips, ttl), _)) => Some((ips, ttl)),
         Err(_) => None,
     }
+}
+
+/// Typed-record counterpart of `query_pool`: queries a resolver pool for an
+/// arbitrary `RecordType` (TXT, MX, SRV, HTTPS, …) and returns the first
+/// successful `Lookup`. No TTL clamping or cache write — hickory's caching
+/// client owns the per-record cache for non-A/AAAA queries.
+async fn query_pool_generic(
+    resolvers: &[TokioResolver],
+    host: &str,
+    record_type: RecordType,
+) -> Option<Lookup> {
+    if resolvers.is_empty() {
+        return None;
+    }
+    if resolvers.len() == 1 {
+        return resolvers[0].lookup(host, record_type).await.ok();
+    }
+    let futs: Vec<_> = resolvers
+        .iter()
+        .map(|r| {
+            let host = host.to_owned();
+            Box::pin(async move {
+                r.lookup(&host, record_type)
+                    .await
+                    .map_err(|e| format!("{e}"))
+            })
+        })
+        .collect();
+    futures::future::select_ok(futs).await.ok().map(|(l, _)| l)
 }
 
 impl Resolver {
@@ -672,6 +703,37 @@ impl Resolver {
         }
 
         self.try_fallback(host).await
+    }
+
+    /// Forward a non-A/AAAA query (TXT, MX, SRV, HTTPS, SOA, PTR, …) through
+    /// the same nameserver pipeline as ordinary lookups: domain-gate → policy
+    /// → main → fallback. Returns the typed `Lookup` so callers can re-emit
+    /// the answer section verbatim in their response.
+    ///
+    /// Skips the `ip_gated` fallback hop — the fallback-filter's IP-CIDR /
+    /// GeoIP gates only apply to address records.
+    pub async fn forward_generic(&self, domain: &str, record_type: RecordType) -> Option<Lookup> {
+        if let Some(ff) = &self.fallback_filter {
+            if ff.domain_gated(domain) {
+                return self.try_fallback_generic(domain, record_type).await;
+            }
+        }
+        if let Some(policy) = &self.policy {
+            if let Some(entry) = policy.lookup(domain) {
+                if let Some(l) = query_pool_generic(&entry.nameservers, domain, record_type).await {
+                    return Some(l);
+                }
+            }
+        }
+        if let Some(l) = query_pool_generic(&self.main, domain, record_type).await {
+            return Some(l);
+        }
+        self.try_fallback_generic(domain, record_type).await
+    }
+
+    async fn try_fallback_generic(&self, domain: &str, record_type: RecordType) -> Option<Lookup> {
+        let fb = self.fallback.as_deref()?;
+        query_pool_generic(fb, domain, record_type).await
     }
 
     async fn try_fallback(&self, host: &str) -> Option<Vec<IpAddr>> {

--- a/crates/mihomo-dns/src/server.rs
+++ b/crates/mihomo-dns/src/server.rs
@@ -1,4 +1,6 @@
 use crate::resolver::Resolver;
+use hickory_resolver::proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_resolver::proto::rr::RecordType;
 use mihomo_common::DnsMode;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -75,10 +77,13 @@ impl DnsServer {
         let (domain, qtype, _offset) = Self::parse_question(&data[12..])?;
         debug!("DNS query: {} type={}", domain, qtype);
 
-        // Only handle A (1) and AAAA (28) queries
+        // Non-address queries (TXT, MX, SRV, HTTPS, SOA, PTR, …) go through
+        // the same nameserver pipeline as A/AAAA — policy → main → fallback —
+        // and the typed `Lookup` is re-emitted into a wire-format response.
+        // We deliberately stop short of fake-IP synthesis here: only address
+        // records ever get a synthetic answer.
         if qtype != 1 && qtype != 28 {
-            // Forward as-is or return NXDOMAIN
-            return Ok(Self::build_nxdomain(id, data));
+            return Self::handle_generic_forward(id, data, &domain, qtype, resolver).await;
         }
 
         // Check hosts trie first. If the domain is present in the hosts table
@@ -123,6 +128,50 @@ impl DnsServer {
             }
             None => Self::build_nxdomain(id, data),
         })
+    }
+
+    /// Forward a non-A/AAAA query through the resolver pipeline and emit the
+    /// returned records as a wire-format response. On upstream failure we
+    /// return SERVFAIL (not NXDOMAIN) — clients may negative-cache NXDOMAIN
+    /// against the bare name, which would poison subsequent A/AAAA lookups.
+    async fn handle_generic_forward(
+        id: u16,
+        query: &[u8],
+        domain: &str,
+        qtype: u16,
+        resolver: &Resolver,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        let record_type = RecordType::from(qtype);
+        debug!("DNS forward (generic): {} type={:?}", domain, record_type);
+        let lookup = resolver.forward_generic(domain, record_type).await;
+
+        // Parse the inbound query just to copy its question section verbatim.
+        // If parsing fails we fall back to the hand-rolled NXDOMAIN builder
+        // rather than dropping the packet.
+        let Ok(req) = Message::from_vec(query) else {
+            return Ok(Self::build_nxdomain(id, query));
+        };
+
+        let mut resp = Message::new(id, MessageType::Response, OpCode::Query);
+        resp.metadata.recursion_desired = req.metadata.recursion_desired;
+        resp.metadata.recursion_available = true;
+        resp.add_queries(req.queries.iter().cloned());
+
+        match lookup {
+            Some(l) => {
+                resp.metadata.response_code = ResponseCode::NoError;
+                for rec in l.answers() {
+                    resp.add_answer(rec.clone());
+                }
+            }
+            None => {
+                resp.metadata.response_code = ResponseCode::ServFail;
+            }
+        }
+
+        Ok(resp
+            .to_vec()
+            .unwrap_or_else(|_| Self::build_nxdomain(id, query)))
     }
 
     fn parse_question(


### PR DESCRIPTION
## Problem

The embedded UDP DNS server replied NXDOMAIN to any qtype other than A or AAAA. HTTPS/SVCB (Chrome's connection-upgrade probe), MX, SRV, TXT, PTR, etc. all failed outright — and NXDOMAIN against the bare name risks poisoning the client's negative cache for subsequent A/AAAA lookups.

## Change

Forward non-address queries through the same pipeline as A/AAAA — domain-gate → nameserver-policy → main → fallback — using the existing nameserver pool. Configured DoH/DoT upstreams are honored.

- `Resolver::forward_generic` calls `TokioResolver::lookup(name, RecordType)` per pool and returns the first successful `Lookup`. Skips the IP-CIDR/GeoIP fallback gate (only meaningful for address records) and the IP cache (hickory's caching client owns the per-record cache).
- Server builds the response via hickory's `Message` API so any record type emits correctly.
- Upstream failure → SERVFAIL, not NXDOMAIN.

Fake-IP mode unaffected: only A/AAAA ever get synthetic answers.

## Divergence from upstream mihomo

Upstream forwards non-address queries via a separate plain-UDP path. We route them through the configured nameserver pool instead, which honors DoH/DoT/policy. Behavior difference is documented in the commit body.

## Gates

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo clippy --all-targets --no-default-features -- -D warnings` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test --lib` → 468 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)