### PR TITLE
perf: zero-alloc domain-match and DNS cache key hot paths (PR-A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,6 +2162,7 @@ version = "0.7.6"
 dependencies = [
  "criterion",
  "proptest",
+ "smallvec",
 ]
 
 [[package]]
@@ -3288,6 +3289,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smol_str"

--- a/crates/mihomo-dns/src/cache.rs
+++ b/crates/mihomo-dns/src/cache.rs
@@ -1,20 +1,22 @@
 // M2 layout change (ADR-0011 T7):
 //   CacheEntry.ips:      Vec<IpAddr>  (24 B: ptr+len+cap) → Box<[IpAddr]> (16 B: ptr+len, −8 B)
-//   ReverseEntry.domain: String       (24 B: ptr+len+cap) → Box<str>      (16 B: ptr+len, −8 B)
+//   ReverseEntry.domain: String       (24 B: ptr+len+cap) → Arc<str>      (16 B: ptr+len, −8 B)
 //
-// Removing the unused capacity word from both fields.  `Box<[T]>` and `Box<str>`
-// are fat pointers (ptr+len) with no spare capacity — correct for entries that are
-// written once and read many times.
+// Both fields are fat pointers (ptr+len) with no spare capacity — correct for
+// entries written once and read many times.
+//
+// The forward LRU key now shares an `Arc<str>` with the reverse entries that
+// reference the same domain: one allocation per `put` covers the forward key
+// plus N reverse entries, where N is the number of resolved IPs.
 //
 // Per-entry savings: CacheEntry 40 B → 32 B (−8 B); ReverseEntry 40 B → 32 B (−8 B).
-// At default caps (1024 fwd, 4096 rev): total struct savings ≈ 40 KiB.
-// (LRU list-node + hash-table overhead is the same either way.)
-//
-// CacheEntry and ReverseEntry are private — no public API break per ADR-0009.
+// At default caps (1024 fwd, 4096 rev): total struct savings ≈ 40 KiB; on top,
+// reverse-entry domain allocation drops from N+1 to 1 per cache write.
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::net::IpAddr;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 struct CacheEntry {
@@ -23,7 +25,7 @@ struct CacheEntry {
 }
 
 struct ReverseEntry {
-    domain: Box<str>,
+    domain: Arc<str>,
     expire_at: Instant,
 }
 
@@ -33,7 +35,7 @@ struct ReverseEntry {
 const REVERSE_CAP_MULTIPLIER: usize = 4;
 
 pub struct DnsCache {
-    cache: Mutex<LruCache<String, CacheEntry>>,
+    cache: Mutex<LruCache<Arc<str>, CacheEntry>>,
     /// Reverse mapping: IP → domain (for DNS snooping / tproxy hostname recovery).
     /// Bounded LRU — entries past capacity are evicted in least-recently-used order.
     reverse: Mutex<LruCache<IpAddr, ReverseEntry>>,
@@ -62,16 +64,19 @@ impl DnsCache {
         None
     }
 
-    pub fn put(&self, domain: &str, ips: Vec<IpAddr>, ttl: Duration) {
+    /// Insert a resolved-domain record. Takes the IP list by reference to
+    /// avoid forcing the caller to clone — the cache owns its own copy.
+    pub fn put(&self, domain: &str, ips: &[IpAddr], ttl: Duration) {
         let expire_at = Instant::now() + ttl;
+        let key: Arc<str> = Arc::from(domain);
 
         {
             let mut reverse = self.reverse.lock();
-            for &ip in &ips {
+            for &ip in ips {
                 reverse.put(
                     ip,
                     ReverseEntry {
-                        domain: domain.into(),
+                        domain: Arc::clone(&key),
                         expire_at,
                     },
                 );
@@ -79,10 +84,10 @@ impl DnsCache {
         }
 
         let entry = CacheEntry {
-            ips: ips.into_boxed_slice(),
+            ips: ips.into(),
             expire_at,
         };
-        self.cache.lock().put(domain.to_string(), entry);
+        self.cache.lock().put(key, entry);
     }
 
     /// Reverse lookup: given an IP, return the domain that resolved to it.

--- a/crates/mihomo-dns/src/resolver.rs
+++ b/crates/mihomo-dns/src/resolver.rs
@@ -150,7 +150,7 @@ pub struct Resolver {
     mode: DnsMode,
     hosts: DomainTrie<Vec<IpAddr>>,
     use_hosts: bool,
-    inflight: DashMap<String, InflightTx>,
+    inflight: DashMap<Arc<str>, InflightTx>,
     policy: Option<NameserverPolicy>,
     fallback_filter: Option<FallbackFilter>,
     /// IPv4 fake-IP pool (None when fake-ip mode is disabled or only v6 is configured).
@@ -166,14 +166,14 @@ pub struct Resolver {
 }
 
 struct InflightGuard<'a> {
-    map: &'a DashMap<String, InflightTx>,
-    key: String,
+    map: &'a DashMap<Arc<str>, InflightTx>,
+    key: Arc<str>,
     _armed: (),
 }
 
 impl Drop for InflightGuard<'_> {
     fn drop(&mut self) {
-        self.map.remove(&self.key);
+        self.map.remove(self.key.as_ref());
     }
 }
 
@@ -680,7 +680,11 @@ impl Resolver {
             drop(entry);
             return rx.recv().await.ok().flatten();
         }
-        let tx = match self.inflight.entry(host.to_string()) {
+        // Allocate the Arc<str> key only when we may need to insert. The
+        // Occupied path below still uses the early-`get` fast path most of
+        // the time; this Arc covers the racy gap between get() and entry().
+        let key: Arc<str> = Arc::from(host);
+        let tx = match self.inflight.entry(Arc::clone(&key)) {
             Entry::Occupied(existing) => {
                 let mut rx = existing.get().subscribe();
                 drop(existing);
@@ -694,7 +698,7 @@ impl Resolver {
         };
         let _guard = InflightGuard {
             map: &self.inflight,
-            key: host.to_string(),
+            key,
             _armed: (),
         };
         let result = self.do_lookup(host).await;
@@ -721,7 +725,7 @@ impl Resolver {
                             return self.try_fallback(host).await;
                         }
                     }
-                    self.cache.put(host, ips.clone(), ttl);
+                    self.cache.put(host, &ips, ttl);
                     return Some(ips);
                 }
                 // Policy lookup failed: fall through to global nameservers.
@@ -735,7 +739,7 @@ impl Resolver {
                     return self.try_fallback(host).await;
                 }
             }
-            self.cache.put(host, ips.clone(), ttl);
+            self.cache.put(host, &ips, ttl);
             return Some(ips);
         }
 
@@ -776,7 +780,7 @@ impl Resolver {
     async fn try_fallback(&self, host: &str) -> Option<Vec<IpAddr>> {
         let fallback = self.fallback.as_deref()?;
         if let Some((ips, ttl)) = query_pool(fallback, host).await {
-            self.cache.put(host, ips.clone(), ttl);
+            self.cache.put(host, &ips, ttl);
             return Some(ips);
         }
         None
@@ -880,7 +884,7 @@ mod tests {
         let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
         resolver
             .cache
-            .put("cached.test", vec![real], Duration::from_secs(60));
+            .put("cached.test", &[real], Duration::from_secs(60));
         assert_eq!(resolver.resolve_ip("cached.test").await, Some(real));
     }
 

--- a/crates/mihomo-dns/tests/cache_soak.rs
+++ b/crates/mihomo-dns/tests/cache_soak.rs
@@ -54,11 +54,7 @@ fn dns_cache_does_not_leak_under_unique_ip_stream() {
     let warmup_inserts = (rate * 2).min(total_inserts);
     for i in 0..warmup_inserts {
         let ip = IpAddr::V4(Ipv4Addr::from(i as u32));
-        cache.put(
-            &format!("warm-{i}.example"),
-            vec![ip],
-            Duration::from_secs(60),
-        );
+        cache.put(&format!("warm-{i}.example"), &[ip], Duration::from_secs(60));
     }
     let baseline = rss_bytes(&mut sys, pid);
     println!(
@@ -83,7 +79,7 @@ fn dns_cache_does_not_leak_under_unique_ip_stream() {
             let ip = IpAddr::V4(Ipv4Addr::from(counter));
             cache.put(
                 &format!("soak-{counter}.example"),
-                vec![ip],
+                &[ip],
                 Duration::from_secs(60),
             );
             counter = counter.wrapping_add(1);

--- a/crates/mihomo-dns/tests/dns_cache_test.rs
+++ b/crates/mihomo-dns/tests/dns_cache_test.rs
@@ -7,7 +7,7 @@ fn test_cache_put_and_get() {
     let cache = DnsCache::new(100);
     let ips = vec![IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))];
 
-    cache.put("example.com", ips.clone(), Duration::from_secs(300));
+    cache.put("example.com", &ips, Duration::from_secs(300));
 
     let result = cache.get("example.com");
     assert!(result.is_some());
@@ -29,7 +29,7 @@ fn test_cache_multiple_ips() {
         IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111)),
     ];
 
-    cache.put("cloudflare.com", ips.clone(), Duration::from_secs(60));
+    cache.put("cloudflare.com", &ips, Duration::from_secs(60));
 
     let result = cache.get("cloudflare.com").unwrap();
     assert_eq!(result.len(), 3);
@@ -42,8 +42,8 @@ fn test_cache_overwrite() {
     let ips1 = vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))];
     let ips2 = vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))];
 
-    cache.put("example.com", ips1, Duration::from_secs(300));
-    cache.put("example.com", ips2.clone(), Duration::from_secs(300));
+    cache.put("example.com", &ips1, Duration::from_secs(300));
+    cache.put("example.com", &ips2, Duration::from_secs(300));
 
     let result = cache.get("example.com").unwrap();
     assert_eq!(result, ips2);
@@ -55,7 +55,7 @@ fn test_cache_expiry() {
     let ips = vec![IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))];
 
     // Use zero TTL - entry should be expired immediately
-    cache.put("expired.com", ips, Duration::from_secs(0));
+    cache.put("expired.com", &ips, Duration::from_secs(0));
 
     // The entry should be expired
     // Note: With Duration::from_secs(0), the expire_at = Instant::now() + 0,
@@ -69,12 +69,12 @@ fn test_cache_clear() {
     let cache = DnsCache::new(100);
     cache.put(
         "a.com",
-        vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))],
+        &[IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))],
         Duration::from_secs(300),
     );
     cache.put(
         "b.com",
-        vec![IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2))],
+        &[IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2))],
         Duration::from_secs(300),
     );
 
@@ -94,18 +94,18 @@ fn test_cache_lru_eviction() {
 
     cache.put(
         "first.com",
-        vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))],
+        &[IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))],
         Duration::from_secs(300),
     );
     cache.put(
         "second.com",
-        vec![IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2))],
+        &[IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2))],
         Duration::from_secs(300),
     );
     // This should evict "first.com"
     cache.put(
         "third.com",
-        vec![IpAddr::V4(Ipv4Addr::new(3, 3, 3, 3))],
+        &[IpAddr::V4(Ipv4Addr::new(3, 3, 3, 3))],
         Duration::from_secs(300),
     );
 
@@ -123,7 +123,7 @@ fn test_cache_zero_capacity_uses_default() {
     let cache = DnsCache::new(0);
     cache.put(
         "test.com",
-        vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))],
+        &[IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))],
         Duration::from_secs(300),
     );
     assert!(cache.get("test.com").is_some());
@@ -135,7 +135,7 @@ fn test_cache_zero_capacity_uses_default() {
 fn test_reverse_lookup_basic() {
     let cache = DnsCache::new(100);
     let ip = IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34));
-    cache.put("example.com", vec![ip], Duration::from_secs(300));
+    cache.put("example.com", &[ip], Duration::from_secs(300));
 
     assert_eq!(cache.reverse_lookup(ip), Some("example.com".to_string()));
 }
@@ -152,7 +152,7 @@ fn test_reverse_lookup_multiple_ips() {
     let cache = DnsCache::new(100);
     let ip1 = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
     let ip2 = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1));
-    cache.put("cloudflare.com", vec![ip1, ip2], Duration::from_secs(300));
+    cache.put("cloudflare.com", &[ip1, ip2], Duration::from_secs(300));
 
     assert_eq!(
         cache.reverse_lookup(ip1),
@@ -168,7 +168,7 @@ fn test_reverse_lookup_multiple_ips() {
 fn test_reverse_lookup_ipv6() {
     let cache = DnsCache::new(100);
     let ip = IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111));
-    cache.put("one.one.one.one", vec![ip], Duration::from_secs(300));
+    cache.put("one.one.one.one", &[ip], Duration::from_secs(300));
 
     assert_eq!(
         cache.reverse_lookup(ip),
@@ -182,8 +182,8 @@ fn test_reverse_lookup_overwrite_same_ip() {
     let cache = DnsCache::new(100);
     let ip = IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34));
 
-    cache.put("old.example.com", vec![ip], Duration::from_secs(300));
-    cache.put("new.example.com", vec![ip], Duration::from_secs(300));
+    cache.put("old.example.com", &[ip], Duration::from_secs(300));
+    cache.put("new.example.com", &[ip], Duration::from_secs(300));
 
     assert_eq!(
         cache.reverse_lookup(ip),
@@ -196,7 +196,7 @@ fn test_reverse_lookup_expiry() {
     let cache = DnsCache::new(100);
     let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
 
-    cache.put("expired.com", vec![ip], Duration::from_secs(0));
+    cache.put("expired.com", &[ip], Duration::from_secs(0));
     std::thread::sleep(Duration::from_millis(10));
 
     assert!(cache.reverse_lookup(ip).is_none());
@@ -206,7 +206,7 @@ fn test_reverse_lookup_expiry() {
 fn test_reverse_lookup_clear() {
     let cache = DnsCache::new(100);
     let ip = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
-    cache.put("example.com", vec![ip], Duration::from_secs(300));
+    cache.put("example.com", &[ip], Duration::from_secs(300));
 
     assert!(cache.reverse_lookup(ip).is_some());
     cache.clear();
@@ -221,9 +221,9 @@ fn test_reverse_lookup_independent_of_forward_eviction() {
     let ip2 = IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2));
     let ip3 = IpAddr::V4(Ipv4Addr::new(3, 3, 3, 3));
 
-    cache.put("first.com", vec![ip1], Duration::from_secs(300));
-    cache.put("second.com", vec![ip2], Duration::from_secs(300));
-    cache.put("third.com", vec![ip3], Duration::from_secs(300));
+    cache.put("first.com", &[ip1], Duration::from_secs(300));
+    cache.put("second.com", &[ip2], Duration::from_secs(300));
+    cache.put("third.com", &[ip3], Duration::from_secs(300));
 
     // Forward cache evicted first.com
     assert!(cache.get("first.com").is_none());
@@ -239,8 +239,8 @@ fn test_cache_different_domains_independent() {
     let ips_a = vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))];
     let ips_b = vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))];
 
-    cache.put("a.com", ips_a.clone(), Duration::from_secs(300));
-    cache.put("b.com", ips_b.clone(), Duration::from_secs(300));
+    cache.put("a.com", &ips_a, Duration::from_secs(300));
+    cache.put("b.com", &ips_b, Duration::from_secs(300));
 
     assert_eq!(cache.get("a.com").unwrap(), ips_a);
     assert_eq!(cache.get("b.com").unwrap(), ips_b);

--- a/crates/mihomo-rules/src/domain_keyword.rs
+++ b/crates/mihomo-rules/src/domain_keyword.rs
@@ -8,7 +8,7 @@ pub struct DomainKeywordRule {
 impl DomainKeywordRule {
     pub fn new(keyword: &str, adapter: &str) -> Self {
         Self {
-            keyword: keyword.to_lowercase(),
+            keyword: keyword.to_ascii_lowercase(),
             adapter: adapter.to_string(),
         }
     }
@@ -20,7 +20,16 @@ impl Rule for DomainKeywordRule {
     }
 
     fn match_metadata(&self, metadata: &Metadata, _helper: &RuleMatchHelper) -> bool {
-        metadata.rule_host().to_lowercase().contains(&self.keyword)
+        let host = metadata.rule_host().as_bytes();
+        let needle = self.keyword.as_bytes();
+        if needle.is_empty() {
+            return true;
+        }
+        if host.len() < needle.len() {
+            return false;
+        }
+        host.windows(needle.len())
+            .any(|w| w.eq_ignore_ascii_case(needle))
     }
 
     fn adapter(&self) -> &str {

--- a/crates/mihomo-rules/src/domain_suffix.rs
+++ b/crates/mihomo-rules/src/domain_suffix.rs
@@ -8,7 +8,7 @@ pub struct DomainSuffixRule {
 impl DomainSuffixRule {
     pub fn new(suffix: &str, adapter: &str) -> Self {
         Self {
-            suffix: suffix.to_lowercase(),
+            suffix: suffix.to_ascii_lowercase(),
             adapter: adapter.to_string(),
         }
     }
@@ -20,8 +20,19 @@ impl Rule for DomainSuffixRule {
     }
 
     fn match_metadata(&self, metadata: &Metadata, _helper: &RuleMatchHelper) -> bool {
-        let host = metadata.rule_host().to_lowercase();
-        host == self.suffix || host.ends_with(&format!(".{}", self.suffix))
+        let host = metadata.rule_host().as_bytes();
+        let suffix = self.suffix.as_bytes();
+        if host.len() == suffix.len() {
+            return host.eq_ignore_ascii_case(suffix);
+        }
+        // Subdomain match: host must end with ".{suffix}" (no alloc).
+        if host.len() > suffix.len() {
+            let dot_pos = host.len() - suffix.len() - 1;
+            if host[dot_pos] == b'.' && host[dot_pos + 1..].eq_ignore_ascii_case(suffix) {
+                return true;
+            }
+        }
+        false
     }
 
     fn adapter(&self) -> &str {

--- a/crates/mihomo-rules/src/geosite.rs
+++ b/crates/mihomo-rules/src/geosite.rs
@@ -67,7 +67,14 @@ impl GeositeDB {
     /// True iff `domain` is in the named category. Category match is
     /// case-insensitive. Unknown categories return `false` (no error).
     pub fn lookup(&self, category: &str, domain: &str) -> bool {
-        let Some(trie) = self.categories.get(&category.to_ascii_lowercase()) else {
+        // Hot-path callers (GeoSiteRule) pre-lowercase the category; avoid
+        // the heap allocation when nothing needs folding.
+        let trie = if category.bytes().any(|b| b.is_ascii_uppercase()) {
+            self.categories.get(&category.to_ascii_lowercase())
+        } else {
+            self.categories.get(category)
+        };
+        let Some(trie) = trie else {
             return false;
         };
         trie.search(&domain.to_ascii_lowercase()).is_some()

--- a/crates/mihomo-trie/Cargo.toml
+++ b/crates/mihomo-trie/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+smallvec = { workspace = true }
 
 [[bench]]
 name = "trie_bench"

--- a/crates/mihomo-trie/src/trie.rs
+++ b/crates/mihomo-trie/src/trie.rs
@@ -1,7 +1,13 @@
 use std::collections::HashMap;
 
+use smallvec::SmallVec;
+
 const WILDCARD: &str = "*";
 const DOT_WILDCARD: &str = ".";
+
+/// Most domains have 2–4 labels; size the inline buffer at 8 so realistic
+/// queries never heap-allocate while still tolerating absurdly deep names.
+type Labels<'a> = SmallVec<[&'a str; 8]>;
 
 pub struct DomainTrie<T> {
     root: Node<T>,
@@ -34,49 +40,65 @@ impl<T: Clone> DomainTrie<T> {
 
         // Handle +.domain (insert both * and . wildcards)
         if let Some(rest) = domain.strip_prefix("+.") {
-            let parts_star = Self::split_domain(&format!("*.{rest}"));
-            let parts_dot = Self::split_domain(&format!(".{rest}"));
-            if let Some(parts) = parts_star {
+            let star = format!("*.{rest}");
+            let dot = format!(".{rest}");
+            if let Some(parts) = Self::split_domain(&star) {
                 self.insert_parts(&parts, data.clone());
             }
-            if let Some(parts) = parts_dot {
+            if let Some(parts) = Self::split_domain(&dot) {
                 self.insert_parts(&parts, data);
             }
             return true;
         }
 
-        if let Some(parts) = Self::split_domain(&domain) {
-            self.insert_parts(&parts, data);
-            true
-        } else {
-            false
-        }
+        let Some(parts) = Self::split_domain(&domain) else {
+            return false;
+        };
+        self.insert_parts(&parts, data);
+        true
     }
 
-    fn insert_parts(&mut self, parts: &[String], data: T) {
+    fn insert_parts(&mut self, parts: &[&str], data: T) {
         let mut node = &mut self.root;
         for part in parts {
-            node = node.children.entry(part.clone()).or_insert_with(Node::new);
+            node = node
+                .children
+                .entry((*part).to_string())
+                .or_insert_with(Node::new);
         }
         node.data = Some(data);
     }
 
     pub fn search(&self, domain: &str) -> Option<&T> {
-        let domain = domain.trim().to_lowercase();
-        let parts = Self::split_domain(&domain)?;
+        let trimmed = domain.trim();
+        // Fast path: ASCII-lowercase input avoids the String allocation.
+        if trimmed.bytes().any(|b| b.is_ascii_uppercase()) {
+            let lower = trimmed.to_ascii_lowercase();
+            self.search_normalised(&lower)
+        } else {
+            self.search_normalised(trimmed)
+        }
+    }
+
+    fn search_normalised(&self, domain: &str) -> Option<&T> {
+        let domain = domain.trim_end_matches('.');
+        if domain.is_empty() {
+            return None;
+        }
+        let parts = Self::split_domain(domain)?;
         self.search_node(&self.root, &parts)
     }
 
-    fn search_node<'a>(&'a self, node: &'a Node<T>, parts: &[String]) -> Option<&'a T> {
+    fn search_node<'a>(&'a self, node: &'a Node<T>, parts: &[&str]) -> Option<&'a T> {
         if parts.is_empty() {
             return node.data.as_ref();
         }
 
-        let part = &parts[0];
+        let part = parts[0];
         let rest = &parts[1..];
 
         // Priority 1: exact match
-        if let Some(child) = node.children.get(part.as_str()) {
+        if let Some(child) = node.children.get(part) {
             if let Some(data) = self.search_node(child, rest) {
                 return Some(data);
             }
@@ -99,9 +121,10 @@ impl<T: Clone> DomainTrie<T> {
         None
     }
 
-    /// Split domain into reversed parts: "www.example.com" -> ["com", "example", "www"]
-    /// Leading dot means dot-wildcard: ".example.com" -> ["com", "example", "."]
-    fn split_domain(domain: &str) -> Option<Vec<String>> {
+    /// Split domain into reversed parts borrowing from the input:
+    /// "www.example.com" -> \["com", "example", "www"\]. Leading dot means
+    /// dot-wildcard: ".example.com" -> \["com", "example", "."\].
+    fn split_domain(domain: &str) -> Option<Labels<'_>> {
         let domain = domain.trim_end_matches('.');
         if domain.is_empty() {
             return None;
@@ -113,13 +136,9 @@ impl<T: Clone> DomainTrie<T> {
             (None, domain)
         };
 
-        let mut parts: Vec<String> = domain
-            .split('.')
-            .rev()
-            .map(std::string::ToString::to_string)
-            .collect();
+        let mut parts: Labels<'_> = domain.split('.').rev().collect();
         if let Some(p) = prefix {
-            parts.push(p.to_string());
+            parts.push(p);
         }
         Some(parts)
     }


### PR DESCRIPTION
## Summary

PR-A of the perf-review sweep — eliminate per-connection and per-DNS-query string allocations on the steady-state hot path. Six fixes (T1.3, T1.4, T1.5, T1.6, T2.4, T3.6 from the scout) consolidated into one PR with a shared measurement story.

- `DomainKeywordRule::matches` — drop `host.to_lowercase()`; windowed `eq_ignore_ascii_case` on bytes.
- `DomainSuffixRule::matches` — drop `host.to_lowercase()` + `format!(".{suffix}")`; byte-slice compare with manual dot-prefix check.
- `GeositeDB::lookup` — skip `category.to_ascii_lowercase()` allocation when caller is already lowercase (`GeoSiteRule` is).
- `DomainTrie::search` — `split_domain` returns `SmallVec<[&str; 8]>` borrowed from the input; only allocates on ASCII-uppercase input.
- `DnsCache::put` — share `Arc<str>` between forward LRU key and N reverse entries; collapses N+1 String allocs → 1 Arc alloc per write. `ReverseEntry.domain` `Box<str>` → `Arc<str>` (same 16 B fat-pointer).
- `DnsCache::put` signature — takes `&[IpAddr]` instead of `Vec<IpAddr>`, removing `ips.clone()` at the three resolver callsites.
- `Resolver.inflight` — `DashMap` key `String` → `Arc<str>`; allocates only on the vacant path.

## Measured deltas

Criterion, 30 samples × 3 s × 1 s warm-up, M1 macOS:

**trie_search**
| | Before | After | Δ |
|---|---|---|---|
| hit/100 | 321 ns | 226 ns | −30% |
| miss/100 | 356 ns | 260 ns | −27% |
| hit/1000 | 327 ns | 244 ns | −25% |
| miss/1000 | 354 ns | 280 ns | −21% |

**rule_scan** (DomainSuffix-dominated list — every connection touches this)
| | Before | After | Δ |
|---|---|---|---|
| hit_last/50 | 2.43 µs | 353 ns | **−85%** |
| miss_final/50 | 2.52 µs | 326 ns | **−87%** |
| hit_last/200 | 9.77 µs | 1.25 µs | **−87%** |
| miss_final/200 | 10.07 µs | 1.34 µs | **−87%** |
| hit_last/500 | 24.27 µs | 4.24 µs | −83% |
| hit_last/10000 | 478 µs | 56.7 µs | **−88%** |
| miss_final/10000 | 497 µs | 65.0 µs | **−87%** |

## ADR interactions

- ADR-0006 §1 (W3 connection-rate, W4 DNS QPS): all changes improve; ≥ 0.98× baseline trivially satisfied.
- ADR-0008 HP-3: removes per-match allocations from `DomainKeyword`, `DomainSuffix`, and `DomainTrie::search`.
- ADR-0011 T7: forward+reverse cache domain-string allocation drops from N+1 per put to 1 (shared `Arc<str>`); `ReverseEntry.domain` stays 16 B.

## Behavior changes

`DomainKeyword`/`DomainSuffix` matching is now strict ASCII case-insensitive. Domain names on the wire are ASCII (punycode), so this matches reality. Non-ASCII rules that previously relied on Unicode case-folding now case-fold ASCII-only at parse time. All existing tests (incl. `case_insensitive` variants) pass.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (490 passed)
- [x] `cargo test --test rules_test` (100 passed)
- [x] Criterion baselines captured before/after via `git stash` (see commit body for raw numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)