### PR TITLE
feat(config): per-proxy DNS for type: direct proxies

### DIFF
--- a/crates/mihomo-config/src/proxy_parser.rs
+++ b/crates/mihomo-config/src/proxy_parser.rs
@@ -8,8 +8,8 @@ use mihomo_proxy::ShadowsocksAdapter;
 #[cfg(feature = "trojan")]
 use mihomo_proxy::TrojanAdapter;
 use mihomo_proxy::{
-    FallbackGroup, HttpAdapter, LbStrategy, LoadBalanceGroup, RelayGroup, SelectorGroup,
-    Socks5Adapter, UrlTestGroup,
+    DirectAdapter, FallbackGroup, HttpAdapter, LbStrategy, LoadBalanceGroup, RelayGroup,
+    SelectorGroup, Socks5Adapter, UrlTestGroup,
 };
 #[cfg(feature = "vless")]
 use mihomo_proxy::{TransportChain, VlessAdapter, VlessFlow};
@@ -169,6 +169,10 @@ pub fn parse_proxy(
             let adapter = parse_socks5(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
+        "direct" => {
+            let adapter = parse_direct(name, config)?;
+            Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
+        }
         _ => Err(format!("unsupported proxy type: {proxy_type}")),
     }
 }
@@ -304,6 +308,79 @@ fn parse_socks5(
         tls,
         skip_cert_verify,
     ))
+}
+
+/// Parse a `type: direct` proxy block into a [`DirectAdapter`].
+///
+/// Accepts an optional `dns:` field — a single `host:port` string or a list
+/// of them — that scopes hostname resolution for this proxy to the given DNS
+/// servers (plain UDP). Closes #67: lets users route a subset of direct
+/// traffic through a different DNS than the global resolver (e.g. a LAN
+/// resolver for `*.local` while the global resolver handles WAN).
+///
+/// `dns:` entries must include an explicit port (`:53` is conventional).
+/// Hard error (Class A per ADR-0002) on an unparseable address — silently
+/// falling back to the global resolver would surprise the user by leaking
+/// queries.
+fn parse_direct(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<DirectAdapter, String> {
+    use mihomo_common::DnsMode;
+    use mihomo_dns::Resolver;
+    use mihomo_trie::DomainTrie;
+    use std::net::{IpAddr, SocketAddr};
+
+    let mut adapter = DirectAdapter::new();
+
+    if let Some(v) = config.get("dns") {
+        let entries: Vec<String> = match v {
+            serde_yaml::Value::String(s) => vec![s.clone()],
+            serde_yaml::Value::Sequence(seq) => seq
+                .iter()
+                .map(|e| {
+                    e.as_str()
+                        .map(str::to_string)
+                        .ok_or_else(|| format!("direct[{name}]: dns entries must be strings"))
+                })
+                .collect::<std::result::Result<_, _>>()?,
+            _ => {
+                return Err(format!(
+                    "direct[{name}]: dns must be a string or list of strings"
+                ));
+            }
+        };
+
+        let mut servers: Vec<SocketAddr> = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            // Accept `IP` (default port 53), `IP:53`, or bracketed IPv6.
+            let parsed = if let Ok(sa) = entry.parse::<SocketAddr>() {
+                sa
+            } else if let Ok(ip) = entry.parse::<IpAddr>() {
+                SocketAddr::new(ip, 53)
+            } else {
+                return Err(format!(
+                    "direct[{name}]: dns entry '{entry}' is not a valid IP or host:port"
+                ));
+            };
+            servers.push(parsed);
+        }
+
+        if servers.is_empty() {
+            return Err(format!("direct[{name}]: dns list is empty"));
+        }
+
+        let resolver = Arc::new(Resolver::new(
+            servers,
+            Vec::new(),
+            DnsMode::Normal,
+            DomainTrie::<Vec<IpAddr>>::new(),
+            false,
+        ));
+        adapter = adapter.with_resolver(resolver);
+    }
+
+    Ok(adapter)
 }
 
 /// Parse the `strategy` field for a `load-balance` group.
@@ -981,6 +1058,58 @@ tls: true
         let yaml: serde_yaml::Value = serde_yaml::from_str("port: 8080").unwrap();
         let result = serialize_plugin_opts(&yaml).unwrap();
         assert_eq!(result, "port=8080");
+    }
+
+    // ─── direct proxy with per-proxy DNS (issue #67) ─────────────────────────
+
+    fn direct_config(yaml: &str) -> HashMap<String, serde_yaml::Value> {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn parse_direct_without_dns_ok() {
+        let cfg = direct_config("name: my-direct\ntype: direct\n");
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[test]
+    fn parse_direct_with_single_dns_string() {
+        let cfg = direct_config("name: lan\ntype: direct\ndns: 192.168.1.1\n");
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[test]
+    fn parse_direct_with_dns_list_and_explicit_port() {
+        let cfg = direct_config("name: lan\ntype: direct\ndns:\n  - 192.168.1.1\n  - 8.8.8.8:53\n");
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[test]
+    fn parse_direct_rejects_invalid_dns_entry() {
+        let cfg = direct_config("name: bad\ntype: direct\ndns: not-an-ip\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("invalid dns entry must hard-error (Class A)");
+        };
+        assert!(err.contains("not a valid IP or host:port"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_direct_rejects_empty_dns_list() {
+        let cfg = direct_config("name: bad\ntype: direct\ndns: []\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("empty dns list must hard-error (Class A)");
+        };
+        assert!(err.contains("dns list is empty"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_direct_rejects_wrong_dns_type() {
+        let cfg = direct_config("name: bad\ntype: direct\ndns: 53\n");
+        // Integer 53 is neither a string nor a list — must be rejected.
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("scalar non-string dns must hard-error (Class A)");
+        };
+        assert!(err.contains("dns must be a string or list"), "msg: {err}");
     }
 
     // ─── Load-balance strategy parser (F1-F7) ────────────────────────────────


### PR DESCRIPTION
## Summary
First slice of #67. Adds `type: direct` to the proxy config parser with an optional `dns:` field (single `host:port` string or a list). When set, the DirectAdapter resolves hostnames via those servers instead of the global resolver, by injecting a per-proxy `mihomo-dns::Resolver` through the existing `with_resolver` builder.

Example:
\`\`\`yaml
proxies:
  - name: lan
    type: direct
    dns:
      - 192.168.1.1
      - 8.8.8.8:53

rules:
  - DOMAIN-SUFFIX,local,lan
\`\`\`

## What this does NOT do
Issue #67 also asks for **\"DNS query routed through the matched proxy.\"** That's largely already true for non-direct outbounds: SS / Trojan / VLESS / HTTP adapters forward the hostname to the remote, which performs the lookup server-side (see e.g. `shadowsocks_adapter.rs:295` — `parse_address` prefers `DomainNameAddress` over a locally-resolved IP). What's *not* in this PR is the deeper machinery for routing **the local DNS client itself** through a proxy adapter (\`nameserver: 1.1.1.1#PROXY-A\` upstream syntax). That requires threading a proxy handle through \`DnsClient::exchange\`, parsing the \`#proxy\` suffix in nameserver URLs, and designing loop-prevention for the chicken-and-egg case where the proxy's own DNS lookup would re-enter the same client. It warrants its own ADR and will land as a follow-up.

The pre-resolve path for GeoIP / IP-CIDR rules continues to use the global resolver — that's fundamental: rule matching needs an IP, but the IP-determining proxy can't be picked until after the match.

## Design notes
- Hard errors (Class A per ADR-0002) on unparseable dns entry, empty list, or non-string scalar — silently falling back to the global resolver would surprise the user by leaking queries to the wrong upstream.
- DNS port defaults to 53 when only an IP is given; explicit \`host:port\` is honoured.
- The implicit \`DIRECT\` proxy (always present, used when no rule matches a configured proxy) still uses the global resolver. Users wanting custom DNS for direct traffic must define a named \`type: direct\` proxy and route to it via rules.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (default / no-default-features / all-features)
- [x] \`cargo test --lib\` — 485 passed (incl. 6 new \`parse_direct_*\` tests)
- [x] New tests cover: no \`dns\` (passthrough), single string, list, invalid IP rejection, empty list rejection, wrong-type rejection

Refs #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)