### PR TITLE
feat(dns): route DNS queries through proxy adapters (closes #67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,6 +2042,7 @@ dependencies = [
 name = "mihomo-dns"
 version = "0.7.6"
 dependencies = [
+ "async-trait",
  "dashmap",
  "futures",
  "hickory-proto",
@@ -2055,6 +2056,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "smol_str",
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/mihomo-config/src/dns_parser.rs
+++ b/crates/mihomo-config/src/dns_parser.rs
@@ -3,7 +3,7 @@ use crate::DnsConfig;
 use mihomo_common::DnsMode;
 use mihomo_dns::fakeip::{FileStore, MemoryStore, Pool, Skipper, SkipperMode, Store};
 use mihomo_dns::resolver::{FallbackFilter, NameserverPolicy, PolicyEntry};
-use mihomo_dns::upstream::NameServerUrl;
+use mihomo_dns::upstream::{NameServerEntry, NameServerUrl};
 use mihomo_dns::{HostOrIp, Resolver};
 use mihomo_trie::DomainTrie;
 use std::collections::HashMap;
@@ -19,6 +19,7 @@ pub async fn parse_dns(
     raw: &RawConfig,
     mmdb_path: Option<&std::path::Path>,
     cache_dir: Option<&std::path::Path>,
+    proxy_registry: &HashMap<String, Arc<dyn mihomo_common::Proxy>>,
 ) -> Result<DnsConfig, anyhow::Error> {
     let dns = match &raw.dns {
         Some(dns) if dns.enable.unwrap_or(false) => dns,
@@ -42,9 +43,10 @@ pub async fn parse_dns(
     let use_hosts = dns.use_hosts.unwrap_or(true);
     let use_system_hosts = dns.use_system_hosts.unwrap_or(true);
 
-    let main_urls = parse_nameserver_urls(dns.nameserver.as_deref().unwrap_or(&[]))?;
-    let fallback_urls = parse_nameserver_urls(dns.fallback.as_deref().unwrap_or(&[]))?;
-    let default_ns_urls = parse_nameserver_urls(dns.default_nameserver.as_deref().unwrap_or(&[]))?;
+    let main_urls = parse_nameserver_entries(dns.nameserver.as_deref().unwrap_or(&[]))?;
+    let fallback_urls = parse_nameserver_entries(dns.fallback.as_deref().unwrap_or(&[]))?;
+    let default_ns_urls =
+        parse_nameserver_entries(dns.default_nameserver.as_deref().unwrap_or(&[]))?;
 
     let mode = match dns.enhanced_mode.as_deref() {
         Some("fake-ip") => DnsMode::FakeIp,
@@ -80,7 +82,7 @@ pub async fn parse_dns(
         ))
     };
 
-    let mut resolver = Resolver::new_with_bootstrap(
+    let mut resolver = Resolver::new_with_bootstrap_with_proxies(
         main_urls,
         fallback_urls,
         default_ns_urls,
@@ -89,6 +91,7 @@ pub async fn parse_dns(
         use_hosts,
         policy,
         fallback_filter,
+        proxy_registry,
     )
     .await
     .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -171,16 +174,24 @@ fn install_fakeip(
     Ok(())
 }
 
-/// Parse nameserver strings into `NameServerUrl`s — every entry must parse
-/// or load fails. No silent warn-and-drop.
-fn parse_nameserver_urls(servers: &[String]) -> Result<Vec<NameServerUrl>, anyhow::Error> {
+/// Parse nameserver strings into `NameServerEntry`s — every entry must
+/// parse or load fails. No silent warn-and-drop.
+fn parse_nameserver_entries(servers: &[String]) -> Result<Vec<NameServerEntry>, anyhow::Error> {
     servers
         .iter()
         .map(|s| {
-            NameServerUrl::parse(s)
+            NameServerEntry::parse(s)
                 .map_err(|e| anyhow::anyhow!("failed to parse nameserver '{s}': {e}"))
         })
         .collect()
+}
+
+/// Pre-`NameServerEntry` shim kept for the existing tests below that build
+/// raw `NameServerUrl`s and compare against the result. New code should use
+/// [`parse_nameserver_entries`].
+#[cfg(test)]
+fn parse_nameserver_urls(servers: &[String]) -> Result<Vec<NameServerUrl>, anyhow::Error> {
+    parse_nameserver_entries(servers).map(|v| v.into_iter().map(|e| e.url).collect())
 }
 
 /// Build a `NameserverPolicy` from the raw YAML map.

--- a/crates/mihomo-config/src/lib.rs
+++ b/crates/mihomo-config/src/lib.rs
@@ -729,10 +729,6 @@ async fn build_config(
         bind_address,
     };
 
-    // DNS — pass the explicit mmdb path so fallback-filter GeoIP uses the
-    // same path as the rule engine.
-    let dns_config = dns_parser::parse_dns(&raw, geodata.mmdb_path.as_deref(), cache_dir).await?;
-
     // Load proxy providers (async: may HTTP-fetch provider files).
     let proxy_providers = if let Some(raw_pp) = raw.proxy_providers.as_ref() {
         if raw_pp.is_empty() {
@@ -744,9 +740,26 @@ async fn build_config(
         HashMap::new()
     };
 
-    // Proxies and rules via rebuild — pass the resolver so DIRECT can avoid
-    // the OS resolver (and the resulting DNS-loop when mihomo is system DNS).
-    // Uses geodata paths from the raw config (already validated above).
+    // Two-pass build so DNS can see the proxy registry without a circular
+    // dependency on the resolver itself (issue #67 phase 2, ADR-0012):
+    //
+    //   1. Build proxies with no resolver injected. Every adapter except
+    //      DIRECT is fully functional here; DIRECT falls back to the OS
+    //      resolver, which would loop if mihomo were the system DNS.
+    //   2. Build the DNS resolver, passing those proxies as the
+    //      `#PROXY-NAME` registry. The resolver does not call back into
+    //      proxies during construction, so this is safe.
+    //   3. Rebuild proxies with the real resolver attached. The two
+    //      passes only differ in DIRECT's resolver field; nothing else
+    //      depends on the placeholder built in step 1.
+    let (proxies, _) = rebuild_from_raw_impl(&raw, cache_dir, None, &proxy_providers)?;
+
+    // DNS — pass the explicit mmdb path so fallback-filter GeoIP uses the
+    // same path as the rule engine, plus the proxy registry from step 1
+    // so #PROXY-tagged nameservers can resolve their referenced adapter.
+    let dns_config =
+        dns_parser::parse_dns(&raw, geodata.mmdb_path.as_deref(), cache_dir, &proxies).await?;
+
     let (proxies, rules) = rebuild_from_raw_impl(
         &raw,
         cache_dir,

--- a/crates/mihomo-dns/Cargo.toml
+++ b/crates/mihomo-dns/Cargo.toml
@@ -30,10 +30,13 @@ maxminddb = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+smol_str = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 sysinfo = "0.32"
+async-trait = { workspace = true }
+hickory-proto = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mihomo-dns/src/client.rs
+++ b/crates/mihomo-dns/src/client.rs
@@ -95,10 +95,16 @@ pub enum ClientError {
     Rcode(hickory_proto::op::ResponseCode),
 }
 
+/// Optional proxy adapter for routing DNS queries through. When set, the
+/// TCP exchange is performed via `proxy.dial_tcp` instead of
+/// `factory().connect_tcp` — see ADR-0012 (issue #67 phase 2).
+pub type DnsProxy = Arc<dyn mihomo_common::Proxy>;
+
 /// A single DNS upstream the resolver can query.
 pub struct DnsClient {
     transport: Transport,
     timeout: Duration,
+    proxy: Option<DnsProxy>,
 }
 
 enum Transport {
@@ -129,6 +135,7 @@ impl DnsClient {
         Self {
             transport: Transport::Udp { addr },
             timeout: DEFAULT_QUERY_TIMEOUT,
+            proxy: None,
         }
     }
 
@@ -137,6 +144,7 @@ impl DnsClient {
         Self {
             transport: Transport::Tcp { addr },
             timeout: DEFAULT_QUERY_TIMEOUT,
+            proxy: None,
         }
     }
 
@@ -150,6 +158,7 @@ impl DnsClient {
                 tls: tls_client_config("dot"),
             },
             timeout: DEFAULT_QUERY_TIMEOUT,
+            proxy: None,
         }
     }
 
@@ -164,12 +173,26 @@ impl DnsClient {
                 tls: tls_client_config("doh"),
             },
             timeout: DEFAULT_QUERY_TIMEOUT,
+            proxy: None,
         }
     }
 
     /// Override the per-query timeout.
     pub fn with_timeout(mut self, t: Duration) -> Self {
         self.timeout = t;
+        self
+    }
+
+    /// Route this client's exchanges through `proxy` (issue #67 phase 2).
+    ///
+    /// When set:
+    /// - TCP / DoT / DoH exchanges use `proxy.dial_tcp` instead of opening
+    ///   a direct TCP connection.
+    /// - UDP exchanges fall through to TCP-over-proxy, since most proxy
+    ///   adapters can't relay arbitrary UDP. The fallback matches the
+    ///   semantics in ADR-0012.
+    pub fn with_proxy(mut self, proxy: DnsProxy) -> Self {
+        self.proxy = Some(proxy);
         self
     }
 
@@ -228,6 +251,26 @@ impl DnsClient {
     }
 
     async fn exchange(&self, wire: &[u8]) -> Result<Vec<u8>, ClientError> {
+        if let Some(proxy) = self.proxy.as_ref() {
+            let addr = match &self.transport {
+                Transport::Udp { addr } | Transport::Tcp { addr } => *addr,
+                #[cfg(feature = "encrypted")]
+                Transport::Dot { .. } | Transport::Doh { .. } => {
+                    // DoT/DoH-over-proxy needs TLS layered on a Box<dyn
+                    // ProxyConn>; the upstream tokio_rustls TlsConnector
+                    // is generic over the IO stream but the call sites
+                    // here aren't wired yet. ADR-0012 marks it
+                    // follow-up. Refuse so misconfiguration is loud.
+                    return Err(ClientError::Tls(
+                        "DoT/DoH routing through a proxy is not implemented yet \
+                        (issue #67 phase 2 follow-up); use plain udp:// or tcp:// for \
+                        a #PROXY-tagged nameserver"
+                            .to_string(),
+                    ));
+                }
+            };
+            return proxy_tcp_exchange(proxy, addr, wire).await;
+        }
         match &self.transport {
             Transport::Udp { addr } => udp_exchange(*addr, wire).await,
             Transport::Tcp { addr } => tcp_exchange(*addr, wire).await,
@@ -244,6 +287,28 @@ impl DnsClient {
             } => doh_exchange(*addr, sni, path, Arc::clone(tls), wire).await,
         }
     }
+}
+
+async fn proxy_tcp_exchange(
+    proxy: &DnsProxy,
+    addr: SocketAddr,
+    wire: &[u8],
+) -> Result<Vec<u8>, ClientError> {
+    use mihomo_common::{ConnType, Metadata, Network};
+    let metadata = Metadata {
+        network: Network::Tcp,
+        conn_type: ConnType::Inner,
+        host: smol_str::SmolStr::from(addr.ip().to_string()),
+        dst_ip: Some(addr.ip()),
+        dst_port: addr.port(),
+        ..Default::default()
+    };
+    let mut stream = proxy
+        .dial_tcp(&metadata)
+        .await
+        .map_err(|e| io::Error::other(format!("dns-via-proxy dial: {e}")))?;
+    write_lp(&mut stream, wire).await?;
+    read_lp(&mut stream).await
 }
 
 fn ip_from_record(rec: &Record) -> Option<IpAddr> {

--- a/crates/mihomo-dns/src/lib.rs
+++ b/crates/mihomo-dns/src/lib.rs
@@ -10,4 +10,4 @@ pub use client::{set_socket_factory, ClientError, DnsClient, SocketFactory};
 pub use fakeip::{FileStore, MemoryStore, Pool, PoolError, Skipper, SkipperMode, Store};
 pub use resolver::{BootstrapError, FallbackFilter, NameserverPolicy, PolicyEntry, Resolver};
 pub use server::DnsServer;
-pub use upstream::{HostOrIp, NameServerParseError, NameServerUrl};
+pub use upstream::{HostOrIp, NameServerEntry, NameServerParseError, NameServerUrl};

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -1,7 +1,7 @@
 use crate::cache::DnsCache;
 use crate::client::DnsClient;
 use crate::fakeip::{Pool, Skipper};
-use crate::upstream::{HostOrIp, NameServerUrl};
+use crate::upstream::{HostOrIp, NameServerEntry, NameServerUrl};
 use dashmap::DashMap;
 use hickory_proto::op::Message;
 use hickory_proto::rr::RecordType;
@@ -31,6 +31,14 @@ pub enum BootstrapError {
         input: String,
         source: crate::upstream::NameServerParseError,
     },
+    #[error("nameserver '{nameserver}' references proxy '{proxy}', which is not defined")]
+    UnknownProxy { nameserver: String, proxy: String },
+    #[error(
+        "nameserver '{nameserver}' uses proxy '{proxy}' on a tls:///https:// entry; \
+        DoT/DoH routing through a proxy is not implemented yet — use plain udp:// or tcp:// \
+        (issue #67 phase 2 follow-up)"
+    )]
+    EncryptedProxyUnsupported { nameserver: String, proxy: String },
 }
 
 /// Broadcast channel used to share a singleflight lookup result.
@@ -304,8 +312,10 @@ impl Resolver {
             .collect()
     }
 
-    /// Build a `Resolver` from structured `NameServerUrl` lists, running a
-    /// bootstrap DNS lookup for any encrypted upstream that uses a hostname.
+    /// Build a `Resolver` from `NameServerUrl` lists with no `#PROXY`
+    /// support. Equivalent to [`new_with_bootstrap_with_proxies`] with an
+    /// empty registry; convenient for tests and call sites that don't
+    /// need proxy-routed DNS.
     #[allow(clippy::too_many_arguments)]
     pub async fn new_with_bootstrap(
         main_urls: Vec<NameServerUrl>,
@@ -317,6 +327,93 @@ impl Resolver {
         policy: Option<NameserverPolicy>,
         fallback_filter: Option<FallbackFilter>,
     ) -> Result<Self, BootstrapError> {
+        Self::new_with_bootstrap_with_proxies(
+            main_urls.into_iter().map(Into::into).collect(),
+            fallback_urls.into_iter().map(Into::into).collect(),
+            default_ns.into_iter().map(Into::into).collect(),
+            mode,
+            hosts,
+            use_hosts,
+            policy,
+            fallback_filter,
+            &HashMap::new(),
+        )
+        .await
+    }
+
+    /// Build a `Resolver` from structured nameserver entries, running a
+    /// bootstrap DNS lookup for any encrypted upstream that uses a
+    /// hostname.
+    ///
+    /// `proxy_registry` resolves any `#PROXY` references on plain
+    /// (`udp://`/`tcp://`) entries (issue #67 phase 2). Pass an empty map
+    /// when proxies aren't yet built — entries that reference proxies
+    /// will then be rejected with `BootstrapError::UnknownProxy`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_with_bootstrap_with_proxies(
+        main_urls: Vec<NameServerEntry>,
+        fallback_urls: Vec<NameServerEntry>,
+        default_ns: Vec<NameServerEntry>,
+        mode: DnsMode,
+        hosts: DomainTrie<Vec<IpAddr>>,
+        use_hosts: bool,
+        policy: Option<NameserverPolicy>,
+        fallback_filter: Option<FallbackFilter>,
+        proxy_registry: &HashMap<String, Arc<dyn mihomo_common::Proxy>>,
+    ) -> Result<Self, BootstrapError> {
+        // ── Validate proxy references up front so misconfig fails loud.
+        // `default_ns` entries are forbidden from carrying #PROXY — they
+        // are the bootstrap path that resolves the proxy server's own
+        // hostname, so routing them through a proxy would create the
+        // chicken-and-egg loop ADR-0012 warns about.
+        for entry in &default_ns {
+            if let Some(p) = entry.proxy.as_ref() {
+                return Err(BootstrapError::UnknownProxy {
+                    nameserver: entry.url.to_string(),
+                    proxy: format!("{p} (default-nameserver may not use #PROXY)"),
+                });
+            }
+        }
+        for entry in main_urls.iter().chain(fallback_urls.iter()) {
+            let Some(p) = entry.proxy.as_ref() else {
+                continue;
+            };
+            if matches!(
+                entry.url,
+                NameServerUrl::Tls { .. } | NameServerUrl::Https { .. }
+            ) {
+                return Err(BootstrapError::EncryptedProxyUnsupported {
+                    nameserver: entry.url.to_string(),
+                    proxy: p.clone(),
+                });
+            }
+            if !proxy_registry.contains_key(p) {
+                return Err(BootstrapError::UnknownProxy {
+                    nameserver: entry.url.to_string(),
+                    proxy: p.clone(),
+                });
+            }
+        }
+
+        // Split out the bare URLs (for the existing match-arm helpers
+        // below) and a parallel proxy-handle vector (Some when the entry
+        // carried a validated #PROXY tag).
+        let resolve_proxy =
+            |entries: &[NameServerEntry]| -> Vec<Option<Arc<dyn mihomo_common::Proxy>>> {
+                entries
+                    .iter()
+                    .map(|e| {
+                        e.proxy
+                            .as_ref()
+                            .and_then(|p| proxy_registry.get(p).cloned())
+                    })
+                    .collect()
+            };
+        let main_proxies = resolve_proxy(&main_urls);
+        let fallback_proxies = resolve_proxy(&fallback_urls);
+        let main_urls: Vec<NameServerUrl> = main_urls.into_iter().map(|e| e.url).collect();
+        let fallback_urls: Vec<NameServerUrl> = fallback_urls.into_iter().map(|e| e.url).collect();
+        let default_ns: Vec<NameServerUrl> = default_ns.into_iter().map(|e| e.url).collect();
         // Step 1: Validate default_ns — only plain entries allowed.
         for ns in &default_ns {
             if !ns.is_plain() {
@@ -384,9 +481,10 @@ impl Resolver {
         };
 
         // Steps 5 & 6: Build main + fallback — one resolver per URL for parallel dispatch.
-        let main = main_urls
+        let main: Vec<Arc<DnsClient>> = main_urls
             .iter()
-            .map(|url| Self::build_single_resolver(url, &resolved_map))
+            .zip(main_proxies)
+            .map(|(url, proxy)| Self::build_single_resolver_with_proxy(url, &resolved_map, proxy))
             .collect();
         let fallback = if fallback_urls.is_empty() {
             None
@@ -394,7 +492,10 @@ impl Resolver {
             Some(
                 fallback_urls
                     .iter()
-                    .map(|url| Self::build_single_resolver(url, &resolved_map))
+                    .zip(fallback_proxies)
+                    .map(|(url, proxy)| {
+                        Self::build_single_resolver_with_proxy(url, &resolved_map, proxy)
+                    })
                     .collect(),
             )
         };
@@ -422,6 +523,17 @@ impl Resolver {
     pub fn build_single_resolver(
         url: &NameServerUrl,
         resolved: &HashMap<String, IpAddr>,
+    ) -> Arc<DnsClient> {
+        Self::build_single_resolver_with_proxy(url, resolved, None)
+    }
+
+    /// Like [`build_single_resolver`] but also attaches an optional
+    /// proxy adapter so queries route via `proxy.dial_tcp` (issue #67
+    /// phase 2). Pass `None` to get the unrouted client.
+    pub fn build_single_resolver_with_proxy(
+        url: &NameServerUrl,
+        resolved: &HashMap<String, IpAddr>,
+        proxy: Option<Arc<dyn mihomo_common::Proxy>>,
     ) -> Arc<DnsClient> {
         let socket_addr = match url {
             NameServerUrl::Udp { addr, port }
@@ -462,6 +574,10 @@ impl Resolver {
                     )
                 }
             }
+        };
+        let client = match proxy {
+            Some(p) => client.with_proxy(p),
+            None => client,
         };
         Arc::new(client)
     }

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -313,9 +313,10 @@ impl Resolver {
     }
 
     /// Build a `Resolver` from `NameServerUrl` lists with no `#PROXY`
-    /// support. Equivalent to [`new_with_bootstrap_with_proxies`] with an
-    /// empty registry; convenient for tests and call sites that don't
-    /// need proxy-routed DNS.
+    /// support. Equivalent to
+    /// [`Resolver::new_with_bootstrap_with_proxies`] with an empty
+    /// registry; convenient for tests and call sites that don't need
+    /// proxy-routed DNS.
     #[allow(clippy::too_many_arguments)]
     pub async fn new_with_bootstrap(
         main_urls: Vec<NameServerUrl>,
@@ -527,7 +528,7 @@ impl Resolver {
         Self::build_single_resolver_with_proxy(url, resolved, None)
     }
 
-    /// Like [`build_single_resolver`] but also attaches an optional
+    /// Like [`Resolver::build_single_resolver`] but also attaches an optional
     /// proxy adapter so queries route via `proxy.dial_tcp` (issue #67
     /// phase 2). Pass `None` to get the unrouted client.
     pub fn build_single_resolver_with_proxy(

--- a/crates/mihomo-dns/src/upstream.rs
+++ b/crates/mihomo-dns/src/upstream.rs
@@ -60,6 +60,63 @@ impl fmt::Display for NameServerUrl {
     }
 }
 
+/// A nameserver entry — a [`NameServerUrl`] plus an optional `#PROXY` tag
+/// telling the resolver to tunnel queries through the named proxy.
+///
+/// See [ADR-0012](../../../../docs/adr/0012-dns-via-proxy.md) for the
+/// design (issue #67 phase 2). Only the plain `Udp` / `Tcp` URL forms
+/// accept a `#PROXY` fragment in this slice; `Tls` / `Https` already use
+/// `#` for SNI and need the `?proxy=NAME` query-string disambiguator
+/// from the ADR, which is left for a follow-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NameServerEntry {
+    pub url: NameServerUrl,
+    pub proxy: Option<String>,
+}
+
+impl NameServerEntry {
+    pub fn plain(url: NameServerUrl) -> Self {
+        Self { url, proxy: None }
+    }
+
+    /// Parse a nameserver string, returning the parsed `NameServerUrl` plus
+    /// the optional proxy name if a `#PROXY` fragment was present on a
+    /// plain (Udp/Tcp) entry.
+    pub fn parse(s: &str) -> Result<Self, NameServerParseError> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Err(NameServerParseError::EmptyInput);
+        }
+
+        // Only plain forms (no scheme, `udp://`, `tcp://`) treat the `#`
+        // fragment as a proxy name. For `tls://` / `https://` the
+        // fragment is SNI — leave it intact and let NameServerUrl::parse
+        // consume it normally.
+        let is_plain_form = !(s.starts_with("tls://") || s.starts_with("https://"));
+        if is_plain_form {
+            if let Some(idx) = s.find('#') {
+                let head = &s[..idx];
+                let proxy = s[idx + 1..].trim();
+                if proxy.is_empty() {
+                    return Err(NameServerParseError::InvalidHost(s.to_string()));
+                }
+                let url = NameServerUrl::parse(head)?;
+                return Ok(Self {
+                    url,
+                    proxy: Some(proxy.to_string()),
+                });
+            }
+        }
+        Ok(Self::plain(NameServerUrl::parse(s)?))
+    }
+}
+
+impl From<NameServerUrl> for NameServerEntry {
+    fn from(url: NameServerUrl) -> Self {
+        Self::plain(url)
+    }
+}
+
 impl NameServerUrl {
     /// Returns `Some(hostname)` if this entry needs bootstrap DNS resolution,
     /// `None` if the address is already an IP literal.
@@ -620,5 +677,59 @@ mod tests {
             msg.contains("encrypted"),
             "error message must mention the 'encrypted' feature, got: {msg}"
         );
+    }
+
+    // ─── #PROXY suffix parsing (issue #67 phase 2, ADR-0012) ──────────────
+
+    #[test]
+    fn entry_no_proxy_default() {
+        let e = NameServerEntry::parse("8.8.8.8").unwrap();
+        assert!(e.proxy.is_none());
+        assert_eq!(
+            e.url,
+            NameServerUrl::Udp {
+                addr: ip4(8, 8, 8, 8),
+                port: 53,
+            }
+        );
+    }
+
+    #[test]
+    fn entry_plain_udp_with_proxy_tag() {
+        let e = NameServerEntry::parse("1.1.1.1#PROXY-JP").unwrap();
+        assert_eq!(e.proxy.as_deref(), Some("PROXY-JP"));
+        assert_eq!(
+            e.url,
+            NameServerUrl::Udp {
+                addr: ip4(1, 1, 1, 1),
+                port: 53,
+            }
+        );
+    }
+
+    #[test]
+    fn entry_tcp_scheme_with_proxy_tag() {
+        let e = NameServerEntry::parse("tcp://1.1.1.1:53#PROXY-JP").unwrap();
+        assert_eq!(e.proxy.as_deref(), Some("PROXY-JP"));
+        assert!(matches!(e.url, NameServerUrl::Tcp { .. }));
+    }
+
+    #[test]
+    #[cfg(feature = "encrypted")]
+    fn entry_tls_fragment_is_sni_not_proxy() {
+        // For tls:// the `#` is SNI per the existing parser; the
+        // NameServerEntry layer must NOT steal that fragment as a proxy
+        // name. ADR-0012 reserves `?proxy=NAME` for TLS/HTTPS — not yet
+        // implemented, but the existing SNI semantics must keep working.
+        let e = NameServerEntry::parse("tls://1.1.1.1:853#dns.google").unwrap();
+        assert!(e.proxy.is_none());
+        assert!(matches!(e.url, NameServerUrl::Tls { .. }));
+    }
+
+    #[test]
+    fn entry_empty_proxy_tag_errors() {
+        // `1.1.1.1#` with nothing after the # is a typo, not "no proxy."
+        let err = NameServerEntry::parse("1.1.1.1#").unwrap_err();
+        assert!(matches!(err, NameServerParseError::InvalidHost(_)));
     }
 }

--- a/crates/mihomo-dns/tests/proxy_routed_dns.rs
+++ b/crates/mihomo-dns/tests/proxy_routed_dns.rs
@@ -1,0 +1,168 @@
+//! Integration test for DNS-via-proxy (issue #67 phase 2, ADR-0012).
+//!
+//! Sets up a tiny in-process TCP "DNS server" that speaks RFC-7766
+//! length-prefixed DNS over TCP and always answers `A example.com` →
+//! `203.0.113.7`. Then plugs a mock [`Proxy`] adapter in front of it
+//! and verifies that a `DnsClient::tcp(...).with_proxy(...)` query
+//! routes through the proxy (the proxy records the destination it was
+//! asked to dial; we assert it matches the configured DNS server).
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::rdata::A;
+use hickory_proto::rr::{Name, RData, Record, RecordType};
+use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
+use mihomo_common::{
+    AdapterType, DelayHistory, Metadata, Proxy, ProxyAdapter, ProxyConn, ProxyHealth,
+    ProxyPacketConn, Result as MihomoResult,
+};
+use mihomo_dns::client::DnsClient;
+use parking_lot::Mutex;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{timeout, Duration};
+
+const T: Duration = Duration::from_secs(5);
+
+/// Start a stub DNS-over-TCP server that always answers `A example.com.` →
+/// `203.0.113.7`. Returns the bound address.
+async fn start_dns_tcp_stub() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Ok((mut sock, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut len_buf = [0u8; 2];
+                if sock.read_exact(&mut len_buf).await.is_err() {
+                    return;
+                }
+                let len = u16::from_be_bytes(len_buf) as usize;
+                let mut req = vec![0u8; len];
+                if sock.read_exact(&mut req).await.is_err() {
+                    return;
+                }
+                let Ok(req_msg) = Message::from_bytes(&req) else {
+                    return;
+                };
+
+                let mut resp = Message::new(req_msg.id, MessageType::Response, OpCode::Query);
+                resp.metadata.response_code = ResponseCode::NoError;
+                resp.metadata.recursion_available = true;
+                for q in &req_msg.queries {
+                    resp.add_query(q.clone());
+                    if q.query_type == RecordType::A {
+                        let name: Name = "example.com.".parse().unwrap();
+                        let rec = Record::from_rdata(
+                            name,
+                            60,
+                            RData::A(A(Ipv4Addr::new(203, 0, 113, 7))),
+                        );
+                        resp.add_answer(rec);
+                    }
+                }
+
+                let wire = resp.to_bytes().unwrap();
+                let lenb = (wire.len() as u16).to_be_bytes();
+                if sock.write_all(&lenb).await.is_err() {
+                    return;
+                }
+                let _ = sock.write_all(&wire).await;
+            });
+        }
+    });
+    addr
+}
+
+/// Mock proxy adapter: records the destinations it was asked to dial,
+/// then opens a normal TCP connection to the recorded address so the
+/// caller (DnsClient) actually exchanges a real query. This proves the
+/// DNS exchange went through the proxy, not through the global socket
+/// factory.
+struct MockProxy {
+    name: String,
+    dialed: Arc<Mutex<Vec<SocketAddr>>>,
+}
+
+#[async_trait]
+impl ProxyAdapter for MockProxy {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn adapter_type(&self) -> AdapterType {
+        AdapterType::Direct
+    }
+    fn addr(&self) -> &str {
+        ""
+    }
+    fn support_udp(&self) -> bool {
+        false
+    }
+    async fn dial_tcp(&self, metadata: &Metadata) -> MihomoResult<Box<dyn ProxyConn>> {
+        let ip = metadata.dst_ip.unwrap();
+        let port = metadata.dst_port;
+        let sa = SocketAddr::new(ip, port);
+        self.dialed.lock().push(sa);
+        let stream = TcpStream::connect(sa).await.unwrap();
+        Ok(Box::new(stream))
+    }
+    async fn dial_udp(&self, _metadata: &Metadata) -> MihomoResult<Box<dyn ProxyPacketConn>> {
+        unimplemented!("test mock has no UDP")
+    }
+    fn health(&self) -> &ProxyHealth {
+        static H: std::sync::OnceLock<ProxyHealth> = std::sync::OnceLock::new();
+        H.get_or_init(ProxyHealth::new)
+    }
+}
+
+impl Proxy for MockProxy {
+    fn alive(&self) -> bool {
+        true
+    }
+    fn alive_for_url(&self, _url: &str) -> bool {
+        true
+    }
+    fn last_delay(&self) -> u16 {
+        0
+    }
+    fn last_delay_for_url(&self, _url: &str) -> u16 {
+        0
+    }
+    fn delay_history(&self) -> Vec<DelayHistory> {
+        Vec::new()
+    }
+}
+
+#[tokio::test]
+async fn dns_client_routes_tcp_query_through_proxy() {
+    let dns_addr = start_dns_tcp_stub().await;
+
+    let dialed = Arc::new(Mutex::new(Vec::<SocketAddr>::new()));
+    let proxy: Arc<dyn Proxy> = Arc::new(MockProxy {
+        name: "PROXY-A".to_string(),
+        dialed: Arc::clone(&dialed),
+    });
+
+    let client = DnsClient::tcp(dns_addr).with_proxy(proxy);
+    let msg = timeout(T, client.query("example.com", RecordType::A))
+        .await
+        .expect("must not stall")
+        .expect("query must succeed");
+
+    let mut got: Option<IpAddr> = None;
+    for ans in &msg.answers {
+        if let RData::A(a) = &ans.data {
+            got = Some(IpAddr::V4(a.0));
+        }
+    }
+    assert_eq!(got, Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7))));
+
+    let dialed_snap = dialed.lock().clone();
+    assert_eq!(
+        dialed_snap,
+        vec![dns_addr],
+        "proxy must have been the dialer for the DNS exchange"
+    );
+}

--- a/crates/mihomo-proxy/src/anytls_adapter.rs
+++ b/crates/mihomo-proxy/src/anytls_adapter.rs
@@ -1,6 +1,6 @@
 //! AnyTLS outbound (issue #75).
 //!
-//! Thin wrapper over the [`anytls-rs`] crate's `Client`. The protocol itself
+//! Thin wrapper over the `anytls-rs` crate's `Client`. The protocol itself
 //! — TLS handshake, password auth, session multiplexing, padding scheme —
 //! lives upstream; this file only translates between mihomo's `ProxyAdapter`
 //! trait and `anytls_rs`'s `Client::create_proxy_stream` / `Session` API.


### PR DESCRIPTION
## Summary
Closes #67 (phase 2 follow-up to PR #88 / ADR-0012). Plain UDP/TCP nameserver entries may now carry a \`#PROXY-NAME\` suffix that routes the DNS exchange through the named proxy adapter.

\`\`\`yaml
dns:
  nameserver:
    - "1.1.1.1#PROXY-JP"          # plain UDP, tunneled over PROXY-JP
    - "tcp://1.1.1.1:53#PROXY-JP"
\`\`\`

## Surfaces
- \`NameServerEntry { url, proxy }\` wrapper at the parser boundary so the 14 existing \`NameServerUrl\` match-arm sites keep working unchanged.
- \`DnsClient::with_proxy(Arc<dyn Proxy>)\` builder. When set, \`tcp_exchange\` routes via \`proxy.dial_tcp\`; UDP-with-proxy falls through to TCP-over-proxy (per ADR — most adapters can't relay arbitrary UDP).
- \`Resolver::new_with_bootstrap\` keeps its legacy \`Vec<NameServerUrl>\` signature for tests; production callers use the new \`new_with_bootstrap_with_proxies\` which takes a registry and validates every \`#PROXY\` reference (Class A per ADR-0002).

## Loop prevention (ADR-0012)
- \`default_nameserver\` entries are forbidden from carrying \`#PROXY\` — they're the bootstrap path that resolves proxy server hostnames.
- \`tls://\` / \`https://\` entries with \`#PROXY\` hard-error (\`EncryptedProxyUnsupported\`). The \`?proxy=NAME\` query-string disambiguator from the ADR is reserved for a follow-up PR.
- \`build_config\` now runs a two-pass build: proxies-without-resolver → DNS-with-registry → proxies-with-real-resolver. Only DIRECT's injected resolver differs between passes.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (default / no-default-features / all-features)
- [x] \`cargo test --workspace --all-features --lib\` — 503 passed (incl. 5 new \`NameServerEntry::parse\` tests in upstream.rs)
- [x] \`cargo test -p mihomo-dns --test proxy_routed_dns\` — new integration test: a mock \`Proxy\` adapter that records what it was asked to dial, plus an in-process DNS-over-TCP stub. Asserts (a) the DNS answer arrives and (b) the proxy was the dialer for the DNS server address.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)