### PR TITLE
perf: connection-setup hygiene — listener leak, syscall, alloc fixes (PR-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/mihomo-api/Cargo.toml
+++ b/crates/mihomo-api/Cargo.toml
@@ -25,6 +25,7 @@ futures = { workspace = true }
 parking_lot = { workspace = true }
 subtle = "2"
 sysinfo = "0.32"
+uuid = { workspace = true }
 time = { workspace = true }
 base64 = "0.22"
 prometheus-client = "0.22"

--- a/crates/mihomo-api/src/routes.rs
+++ b/crates/mihomo-api/src/routes.rs
@@ -393,8 +393,13 @@ async fn close_connection(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> StatusCode {
-    state.tunnel.statistics().close_connection(&id);
-    StatusCode::NO_CONTENT
+    match uuid::Uuid::parse_str(&id) {
+        Ok(uuid) => {
+            state.tunnel.statistics().close_connection(uuid);
+            StatusCode::NO_CONTENT
+        }
+        Err(_) => StatusCode::BAD_REQUEST,
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/mihomo-api/tests/api_test.rs
+++ b/crates/mihomo-api/tests/api_test.rs
@@ -2255,7 +2255,7 @@ async fn delete_connection_by_id_returns_204_and_removes_entry() {
     let json = body_json(resp).await;
     let conns = json["connections"].as_array().unwrap();
     assert_eq!(conns.len(), 1);
-    assert_eq!(conns[0]["id"], conn_id);
+    assert_eq!(conns[0]["id"], conn_id.to_string());
 
     // DELETE the specific connection.
     let app = create_router(Arc::clone(&state));

--- a/crates/mihomo-listener/src/http_proxy.rs
+++ b/crates/mihomo-listener/src/http_proxy.rs
@@ -1,7 +1,7 @@
 use crate::sniffer::SnifferRuntime;
 use base64::Engine;
 use mihomo_common::{AuthConfig, ConnType, Metadata, Network};
-use mihomo_tunnel::{copy_bidirectional_buf, Tunnel, RELAY_BUF_SIZE};
+use mihomo_tunnel::{copy_bidirectional_buf, ConnectionGuard, Tunnel, RELAY_BUF_SIZE};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -46,32 +46,35 @@ async fn handle_http_inner(
     let mut relay_buf_up = [0u8; RELAY_BUF_SIZE];
     let mut relay_buf_dn = [0u8; RELAY_BUF_SIZE];
 
-    // Read the HTTP request line and headers byte by byte until we find \r\n\r\n.
-    // We avoid BufReader to prevent borrow issues with the stream.
+    // Read the HTTP request line and headers in chunks until we find
+    // \r\n\r\n. Reading one byte at a time costs ~100 syscalls per CONNECT;
+    // chunked reads cap the syscall count at ceil(headers / 1024).
+    //
+    // Bytes that arrive past the marker (e.g. POST body in a single TCP
+    // segment) are sliced off into `leftover` so the relay path can re-emit
+    // them after sending the rewritten request line.
+    const CHUNK: usize = 1024;
+    const MAX_HEADERS: usize = 8192;
     let mut request_buf = Vec::with_capacity(4096);
-    let mut headers_done = false;
-
-    while !headers_done {
-        let mut byte = [0u8; 1];
-        let n = stream.read(&mut byte).await?;
+    let mut chunk = [0u8; CHUNK];
+    let header_end = loop {
+        let n = stream.read(&mut chunk).await?;
         if n == 0 {
             return Err("connection closed before headers complete".into());
         }
-        request_buf.push(byte[0]);
-
-        // Check for \r\n\r\n at the end
-        if request_buf.len() >= 4 {
-            let len = request_buf.len();
-            if request_buf[len - 4..] == [b'\r', b'\n', b'\r', b'\n'] {
-                headers_done = true;
-            }
+        // Overlap the previous tail by 3 bytes so a marker straddling two
+        // reads (e.g. "\r\n\r" then "\n…") is still detected.
+        let search_start = request_buf.len().saturating_sub(3);
+        request_buf.extend_from_slice(&chunk[..n]);
+        if let Some(rel) = find_crlf_crlf(&request_buf[search_start..]) {
+            break search_start + rel + 4;
         }
-
-        // Safety limit
-        if request_buf.len() > 8192 {
+        if request_buf.len() > MAX_HEADERS {
             return Err("request headers too large".into());
         }
-    }
+    };
+    let leftover: Vec<u8> = request_buf[header_end..].to_vec();
+    request_buf.truncate(header_end);
 
     // Auth check: verify Proxy-Authorization before dispatching.
     let needs_auth = auth.is_some_and(|a| !a.credentials.is_empty())
@@ -168,7 +171,8 @@ async fn handle_http_inner(
             proxy.name()
         );
 
-        let conn_id = inner.stats.track_connection(
+        let _guard = ConnectionGuard::track(
+            &inner.stats,
             metadata.pure(),
             &rule_name,
             &rule_payload,
@@ -177,6 +181,13 @@ async fn handle_http_inner(
 
         match proxy.dial_tcp(&metadata).await {
             Ok(mut remote) => {
+                // Per RFC 7230 the client must wait for 200 OK before sending
+                // application data, but if a client pipelined bytes ahead of
+                // that we already read them — forward before relaying.
+                if !leftover.is_empty() {
+                    remote.write_all(&leftover).await?;
+                    inner.stats.add_upload(leftover.len() as i64);
+                }
                 match copy_bidirectional_buf(
                     stream,
                     &mut remote,
@@ -194,8 +205,7 @@ async fn handle_http_inner(
             }
             Err(e) => warn!("HTTP CONNECT dial error: {}", e),
         }
-
-        inner.stats.close_connection(&conn_id);
+        // _guard drops here, removing the entry from Statistics.
     } else {
         // Plain HTTP proxy (GET/POST/etc via proxy)
         let url = target;
@@ -241,7 +251,8 @@ async fn handle_http_inner(
             proxy.name()
         );
 
-        let conn_id = inner.stats.track_connection(
+        let _guard = ConnectionGuard::track(
+            &inner.stats,
             metadata.pure(),
             &rule_name,
             &rule_payload,
@@ -270,8 +281,14 @@ async fn handle_http_inner(
                 }
                 rewritten.push_str("\r\n");
 
-                // Send the rewritten request to remote
+                // Send the rewritten request to remote, then any body bytes
+                // that arrived in the same TCP segment as the headers (POST
+                // payloads typically do).
                 remote.write_all(rewritten.as_bytes()).await?;
+                if !leftover.is_empty() {
+                    remote.write_all(&leftover).await?;
+                    inner.stats.add_upload(leftover.len() as i64);
+                }
 
                 // Relay bidirectionally
                 match copy_bidirectional_buf(
@@ -296,11 +313,18 @@ async fn handle_http_inner(
                     .await?;
             }
         }
-
-        inner.stats.close_connection(&conn_id);
+        // _guard drops here, removing the entry from Statistics.
     }
 
     Ok(())
+}
+
+/// Locate `b"\r\n\r\n"` in `buf` and return the index of the first `\r`.
+fn find_crlf_crlf(buf: &[u8]) -> Option<usize> {
+    if buf.len() < 4 {
+        return None;
+    }
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
 }
 
 fn parse_host_port(target: &str, default_port: u16) -> (String, u16) {

--- a/crates/mihomo-listener/src/socks5.rs
+++ b/crates/mihomo-listener/src/socks5.rs
@@ -1,6 +1,6 @@
 use crate::sniffer::SnifferRuntime;
 use mihomo_common::{AuthConfig, ConnType, Metadata, Network};
-use mihomo_tunnel::{copy_bidirectional_buf, Tunnel, RELAY_BUF_SIZE};
+use mihomo_tunnel::{copy_bidirectional_buf, ConnectionGuard, Tunnel, RELAY_BUF_SIZE};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -176,7 +176,11 @@ async fn handle_socks5_inner(
         proxy.name()
     );
 
-    let conn_id = inner.stats.track_connection(
+    // RAII-tracked so the entry is removed from `Statistics.connections` even
+    // if the relay future is cancelled (listener shutdown, iOS idle sweeper,
+    // panic-unwind).
+    let _guard = ConnectionGuard::track(
+        &inner.stats,
         metadata.pure(),
         &rule_name,
         &rule_payload,
@@ -202,7 +206,6 @@ async fn handle_socks5_inner(
         Err(e) => warn!("SOCKS5 dial error: {}", e),
     }
 
-    inner.stats.close_connection(&conn_id);
     Ok(())
 }
 

--- a/crates/mihomo-listener/src/tproxy/mod.rs
+++ b/crates/mihomo-listener/src/tproxy/mod.rs
@@ -4,7 +4,7 @@ mod orig_dest;
 use crate::sniffer::SnifferRuntime;
 use firewall::FirewallGuard;
 use mihomo_common::{ConnType, Metadata, Network};
-use mihomo_tunnel::{copy_bidirectional_buf, Tunnel, RELAY_BUF_SIZE};
+use mihomo_tunnel::{copy_bidirectional_buf, ConnectionGuard, Tunnel, RELAY_BUF_SIZE};
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
@@ -204,7 +204,8 @@ async fn handle_tproxy_conn(
         proxy.name()
     );
 
-    let conn_id = inner.stats.track_connection(
+    let _guard = ConnectionGuard::track(
+        &inner.stats,
         metadata.pure(),
         &rule_name,
         &rule_payload,
@@ -234,7 +235,6 @@ async fn handle_tproxy_conn(
         }
         Err(e) => warn!("TProxy dial error: {e}"),
     }
-
-    inner.stats.close_connection(&conn_id);
+    // _guard drops here, removing the entry from Statistics.
     Ok(())
 }

--- a/crates/mihomo-proxy/src/health.rs
+++ b/crates/mihomo-proxy/src/health.rs
@@ -174,20 +174,28 @@ where
 }
 
 fn tls_connector() -> tokio_rustls::TlsConnector {
-    let root_store = rustls::RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    };
-    // Be explicit about the provider: when `ech-tls-tunnel` (or any other
-    // feature that pulls aws-lc-rs) is on, rustls' `builder()` would panic
-    // because two providers are compiled in.
-    let config = rustls::ClientConfig::builder_with_provider(Arc::new(
-        rustls::crypto::ring::default_provider(),
-    ))
-    .with_safe_default_protocol_versions()
-    .expect("rustls protocol versions are safe defaults")
-    .with_root_certificates(root_store)
-    .with_no_client_auth();
-    tokio_rustls::TlsConnector::from(Arc::new(config))
+    // Lazy singleton: one TlsConnector + ClientConfig + root-store clone for
+    // the whole process. URLTest probe cycles previously rebuilt this on every
+    // HTTPS probe, cloning webpki_roots::TLS_SERVER_ROOTS per call.
+    static CONNECTOR: std::sync::OnceLock<tokio_rustls::TlsConnector> = std::sync::OnceLock::new();
+    CONNECTOR
+        .get_or_init(|| {
+            let root_store = rustls::RootCertStore {
+                roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+            };
+            // Be explicit about the provider: when `ech-tls-tunnel` (or any other
+            // feature that pulls aws-lc-rs) is on, rustls' `builder()` would panic
+            // because two providers are compiled in.
+            let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+                rustls::crypto::ring::default_provider(),
+            ))
+            .with_safe_default_protocol_versions()
+            .expect("rustls protocol versions are safe defaults")
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+            tokio_rustls::TlsConnector::from(Arc::new(config))
+        })
+        .clone()
 }
 
 #[derive(Debug, Clone)]

--- a/crates/mihomo-proxy/src/trojan.rs
+++ b/crates/mihomo-proxy/src/trojan.rs
@@ -87,7 +87,8 @@ impl TrojanAdapter {
     }
 
     fn build_header(&self, metadata: &Metadata, cmd: u8) -> Vec<u8> {
-        let mut buf = Vec::new();
+        // Worst case: 56 (hex password) + 2 (CRLF) + 1 (cmd) + 1+255 (FQDN) + 2 (port) + 2 (CRLF) = 319 B.
+        let mut buf = Vec::with_capacity(320);
         // hex password + CRLF
         buf.extend_from_slice(self.hex_password.as_bytes());
         buf.extend_from_slice(b"\r\n");

--- a/crates/mihomo-transport/src/ws.rs
+++ b/crates/mihomo-transport/src/ws.rs
@@ -479,6 +479,14 @@ impl AsyncWrite for WsStream {
                         }
                         Poll::Pending => return Poll::Pending,
                     }
+                    // ADR-0008 HP-3: this `buf.to_vec()` allocates one
+                    // Vec<u8> per WS-relayed chunk and is the largest per-byte
+                    // allocation in the transport stack. tokio-tungstenite 0.24
+                    // requires `Message::Binary(Vec<u8>)`; 0.26+ accepts
+                    // `Bytes` and would let this be a refcount bump on a
+                    // shared `Bytes` buf. Tracked separately — upgrading the
+                    // tungstenite version is out of scope here because the
+                    // call/handshake API changed.
                     if let Err(e) =
                         Pin::new(&mut state.ws).start_send(Message::Binary(buf.to_vec()))
                     {

--- a/crates/mihomo-tunnel/benches/rules_bench.rs
+++ b/crates/mihomo-tunnel/benches/rules_bench.rs
@@ -80,11 +80,7 @@ fn bench_rules(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("after_indexed", n), &n, |b, _| {
             b.iter(|| {
-                black_box(match_rules(
-                    black_box(&meta_hit),
-                    black_box(&rules),
-                    black_box(&index),
-                ))
+                black_box(match_rules(black_box(&meta_hit), black_box(&rules), black_box(&index), false))
             });
         });
 
@@ -100,11 +96,7 @@ fn bench_rules(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("after_indexed", n), &n, |b, _| {
             b.iter(|| {
-                black_box(match_rules(
-                    black_box(&meta_miss),
-                    black_box(&rules),
-                    black_box(&index),
-                ))
+                black_box(match_rules(black_box(&meta_miss), black_box(&rules), black_box(&index), false))
             });
         });
 

--- a/crates/mihomo-tunnel/src/lib.rs
+++ b/crates/mihomo-tunnel/src/lib.rs
@@ -7,4 +7,5 @@ pub mod udp;
 
 pub use relay::{copy_bidirectional_buf, RELAY_BUF_SIZE};
 pub use statistics::Statistics;
+pub use tcp::ConnectionGuard;
 pub use tunnel::Tunnel;

--- a/crates/mihomo-tunnel/src/match_engine.rs
+++ b/crates/mihomo-tunnel/src/match_engine.rs
@@ -77,10 +77,15 @@ pub fn match_rules(
     metadata: &Metadata,
     rules: &[Box<dyn Rule>],
     index: &DomainIndex,
+    needs_process_lookup: bool,
 ) -> Option<MatchResult> {
     let helper = RuleMatchHelper;
 
-    let enriched = maybe_enrich_with_process(metadata, rules);
+    let enriched = if needs_process_lookup {
+        maybe_enrich_with_process(metadata)
+    } else {
+        None
+    };
     let meta: &Metadata = enriched.as_ref().unwrap_or(metadata);
 
     let host = meta.rule_host();
@@ -132,11 +137,8 @@ pub fn match_rules(
     None
 }
 
-fn maybe_enrich_with_process(metadata: &Metadata, rules: &[Box<dyn Rule>]) -> Option<Metadata> {
+fn maybe_enrich_with_process(metadata: &Metadata) -> Option<Metadata> {
     if !metadata.process.is_empty() {
-        return None;
-    }
-    if !rules.iter().any(|r| r.should_find_process()) {
         return None;
     }
     let src_ip = metadata.src_ip?;
@@ -207,7 +209,7 @@ mod tests {
 
         let meta = base_metadata(local);
         let index = DomainIndex::build(&rules);
-        let result = match_rules(&meta, &rules, &index).expect("engine must return a match");
+        let result = match_rules(&meta, &rules, &index, true).expect("engine must return a match");
         assert_eq!(result.adapter_name, "Proxy");
         assert_eq!(result.rule_type.as_str(), "PROCESS-NAME");
     }
@@ -226,7 +228,7 @@ mod tests {
 
         let meta = base_metadata(local);
         let index = DomainIndex::build(&rules);
-        let result = match_rules(&meta, &rules, &index).expect("final rule should match");
+        let result = match_rules(&meta, &rules, &index, true).expect("final rule should match");
         assert_eq!(result.adapter_name, "DIRECT");
         assert_eq!(result.rule_type.as_str(), "MATCH");
     }
@@ -245,7 +247,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index).expect("final rule should match");
+        let result = match_rules(&meta, &rules, &index, true).expect("final rule should match");
         assert_eq!(result.adapter_name, "DIRECT");
     }
 
@@ -265,7 +267,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index).expect("must match");
+        let result = match_rules(&meta, &rules, &index, true).expect("must match");
         assert_eq!(result.adapter_name, "Proxy");
         assert_eq!(result.rule_type.as_str(), "DOMAIN-SUFFIX");
     }
@@ -288,7 +290,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index).expect("must match");
+        let result = match_rules(&meta, &rules, &index, true).expect("must match");
         assert_eq!(result.adapter_name, "Direct");
     }
 
@@ -316,7 +318,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index).expect("must match");
+        let result = match_rules(&meta, &rules, &index, true).expect("must match");
         assert_eq!(
             result.adapter_name, "Broad",
             "first-match-wins: broader rule at lower index must take precedence"

--- a/crates/mihomo-tunnel/src/statistics.rs
+++ b/crates/mihomo-tunnel/src/statistics.rs
@@ -68,8 +68,10 @@ pub struct ConnectionInfo {
 pub struct Statistics {
     pub upload_total: AtomicI64,
     pub download_total: AtomicI64,
-    /// Key is the UUID as a hyphenated String for external-API stability.
-    pub connections: DashMap<String, ConnectionInfo>,
+    /// Keyed by `Uuid` (16 B Copy) — formerly `String`, which heap-allocated a
+    /// 36-byte hyphenated representation per insert.  REST handlers parse the
+    /// query path back into a `Uuid` at lookup time.
+    pub connections: DashMap<Uuid, ConnectionInfo>,
     pub rule_match: Arc<RuleMatchCounters>,
 }
 
@@ -97,9 +99,8 @@ impl Statistics {
         rule: &str,
         rule_payload: &str,
         chains: Vec<Arc<str>>,
-    ) -> String {
+    ) -> Uuid {
         let uuid = Uuid::new_v4();
-        let id_str = uuid.to_string();
         let info = ConnectionInfo {
             id: uuid,
             metadata: Arc::new(metadata),
@@ -110,12 +111,12 @@ impl Statistics {
             rule: rule.into(),
             rule_payload: rule_payload.into(),
         };
-        self.connections.insert(id_str.clone(), info);
-        id_str
+        self.connections.insert(uuid, info);
+        uuid
     }
 
-    pub fn close_connection(&self, id: &str) {
-        self.connections.remove(id);
+    pub fn close_connection(&self, id: Uuid) {
+        self.connections.remove(&id);
     }
 
     pub fn snapshot(&self) -> (i64, i64) {

--- a/crates/mihomo-tunnel/src/tcp.rs
+++ b/crates/mihomo-tunnel/src/tcp.rs
@@ -19,13 +19,13 @@ use tracing::{debug, info, warn};
 /// removed regardless of how the surrounding future ends. Holding an
 /// `&Statistics` is sufficient — the caller already owns an
 /// `Arc<Statistics>` (via `TunnelInner.stats`) that outlives the guard.
-struct ConnectionGuard<'a> {
+pub struct ConnectionGuard<'a> {
     stats: &'a Statistics,
-    id: String,
+    id: uuid::Uuid,
 }
 
 impl<'a> ConnectionGuard<'a> {
-    fn track(
+    pub fn track(
         stats: &'a Statistics,
         metadata: Metadata,
         rule: &str,
@@ -35,11 +35,15 @@ impl<'a> ConnectionGuard<'a> {
         let id = stats.track_connection(metadata, rule, rule_payload, chains);
         Self { stats, id }
     }
+
+    pub fn id(&self) -> uuid::Uuid {
+        self.id
+    }
 }
 
 impl Drop for ConnectionGuard<'_> {
     fn drop(&mut self) {
-        self.stats.close_connection(&self.id);
+        self.stats.close_connection(self.id);
     }
 }
 

--- a/crates/mihomo-tunnel/src/tunnel.rs
+++ b/crates/mihomo-tunnel/src/tunnel.rs
@@ -27,6 +27,10 @@ pub struct TunnelInner {
     /// Cached: true if any rule needs the dst_ip resolved (GeoIP / IP-CIDR).
     /// Recomputed by `Tunnel::update_rules`.
     pub needs_ip_resolution: AtomicBool,
+    /// Cached: true if any rule needs process-name enrichment (PROCESS-NAME /
+    /// PROCESS-PATH / UID). Recomputed by `Tunnel::update_rules`. Avoids an
+    /// O(n) virtual-dispatch scan of the rule list on every connection.
+    pub needs_process_lookup: AtomicBool,
 }
 
 impl TunnelInner {
@@ -118,7 +122,8 @@ impl TunnelInner {
             TunnelMode::Rule => {
                 let rules = self.rules.read();
                 let index = self.domain_index.read();
-                let result = match_engine::match_rules(metadata, &rules, &index);
+                let needs_proc = self.needs_process_lookup.load(Ordering::Relaxed);
+                let result = match_engine::match_rules(metadata, &rules, &index, needs_proc);
                 match result {
                     Some(m) => {
                         let action = if m.adapter_name == "DIRECT" {
@@ -173,6 +178,7 @@ impl Tunnel {
                 nat_table: udp::new_nat_table(),
                 stats: Arc::new(Statistics::new()),
                 needs_ip_resolution: AtomicBool::new(false),
+                needs_process_lookup: AtomicBool::new(false),
             }),
         }
     }
@@ -191,7 +197,8 @@ impl Tunnel {
     }
 
     pub fn update_rules(&self, rules: Vec<Box<dyn Rule>>) {
-        let needs = rules.iter().any(|r| r.should_resolve_ip());
+        let needs_ip = rules.iter().any(|r| r.should_resolve_ip());
+        let needs_proc = rules.iter().any(|r| r.should_find_process());
         let new_index = DomainIndex::build(&rules);
         {
             let mut rules_guard = self.inner.rules.write();
@@ -200,9 +207,15 @@ impl Tunnel {
             *index_guard = new_index;
             self.inner
                 .needs_ip_resolution
-                .store(needs, Ordering::Relaxed);
+                .store(needs_ip, Ordering::Relaxed);
+            self.inner
+                .needs_process_lookup
+                .store(needs_proc, Ordering::Relaxed);
         }
-        info!("Rules updated (needs_ip_resolution={})", needs);
+        info!(
+            "Rules updated (needs_ip_resolution={}, needs_process_lookup={})",
+            needs_ip, needs_proc
+        );
     }
 
     pub fn update_proxies(&self, proxies: HashMap<String, Arc<dyn Proxy>>) {

--- a/crates/mihomo-tunnel/tests/statistics_test.rs
+++ b/crates/mihomo-tunnel/tests/statistics_test.rs
@@ -59,10 +59,10 @@ fn test_track_connection() {
         vec![Arc::from("DIRECT")],
     );
 
-    assert!(!id.is_empty());
+    assert!(!id.is_nil());
     let conns = stats.active_connections();
     assert_eq!(conns.len(), 1);
-    assert_eq!(conns[0].id.to_string(), id);
+    assert_eq!(conns[0].id, id);
     assert_eq!(&*conns[0].rule, "DOMAIN-SUFFIX");
     assert_eq!(&*conns[0].rule_payload, "google.com");
     assert_eq!(&*conns[0].chains[0], "DIRECT");
@@ -76,7 +76,7 @@ fn test_close_connection() {
     let id = stats.track_connection(metadata, "MATCH", "", vec![Arc::from("DIRECT")]);
     assert_eq!(stats.active_connections().len(), 1);
 
-    stats.close_connection(&id);
+    stats.close_connection(id);
     assert!(stats.active_connections().is_empty());
 }
 
@@ -84,7 +84,7 @@ fn test_close_connection() {
 fn test_close_nonexistent_connection() {
     let stats = Statistics::new();
     // Should not panic
-    stats.close_connection("nonexistent-id");
+    stats.close_connection(uuid::Uuid::nil());
     assert!(stats.active_connections().is_empty());
 }
 
@@ -108,12 +108,12 @@ fn test_multiple_connections() {
 
     assert_eq!(stats.active_connections().len(), 3);
 
-    stats.close_connection(&id2);
+    stats.close_connection(id2);
     assert_eq!(stats.active_connections().len(), 2);
 
     // Verify remaining connections
     let conns = stats.active_connections();
-    let ids: Vec<String> = conns.iter().map(|c| c.id.to_string()).collect();
+    let ids: Vec<uuid::Uuid> = conns.iter().map(|c| c.id).collect();
     assert!(ids.contains(&id1));
     assert!(!ids.contains(&id2));
     assert!(ids.contains(&id3));


### PR DESCRIPTION
## Summary

PR-B of the perf-review sweep — Tier-1 connection-setup hygiene targeting the **W3 conn/s axis** (ADR-0006). Six fixes shipped + one scout-finding-was-already-done + one deferred to a tungstenite upgrade.

- **T1.7 Trojan `build_header`** — `Vec::with_capacity(320)`; eliminates 3–4 realloc cycles on every Trojan TCP dial.
- **T1.12 `health.rs` `tls_connector()`** — wrapped in `OnceLock<TlsConnector>`; URLTest probe cycles no longer rebuild `rustls::ClientConfig` + clone `webpki_roots::TLS_SERVER_ROOTS` per probe.
- **T1.10 `needs_process_lookup` cached AtomicBool** — new field on `TunnelInner`, mirrors `needs_ip_resolution`. Removes the O(n) `rules.iter().any(|r| r.should_find_process())` virtual-dispatch scan from every connection's match. `match_rules` takes the cached bool; `maybe_enrich_with_process` no longer takes `&[Box<dyn Rule>]`.
- **T1.11** — scout flagged "unconditional Metadata::clone before find_process" but the clone is already past the `find_process(...)?` early return. No code change beyond the cleanup that T1.10 brought.
- **T1.2 HTTP proxy header read** — replace byte-by-byte read loop with 1024-byte chunked reads. Caps syscall count at `ceil(headers / 1024)` (typically 1) versus ~80–200 per CONNECT. Bytes that arrive past `\r\n\r\n` in the same TCP segment (POST body) are sliced into a `leftover` buffer and re-emitted to the remote after the rewritten request — preserves correctness for pipelined bodies.
- **T1.8 `ConnectionGuard` RAII** — promoted to a public `mihomo_tunnel::ConnectionGuard`. SOCKS5, HTTP CONNECT/plain, and **TProxy** listeners switched off the manual `close_connection` call (which was unreachable when the relay future was cancelled). Closes a real unbounded-growth leak under iOS-tun2socks-style embedders with frequent task aborts.
- **T1.9 `Statistics.connections` re-keyed `Uuid`** — `DashMap<String, ConnectionInfo>` → `DashMap<Uuid, ConnectionInfo>`. `Uuid` is 16 B Copy; the previous String key heap-allocated 36 B per insert. `close_connection(Uuid)` by value. REST API parses `Uuid::parse_str` at the handler boundary; the JSON wire format is unchanged.
- **T1.1 WebSocket write `Vec` alloc** — **DEFERRED**. `tokio-tungstenite 0.24`'s `Message::Binary` requires `Vec<u8>`; the `Bytes` variant is a 0.26+ API. Upgrading the tungstenite dep changes the handshake call shape and is out of PR-B scope. Inline note added at the site referencing ADR-0008 HP-3.

## Why no Criterion table

Most fixes here are correctness or obvious wins (HTTP syscall count, listener leak, alloc-per-insert, lock-frees) that don't show in Criterion micros — they show in the aggregate W3 conn/s number from `bash bench.sh`. PR-A's perf wins were Criterion-measurable; PR-B's are integration-level.

The one item that *could* have moved a micro (T1.10 cached `needs_process_lookup`) only affects rule scans through `match_rules` proper, and the bench fixture in `mihomo-rules/benches/rules_bench.rs` doesn't go through it. The `mihomo-tunnel/benches/rules_bench.rs` fixture does, but it was updated to pass `false` for the new param — directly modelling the post-fix steady state. Numbers look stable, no regression.

## ADR interactions

- **ADR-0006 §1 W3**: cumulative across T1.2 / T1.7 / T1.10 / T1.12. Each shaves syscalls or allocs from per-connection setup.
- **ADR-0008 HP-3**: T1.7, T1.9, T1.10, T1.12 each remove a steady-state heap allocation. T1.1 deferred and noted at the site.
- **ADR-0011 T2**: `ConnectionInfo` retains its 16 B `Uuid` key; the `DashMap` key now matches (was 36 B `String`).
- **ADR-0008 listener-stats lifetime**: T1.8 closes the unbounded-growth path under abort-heavy embedders.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (490 passed)
- [x] `cargo test --tests` (all suites passed — `statistics_test` covers the `Uuid`-by-value API; `api_test` covers the new `Uuid::parse_str` parsing in the DELETE `/connections/{id}` handler)
- [ ] Optional: `bash bench.sh` to capture aggregate W3 delta vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)