### PR TITLE
fix(direct): bound TcpStream::connect with optional connect timeout

### DIFF
--- a/crates/mihomo-proxy/src/direct.rs
+++ b/crates/mihomo-proxy/src/direct.rs
@@ -6,6 +6,7 @@ use mihomo_common::{
 use mihomo_dns::Resolver;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::{TcpStream, UdpSocket};
 
 pub struct DirectAdapter {
@@ -15,6 +16,15 @@ pub struct DirectAdapter {
     /// important when mihomo *is* the system DNS, because routing a direct
     /// DNS query back through the OS would loop the query back into mihomo.
     resolver: Option<Arc<Resolver>>,
+    /// Wall-clock bound on `TcpStream::connect`. iOS / macOS scoped-routing
+    /// and reachability-cache transients can leave a `connect()` hanging
+    /// indefinitely against a destination whose route is in flux (Wi-Fi
+    /// assoc churn, IPv6 RA churn, post-wake route reassessment). Without
+    /// this bound the dial holds whatever upstream scheduling resource the
+    /// caller allocated to it until the OS gives up (~75 s on iOS BSD-style
+    /// SYN retransmit grid). `None` preserves the legacy unbounded
+    /// behaviour for downstream consumers that haven't opted in.
+    connect_timeout: Option<Duration>,
     health: ProxyHealth,
 }
 
@@ -23,6 +33,7 @@ impl DirectAdapter {
         Self {
             routing_mark: None,
             resolver: None,
+            connect_timeout: None,
             health: ProxyHealth::new(),
         }
     }
@@ -34,6 +45,17 @@ impl DirectAdapter {
 
     pub fn with_resolver(mut self, resolver: Arc<Resolver>) -> Self {
         self.resolver = Some(resolver);
+        self
+    }
+
+    /// Bound `TcpStream::connect` on `dial_tcp`. Returns `MihomoError::Io`
+    /// with `ErrorKind::TimedOut` if the connect exceeds `timeout`. See
+    /// the `connect_timeout` field doc for the motivating failure mode
+    /// (iOS routing-cache transients) and meow-ios'
+    /// `docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md` for
+    /// the device-side trace.
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = Some(timeout);
         self
     }
 
@@ -205,9 +227,19 @@ impl ProxyAdapter for DirectAdapter {
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
         let dest = self.resolve_target(metadata).await?;
-        let stream = connect_with_mark(dest, self.routing_mark)
-            .await
-            .map_err(MihomoError::Io)?;
+        let connect = connect_with_mark(dest, self.routing_mark);
+        let stream = match self.connect_timeout {
+            Some(t) => match tokio::time::timeout(t, connect).await {
+                Ok(res) => res.map_err(MihomoError::Io)?,
+                Err(_) => {
+                    return Err(MihomoError::Io(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("direct: connect to {dest} timed out after {t:?}"),
+                    )));
+                }
+            },
+            None => connect.await.map_err(MihomoError::Io)?,
+        };
         Ok(Box::new(DirectConn(stream)))
     }
 
@@ -237,5 +269,86 @@ impl ProxyAdapter for DirectAdapter {
 
     fn health(&self) -> &ProxyHealth {
         &self.health
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mihomo_common::{ConnType, Network};
+    use std::net::Ipv4Addr;
+
+    /// Dial against `192.0.2.1` (RFC 5737 TEST-NET-1, reserved as a
+    /// documentation black-hole — packets to this address never get a
+    /// response on a properly-routed network). Without the timeout the
+    /// connect would hang for the OS SYN-retransmit grid (~75 s on
+    /// macOS/iOS). With `with_connect_timeout` set, the dial must surface
+    /// a `TimedOut` error inside the configured budget.
+    ///
+    /// Wrapped in `tokio::time::timeout` with a generous outer cap so a
+    /// regression — i.e. the timeout *not* firing — fails the test in a
+    /// bounded wall-clock window rather than wedging CI.
+    #[tokio::test]
+    async fn dial_tcp_honours_connect_timeout_against_blackhole() {
+        let adapter = DirectAdapter::new().with_connect_timeout(Duration::from_millis(500));
+
+        let metadata = Metadata {
+            network: Network::Tcp,
+            conn_type: ConnType::Inner,
+            dst_ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+            dst_port: 1,
+            ..Default::default()
+        };
+
+        let started = std::time::Instant::now();
+        let res = tokio::time::timeout(Duration::from_secs(5), adapter.dial_tcp(&metadata)).await;
+        let elapsed = started.elapsed();
+
+        let inner = res.expect("outer guard: timeout never fired within 5 s");
+        let Err(err) = inner else {
+            panic!("dial against TEST-NET-1 must fail, got success");
+        };
+        match err {
+            MihomoError::Io(io_err) => {
+                assert_eq!(
+                    io_err.kind(),
+                    std::io::ErrorKind::TimedOut,
+                    "expected TimedOut, got {io_err:?}"
+                );
+            }
+            other => panic!("expected MihomoError::Io(TimedOut), got {other:?}"),
+        }
+        // 500 ms budget + scheduling slack — generous upper bound so CI
+        // jitter doesn't flake, tight enough to catch a regression where
+        // the timeout is silently ignored.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "dial took {elapsed:?}, expected <2s",
+        );
+    }
+
+    /// When no `connect_timeout` is configured, `dial_tcp` keeps its
+    /// historical unbounded behaviour. We can't easily wait out the OS
+    /// SYN grid in CI, so this test asserts the legacy path is still
+    /// running unbounded by checking that a short outer guard does *not*
+    /// see the dial complete on its own.
+    #[tokio::test]
+    async fn dial_tcp_without_timeout_remains_unbounded() {
+        let adapter = DirectAdapter::new();
+
+        let metadata = Metadata {
+            network: Network::Tcp,
+            conn_type: ConnType::Inner,
+            dst_ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+            dst_port: 1,
+            ..Default::default()
+        };
+
+        let res = tokio::time::timeout(Duration::from_millis(750), adapter.dial_tcp(&metadata))
+            .await;
+        assert!(
+            res.is_err(),
+            "expected outer guard to fire; the unbounded dial finished too quickly",
+        );
     }
 }

--- a/crates/mihomo-proxy/src/direct.rs
+++ b/crates/mihomo-proxy/src/direct.rs
@@ -344,8 +344,8 @@ mod tests {
             ..Default::default()
         };
 
-        let res = tokio::time::timeout(Duration::from_millis(750), adapter.dial_tcp(&metadata))
-            .await;
+        let res =
+            tokio::time::timeout(Duration::from_millis(750), adapter.dial_tcp(&metadata)).await;
         assert!(
             res.is_err(),
             "expected outer guard to fire; the unbounded dial finished too quickly",


### PR DESCRIPTION
## Summary

- Add `DirectAdapter::with_connect_timeout(Duration)` — opt-in builder that wraps `connect_with_mark` in `tokio::time::timeout`.
- On expiry, surface `MihomoError::Io(ErrorKind::TimedOut)` so callers can distinguish a routing stall from a peer refusal.
- Default behaviour (no timeout set) is unchanged — downstream consumers that haven't opted in are unaffected.

## Motivation

On Apple platforms, iOS/macOS scoped-routing and reachability-cache transients can leave `TcpStream::connect` hanging indefinitely against a destination whose route is in flux (Wi-Fi assoc churn, IPv6 RA churn, post-wake route reassessment). The connect doesn't fail — it just sits in `SYN_SENT` until the BSD-style retransmit grid gives up (~75 s on iOS). To the app this looks like "page hangs for ~30s, then errors out" (the meow-ios FFI side reaps the flow earlier via its 30 s idle sweeper).

Linux is also exposed when `SO_MARK` pins a socket to an interface whose route is in flux.

Full device-side trace + root-cause walkthrough: [meow-ios `INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md`](https://github.com/madeye/meow-ios/blob/main/docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md).

## Why builder-style (opt-in) and not a default

A non-zero default would change behaviour for every existing consumer of the crate, including the tproxy / app binaries that don't operate under iOS routing constraints. Opt-in keeps this PR additive — meow-ios will set it explicitly via the FFI side; other consumers can adopt at their own pace or never.

A natural follow-up is to wire this into mihomo's YAML `connect-timeout:` field (which doesn't yet exist for `DirectAdapter`). Left for a separate PR to keep this one minimal.

## Test plan

Two unit tests dial against `192.0.2.1` (RFC 5737 TEST-NET-1, reserved documentation black-hole — packets never get a response on a properly-routed network):

- [x] `dial_tcp_honours_connect_timeout_against_blackhole` — with a 500 ms timeout, dial must return `TimedOut` inside an outer 5 s wall-clock guard.
- [x] `dial_tcp_without_timeout_remains_unbounded` — with no timeout, a 750 ms outer guard must fire (proves the legacy path didn't accidentally sprout a hidden bound).
- [x] `cargo test -p mihomo-proxy --lib` — 151/151 pass locally.
- [x] `cargo clippy -p mihomo-proxy --all-targets --no-deps -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)