### PR TITLE
chore(release): bump version to 0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-app"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-bench"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "dashmap",
  "futures",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-listener"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "base64",
  "libc",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "criterion",
  "ipnet",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "criterion",
  "proptest",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
Bump workspace version to 0.7.5 in preparation for the v0.7.5 GitHub release.

## Changes since v0.7.4
- `feat(proxy)`: native ech-tls-tunnel SIP003 client (Phases 1-5) — 0e88ed0
- `feat(tunnel)`: force UDP DNS to DIRECT, bypassing rule-matched proxies — 6d88965 (#78)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (470 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)