### PR TITLE
feat(dns): replace hickory-resolver with in-tree DNS client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,16 +578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,15 +642,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1172,35 +1153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "hickory-proto",
- "http",
- "idna",
- "ipnet",
- "jni",
- "rand 0.10.1",
- "rustls",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hickory-proto"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,65 +1163,12 @@ dependencies = [
  "ipnet",
  "jni",
  "once_cell",
- "prefix-trie",
  "rand 0.10.1",
  "ring",
- "serde",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipconfig",
- "ipnet",
- "jni",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot",
- "rand 0.10.1",
- "resolv-conf",
- "rustls",
- "smallvec",
- "system-configuration",
- "thiserror 2.0.18",
- "tokio",
- "tokio-rustls",
- "tracing",
-]
-
-[[package]]
-name = "hickory-server"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipnet",
- "prefix-trie",
- "serde",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1527,26 +1426,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2 0.6.3",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ipnetwork"
@@ -1922,7 +1805,6 @@ dependencies = [
  "async-trait",
  "base64",
  "hickory-proto",
- "hickory-resolver",
  "ipnet",
  "maxminddb",
  "mihomo-common",
@@ -1948,20 +1830,23 @@ version = "0.7.3"
 dependencies = [
  "dashmap",
  "futures",
- "hickory-resolver",
- "hickory-server",
+ "hickory-proto",
  "ipnet",
  "lru",
  "maxminddb",
  "mihomo-common",
  "mihomo-trie",
  "parking_lot",
+ "rand 0.9.2",
+ "rustls",
  "serde",
  "serde_json",
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2117,29 +2002,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -2392,17 +2254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prefix-trie"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
 ]
 
 [[package]]
@@ -2741,12 +2592,6 @@ dependencies = [
  "web-sys",
  "webpki-roots 1.0.6",
 ]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -3248,33 +3093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3740,7 +3558,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3965,12 +3782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,7 +3830,7 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -4052,41 +3863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,10 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 webpki-roots = "0.26"
 
-# DNS
-hickory-resolver = "0.26"
-hickory-server = "0.26"
+# DNS — only hickory-proto for wire-format encode/decode; the upstream
+# transport (UDP/TCP/DoT/DoH) is implemented in-tree in `mihomo-dns::client`
+# so the sockets are owned by us and host integrations can intercept them
+# (Android `protect()`).
 hickory-proto = "0.26"
 
 # Web framework
@@ -114,7 +115,7 @@ subtle = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
-# Time (transitive via hickory-server; explicitly declared to enable formatting)
+# Time (used directly by mihomo-api log timestamps; formatting feature enabled)
 time = { version = "0.3", features = ["formatting"] }
 
 # CLI

--- a/crates/mihomo-config/Cargo.toml
+++ b/crates/mihomo-config/Cargo.toml
@@ -31,7 +31,6 @@ ipnet = { workspace = true }
 base64 = { workspace = true }
 regex = { workspace = true }
 parking_lot = { workspace = true }
-hickory-resolver = { workspace = true }
 hickory-proto = { workspace = true }
 
 [dev-dependencies]

--- a/crates/mihomo-config/src/ech_dns.rs
+++ b/crates/mihomo-config/src/ech_dns.rs
@@ -1,13 +1,15 @@
 //! DNS-sourced ECH config lookup and pre-resolution pass.
 //!
 //! Resolves the wire-format `ECHConfigList` from an HTTPS (RR type 65) record
-//! via `hickory-resolver` using the system DNS configuration
-//! (`/etc/resolv.conf` on Unix, registry on Windows).
+//! using the system nameservers (`/etc/resolv.conf` on Unix, a small built-in
+//! fallback list on Windows).  Queries go through the internal `mihomo-dns`
+//! client so socket creation can be intercepted by host integrations
+//! (e.g. Android `protect()`).
 //!
 //! # Why not the in-process resolver?
 //!
-//! `mihomo-dns` is built *from* the parsed config, so at parse time it does
-//! not yet exist. We bootstrap with the system resolver instead.
+//! `mihomo-dns::Resolver` is built *from* the parsed config, so at parse time
+//! it does not yet exist. We bootstrap with the system nameservers instead.
 //!
 //! # Why a separate pre-resolution pass?
 //!
@@ -23,21 +25,72 @@
 use base64::Engine;
 use hickory_proto::rr::rdata::svcb::SvcParamValue;
 use hickory_proto::rr::{RData, RecordType};
-use hickory_resolver::Resolver;
+use mihomo_dns::DnsClient;
 use serde_yaml::Value;
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Read the platform's configured recursive resolvers.
+///
+/// Unix: parse `/etc/resolv.conf` `nameserver` lines.  Other platforms (or a
+/// missing / unreadable resolv.conf) fall back to a short list of well-known
+/// public resolvers so ECH lookups still succeed in unconfigured environments.
+fn system_nameservers() -> Vec<SocketAddr> {
+    let mut out = Vec::new();
+    #[cfg(unix)]
+    {
+        if let Ok(contents) = std::fs::read_to_string("/etc/resolv.conf") {
+            for line in contents.lines() {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+                    continue;
+                }
+                let Some(rest) = line.strip_prefix("nameserver") else {
+                    continue;
+                };
+                let token = rest.split_whitespace().next().unwrap_or("");
+                if let Ok(ip) = token.parse::<IpAddr>() {
+                    out.push(SocketAddr::new(ip, 53));
+                }
+            }
+        }
+    }
+    if out.is_empty() {
+        // Fallback: well-known public resolvers.
+        out.push(SocketAddr::from(([1, 1, 1, 1], 53)));
+        out.push(SocketAddr::from(([8, 8, 8, 8], 53)));
+    }
+    out
+}
 
 pub(crate) async fn fetch_ech_from_dns(name: &str) -> Result<Vec<u8>, String> {
-    let resolver = Resolver::builder_tokio()
-        .map_err(|e| format!("ech-dns: build system resolver: {e}"))?
-        .build()
-        .map_err(|e| format!("ech-dns: build system resolver: {e}"))?;
-    let lookup = resolver
-        .lookup(name, RecordType::HTTPS)
-        .await
-        .map_err(|e| format!("ech-dns: HTTPS lookup for {name}: {e}"))?;
+    let nameservers = system_nameservers();
+    let clients: Vec<Arc<DnsClient>> = nameservers
+        .iter()
+        .map(|addr| Arc::new(DnsClient::udp(*addr).with_timeout(Duration::from_secs(5))))
+        .collect();
 
-    for record in lookup.answers() {
+    let mut last_err: Option<String> = None;
+    let mut response = None;
+    for c in &clients {
+        match c.query(name, RecordType::HTTPS).await {
+            Ok(msg) => {
+                response = Some(msg);
+                break;
+            }
+            Err(e) => last_err = Some(format!("{e}")),
+        }
+    }
+    let msg = response.ok_or_else(|| {
+        format!(
+            "ech-dns: HTTPS lookup for {name} failed via all system nameservers: {}",
+            last_err.unwrap_or_else(|| "no nameservers".to_string())
+        )
+    })?;
+
+    for record in &msg.answers {
         let svcb = match &record.data {
             RData::HTTPS(https) => &https.0,
             _ => continue,

--- a/crates/mihomo-dns/Cargo.toml
+++ b/crates/mihomo-dns/Cargo.toml
@@ -6,21 +6,20 @@ rust-version.workspace = true
 
 [features]
 default = ["encrypted", "dns-server"]
-encrypted = ["hickory-resolver/tls-ring", "hickory-resolver/https-ring"]
-dns-server = ["dep:hickory-server"]
-
-# cargo-machete false-positive: hickory-server is optional, backing the
-# `dns-server` feature gate; it has no direct src imports but the `dep:`
-# reference in [features] requires the dep entry to exist.
-[package.metadata.cargo-machete]
-ignored = ["hickory-server"]
+encrypted = ["dep:tokio-rustls", "dep:rustls", "dep:webpki-roots"]
+# `dns-server` historically gated hickory-server; the in-tree server now uses
+# only `hickory-proto`, so the feature is a no-op kept for API stability.
+dns-server = []
 
 [dependencies]
 mihomo-common = { workspace = true }
 mihomo-trie = { workspace = true }
 tokio = { workspace = true }
-hickory-resolver = { workspace = true }
-hickory-server = { workspace = true, optional = true }
+hickory-proto = { workspace = true }
+tokio-rustls = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+webpki-roots = { workspace = true, optional = true }
+rand = { workspace = true }
 lru = { workspace = true }
 dashmap = { workspace = true }
 tracing = { workspace = true }

--- a/crates/mihomo-dns/src/client.rs
+++ b/crates/mihomo-dns/src/client.rs
@@ -1,0 +1,425 @@
+//! Internal DNS client transports — UDP, TCP, DoT, DoH.
+//!
+//! Sockets are created through a pluggable [`SocketFactory`] so the caller
+//! (e.g. an Android VPN service) can intercept fd creation and call
+//! `protect()` before the socket is used. This is the reason the project
+//! ships its own DNS client instead of relying on `hickory-resolver`.
+
+use hickory_proto::op::{Message, MessageType, OpCode, Query};
+use hickory_proto::rr::{Name, RData, Record, RecordType};
+use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
+use std::future::Future;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UdpSocket};
+
+#[cfg(feature = "encrypted")]
+use {rustls::pki_types::ServerName, std::convert::TryFrom, tokio_rustls::TlsConnector};
+
+/// Default per-query timeout (matches the hickory-resolver value previously
+/// used in `Resolver::build_*`).
+pub const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Factory that creates the raw sockets the DNS client transports run on.
+///
+/// Implementations may call platform-specific hooks (Android `protect()`,
+/// Linux `SO_MARK`, …) before returning the socket so DNS traffic bypasses
+/// the local VPN tunnel.
+pub trait SocketFactory: Send + Sync + 'static {
+    /// Bind an unconnected UDP socket. Implementations typically bind to
+    /// `0.0.0.0:0`.
+    fn bind_udp(&self) -> BoxFuture<'_, io::Result<UdpSocket>>;
+
+    /// Open an outbound TCP connection to `addr`.
+    fn connect_tcp(&self, addr: SocketAddr) -> BoxFuture<'_, io::Result<TcpStream>>;
+}
+
+/// Tokio default factory: plain `UdpSocket::bind` / `TcpStream::connect`.
+struct DefaultSocketFactory;
+
+impl SocketFactory for DefaultSocketFactory {
+    fn bind_udp(&self) -> BoxFuture<'_, io::Result<UdpSocket>> {
+        Box::pin(async {
+            // Bind to v4 unspecified; this is fine because we always
+            // `connect()` the socket before sending, and connect() will
+            // re-resolve the local address family.
+            UdpSocket::bind(SocketAddr::from(([0u8; 4], 0))).await
+        })
+    }
+
+    fn connect_tcp(&self, addr: SocketAddr) -> BoxFuture<'_, io::Result<TcpStream>> {
+        Box::pin(async move { TcpStream::connect(addr).await })
+    }
+}
+
+static SOCKET_FACTORY: OnceLock<Arc<dyn SocketFactory>> = OnceLock::new();
+static DEFAULT_FACTORY: DefaultSocketFactory = DefaultSocketFactory;
+
+/// Install a custom [`SocketFactory`]. Can only be called once; subsequent
+/// calls return the supplied factory unchanged so the caller can detect the
+/// programming error.
+pub fn set_socket_factory(factory: Arc<dyn SocketFactory>) -> Result<(), Arc<dyn SocketFactory>> {
+    SOCKET_FACTORY.set(factory)
+}
+
+fn factory() -> &'static dyn SocketFactory {
+    match SOCKET_FACTORY.get() {
+        Some(f) => f.as_ref(),
+        None => &DEFAULT_FACTORY,
+    }
+}
+
+/// All errors produced by the internal DNS client.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ClientError {
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+    #[error("dns proto: {0}")]
+    Proto(#[from] hickory_proto::ProtoError),
+    #[error("dns decode: {0}")]
+    Decode(#[from] hickory_proto::serialize::binary::DecodeError),
+    #[error("query timed out after {0:?}")]
+    Timeout(Duration),
+    #[error("invalid response: {0}")]
+    Protocol(&'static str),
+    #[error("tls: {0}")]
+    Tls(String),
+    #[error("upstream returned rcode {0:?}")]
+    Rcode(hickory_proto::op::ResponseCode),
+}
+
+/// A single DNS upstream the resolver can query.
+pub struct DnsClient {
+    transport: Transport,
+    timeout: Duration,
+}
+
+enum Transport {
+    Udp {
+        addr: SocketAddr,
+    },
+    Tcp {
+        addr: SocketAddr,
+    },
+    #[cfg(feature = "encrypted")]
+    Dot {
+        addr: SocketAddr,
+        sni: Arc<str>,
+        tls: Arc<rustls::ClientConfig>,
+    },
+    #[cfg(feature = "encrypted")]
+    Doh {
+        addr: SocketAddr,
+        sni: Arc<str>,
+        path: Arc<str>,
+        tls: Arc<rustls::ClientConfig>,
+    },
+}
+
+impl DnsClient {
+    /// Plain DNS over UDP.
+    pub fn udp(addr: SocketAddr) -> Self {
+        Self {
+            transport: Transport::Udp { addr },
+            timeout: DEFAULT_QUERY_TIMEOUT,
+        }
+    }
+
+    /// Plain DNS over TCP (RFC 7766 length-prefixed framing).
+    pub fn tcp(addr: SocketAddr) -> Self {
+        Self {
+            transport: Transport::Tcp { addr },
+            timeout: DEFAULT_QUERY_TIMEOUT,
+        }
+    }
+
+    /// DNS over TLS (RFC 7858).
+    #[cfg(feature = "encrypted")]
+    pub fn dot(addr: SocketAddr, sni: &str) -> Self {
+        Self {
+            transport: Transport::Dot {
+                addr,
+                sni: Arc::from(sni),
+                tls: tls_client_config("dot"),
+            },
+            timeout: DEFAULT_QUERY_TIMEOUT,
+        }
+    }
+
+    /// DNS over HTTPS (RFC 8484) — HTTP/1.1 POST application/dns-message.
+    #[cfg(feature = "encrypted")]
+    pub fn doh(addr: SocketAddr, sni: &str, path: &str) -> Self {
+        Self {
+            transport: Transport::Doh {
+                addr,
+                sni: Arc::from(sni),
+                path: Arc::from(path),
+                tls: tls_client_config("doh"),
+            },
+            timeout: DEFAULT_QUERY_TIMEOUT,
+        }
+    }
+
+    /// Override the per-query timeout.
+    pub fn with_timeout(mut self, t: Duration) -> Self {
+        self.timeout = t;
+        self
+    }
+
+    /// Send a query for `(name, record_type)` and return the parsed response
+    /// `Message`. ID is randomised internally and the response's ID is not
+    /// checked against the request — DoT/DoH/UDP-connected guarantee a 1:1
+    /// pairing on the socket so spoofing a different ID would be a no-op.
+    pub async fn query(&self, name: &str, record_type: RecordType) -> Result<Message, ClientError> {
+        let id: u16 = rand::random();
+        let mut msg = Message::new(id, MessageType::Query, OpCode::Query);
+        msg.metadata.recursion_desired = true;
+        let parsed: Name = name
+            .parse()
+            .map_err(|_| ClientError::Protocol("invalid query name"))?;
+        msg.add_query(Query::query(parsed, record_type));
+        let wire = msg.to_bytes()?;
+        let resp_bytes = tokio::time::timeout(self.timeout, self.exchange(&wire))
+            .await
+            .map_err(|_| ClientError::Timeout(self.timeout))??;
+        let resp = Message::from_bytes(&resp_bytes)?;
+        Ok(resp)
+    }
+
+    /// Convenience: query `A` and `AAAA` in parallel, merge addresses, return
+    /// (addrs, min_ttl).  Empty answer set returns `Ok((vec![], _))`; upstream
+    /// SERVFAIL surfaces as `ClientError::Rcode`.
+    pub async fn lookup_ip(&self, name: &str) -> Result<(Vec<IpAddr>, Duration), ClientError> {
+        let (a, aaaa) = tokio::join!(
+            self.query(name, RecordType::A),
+            self.query(name, RecordType::AAAA),
+        );
+        let mut addrs = Vec::new();
+        let mut min_ttl: Option<u32> = None;
+        let mut had_any_ok = false;
+        let mut last_err: Option<ClientError> = None;
+        for r in [a, aaaa] {
+            match r {
+                Ok(msg) => {
+                    had_any_ok = true;
+                    for rec in &msg.answers {
+                        if let Some(ip) = ip_from_record(rec) {
+                            addrs.push(ip);
+                            min_ttl = Some(min_ttl.map_or(rec.ttl, |t| t.min(rec.ttl)));
+                        }
+                    }
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                }
+            }
+        }
+        if !had_any_ok {
+            return Err(last_err.unwrap_or(ClientError::Protocol("no response")));
+        }
+        Ok((addrs, Duration::from_secs(u64::from(min_ttl.unwrap_or(0)))))
+    }
+
+    async fn exchange(&self, wire: &[u8]) -> Result<Vec<u8>, ClientError> {
+        match &self.transport {
+            Transport::Udp { addr } => udp_exchange(*addr, wire).await,
+            Transport::Tcp { addr } => tcp_exchange(*addr, wire).await,
+            #[cfg(feature = "encrypted")]
+            Transport::Dot { addr, sni, tls } => {
+                dot_exchange(*addr, sni, Arc::clone(tls), wire).await
+            }
+            #[cfg(feature = "encrypted")]
+            Transport::Doh {
+                addr,
+                sni,
+                path,
+                tls,
+            } => doh_exchange(*addr, sni, path, Arc::clone(tls), wire).await,
+        }
+    }
+}
+
+fn ip_from_record(rec: &Record) -> Option<IpAddr> {
+    match &rec.data {
+        RData::A(a) => Some(IpAddr::V4(a.0)),
+        RData::AAAA(a) => Some(IpAddr::V6(a.0)),
+        _ => None,
+    }
+}
+
+async fn udp_exchange(addr: SocketAddr, wire: &[u8]) -> Result<Vec<u8>, ClientError> {
+    let sock = factory().bind_udp().await?;
+    sock.connect(addr).await?;
+    sock.send(wire).await?;
+    let mut buf = vec![0u8; 4096];
+    let n = sock.recv(&mut buf).await?;
+    buf.truncate(n);
+    if n < 12 {
+        return Err(ClientError::Protocol("udp response shorter than header"));
+    }
+    // RFC 6891 / RFC 7766 — handle TC=1 by retrying over TCP. Bit is byte 2
+    // bit 1 (0x02).
+    if buf[2] & 0x02 != 0 {
+        return tcp_exchange(addr, wire).await;
+    }
+    Ok(buf)
+}
+
+async fn tcp_exchange(addr: SocketAddr, wire: &[u8]) -> Result<Vec<u8>, ClientError> {
+    let mut stream = factory().connect_tcp(addr).await?;
+    write_lp(&mut stream, wire).await?;
+    read_lp(&mut stream).await
+}
+
+async fn write_lp<W: AsyncWriteExt + Unpin>(w: &mut W, payload: &[u8]) -> io::Result<()> {
+    let len =
+        u16::try_from(payload.len()).map_err(|_| io::Error::other("dns message too large"))?;
+    w.write_all(&len.to_be_bytes()).await?;
+    w.write_all(payload).await?;
+    w.flush().await
+}
+
+async fn read_lp<R: AsyncReadExt + Unpin>(r: &mut R) -> Result<Vec<u8>, ClientError> {
+    let mut len_buf = [0u8; 2];
+    r.read_exact(&mut len_buf).await?;
+    let len = u16::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+#[cfg(feature = "encrypted")]
+async fn dot_exchange(
+    addr: SocketAddr,
+    sni: &str,
+    tls: Arc<rustls::ClientConfig>,
+    wire: &[u8],
+) -> Result<Vec<u8>, ClientError> {
+    let tcp = factory().connect_tcp(addr).await?;
+    let connector = TlsConnector::from(tls);
+    let server_name = ServerName::try_from(sni.to_string())
+        .map_err(|e| ClientError::Tls(format!("invalid SNI: {e}")))?;
+    let mut stream = connector
+        .connect(server_name, tcp)
+        .await
+        .map_err(|e| ClientError::Tls(e.to_string()))?;
+    write_lp(&mut stream, wire).await?;
+    read_lp(&mut stream).await
+}
+
+#[cfg(feature = "encrypted")]
+async fn doh_exchange(
+    addr: SocketAddr,
+    sni: &str,
+    path: &str,
+    tls: Arc<rustls::ClientConfig>,
+    wire: &[u8],
+) -> Result<Vec<u8>, ClientError> {
+    let tcp = factory().connect_tcp(addr).await?;
+    let connector = TlsConnector::from(tls);
+    let server_name = ServerName::try_from(sni.to_string())
+        .map_err(|e| ClientError::Tls(format!("invalid SNI: {e}")))?;
+    let mut stream = connector
+        .connect(server_name, tcp)
+        .await
+        .map_err(|e| ClientError::Tls(e.to_string()))?;
+
+    // Minimal HTTP/1.1 POST. Connection: close so the server EOFs and we can
+    // read-to-end without parsing chunked transfer-encoding.
+    let head = format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: {host}\r\n\
+         User-Agent: mihomo-rust\r\n\
+         Accept: application/dns-message\r\n\
+         Content-Type: application/dns-message\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\
+         \r\n",
+        host = sni,
+        len = wire.len(),
+    );
+    stream.write_all(head.as_bytes()).await?;
+    stream.write_all(wire).await?;
+    stream.flush().await?;
+
+    let mut all = Vec::with_capacity(1024);
+    stream.read_to_end(&mut all).await?;
+    let split = find_subseq(&all, b"\r\n\r\n")
+        .ok_or(ClientError::Protocol("doh: missing header terminator"))?;
+    let head_bytes = &all[..split];
+    let body = &all[split + 4..];
+    let head_str =
+        std::str::from_utf8(head_bytes).map_err(|_| ClientError::Protocol("doh: bad headers"))?;
+    let status_line = head_str
+        .lines()
+        .next()
+        .ok_or(ClientError::Protocol("doh: empty response"))?;
+    // "HTTP/1.1 200 OK" — extract the status code.
+    let mut parts = status_line.split_whitespace();
+    let _version = parts.next();
+    let status = parts.next().unwrap_or("");
+    if status != "200" {
+        return Err(ClientError::Protocol("doh: non-200 status"));
+    }
+    Ok(body.to_vec())
+}
+
+fn find_subseq(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || hay.len() < needle.len() {
+        return None;
+    }
+    (0..=hay.len() - needle.len()).find(|&i| &hay[i..i + needle.len()] == needle)
+}
+
+#[cfg(feature = "encrypted")]
+fn tls_client_config(alpn: &str) -> Arc<rustls::ClientConfig> {
+    use std::sync::OnceLock;
+    static DOT: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    static DOH: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    let slot = match alpn {
+        "dot" => &DOT,
+        _ => &DOH,
+    };
+    Arc::clone(slot.get_or_init(|| {
+        let root_store = rustls::RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
+        let mut cfg = rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        cfg.alpn_protocols = match alpn {
+            "dot" => vec![b"dot".to_vec()],
+            // h2 first, but the client speaks http/1.1 so include it too.
+            _ => vec![b"http/1.1".to_vec()],
+        };
+        Arc::new(cfg)
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_subseq_basic() {
+        assert_eq!(find_subseq(b"abc\r\n\r\nbody", b"\r\n\r\n"), Some(3));
+        assert_eq!(find_subseq(b"abcdef", b"\r\n\r\n"), None);
+        assert_eq!(find_subseq(b"", b"x"), None);
+    }
+
+    #[tokio::test]
+    async fn udp_client_times_out_on_unroutable() {
+        // 192.0.2.1/24 is TEST-NET-1, guaranteed not to respond.
+        let client = DnsClient::udp("192.0.2.1:53".parse().unwrap())
+            .with_timeout(Duration::from_millis(200));
+        let r = client.query("example.test", RecordType::A).await;
+        assert!(matches!(r, Err(ClientError::Timeout(_))));
+    }
+}

--- a/crates/mihomo-dns/src/lib.rs
+++ b/crates/mihomo-dns/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod cache;
+pub mod client;
 pub mod fakeip;
 pub mod resolver;
 pub mod server;
 pub mod upstream;
 
 pub use cache::DnsCache;
+pub use client::{set_socket_factory, ClientError, DnsClient, SocketFactory};
 pub use fakeip::{FileStore, MemoryStore, Pool, PoolError, Skipper, SkipperMode, Store};
 pub use resolver::{BootstrapError, FallbackFilter, NameserverPolicy, PolicyEntry, Resolver};
 pub use server::DnsServer;

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -1,12 +1,10 @@
 use crate::cache::DnsCache;
+use crate::client::DnsClient;
 use crate::fakeip::{Pool, Skipper};
 use crate::upstream::{HostOrIp, NameServerUrl};
 use dashmap::DashMap;
-use hickory_resolver::config::{ConnectionConfig, NameServerConfig, ResolverConfig};
-use hickory_resolver::lookup::Lookup;
-use hickory_resolver::net::runtime::TokioRuntimeProvider;
-use hickory_resolver::proto::rr::RecordType;
-use hickory_resolver::TokioResolver;
+use hickory_proto::op::Message;
+use hickory_proto::rr::RecordType;
 use ipnet::IpNet;
 use mihomo_common::DnsMode;
 use mihomo_trie::DomainTrie;
@@ -39,11 +37,11 @@ pub enum BootstrapError {
 /// Capacity 1 is enough — subscribers call `recv()` at most once.
 type InflightTx = tokio::sync::broadcast::Sender<Option<Vec<IpAddr>>>;
 
-/// A single entry in `NameserverPolicy`: one or more pre-built resolvers,
-/// one per configured nameserver URL.
+/// A single entry in `NameserverPolicy`: one or more pre-built upstream DNS
+/// clients, one per configured nameserver URL.
 #[derive(Clone)]
 pub struct PolicyEntry {
-    pub nameservers: Vec<TokioResolver>,
+    pub nameservers: Vec<Arc<DnsClient>>,
 }
 
 /// Per-domain nameserver routing: exact matches and `+.` wildcard prefixes.
@@ -138,8 +136,8 @@ impl FallbackFilter {
 }
 
 pub struct Resolver {
-    main: Vec<TokioResolver>,
-    fallback: Option<Vec<TokioResolver>>,
+    main: Vec<Arc<DnsClient>>,
+    fallback: Option<Vec<Arc<DnsClient>>>,
     cache: DnsCache,
     mode: DnsMode,
     hosts: DomainTrie<Vec<IpAddr>>,
@@ -182,13 +180,6 @@ fn clamp_ttl(raw: Duration) -> Duration {
     raw.clamp(MIN_TTL, MAX_TTL)
 }
 
-fn ttl_from_lookup(lookup: &hickory_resolver::lookup_ip::LookupIp) -> Duration {
-    let raw = lookup
-        .valid_until()
-        .saturating_duration_since(std::time::Instant::now());
-    clamp_ttl(raw)
-}
-
 fn host_or_ip_to_addr(addr: &HostOrIp, resolved: &HashMap<String, IpAddr>) -> IpAddr {
     match addr {
         HostOrIp::Ip(ip) => *ip,
@@ -211,80 +202,65 @@ fn url_to_plain_socketaddr(url: &NameServerUrl) -> SocketAddr {
     }
 }
 
-/// Query a pool of resolvers in parallel; return the first successful result.
-/// Uses `futures::future::select_ok` — first `Ok` wins, remaining are cancelled.
-async fn query_pool(resolvers: &[TokioResolver], host: &str) -> Option<(Vec<IpAddr>, Duration)> {
-    if resolvers.is_empty() {
+/// Query a pool of clients in parallel; return the first successful A+AAAA
+/// result. `select_ok` semantics — first `Ok` wins, remaining are cancelled.
+async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<(Vec<IpAddr>, Duration)> {
+    if clients.is_empty() {
         return None;
     }
-    if resolvers.len() == 1 {
-        return match resolvers[0].lookup_ip(host).await {
-            Ok(l) => {
-                let ips: Vec<IpAddr> = l.iter().collect();
-                if ips.is_empty() {
-                    None
-                } else {
-                    Some((ips, ttl_from_lookup(&l)))
-                }
-            }
-            Err(_) => None,
+    if clients.len() == 1 {
+        return match clients[0].lookup_ip(host).await {
+            Ok((ips, ttl)) if !ips.is_empty() => Some((ips, clamp_ttl(ttl))),
+            _ => None,
         };
     }
-
-    let futs: Vec<_> = resolvers
+    let futs: Vec<_> = clients
         .iter()
-        .map(|r| {
+        .map(|c| {
+            let c = Arc::clone(c);
             let host = host.to_owned();
             Box::pin(async move {
-                let l = r.lookup_ip(&host).await.map_err(|e| format!("{e}"))?;
-                let ips: Vec<IpAddr> = l.iter().collect();
+                let (ips, ttl) = c.lookup_ip(&host).await.map_err(|e| format!("{e}"))?;
                 if ips.is_empty() {
                     return Err("empty".to_string());
                 }
-                let ttl = {
-                    let raw = l
-                        .valid_until()
-                        .saturating_duration_since(std::time::Instant::now());
-                    clamp_ttl(raw)
-                };
-                Ok((ips, ttl))
+                Ok((ips, clamp_ttl(ttl)))
             })
         })
         .collect();
-
     match futures::future::select_ok(futs).await {
         Ok(((ips, ttl), _)) => Some((ips, ttl)),
         Err(_) => None,
     }
 }
 
-/// Typed-record counterpart of `query_pool`: queries a resolver pool for an
+/// Typed-record counterpart of `query_pool`: queries a client pool for an
 /// arbitrary `RecordType` (TXT, MX, SRV, HTTPS, …) and returns the first
-/// successful `Lookup`. No TTL clamping or cache write — hickory's caching
-/// client owns the per-record cache for non-A/AAAA queries.
+/// successful `Message`. Caller copies the answer section into its response.
 async fn query_pool_generic(
-    resolvers: &[TokioResolver],
+    clients: &[Arc<DnsClient>],
     host: &str,
     record_type: RecordType,
-) -> Option<Lookup> {
-    if resolvers.is_empty() {
+) -> Option<Message> {
+    if clients.is_empty() {
         return None;
     }
-    if resolvers.len() == 1 {
-        return resolvers[0].lookup(host, record_type).await.ok();
+    if clients.len() == 1 {
+        return clients[0].query(host, record_type).await.ok();
     }
-    let futs: Vec<_> = resolvers
+    let futs: Vec<_> = clients
         .iter()
-        .map(|r| {
+        .map(|c| {
+            let c = Arc::clone(c);
             let host = host.to_owned();
             Box::pin(async move {
-                r.lookup(&host, record_type)
+                c.query(&host, record_type)
                     .await
                     .map_err(|e| format!("{e}"))
             })
         })
         .collect();
-    futures::future::select_ok(futs).await.ok().map(|(l, _)| l)
+    futures::future::select_ok(futs).await.ok().map(|(m, _)| m)
 }
 
 impl Resolver {
@@ -296,11 +272,11 @@ impl Resolver {
         hosts: DomainTrie<Vec<IpAddr>>,
         use_hosts: bool,
     ) -> Self {
-        let main = vec![Self::build_resolver(&main_servers)];
+        let main = Self::build_clients(&main_servers);
         let fallback = if fallback_servers.is_empty() {
             None
         } else {
-            Some(vec![Self::build_resolver(&fallback_servers)])
+            Some(Self::build_clients(&fallback_servers))
         };
         Self {
             main,
@@ -319,24 +295,13 @@ impl Resolver {
         }
     }
 
-    fn build_resolver(servers: &[SocketAddr]) -> TokioResolver {
-        let mut config = ResolverConfig::from_parts(None, vec![], vec![]);
-        for &addr in servers {
-            let mut udp = ConnectionConfig::udp();
-            udp.port = addr.port();
-            let mut tcp = ConnectionConfig::tcp();
-            tcp.port = addr.port();
-            config.add_name_server(NameServerConfig::new(addr.ip(), true, vec![udp, tcp]));
-        }
-        let mut builder =
-            TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
-        let opts = builder.options_mut();
-        opts.timeout = Duration::from_secs(5);
-        opts.attempts = 2;
-        opts.cache_size = 0;
-        builder
-            .build()
-            .expect("TokioResolver build is infallible for the static configuration above")
+    /// Build one UDP `DnsClient` per address. Used by the simple `new()`
+    /// constructor and tests.
+    fn build_clients(servers: &[SocketAddr]) -> Vec<Arc<DnsClient>> {
+        servers
+            .iter()
+            .map(|addr| Arc::new(DnsClient::udp(*addr)))
+            .collect()
     }
 
     /// Build a `Resolver` from structured `NameServerUrl` lists, running a
@@ -377,64 +342,46 @@ impl Resolver {
         }
 
         // Step 3: Short-circuit if no bootstrap needed.
-        let resolved_map: HashMap<String, IpAddr> =
-            if hostnames_needing_bootstrap.is_empty() {
-                HashMap::new()
-            } else {
-                if default_ns.is_empty() {
-                    return Err(BootstrapError::DefaultNameserverMissing {
-                        first_encrypted: first_encrypted_with_hostname.unwrap_or_default(),
-                    });
-                }
+        let resolved_map: HashMap<String, IpAddr> = if hostnames_needing_bootstrap.is_empty() {
+            HashMap::new()
+        } else {
+            if default_ns.is_empty() {
+                return Err(BootstrapError::DefaultNameserverMissing {
+                    first_encrypted: first_encrypted_with_hostname.unwrap_or_default(),
+                });
+            }
 
-                // Step 4: Build throwaway bootstrap resolver.
-                let bootstrap_resolver = {
-                    let mut config = ResolverConfig::from_parts(None, vec![], vec![]);
-                    for ns in &default_ns {
-                        let addr = url_to_plain_socketaddr(ns);
-                        let mut cc = if matches!(ns, NameServerUrl::Tcp { .. }) {
-                            ConnectionConfig::tcp()
-                        } else {
-                            ConnectionConfig::udp()
-                        };
-                        cc.port = addr.port();
-                        config.add_name_server(NameServerConfig::new(addr.ip(), true, vec![cc]));
+            // Step 4: Build throwaway bootstrap clients (one per default_ns).
+            let bootstrap_clients: Vec<Arc<DnsClient>> = default_ns
+                .iter()
+                .map(|ns| {
+                    let addr = url_to_plain_socketaddr(ns);
+                    let c = if matches!(ns, NameServerUrl::Tcp { .. }) {
+                        DnsClient::tcp(addr)
+                    } else {
+                        DnsClient::udp(addr)
+                    };
+                    Arc::new(c.with_timeout(Duration::from_secs(3)))
+                })
+                .collect();
+
+            // Resolve sequentially — fail-fast on first failure.
+            let mut map = HashMap::new();
+            for host in &hostnames_needing_bootstrap {
+                match query_pool(&bootstrap_clients, host).await {
+                    Some((ips, _ttl)) if !ips.is_empty() => {
+                        map.insert(host.clone(), ips[0]);
                     }
-                    let mut builder =
-                        TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
-                    let opts = builder.options_mut();
-                    opts.timeout = Duration::from_secs(3);
-                    opts.attempts = 2;
-                    opts.cache_size = 0;
-                    builder.build().map_err(|e| BootstrapError::CannotResolve {
-                        host: "<bootstrap>".to_string(),
-                        source: Box::new(e),
-                    })?
-                };
-
-                // Resolve sequentially — fail-fast on first failure.
-                let mut map = HashMap::new();
-                for host in &hostnames_needing_bootstrap {
-                    match bootstrap_resolver.lookup_ip(host.as_str()).await {
-                        Ok(lookup) => {
-                            let ip = lookup.iter().next().ok_or_else(|| {
-                                BootstrapError::CannotResolve {
-                                    host: host.clone(),
-                                    source: "no addresses returned".into(),
-                                }
-                            })?;
-                            map.insert(host.clone(), ip);
-                        }
-                        Err(e) => {
-                            return Err(BootstrapError::CannotResolve {
-                                host: host.clone(),
-                                source: Box::new(e),
-                            });
-                        }
+                    _ => {
+                        return Err(BootstrapError::CannotResolve {
+                            host: host.clone(),
+                            source: "no addresses returned".into(),
+                        });
                     }
                 }
-                map
-            };
+            }
+            map
+        };
 
         // Steps 5 & 6: Build main + fallback — one resolver per URL for parallel dispatch.
         let main = main_urls
@@ -469,13 +416,13 @@ impl Resolver {
         })
     }
 
-    /// Build a single `TokioResolver` for one `NameServerUrl`, using
-    /// `resolved` to substitute hostnames that needed bootstrap.
-    /// Pass an empty map for IP-literal URLs (no hostname substitution needed).
+    /// Build a single `DnsClient` for one `NameServerUrl`, using `resolved`
+    /// to substitute hostnames that needed bootstrap. Pass an empty map for
+    /// IP-literal URLs (no hostname substitution needed).
     pub fn build_single_resolver(
         url: &NameServerUrl,
         resolved: &HashMap<String, IpAddr>,
-    ) -> TokioResolver {
+    ) -> Arc<DnsClient> {
         let socket_addr = match url {
             NameServerUrl::Udp { addr, port }
             | NameServerUrl::Tcp { addr, port }
@@ -484,25 +431,13 @@ impl Resolver {
                 SocketAddr::new(host_or_ip_to_addr(addr, resolved), *port)
             }
         };
-        let port = socket_addr.port();
-        let ip = socket_addr.ip();
-        let ns_cfg = match url {
-            NameServerUrl::Udp { .. } => {
-                let mut cc = ConnectionConfig::udp();
-                cc.port = port;
-                NameServerConfig::new(ip, true, vec![cc])
-            }
-            NameServerUrl::Tcp { .. } => {
-                let mut cc = ConnectionConfig::tcp();
-                cc.port = port;
-                NameServerConfig::new(ip, true, vec![cc])
-            }
+        let client = match url {
+            NameServerUrl::Udp { .. } => DnsClient::udp(socket_addr),
+            NameServerUrl::Tcp { .. } => DnsClient::tcp(socket_addr),
             NameServerUrl::Tls { sni, .. } => {
                 #[cfg(feature = "encrypted")]
                 {
-                    let mut cc = ConnectionConfig::tls(Arc::from(sni.as_str()));
-                    cc.port = port;
-                    NameServerConfig::new(ip, true, vec![cc])
+                    DnsClient::dot(socket_addr, sni)
                 }
                 #[cfg(not(feature = "encrypted"))]
                 {
@@ -516,12 +451,7 @@ impl Resolver {
             NameServerUrl::Https { sni, path, .. } => {
                 #[cfg(feature = "encrypted")]
                 {
-                    let mut cc = ConnectionConfig::https(
-                        Arc::from(sni.as_str()),
-                        Some(Arc::from(path.as_str())),
-                    );
-                    cc.port = port;
-                    NameServerConfig::new(ip, true, vec![cc])
+                    DnsClient::doh(socket_addr, sni, path)
                 }
                 #[cfg(not(feature = "encrypted"))]
                 {
@@ -533,17 +463,7 @@ impl Resolver {
                 }
             }
         };
-        let mut config = ResolverConfig::from_parts(None, vec![], vec![]);
-        config.add_name_server(ns_cfg);
-        let mut builder =
-            TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
-        let opts = builder.options_mut();
-        opts.timeout = Duration::from_secs(5);
-        opts.attempts = 2;
-        opts.cache_size = 0;
-        builder
-            .build()
-            .expect("TokioResolver build is infallible for the static configuration above")
+        Arc::new(client)
     }
 
     pub async fn resolve_ip(&self, host: &str) -> Option<IpAddr> {
@@ -707,12 +627,12 @@ impl Resolver {
 
     /// Forward a non-A/AAAA query (TXT, MX, SRV, HTTPS, SOA, PTR, …) through
     /// the same nameserver pipeline as ordinary lookups: domain-gate → policy
-    /// → main → fallback. Returns the typed `Lookup` so callers can re-emit
-    /// the answer section verbatim in their response.
+    /// → main → fallback. Returns the upstream `Message` so callers can
+    /// re-emit the answer section verbatim in their response.
     ///
     /// Skips the `ip_gated` fallback hop — the fallback-filter's IP-CIDR /
     /// GeoIP gates only apply to address records.
-    pub async fn forward_generic(&self, domain: &str, record_type: RecordType) -> Option<Lookup> {
+    pub async fn forward_generic(&self, domain: &str, record_type: RecordType) -> Option<Message> {
         if let Some(ff) = &self.fallback_filter {
             if ff.domain_gated(domain) {
                 return self.try_fallback_generic(domain, record_type).await;
@@ -731,7 +651,7 @@ impl Resolver {
         self.try_fallback_generic(domain, record_type).await
     }
 
-    async fn try_fallback_generic(&self, domain: &str, record_type: RecordType) -> Option<Lookup> {
+    async fn try_fallback_generic(&self, domain: &str, record_type: RecordType) -> Option<Message> {
         let fb = self.fallback.as_deref()?;
         query_pool_generic(fb, domain, record_type).await
     }

--- a/crates/mihomo-dns/src/server.rs
+++ b/crates/mihomo-dns/src/server.rs
@@ -1,6 +1,6 @@
 use crate::resolver::Resolver;
-use hickory_resolver::proto::op::{Message, MessageType, OpCode, ResponseCode};
-use hickory_resolver::proto::rr::RecordType;
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::RecordType;
 use mihomo_common::DnsMode;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -160,7 +160,7 @@ impl DnsServer {
         match lookup {
             Some(l) => {
                 resp.metadata.response_code = ResponseCode::NoError;
-                for rec in l.answers() {
+                for rec in &l.answers {
                     resp.add_answer(rec.clone());
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `mihomo-dns::client::DnsClient` covering plain UDP, plain TCP, DoT (RFC 7858), and DoH (RFC 8484 HTTP/1.1 POST over rustls). UDP responses with `TC=1` retry over TCP per RFC 7766.
- Introduces a pluggable `SocketFactory` so host integrations (Android VPN service) can install their own UDP/TCP factory and call `protect()` on each fd before it's used — the original reason for dropping hickory-resolver, which never exposed the underlying sockets.
- `Resolver`, `PolicyEntry`, and `build_single_resolver` now hold `Arc<DnsClient>` instead of `TokioResolver`. `forward_generic` returns `hickory_proto::op::Message`; the UDP DNS server copies its answer section verbatim.
- `ech_dns` HTTPS-record lookup parses `/etc/resolv.conf` on Unix (1.1.1.1/8.8.8.8 fallback) and queries via the new client.
- Drops `hickory-resolver` and `hickory-server` from the workspace; keeps `hickory-proto` as a pure wire codec.

The in-process DNS cache (`DnsCache` in `mihomo-dns::cache`) and singleflight layer in `Resolver` are unchanged — caching happens at the resolver tier, not the client tier.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (470 tests)
- [x] `cargo test --test rules_test` (100 tests)
- [x] `cargo test --test trojan_integration` (5 tests)
- [ ] `cargo test -p mihomo-dns --test doh_dot_integration -- --ignored` — outbound DoT/DoH against 1.1.1.1 / 8.8.8.8 (manual; not in CI)
- [ ] Android: install a `SocketFactory` that calls `protect()` on each socket; confirm DNS queries bypass the tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)