### PR TITLE
chore(release): bump version to 0.7.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-app"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-bench"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "dashmap",
  "futures",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-listener"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "base64",
  "libc",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "criterion",
  "ipnet",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "criterion",
  "proptest",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
Bump workspace version to 0.7.6.

## Changes since v0.7.5
- `fix(ech-dns)`: accept IPv6 zone-id nameservers + DoH bootstrap fallback (#84)
- `perf(footprint)`: cap inbound connections + bound WS buffers, default boring-tls (#81)
- `ci(tproxy)`: build mihomo-app without boring-tls inside the Alpine builder

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (475 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)