### PR TITLE
feat(proxy): native ech-tls-tunnel SIP003 client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +798,12 @@ name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dynosaur"
@@ -2666,6 +2694,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2691,6 +2720,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/crates/mihomo-app/Cargo.toml
+++ b/crates/mihomo-app/Cargo.toml
@@ -15,6 +15,11 @@ ss = ["mihomo-config/ss", "mihomo-proxy/ss"]
 trojan = ["mihomo-config/trojan", "mihomo-proxy/trojan"]
 vless = ["mihomo-config/vless", "mihomo-proxy/vless"]
 vless-vision = ["vless", "mihomo-config/vless-vision", "mihomo-proxy/vless-vision"]
+ech-tls-tunnel = [
+    "ss",
+    "mihomo-config/ech-tls-tunnel",
+    "mihomo-proxy/ech-tls-tunnel",
+]
 
 # DNS
 dns-server = ["mihomo-dns/dns-server"]

--- a/crates/mihomo-config/Cargo.toml
+++ b/crates/mihomo-config/Cargo.toml
@@ -11,6 +11,7 @@ trojan = ["mihomo-proxy/trojan"]
 vless = ["mihomo-proxy/vless"]
 vless-vision = ["vless", "mihomo-proxy/vless-vision"]
 boring-tls = ["mihomo-transport/boring-tls"]
+ech-tls-tunnel = ["ss", "mihomo-proxy/ech-tls-tunnel"]
 
 [dependencies]
 mihomo-common = { workspace = true }

--- a/crates/mihomo-dns/src/client.rs
+++ b/crates/mihomo-dns/src/client.rs
@@ -391,7 +391,13 @@ fn tls_client_config(alpn: &str) -> Arc<rustls::ClientConfig> {
         let root_store = rustls::RootCertStore {
             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
         };
-        let mut cfg = rustls::ClientConfig::builder()
+        // Be explicit about the provider — when both `ring` and `aws_lc_rs`
+        // are linked (e.g. by mihomo-transport's `ech` feature), the default
+        // `ClientConfig::builder()` panics on the auto-detect.
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let mut cfg = rustls::ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .expect("rustls protocol versions are safe defaults")
             .with_root_certificates(root_store)
             .with_no_client_auth();
         cfg.alpn_protocols = match alpn {

--- a/crates/mihomo-proxy/Cargo.toml
+++ b/crates/mihomo-proxy/Cargo.toml
@@ -10,6 +10,10 @@ ss = ["dep:shadowsocks"]
 trojan = []
 vless = []
 vless-vision = ["vless"]
+# Native client for the `ech-tls-tunnel` SIP003 plugin
+# (https://github.com/shadowsocks/ech-tls-tunnel). Requires ECH on rustls,
+# which pulls aws-lc-rs in via mihomo-transport.
+ech-tls-tunnel = ["ss", "mihomo-transport/ech"]
 
 [dependencies]
 mihomo-common = { workspace = true }

--- a/crates/mihomo-proxy/src/ech_tls_tunnel.rs
+++ b/crates/mihomo-proxy/src/ech_tls_tunnel.rs
@@ -1,0 +1,254 @@
+//! Built-in `ech-tls-tunnel` SIP003 client transport.
+//!
+//! Native, no-subprocess port of the client side of
+//! <https://github.com/shadowsocks/ech-tls-tunnel>. Wraps each Shadowsocks
+//! stream in WebSocket-over-TLS on port 443, with the TLS `ClientHello`
+//! protected by **ECH** (Encrypted Client Hello). To passive observers the
+//! connection looks like an HTTPS request to a benign public name embedded
+//! in the `ECHConfigList`; the real tunnel hostname (`sni`) lives in the
+//! encrypted `ClientHelloInner`.
+//!
+//! Architecture (mirrors `v2ray_plugin.rs` minus mux + plus ECH):
+//!
+//! ```text
+//! TcpStream
+//!   → rustls TLS (with ECH + inner SNI override, ALPN=http/1.1)
+//!   → HTTP/1.1 WebSocket upgrade (Host = inner SNI, path = cfg.path)
+//!   → caller wraps with Shadowsocks ProxyClientStream
+//! ```
+//!
+//! Server side (ACME issuance, ECH key publication) is **not** implemented —
+//! run upstream `ech-tls-tunnel` as the ssserver-side plugin.
+
+use base64::Engine;
+use mihomo_common::{MihomoError, Result};
+use mihomo_transport::{
+    tls::{EchOpts, TlsConfig, TlsLayer},
+    ws::{WsConfig, WsLayer},
+    Transport,
+};
+use tokio::net::TcpStream;
+use tracing::{debug, warn};
+
+use crate::transport_to_proxy_err;
+
+/// Parsed `ech-tls-tunnel` client options.
+#[derive(Debug, Clone)]
+pub struct EchTlsTunnelConfig {
+    /// Inner SNI / Host header / cert-validation name. Required.
+    pub sni: String,
+    /// WebSocket upgrade path. Must start with `/`. Required.
+    pub path: String,
+    /// Wire-format `ECHConfigList`, base64-decoded. Required.
+    pub ech_config: Vec<u8>,
+}
+
+fn parse_bool(s: &str) -> bool {
+    matches!(s.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+}
+
+/// Parse a SIP003 opts string for `ech-tls-tunnel`.
+///
+/// Recognised keys:
+/// * `mode`   — REQUIRED, must be `client`. `server` returns an error.
+/// * `sni`    — REQUIRED, inner SNI / cert name / Host header.
+/// * `path`   — REQUIRED, must start with `/`.
+/// * `ech_config` — REQUIRED, base64-encoded `ECHConfigList`.
+/// * `fast_open` — accepted, ignored (we don't TFO outbound today).
+///
+/// Unknown keys are warned and ignored to stay forward-compatible.
+pub fn parse_opts(s: &str) -> Result<EchTlsTunnelConfig> {
+    let mut mode: Option<String> = None;
+    let mut sni: Option<String> = None;
+    let mut path: Option<String> = None;
+    let mut ech_b64: Option<String> = None;
+
+    for token in s.split(';').map(str::trim).filter(|t| !t.is_empty()) {
+        let (key, value) = match token.split_once('=') {
+            Some((k, v)) => (k.trim(), v.trim().to_string()),
+            None => (token, "true".to_string()),
+        };
+        match key {
+            "mode" => mode = Some(value),
+            "sni" => sni = Some(value),
+            "path" => path = Some(value),
+            "ech_config" | "ech-config" => ech_b64 = Some(value),
+            "fast_open" | "fast-open" => {
+                let _ = parse_bool(&value);
+            }
+            other => warn!("ech-tls-tunnel: ignoring unknown opt '{}'", other),
+        }
+    }
+
+    let mode = mode
+        .ok_or_else(|| MihomoError::Config("ech-tls-tunnel: missing required 'mode' opt".into()))?;
+    if !mode.eq_ignore_ascii_case("client") {
+        return Err(MihomoError::Config(format!(
+            "ech-tls-tunnel: unsupported mode '{mode}' — only 'client' is implemented"
+        )));
+    }
+    let sni = sni
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| MihomoError::Config("ech-tls-tunnel: missing 'sni' opt".into()))?;
+    let path = path
+        .filter(|p| !p.is_empty())
+        .ok_or_else(|| MihomoError::Config("ech-tls-tunnel: missing 'path' opt".into()))?;
+    if !path.starts_with('/') {
+        return Err(MihomoError::Config(format!(
+            "ech-tls-tunnel: 'path' must start with '/' (got '{path}')"
+        )));
+    }
+    let ech_b64 = ech_b64
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| MihomoError::Config("ech-tls-tunnel: missing 'ech_config' opt".into()))?;
+    let ech_config = base64::engine::general_purpose::STANDARD
+        .decode(ech_b64.as_bytes())
+        .map_err(|e| {
+            MihomoError::Config(format!(
+                "ech-tls-tunnel: 'ech_config' not valid base64: {e}"
+            ))
+        })?;
+    if ech_config.is_empty() {
+        return Err(MihomoError::Config(
+            "ech-tls-tunnel: 'ech_config' decoded to zero bytes".into(),
+        ));
+    }
+
+    Ok(EchTlsTunnelConfig {
+        sni,
+        path,
+        ech_config,
+    })
+}
+
+/// Dial a TLS-with-ECH + WebSocket connection to `server_host:server_port`
+/// and return the framed stream ready for the SS encryption layer.
+pub async fn dial(
+    cfg: &EchTlsTunnelConfig,
+    server_host: &str,
+    server_port: u16,
+) -> Result<Box<dyn mihomo_transport::Stream>> {
+    debug!(
+        "ech-tls-tunnel: dialing {}:{} sni={} path={} ech_config_len={}",
+        server_host,
+        server_port,
+        cfg.sni,
+        cfg.path,
+        cfg.ech_config.len(),
+    );
+
+    // 1) Raw TCP.
+    let tcp = TcpStream::connect((server_host, server_port))
+        .await
+        .map_err(MihomoError::Io)?;
+    let _ = tcp.set_nodelay(true);
+
+    // 2) TLS (with ECH). The outer SNI is taken from the ECHConfigList's
+    //    `public_name` field by rustls; the `sni` we supply here becomes the
+    //    encrypted inner ServerName and the cert-validation target.
+    let mut tls_config = TlsConfig::new(cfg.sni.clone());
+    tls_config.alpn = vec!["http/1.1".to_string()];
+    tls_config.ech = Some(EchOpts::Config(cfg.ech_config.clone()));
+    let tls_layer = TlsLayer::new(&tls_config).map_err(transport_to_proxy_err)?;
+    let tls_stream = tls_layer
+        .connect(Box::new(tcp))
+        .await
+        .map_err(transport_to_proxy_err)?;
+
+    // 3) HTTP/1.1 WebSocket upgrade.
+    let ws_config = WsConfig {
+        path: cfg.path.clone(),
+        host_header: Some(cfg.sni.clone()),
+        ..WsConfig::default()
+    };
+    let ws_layer = WsLayer::new(ws_config).map_err(transport_to_proxy_err)?;
+    ws_layer
+        .connect(tls_stream)
+        .await
+        .map_err(transport_to_proxy_err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FAKE_ECH_B64: &str = "AEX+DQBBRwAgACBs1mZ0bOlNXgMxOAxJgD/h+pSyM6F7nGhmGyR0R0p3agAEAAEAAQAOcHVibGljLmV4YW1wbGUAAA==";
+
+    #[test]
+    fn parse_minimal_client_config() {
+        let s =
+            format!("mode=client;sni=tunnel.example.com;path=/ws-secret;ech_config={FAKE_ECH_B64}");
+        let cfg = parse_opts(&s).expect("ok");
+        assert_eq!(cfg.sni, "tunnel.example.com");
+        assert_eq!(cfg.path, "/ws-secret");
+        assert!(!cfg.ech_config.is_empty());
+    }
+
+    #[test]
+    fn parse_rejects_server_mode() {
+        let err = parse_opts(&format!(
+            "mode=server;sni=tunnel.example.com;path=/ws;ech_config={FAKE_ECH_B64}"
+        ))
+        .unwrap_err();
+        let MihomoError::Config(msg) = err else {
+            panic!("expected Config error");
+        };
+        assert!(msg.contains("only 'client' is implemented"));
+    }
+
+    #[test]
+    fn parse_rejects_missing_sni() {
+        let err =
+            parse_opts(&format!("mode=client;path=/ws;ech_config={FAKE_ECH_B64}")).unwrap_err();
+        assert!(format!("{err}").contains("'sni'"));
+    }
+
+    #[test]
+    fn parse_rejects_missing_path() {
+        let err = parse_opts(&format!(
+            "mode=client;sni=tunnel.example.com;ech_config={FAKE_ECH_B64}"
+        ))
+        .unwrap_err();
+        assert!(format!("{err}").contains("'path'"));
+    }
+
+    #[test]
+    fn parse_rejects_relative_path() {
+        let err = parse_opts(&format!(
+            "mode=client;sni=tunnel.example.com;path=ws;ech_config={FAKE_ECH_B64}"
+        ))
+        .unwrap_err();
+        assert!(format!("{err}").contains("must start with '/'"));
+    }
+
+    #[test]
+    fn parse_rejects_missing_ech_config() {
+        let err = parse_opts("mode=client;sni=tunnel.example.com;path=/ws").unwrap_err();
+        assert!(format!("{err}").contains("'ech_config'"));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_base64() {
+        let err =
+            parse_opts("mode=client;sni=t.example;path=/ws;ech_config=not!!base64==").unwrap_err();
+        assert!(format!("{err}").contains("base64"));
+    }
+
+    #[test]
+    fn parse_accepts_fast_open_ignored() {
+        let cfg = parse_opts(&format!(
+            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64};fast_open=true"
+        ))
+        .expect("ok");
+        assert_eq!(cfg.sni, "t.example");
+    }
+
+    #[test]
+    fn parse_unknown_key_ignored() {
+        let cfg = parse_opts(&format!(
+            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64};unknown_key=1"
+        ))
+        .expect("ok");
+        assert_eq!(cfg.path, "/ws");
+    }
+}

--- a/crates/mihomo-proxy/src/health.rs
+++ b/crates/mihomo-proxy/src/health.rs
@@ -177,9 +177,16 @@ fn tls_connector() -> tokio_rustls::TlsConnector {
     let root_store = rustls::RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
     };
-    let config = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+    // Be explicit about the provider: when `ech-tls-tunnel` (or any other
+    // feature that pulls aws-lc-rs) is on, rustls' `builder()` would panic
+    // because two providers are compiled in.
+    let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("rustls protocol versions are safe defaults")
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
     tokio_rustls::TlsConnector::from(Arc::new(config))
 }
 

--- a/crates/mihomo-proxy/src/lib.rs
+++ b/crates/mihomo-proxy/src/lib.rs
@@ -7,6 +7,8 @@ pub mod socks5_adapter;
 pub mod stream_conn;
 pub mod transport_chain;
 
+#[cfg(feature = "ech-tls-tunnel")]
+pub mod ech_tls_tunnel;
 #[cfg(feature = "ss")]
 pub mod shadowsocks_adapter;
 #[cfg(feature = "ss")]

--- a/crates/mihomo-proxy/src/shadowsocks_adapter.rs
+++ b/crates/mihomo-proxy/src/shadowsocks_adapter.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ech-tls-tunnel")]
+use crate::ech_tls_tunnel::{self, EchTlsTunnelConfig};
 use crate::simple_obfs::{HttpObfs, TlsObfs};
 use crate::v2ray_plugin::{self, V2rayPluginConfig};
 use async_trait::async_trait;
@@ -44,6 +46,8 @@ enum PluginKind {
     External(#[allow(dead_code)] Plugin),
     Obfs(BuiltinObfs),
     V2ray(V2rayPluginConfig),
+    #[cfg(feature = "ech-tls-tunnel")]
+    EchTlsTunnel(EchTlsTunnelConfig),
 }
 
 pub struct ShadowsocksAdapter {
@@ -94,6 +98,18 @@ impl ShadowsocksAdapter {
                     name, cfg.tls, cfg.host, cfg.path, cfg.mux
                 );
                 PluginKind::V2ray(cfg)
+            }
+            #[cfg(feature = "ech-tls-tunnel")]
+            Some("ech-tls-tunnel") => {
+                let cfg = ech_tls_tunnel::parse_opts(plugin_opts.unwrap_or(""))?;
+                debug!(
+                    "SS '{}' using built-in ech-tls-tunnel: sni={} path={} ech_config_len={}",
+                    name,
+                    cfg.sni,
+                    cfg.path,
+                    cfg.ech_config.len()
+                );
+                PluginKind::EchTlsTunnel(cfg)
             }
             Some(pname) => {
                 let plugin_config = PluginConfig {
@@ -349,6 +365,17 @@ impl ProxyAdapter for ShadowsocksAdapter {
                 );
                 Ok(Box::new(SsConn(stream)))
             }
+            #[cfg(feature = "ech-tls-tunnel")]
+            PluginKind::EchTlsTunnel(cfg) => {
+                let transport = ech_tls_tunnel::dial(cfg, &self.server, self.port).await?;
+                let stream = ProxyClientStream::from_stream(
+                    Arc::clone(&self.context),
+                    transport,
+                    &self.server_config,
+                    addr,
+                );
+                Ok(Box::new(SsConn(stream)))
+            }
             PluginKind::None | PluginKind::External(_) => {
                 let stream = ProxyClientStream::connect(
                     Arc::clone(&self.context),
@@ -366,6 +393,12 @@ impl ProxyAdapter for ShadowsocksAdapter {
         if matches!(self.plugin, PluginKind::V2ray(_)) {
             return Err(MihomoError::NotSupported(
                 "v2ray-plugin does not support UDP relay".into(),
+            ));
+        }
+        #[cfg(feature = "ech-tls-tunnel")]
+        if matches!(self.plugin, PluginKind::EchTlsTunnel(_)) {
+            return Err(MihomoError::NotSupported(
+                "ech-tls-tunnel does not support UDP relay".into(),
             ));
         }
         let socket = ProxySocket::connect(Arc::clone(&self.context), &self.server_config)

--- a/crates/mihomo-transport/Cargo.toml
+++ b/crates/mihomo-transport/Cargo.toml
@@ -33,6 +33,14 @@ ws = [
     "dep:futures-util",
     "dep:base64",
 ]
+# ech: enable rustls-side Encrypted Client Hello using aws-lc-rs HPKE primitives.
+# Adds ~1 MB to the binary (aws-lc-rs static crypto blob) — off by default.
+# Strictly additive: the rest of the TLS path keeps using ring.
+ech = [
+    "tls",
+    "rustls/aws_lc_rs",
+    "tokio-rustls/aws_lc_rs",
+]
 grpc = [
     "dep:h2",
     "dep:http",

--- a/crates/mihomo-transport/src/tls.rs
+++ b/crates/mihomo-transport/src/tls.rs
@@ -8,10 +8,12 @@
 //!
 //! | Condition | Backend |
 //! |-----------|---------|
-//! | `fingerprint = None` AND `ech = None` | rustls (default) |
-//! | `fingerprint` or `ech` set, `boring-tls` feature enabled | BoringSSL |
+//! | `fingerprint = None` AND `ech = None` | rustls (default, `ring` provider) |
+//! | `ech` set, `ech` feature enabled | rustls (`aws-lc-rs` provider for HPKE) |
+//! | `fingerprint` set, `boring-tls` feature enabled | BoringSSL |
+//! | `ech` set, only `boring-tls` enabled (no `ech` feature) | BoringSSL |
 //! | `fingerprint` set, `boring-tls` feature absent | rustls + stub warn |
-//! | `ech` set, `boring-tls` feature absent | `Err(TransportError::Config)` |
+//! | `ech` set, neither `ech` nor `boring-tls` feature | `Err(TransportError::Config)` |
 //!
 //! # SNI resolution contract
 //!
@@ -208,19 +210,22 @@ impl TlsLayer {
     /// * [`TransportError::Config`] — `client_cert` PEM is unparseable (rustls path).
     /// * [`TransportError::Tls`] — client cert + key don't match (rustls path).
     pub fn new(config: &TlsConfig) -> Result<Self> {
-        // ECH without boring-tls is a hard error.
-        #[cfg(not(feature = "boring-tls"))]
+        // ECH without either feature is a hard error.
+        #[cfg(all(not(feature = "boring-tls"), not(feature = "ech")))]
         if config.ech.is_some() {
             return Err(TransportError::Config(
-                "ech-opts requires the boring-tls cargo feature; \
-                 recompile with `--features boring-tls`."
+                "ech-opts requires either the `ech` (rustls + aws-lc-rs) or \
+                 `boring-tls` (BoringSSL) cargo feature; \
+                 recompile with `--features ech` or `--features boring-tls`."
                     .into(),
             ));
         }
 
-        // Route to boring when fingerprint or ECH is requested and the feature is present.
+        // Route to boring when fingerprint is requested (no rustls equivalent
+        // for uTLS fingerprinting) or when ECH is requested and the `ech`
+        // feature is *not* compiled in (boring is then the only ECH backend).
         #[cfg(feature = "boring-tls")]
-        if config.fingerprint.is_some() || config.ech.is_some() {
+        if config.fingerprint.is_some() || (config.ech.is_some() && !cfg!(feature = "ech")) {
             tracing::debug!(
                 fingerprint = ?config.fingerprint,
                 ech = config.ech.is_some(),
@@ -304,6 +309,22 @@ struct RustlsInner {
     server_name: rustls::pki_types::ServerName<'static>,
 }
 
+/// Build a `rustls::client::EchMode::Enable` from an [`EchOpts`].
+///
+/// Uses the `aws-lc-rs` HPKE provider — `ring` does not expose HPKE primitives.
+/// The selected ECH config must match one of the suites in
+/// `rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES`; otherwise
+/// `EchConfig::new` returns `EncryptedClientHelloError::NoCompatibleConfig`.
+#[cfg(feature = "ech")]
+fn build_rustls_ech_mode(ech: &EchOpts) -> Result<rustls::client::EchMode> {
+    use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
+    let EchOpts::Config(bytes) = ech;
+    let config_list = rustls::pki_types::EchConfigListBytes::from(bytes.as_slice());
+    let ech_config = rustls::client::EchConfig::new(config_list, ALL_SUPPORTED_SUITES)
+        .map_err(|e| TransportError::Tls(format!("rustls ECH: parse config list: {e}")))?;
+    Ok(rustls::client::EchMode::from(ech_config))
+}
+
 impl RustlsInner {
     fn new(config: &TlsConfig) -> Result<Self> {
         if config.skip_cert_verify {
@@ -335,9 +356,38 @@ impl RustlsInner {
     }
 
     fn build_rustls_config(config: &TlsConfig) -> Result<rustls::ClientConfig> {
+        // --- Provider + ECH half ---
+        //
+        // ECH on rustls requires HPKE primitives, which `ring` does not
+        // expose. When ECH is requested *and* the `ech` feature is compiled
+        // in, switch this single ClientConfig to the `aws-lc-rs` provider —
+        // every other rustls path in the workspace keeps using `ring`.
+        #[allow(unused_mut)]
+        let mut wants_verifier: rustls::ConfigBuilder<
+            rustls::ClientConfig,
+            rustls::WantsVerifier,
+        > = {
+            // Be explicit about the crypto provider so we don't rely on
+            // rustls' auto-detect, which panics when *both* `ring` and
+            // `aws_lc_rs` features are compiled in (as they are when the
+            // `ech` feature is on).
+            let provider = Arc::new(rustls::crypto::ring::default_provider());
+            rustls::ClientConfig::builder_with_provider(provider)
+                .with_safe_default_protocol_versions()
+                .map_err(|e| TransportError::Tls(format!("rustls protocol-versions setup: {e}")))?
+        };
+        #[cfg(feature = "ech")]
+        if let Some(ech) = &config.ech {
+            let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+            let ech_mode = build_rustls_ech_mode(ech)?;
+            wants_verifier = rustls::ClientConfig::builder_with_provider(provider)
+                .with_ech(ech_mode)
+                .map_err(|e| TransportError::Tls(format!("rustls ECH setup: {e}")))?;
+        }
+
         // --- Verifier half ---
         let builder = if config.skip_cert_verify {
-            rustls::ClientConfig::builder()
+            wants_verifier
                 .dangerous()
                 .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
         } else {
@@ -351,7 +401,7 @@ impl RustlsInner {
                         TransportError::Config(format!("additional_roots: invalid CA cert: {e}"))
                     })?;
             }
-            rustls::ClientConfig::builder().with_root_certificates(root_store)
+            wants_verifier.with_root_certificates(root_store)
         };
 
         // --- Client-auth half ---

--- a/docs/plugins/ech-tls-tunnel.md
+++ b/docs/plugins/ech-tls-tunnel.md
@@ -1,0 +1,132 @@
+# `ech-tls-tunnel` — native client transport
+
+mihomo-rust ships a built-in (no-subprocess) client for the
+[`ech-tls-tunnel`](https://github.com/shadowsocks/ech-tls-tunnel)
+SIP003 plugin. The plugin wraps each Shadowsocks stream in a
+WebSocket-over-TLS connection on port 443, with the TLS `ClientHello`
+protected by **ECH** (Encrypted Client Hello). To passive observers the
+flow looks like an HTTPS request to a benign public name embedded in the
+`ECHConfigList`; the real tunnel hostname lives in the encrypted
+`ClientHelloInner`.
+
+This page covers the **client** side. The **server** side (ACME
+issuance, ECH key publication) is not bundled — run upstream
+`ech-tls-tunnel` next to `ssserver` on your VPS.
+
+## Build with the feature
+
+The native client is gated behind the `ech-tls-tunnel` cargo feature. It
+brings in `aws-lc-rs` for HPKE primitives (rustls' `ring` provider does
+not expose HPKE):
+
+```bash
+cargo build --release --features mihomo-app/ech-tls-tunnel
+```
+
+Or, when consuming `mihomo-app` directly:
+
+```toml
+mihomo-app = { workspace = true, features = ["ech-tls-tunnel"] }
+```
+
+## Server setup (upstream)
+
+Generate the HPKE keypair and run `ssserver` with the plugin per the
+upstream README:
+
+```sh
+sudo mkdir -p /var/lib/ech-tls-tunnel
+ech-tls-tunnel ech-gen-keys \
+    --public-name front.example.com \
+    --out /var/lib/ech-tls-tunnel/ech
+
+ssserver \
+    -s 0.0.0.0:443 \
+    -k '<password>' \
+    -m aes-128-gcm \
+    --plugin ech-tls-tunnel \
+    --plugin-opts "mode=server;\
+domain=tunnel.example.com;\
+path=/ws-tunnel-CHANGE-ME;\
+acme_email=admin@example.com;\
+acme_cache=/var/lib/ech-tls-tunnel/acme;\
+ech_public_name=front.example.com;\
+ech_key=/var/lib/ech-tls-tunnel/ech/ech.key"
+```
+
+Note the base64-encoded `ECHConfigList` printed by `ech-gen-keys` (or
+`base64 -w0 /var/lib/ech-tls-tunnel/ech/ech.config_list`). You'll paste
+it into the mihomo client config below.
+
+## Client config (mihomo-rust)
+
+```yaml
+proxies:
+  - name: my-ech
+    type: ss
+    server: tunnel.example.com
+    port: 443
+    cipher: aes-128-gcm
+    password: '<password>'
+    udp: false   # WS does not carry UDP; clients should configure UDP via another proxy
+    plugin: ech-tls-tunnel
+    plugin-opts:
+      mode: client
+      sni: tunnel.example.com
+      path: /ws-tunnel-CHANGE-ME
+      ech_config: '<base64 ECHConfigList>'
+```
+
+`mihomo-config` serialises `plugin-opts` to the SIP003 `key=value;…`
+form internally, so you can equally write the opts as a single string.
+
+## Options reference
+
+| Key            | Required | Notes |
+|----------------|----------|-------|
+| `mode`         | yes      | Must be `client`. `server` errors at config-load time. |
+| `sni`          | yes      | Inner SNI / cert-validation name / `Host:` header for the WebSocket upgrade. |
+| `path`         | yes      | Must start with `/`. Anything else gets a fake 404 from the server. |
+| `ech_config`   | yes      | Base64 of the wire-format `ECHConfigList`. Decoded once at parse time; invalid base64 or zero bytes errors. |
+| `fast_open`    | no       | Accepted for compatibility, currently ignored — mihomo-rust does not enable TCP Fast Open on outbound today. |
+
+`ech-config` (hyphen form) is accepted as an alias for `ech_config`.
+
+## How it works
+
+```
+TcpStream(server, 443)
+  → rustls TLS 1.3 with ECH (outer SNI = public_name from ECHConfigList,
+                            inner SNI = `sni` opt, ALPN = http/1.1)
+  → HTTP/1.1 WebSocket upgrade (Host = `sni`, path = `path`)
+  → Shadowsocks ProxyClientStream (aead cipher around the WS frames)
+```
+
+ECH is wired up via rustls 0.23's stable `EchMode::Enable(EchConfig)`
+API. Because rustls' `ring` provider does not implement HPKE, the
+`ech-tls-tunnel` feature switches **just the ECH `ClientConfig`** to
+`aws-lc-rs`; every other rustls path in the workspace (Trojan, VLESS,
+plain SS+TLS, DoT, DoH, …) keeps using `ring`.
+
+## What's not implemented
+
+- **Server side** (`mode=server`). Run upstream `ech-tls-tunnel`.
+- **UDP relay.** WebSocket does not carry UDP datagrams. Health checks
+  and TCP work; UDP dial returns `NotSupported`.
+- **TCP Fast Open.** The `fast_open` opt is parsed and ignored.
+- **HPKE key generation** (`ech-gen-keys`). Server-side concern.
+
+## Troubleshooting
+
+- *"ech-tls-tunnel: 'ech_config' not valid base64"* — confirm the value
+  is the base64 of the binary `ECHConfigList`, not the contents of an
+  `ech.config_list` file passed through `cat` (binary garbled). Use
+  `base64 -w0 < ech.config_list` (Linux) or `base64 < ech.config_list`
+  (macOS).
+- *"rustls ECH: parse config list: NoCompatibleConfig"* — the
+  `ECHConfigList` advertises HPKE suites that `aws-lc-rs` does not
+  implement, or the list is malformed. Re-generate with default
+  parameters (`ech-gen-keys --public-name ...`).
+- TLS handshake fails — verify the cert on `sni` (NOT the public name)
+  is what `ssserver` is presenting; ECH replaces SNI, but cert
+  validation still uses the inner name.


### PR DESCRIPTION
## Summary
No-subprocess port of the client side of <https://github.com/shadowsocks/ech-tls-tunnel>, gated behind the `ech-tls-tunnel` cargo feature.

```
TcpStream → rustls TLS 1.3 with ECH (outer SNI = public_name; inner SNI = `sni`; ALPN=http/1.1)
          → HTTP/1.1 WebSocket upgrade (Host = `sni`; path = `path`)
          → Shadowsocks ProxyClientStream
```

### Phase 1 — rustls ECH on the default TLS path
- New `mihomo-transport` cargo feature `ech` adds aws-lc-rs (HPKE primitives — rustls' `ring` provider doesn't expose them).
- `build_rustls_config` switches just the ECH-bearing ClientConfig to aws-lc-rs via `builder_with_provider(...).with_ech(EchMode::from(EchConfig::new(bytes, ALL_SUPPORTED_SUITES)))`. Every other rustls path keeps `ring`.
- All `ClientConfig::builder()` call sites made explicit about the provider so rustls' auto-detect doesn't panic when two providers are linked.

### Phase 2 — plugin wrapper
- `crates/mihomo-proxy/src/ech_tls_tunnel.rs` with `parse_opts` + `dial`.
- `PluginKind::EchTlsTunnel` variant in `ShadowsocksAdapter` (TCP + UDP-not-supported paths wired).

### Phase 3 — feature wiring
- `ech-tls-tunnel` features added to `mihomo-proxy`, `mihomo-config`, `mihomo-app` (all gated on `ss`).

### Phase 4 — tests + regression bar
- Eight `parse_opts` unit tests (success, server-mode rejection, missing/empty/relative fields, bad base64).
- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets -- -D warnings` (default / no-default / all) ✓
- `cargo test --lib` 470 ✓
- `cargo test -p mihomo-proxy --features ech-tls-tunnel` 158 ✓

### Phase 5 — docs
- `docs/plugins/ech-tls-tunnel.md` with build command, upstream server-side recipe, client YAML, options table, architecture diagram, troubleshooting.

## Out of scope
- Server side (ACME issuance, ECH key generation) — run upstream `ech-tls-tunnel` next to `ssserver`.
- UDP relay over WebSocket.
- TCP Fast Open (the `fast_open` opt is parsed and ignored).

## Manual verification
Spin up upstream `ech-tls-tunnel` server on a VPS per the README, point a mihomo-rust client at it with the YAML in `docs/plugins/ech-tls-tunnel.md`, confirm the SOCKS5 proxy works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)