### PR TITLE
feat(tunnel): force UDP DNS to DIRECT, bypassing proxies

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8d3504e3-e6c2-4ad6-8768-36ddb23cf1cb","pid":66868,"procStart":"Sun May 17 06:38:17 2026","acquiredAt":1779002623464}

--- a/crates/mihomo-tunnel/src/udp.rs
+++ b/crates/mihomo-tunnel/src/udp.rs
@@ -1,5 +1,6 @@
 use crate::tunnel::TunnelInner;
 use dashmap::DashMap;
+use mihomo_common::adapter::ProxyAdapter;
 use mihomo_common::{Metadata, ProxyPacketConn};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -140,9 +141,24 @@ pub async fn handle_udp(
     }
 
     // Slow path: new session — match rules and dial.
-    let Some((proxy, rule_name, rule_payload)) = tunnel.resolve_proxy(&metadata) else {
-        warn!("no matching rule for UDP {}", metadata.remote_address());
-        return;
+    //
+    // UDP DNS bypass: any UDP packet destined for port 53 short-circuits
+    // rule matching and is dialled DIRECT. Routing client DNS through a
+    // proxy would defeat the whole point of the in-process DNS resolver
+    // (rule-set selection, fake-IP, snooping) and on Android would push
+    // queries through the VPN tun rather than over the protected fd.
+    let (proxy, rule_name, rule_payload) = if metadata.dst_port == 53 {
+        (
+            Arc::clone(&tunnel.direct) as Arc<dyn ProxyAdapter>,
+            "DnsBypass".to_string(),
+            String::new(),
+        )
+    } else {
+        let Some(matched) = tunnel.resolve_proxy(&metadata) else {
+            warn!("no matching rule for UDP {}", metadata.remote_address());
+            return;
+        };
+        matched
     };
 
     info!(


### PR DESCRIPTION
## Summary
- `udp::handle_udp` short-circuits any UDP packet with `dst_port == 53` to the DirectAdapter before rule matching, so client DNS never gets dialled through a remote proxy.
- Why this matters: routing DNS through a proxy defeats the in-process resolver (rule-set selection, fake-IP, DNS snooping), and on Android would push queries through the VPN tun device rather than over the protected fd that `mihomo-dns::client` owns directly.
- Forward-looking: `handle_udp` has no caller today (UDP-tproxy capture isn't wired up yet). Landing the invariant now so the listener side cannot accidentally proxy DNS when it arrives.
- Internal resolver upstreams were already safe — `mihomo-dns::DnsClient` uses `tokio::UdpSocket` via the pluggable `SocketFactory`, not any `ProxyAdapter`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` (default / no-default / all features)
- [x] `cargo test --lib` (470 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)