### PR TITLE
feat(proxy): anytls outbound adapter (closes #75)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +139,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anytls-rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa494bfdf944c403ffb86d3387cb8a15422ca9a59af66fad50b941340aded56"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "md5",
+ "notify",
+ "once_cell",
+ "rand 0.9.2",
+ "rcgen 0.14.8",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "sha2",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "x509-parser",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +177,45 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
@@ -292,7 +368,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -300,6 +376,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -471,6 +556,19 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -747,6 +845,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +1040,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "fslock"
@@ -1324,6 +1445,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1587,26 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1594,6 +1759,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -1896,6 +2081,7 @@ dependencies = [
 name = "mihomo-proxy"
 version = "0.7.6"
 dependencies = [
+ "anytls-rs",
  "async-trait",
  "base64",
  "bytes",
@@ -1907,11 +2093,12 @@ dependencies = [
  "mihomo-transport",
  "parking_lot",
  "rand 0.9.2",
- "rcgen",
+ "rcgen 0.13.2",
  "rustls",
  "serde_json",
  "sha2",
  "shadowsocks",
+ "smol_str",
  "socket2 0.5.10",
  "tempfile",
  "tokio",
@@ -1953,7 +2140,7 @@ dependencies = [
  "httparse",
  "md5",
  "rand 0.9.2",
- "rcgen",
+ "rcgen 0.13.2",
  "regex",
  "rustls",
  "thiserror 2.0.18",
@@ -2028,6 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2040,6 +2228,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2061,10 +2276,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2082,6 +2316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2334,7 +2577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.2",
@@ -2543,7 +2786,21 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "yasna",
+ "yasna 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -2677,6 +2934,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,6 +2969,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4153,11 +4428,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 
 # Networking
+anytls-rs = "0.5"
 shadowsocks = { version = "1.21", default-features = false, features = ["aead-cipher", "aead-cipher-2022", "stream-cipher"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }

--- a/crates/mihomo-common/src/adapter_type.rs
+++ b/crates/mihomo-common/src/adapter_type.rs
@@ -17,6 +17,7 @@ pub enum AdapterType {
     Vless,
     Trojan,
     Hysteria2,
+    Anytls,
 }
 
 impl fmt::Display for AdapterType {
@@ -36,6 +37,7 @@ impl fmt::Display for AdapterType {
             AdapterType::Vless => write!(f, "Vless"),
             AdapterType::Trojan => write!(f, "Trojan"),
             AdapterType::Hysteria2 => write!(f, "Hysteria2"),
+            AdapterType::Anytls => write!(f, "AnyTLS"),
         }
     }
 }

--- a/crates/mihomo-config/Cargo.toml
+++ b/crates/mihomo-config/Cargo.toml
@@ -10,6 +10,7 @@ ss = ["mihomo-proxy/ss"]
 trojan = ["mihomo-proxy/trojan"]
 vless = ["mihomo-proxy/vless"]
 vless-vision = ["vless", "mihomo-proxy/vless-vision"]
+anytls = ["mihomo-proxy/anytls"]
 boring-tls = ["mihomo-transport/boring-tls"]
 ech-tls-tunnel = ["ss", "mihomo-proxy/ech-tls-tunnel"]
 

--- a/crates/mihomo-config/src/proxy_parser.rs
+++ b/crates/mihomo-config/src/proxy_parser.rs
@@ -173,6 +173,11 @@ pub fn parse_proxy(
             let adapter = parse_direct(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
+        #[cfg(feature = "anytls")]
+        "anytls" => {
+            let adapter = parse_anytls(name, config)?;
+            Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
+        }
         _ => Err(format!("unsupported proxy type: {proxy_type}")),
     }
 }
@@ -381,6 +386,47 @@ fn parse_direct(
     }
 
     Ok(adapter)
+}
+
+/// Parse a `type: anytls` proxy block into an [`AnytlsAdapter`].
+///
+/// Required fields: `server`, `port`, `password`. Optional: `sni`,
+/// `skip-cert-verify`. Closes the parser side of issue #75; the wire
+/// protocol itself is provided by the `anytls-rs` crate.
+///
+/// # Hard errors (Class A per ADR-0002)
+///
+/// - missing `server`, `port`, or `password` — required by the protocol.
+/// - `port == 0` — never a valid endpoint.
+///
+/// upstream: `adapter/outbound/anytls.go`
+#[cfg(feature = "anytls")]
+fn parse_anytls(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<mihomo_proxy::AnytlsAdapter, String> {
+    let server = config
+        .get("server")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("anytls[{name}]: missing server"))?;
+    let port = config
+        .get("port")
+        .and_then(serde_yaml::Value::as_u64)
+        .ok_or_else(|| format!("anytls[{name}]: missing port"))? as u16;
+    if port == 0 {
+        return Err(format!("anytls[{name}]: port must be non-zero"));
+    }
+    let password = config
+        .get("password")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("anytls[{name}]: missing password"))?;
+    let sni = config.get("sni").and_then(|v| v.as_str());
+    let skip_cert_verify = config
+        .get("skip-cert-verify")
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(false);
+
+    mihomo_proxy::AnytlsAdapter::new(name, server, port, password, sni, skip_cert_verify)
 }
 
 /// Parse the `strategy` field for a `load-balance` group.
@@ -1110,6 +1156,56 @@ tls: true
             panic!("scalar non-string dns must hard-error (Class A)");
         };
         assert!(err.contains("dns must be a string or list"), "msg: {err}");
+    }
+
+    // ─── anytls proxy parser (issue #75) ─────────────────────────────────────
+
+    #[cfg(feature = "anytls")]
+    fn anytls_config(yaml: &str) -> HashMap<String, serde_yaml::Value> {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    // The upstream `anytls-rs` Client constructor spawns a background pool
+    // reaper task synchronously, which requires a live tokio reactor. The
+    // production code path always calls parse_proxy from inside the main
+    // runtime, but tests have to opt in explicitly with #[tokio::test].
+
+    #[cfg(feature = "anytls")]
+    #[tokio::test]
+    async fn parse_anytls_minimum_fields_ok() {
+        let cfg =
+            anytls_config("name: jp\ntype: anytls\nserver: 1.2.3.4\nport: 443\npassword: secret\n");
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[cfg(feature = "anytls")]
+    #[tokio::test]
+    async fn parse_anytls_with_sni_and_skip_verify_ok() {
+        let cfg = anytls_config(
+            "name: jp\ntype: anytls\nserver: 1.2.3.4\nport: 443\npassword: secret\nsni: example.com\nskip-cert-verify: true\n",
+        );
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[cfg(feature = "anytls")]
+    #[tokio::test]
+    async fn parse_anytls_rejects_missing_password() {
+        let cfg = anytls_config("name: jp\ntype: anytls\nserver: 1.2.3.4\nport: 443\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("missing password must hard-error (Class A)");
+        };
+        assert!(err.contains("missing password"), "msg: {err}");
+    }
+
+    #[cfg(feature = "anytls")]
+    #[tokio::test]
+    async fn parse_anytls_rejects_zero_port() {
+        let cfg =
+            anytls_config("name: jp\ntype: anytls\nserver: 1.2.3.4\nport: 0\npassword: secret\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("zero port must hard-error (Class A)");
+        };
+        assert!(err.contains("port must be non-zero"), "msg: {err}");
     }
 
     // ─── Load-balance strategy parser (F1-F7) ────────────────────────────────

--- a/crates/mihomo-proxy/Cargo.toml
+++ b/crates/mihomo-proxy/Cargo.toml
@@ -10,6 +10,11 @@ ss = ["dep:shadowsocks"]
 trojan = []
 vless = []
 vless-vision = ["vless"]
+# Opt-in anytls outbound (uses the `anytls-rs` crate). Adds ~one extra TLS
+# provider to the binary because the upstream crate pins default rustls
+# features — accept the bloat in exchange for not re-implementing the
+# wire protocol. Off by default.
+anytls = ["dep:anytls-rs"]
 # Native client for the `ech-tls-tunnel` SIP003 plugin
 # (https://github.com/shadowsocks/ech-tls-tunnel). Requires ECH on rustls,
 # which pulls aws-lc-rs in via mihomo-transport.
@@ -20,6 +25,7 @@ mihomo-common = { workspace = true }
 mihomo-dns = { workspace = true }
 mihomo-transport = { workspace = true }
 tokio = { workspace = true }
+anytls-rs = { workspace = true, optional = true }
 shadowsocks = { workspace = true, optional = true }
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }
@@ -46,6 +52,7 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
+smol_str = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mihomo-proxy/src/anytls_adapter.rs
+++ b/crates/mihomo-proxy/src/anytls_adapter.rs
@@ -1,0 +1,340 @@
+//! AnyTLS outbound (issue #75).
+//!
+//! Thin wrapper over the [`anytls-rs`] crate's `Client`. The protocol itself
+//! — TLS handshake, password auth, session multiplexing, padding scheme —
+//! lives upstream; this file only translates between mihomo's `ProxyAdapter`
+//! trait and `anytls_rs`'s `Client::create_proxy_stream` / `Session` API.
+//!
+//! Live integration tests are not included: they would require a running
+//! anytls server. Parser-level tests cover config validation.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use anytls_rs::client::Client as AnytlsClient;
+use anytls_rs::padding::PaddingFactory;
+use anytls_rs::session::{Session, Stream as AnytlsStream};
+use async_trait::async_trait;
+use bytes::Bytes;
+use parking_lot::Mutex;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::TlsConnector;
+
+use mihomo_common::{
+    AdapterType, Metadata, MihomoError, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn,
+    Result,
+};
+
+/// AnyTLS outbound adapter.
+pub struct AnytlsAdapter {
+    name: String,
+    addr: String,
+    health: ProxyHealth,
+    client: AnytlsClient,
+}
+
+impl AnytlsAdapter {
+    /// Build a new adapter.
+    ///
+    /// `server`/`port` is the AnyTLS server's TLS endpoint. `password` is the
+    /// shared secret. `sni` is the SNI sent during the TLS handshake; pass
+    /// `None` to default to `server`. When `skip_cert_verify` is set, the TLS
+    /// stack accepts any certificate — useful for self-signed dev servers and
+    /// matches the `skip-cert-verify` semantics of the trojan/vless adapters.
+    pub fn new(
+        name: &str,
+        server: &str,
+        port: u16,
+        password: &str,
+        sni: Option<&str>,
+        skip_cert_verify: bool,
+    ) -> std::result::Result<Self, String> {
+        let server_addr = format!("{server}:{port}");
+
+        let effective_sni = sni.filter(|s| !s.trim().is_empty()).unwrap_or(server);
+        let server_name =
+            build_server_name(effective_sni).map_err(|e| format!("anytls[{name}]: {e}"))?;
+
+        let tls_config = build_tls_client_config(skip_cert_verify)
+            .map_err(|e| format!("anytls[{name}]: tls config: {e}"))?;
+        let tls_connector = Arc::new(TlsConnector::from(tls_config));
+
+        let padding = PaddingFactory::default();
+
+        let client = AnytlsClient::new(
+            password,
+            server_addr.clone(),
+            server_name,
+            tls_connector,
+            padding,
+        );
+
+        Ok(Self {
+            name: name.to_string(),
+            addr: server_addr,
+            health: ProxyHealth::new(),
+            client,
+        })
+    }
+}
+
+#[async_trait]
+impl ProxyAdapter for AnytlsAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn adapter_type(&self) -> AdapterType {
+        AdapterType::Anytls
+    }
+
+    fn addr(&self) -> &str {
+        &self.addr
+    }
+
+    fn support_udp(&self) -> bool {
+        // UDP is supported by the protocol (udp-over-tcp v2), but the upstream
+        // crate's UDP path requires a separate API. Wire it up in a follow-up.
+        false
+    }
+
+    async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        let host = metadata.rule_host().to_string();
+        let port = metadata.dst_port;
+        let (stream, session) = self
+            .client
+            .create_proxy_stream((host, port))
+            .await
+            .map_err(|e| MihomoError::Proxy(format!("anytls dial: {e}")))?;
+        Ok(Box::new(AnytlsConn::new(stream, session)))
+    }
+
+    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        Err(MihomoError::Proxy(
+            "anytls: UDP not implemented yet".to_string(),
+        ))
+    }
+
+    fn health(&self) -> &ProxyHealth {
+        &self.health
+    }
+}
+
+/// Bridge `(Arc<Stream>, Arc<Session>)` into a `ProxyConn`-shaped value.
+///
+/// The upstream `Stream` impls `AsyncRead`/`AsyncWrite` on `Pin<&mut Self>`,
+/// but `create_proxy_stream` only hands us an `Arc<Stream>` — we can never
+/// obtain `&mut Stream`. So we re-implement the trait against the public
+/// `Stream::reader()` and `Session::write_data_frame()` API surface that the
+/// crate's own SOCKS5 client uses (`src/client/socks5.rs`).
+// The pending futures are `Send` but not `Sync`; `ProxyConn` requires `Sync`,
+// so we wrap them in `parking_lot::Mutex` (which is `Sync` whenever its
+// payload is `Send`). The mutex is uncontended in practice because all
+// access happens through `Pin<&mut Self>` from the AsyncRead/AsyncWrite
+// trait, but the type-level `Sync` bound on `ProxyConn` is what forces the
+// wrapping.
+type PendingRead = Pin<Box<dyn std::future::Future<Output = io::Result<Vec<u8>>> + Send>>;
+type PendingWrite = Pin<Box<dyn std::future::Future<Output = io::Result<()>> + Send>>;
+
+struct AnytlsConn {
+    stream: Arc<AnytlsStream>,
+    session: Arc<Session>,
+    stream_id: u32,
+    pending_read: Mutex<Option<PendingRead>>,
+    pending_write: Mutex<Option<PendingWrite>>,
+}
+
+impl AnytlsConn {
+    fn new(stream: Arc<AnytlsStream>, session: Arc<Session>) -> Self {
+        let stream_id = stream.id();
+        Self {
+            stream,
+            session,
+            stream_id,
+            pending_read: Mutex::new(None),
+            pending_write: Mutex::new(None),
+        }
+    }
+}
+
+impl AsyncRead for AnytlsConn {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let remaining = buf.remaining();
+        if remaining == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let mut guard = self.pending_read.lock();
+        if guard.is_none() {
+            let reader = Arc::clone(self.stream.reader());
+            let fut = async move {
+                let mut g = reader.lock().await;
+                let mut tmp = vec![0u8; remaining];
+                let n = g
+                    .read(&mut tmp)
+                    .await
+                    .map_err(|e| io::Error::other(format!("anytls read: {e}")))?;
+                tmp.truncate(n);
+                Ok(tmp)
+            };
+            *guard = Some(Box::pin(fut));
+        }
+        let fut = guard.as_mut().expect("just set");
+        match fut.as_mut().poll(cx) {
+            Poll::Ready(Ok(data)) => {
+                *guard = None;
+                buf.put_slice(&data);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => {
+                *guard = None;
+                Poll::Ready(Err(e))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl AsyncWrite for AnytlsConn {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let len = buf.len();
+        let mut guard = self.pending_write.lock();
+        if guard.is_none() {
+            let session = Arc::clone(&self.session);
+            let stream_id = self.stream_id;
+            let data = Bytes::copy_from_slice(buf);
+            let fut = async move {
+                session
+                    .write_data_frame(stream_id, data)
+                    .await
+                    .map_err(|e| io::Error::other(format!("anytls write: {e}")))
+            };
+            *guard = Some(Box::pin(fut));
+        }
+        let fut = guard.as_mut().expect("just set");
+        match fut.as_mut().poll(cx) {
+            Poll::Ready(Ok(())) => {
+                *guard = None;
+                Poll::Ready(Ok(len))
+            }
+            Poll::Ready(Err(e)) => {
+                *guard = None;
+                Poll::Ready(Err(e))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // The upstream session writer is unbuffered (each write_data_frame
+        // pushes onto a tokio mpsc that's drained on the wire side), so
+        // there's nothing to flush.
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Dropping the Arc<Stream> + Arc<Session> here would close the
+        // session prematurely if it's pooled for reuse. Rely on the
+        // session pool's idle reaper instead.
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl ProxyConn for AnytlsConn {}
+
+fn build_server_name(value: &str) -> std::result::Result<ServerName<'static>, String> {
+    let normalized = value.trim().trim_start_matches('[').trim_end_matches(']');
+    if normalized.is_empty() {
+        return Err("SNI cannot be empty".to_string());
+    }
+    if let Ok(ip) = normalized.parse::<std::net::IpAddr>() {
+        return Ok(ServerName::IpAddress(ip.into()));
+    }
+    ServerName::try_from(normalized.to_string()).map_err(|_| format!("invalid SNI '{normalized}'"))
+}
+
+fn build_tls_client_config(
+    skip_cert_verify: bool,
+) -> std::result::Result<Arc<rustls::ClientConfig>, String> {
+    use rustls::RootCertStore;
+
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+
+    let config_builder = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("rustls builder: {e}"))?;
+
+    let mut config = config_builder
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    if skip_cert_verify {
+        use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified};
+        use rustls::pki_types::{CertificateDer, ServerName as RsServerName, UnixTime};
+        use rustls::{DigitallySignedStruct, SignatureScheme};
+
+        #[derive(Debug)]
+        struct NoVerify;
+        impl rustls::client::danger::ServerCertVerifier for NoVerify {
+            fn verify_server_cert(
+                &self,
+                _: &CertificateDer<'_>,
+                _: &[CertificateDer<'_>],
+                _: &RsServerName<'_>,
+                _: &[u8],
+                _: UnixTime,
+            ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+                Ok(ServerCertVerified::assertion())
+            }
+            fn verify_tls12_signature(
+                &self,
+                _: &[u8],
+                _: &CertificateDer<'_>,
+                _: &DigitallySignedStruct,
+            ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+            fn verify_tls13_signature(
+                &self,
+                _: &[u8],
+                _: &CertificateDer<'_>,
+                _: &DigitallySignedStruct,
+            ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+            fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+                vec![
+                    SignatureScheme::ECDSA_NISTP256_SHA256,
+                    SignatureScheme::ECDSA_NISTP384_SHA384,
+                    SignatureScheme::ED25519,
+                    SignatureScheme::RSA_PSS_SHA256,
+                    SignatureScheme::RSA_PSS_SHA384,
+                    SignatureScheme::RSA_PSS_SHA512,
+                    SignatureScheme::RSA_PKCS1_SHA256,
+                    SignatureScheme::RSA_PKCS1_SHA384,
+                    SignatureScheme::RSA_PKCS1_SHA512,
+                ]
+            }
+        }
+        config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(NoVerify));
+    }
+
+    Ok(Arc::new(config))
+}

--- a/crates/mihomo-proxy/src/lib.rs
+++ b/crates/mihomo-proxy/src/lib.rs
@@ -19,6 +19,11 @@ pub mod v2ray_plugin;
 #[cfg(feature = "trojan")]
 pub mod trojan;
 
+#[cfg(feature = "anytls")]
+pub mod anytls_adapter;
+#[cfg(feature = "anytls")]
+pub use anytls_adapter::AnytlsAdapter;
+
 #[cfg(feature = "vless")]
 pub(crate) mod vless;
 #[cfg(feature = "vless")]

--- a/crates/mihomo-proxy/tests/anytls_integration.rs
+++ b/crates/mihomo-proxy/tests/anytls_integration.rs
@@ -1,0 +1,194 @@
+#![cfg(feature = "anytls")]
+//! Integration tests for the AnyTLS adapter against the upstream
+//! `anytls-rs` server.
+//!
+//! No external binaries: the test spawns a real `anytls_rs::server::Server`
+//! (its default `TcpProxyHandler` proxies streams to whatever destination
+//! the client supplies in the first SOCKS5-style frame) and our adapter
+//! dials through it to a local TCP echo server.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anytls_rs::padding::PaddingFactory;
+use anytls_rs::server::Server as AnytlsServer;
+use mihomo_common::{Metadata, Network, ProxyAdapter};
+use mihomo_proxy::AnytlsAdapter;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::{timeout, Duration};
+
+const PASSWORD: &str = "test-anytls-password";
+const T: Duration = Duration::from_secs(15);
+
+fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn self_signed_cert() -> (
+    rustls::pki_types::CertificateDer<'static>,
+    rustls::pki_types::PrivateKeyDer<'static>,
+) {
+    let ck = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+    let cert_der = rustls::pki_types::CertificateDer::from(ck.cert.der().to_vec());
+    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(
+        rustls::pki_types::PrivatePkcs8KeyDer::from(ck.key_pair.serialize_der()),
+    );
+    (cert_der, key_der)
+}
+
+/// Local TCP echo server. Returns its bound `127.0.0.1:port`.
+async fn start_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let h = tokio::spawn(async move {
+        while let Ok((mut sock, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    let n = match sock.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => n,
+                    };
+                    if sock.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    (addr, h)
+}
+
+/// Start an upstream `anytls_rs::server::Server` on a free `127.0.0.1` port
+/// using the supplied self-signed cert and the same password the adapter
+/// will authenticate with. Returns the bound socket addr.
+async fn start_anytls_server(
+    cert_der: rustls::pki_types::CertificateDer<'static>,
+    key_der: rustls::pki_types::PrivateKeyDer<'static>,
+) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .unwrap();
+    let acceptor = Arc::new(tokio_rustls::TlsAcceptor::from(Arc::new(tls_config)));
+
+    // Bind first so we can hand the bound port back before spawning the
+    // server's accept loop.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener); // re-bound by Server::listen below
+
+    let padding = PaddingFactory::default();
+    let server = AnytlsServer::new(PASSWORD, acceptor, padding, None);
+    let listen_addr = format!("127.0.0.1:{}", addr.port());
+    let h = tokio::spawn(async move {
+        let _ = server.listen(&listen_addr).await;
+    });
+    // Give the accept loop a beat to rebind.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, h)
+}
+
+#[tokio::test]
+async fn anytls_round_trip_through_upstream_server() {
+    install_crypto_provider();
+
+    let (echo_addr, _echo_h) = start_echo_server().await;
+    let (cert, key) = self_signed_cert();
+    let (server_addr, _server_h) = start_anytls_server(cert, key).await;
+
+    // Adapter points at our anytls server, with skip-cert-verify so it
+    // accepts the self-signed cert.
+    let adapter = AnytlsAdapter::new(
+        "test-anytls",
+        &server_addr.ip().to_string(),
+        server_addr.port(),
+        PASSWORD,
+        Some("localhost"),
+        true,
+    )
+    .expect("adapter must build");
+
+    let metadata = Metadata {
+        network: Network::Tcp,
+        host: smol_str::SmolStr::from(echo_addr.ip().to_string()),
+        dst_port: echo_addr.port(),
+        ..Default::default()
+    };
+
+    let mut conn = timeout(T, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial_tcp must not stall")
+        .expect("dial_tcp must succeed end-to-end");
+
+    let payload = b"mihomo<>anytls round-trip";
+    timeout(T, conn.write_all(payload))
+        .await
+        .expect("write must not stall")
+        .expect("write must succeed");
+    timeout(T, conn.flush())
+        .await
+        .expect("flush must not stall")
+        .expect("flush must succeed");
+
+    let mut buf = vec![0u8; payload.len()];
+    timeout(T, conn.read_exact(&mut buf))
+        .await
+        .expect("echo must not stall")
+        .expect("echo must succeed");
+    assert_eq!(&buf[..], payload, "echo payload must match what we wrote");
+}
+
+#[tokio::test]
+async fn anytls_rejects_wrong_password() {
+    install_crypto_provider();
+
+    let (echo_addr, _echo_h) = start_echo_server().await;
+    let (cert, key) = self_signed_cert();
+    let (server_addr, _server_h) = start_anytls_server(cert, key).await;
+
+    let adapter = AnytlsAdapter::new(
+        "test-anytls-bad",
+        &server_addr.ip().to_string(),
+        server_addr.port(),
+        "WRONG-PASSWORD",
+        Some("localhost"),
+        true,
+    )
+    .expect("adapter must build");
+
+    let metadata = Metadata {
+        network: Network::Tcp,
+        host: smol_str::SmolStr::from(echo_addr.ip().to_string()),
+        dst_port: echo_addr.port(),
+        ..Default::default()
+    };
+
+    // The server hard-closes on bad password. The adapter should not
+    // return a working stream — either dial fails outright or the first
+    // write/read fails. Tolerate both shapes; what we're guarding is that
+    // wrong passwords don't silently succeed.
+    let dial = timeout(T, adapter.dial_tcp(&metadata)).await;
+    match dial {
+        // Timed out (server stalled the auth) or dial errored — both
+        // acceptable shapes of "wrong password is rejected."
+        Err(_) | Ok(Err(_)) => {}
+        Ok(Ok(mut conn)) => {
+            // Dial returned a conn — exercise it and require failure on
+            // either side of the round trip.
+            let payload = b"should-not-reach";
+            let w = timeout(T, conn.write_all(payload)).await;
+            let mut buf = vec![0u8; payload.len()];
+            let r = timeout(T, conn.read_exact(&mut buf)).await;
+            assert!(
+                w.is_err()
+                    || w.unwrap().is_err()
+                    || r.is_err()
+                    || r.unwrap().is_err()
+                    || &buf[..] != payload,
+                "wrong password must not deliver an end-to-end round trip"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #75 — adds an \`anytls\` proxy type behind an opt-in \`anytls\` cargo feature.

Implementation strategy: rather than re-implement the AnyTLS wire protocol (TLS handshake, sha256 auth, session multiplexing, padding scheme), the adapter delegates to the upstream [\`anytls-rs\`](https://github.com/jxo-me/anytls-rs) crate (MIT, actively maintained, v0.5.4). The adapter is a thin bridge between mihomo's \`ProxyAdapter\` trait and \`anytls_rs::client::Client\` / \`Session\`.

Config:
\`\`\`yaml
proxies:
  - name: jp
    type: anytls
    server: 1.2.3.4
    port: 443
    password: secret
    sni: example.com         # optional, defaults to server
    skip-cert-verify: false  # optional
\`\`\`

## Why an opt-in feature flag
The upstream crate pins default rustls features, so enabling \`anytls\` pulls in the aws-lc-rs provider alongside our existing ring provider. Acceptable for users who opt in; worth the binary-size cost vs. re-implementing the wire protocol from scratch.

## Notes
- The \`ProxyConn\` \`Send + Sync\` requirement forces a \`parking_lot::Mutex\` around in-flight read/write futures (the futures are \`Send\` but not \`Sync\`). Mutex is uncontended in practice — AsyncRead/AsyncWrite already hold \`Pin<&mut Self>\`, so the lock is type-system appeasement, not real synchronisation.
- The upstream \`Client::new\` constructor spawns a background session-pool reaper task synchronously, so it requires a live tokio runtime. Production code always calls this from inside the runtime; tests use \`#[tokio::test]\`.
- UDP-over-TCP (AnyTLS v2) is supported by the upstream crate via a separate \`create_udp_proxy\` API; left as a follow-up.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (default / no-default-features / \`--features anytls\` / \`--all-features\`)
- [x] \`cargo test --features anytls --lib\` — 489 passed (incl. 4 new \`parse_anytls_*\` tests)
- [x] \`cargo test --features anytls -p mihomo-proxy --test anytls_integration\` — 2 new live tests:
  - \`anytls_round_trip_through_upstream_server\` — spawns a real \`anytls_rs::server::Server\` with a self-signed cert and verifies an end-to-end payload echo through the adapter
  - \`anytls_rejects_wrong_password\` — same setup, wrong password, asserts the dial/round-trip fails

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)