### PR TITLE
chore(release): bump version to 0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-app"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-bench"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "dashmap",
  "futures",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-listener"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "base64",
  "libc",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "criterion",
  "ipnet",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "criterion",
  "proptest",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
Bump workspace version from 0.7.3 → 0.7.4.

Tag `v0.7.4` will be pushed on merge to trigger the release workflow.

## Notable changes since v0.7.3
- DNS: forward non-A/AAAA queries through the nameserver pipeline (#74-ish, commit 84831fb)
- DNS: replace hickory-resolver with in-tree DNS client (#76) — pluggable socket factory for Android socket-protect; DoT and DoH supported

## Test plan
- [x] `cargo build --workspace`
- [x] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)