### PR TITLE
fix(misc): fakeip Drop-flush, load-balance alloc trims, health VecDeque, misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,23 +116,21 @@ Built-in web UI served at `http://<api-addr>/ui` with:
 
 ## Benchmarks
 
-Latest Rust-only baseline on a developer host (Apple Silicon arm64, macOS 25.4, loopback `127.0.0.1`). Config is `mode: direct`, SOCKS5 listener on port 17890, DNS disabled; the proxy relays traffic to a TCP echo server via the DIRECT adapter. Three runs per metric, median reported per [ADR-0006](docs/adr/0006-m2-benchmark-methodology.md) §4. Reproduce with `bash bench.sh` (auto-downloads Go mihomo for a side-by-side run).
+Side-by-side against upstream Go mihomo on the same host (Apple Silicon arm64, macOS 25.5, loopback `127.0.0.1`). Both binaries use identical config: `mode: direct`, SOCKS5 listener on port 17890, DNS disabled. Reproduce with `bash bench.sh` (auto-downloads the latest Go mihomo release).
 
-| Metric | mihomo-rust v0.7.0 | Notes |
-|--------|--------------------|-------|
-| Binary size (stripped, release LTO) | **5.2 MB** | ADR-0007 cap: well under |
-| RSS idle | **9.2 MB** | |
-| RSS under load (peak) | **12.3 MB** | |
-| TCP throughput, 64 MB×1 | **12.96 Gbps** | |
-| TCP throughput, 1 MB×10 | **11.29 Gbps** | |
-| TCP throughput, 4 KB×10000 | **2.10 Gbps** | small-payload bound by per-conn overhead |
-| Latency p50 (connect + 1 B echo) | **179 µs** | 500 iterations |
-| Latency p99 | 758 µs | IQR/median > 0.10 — see footnote |
-| Connections/sec (10 s, concurrency 64) | **646 /s** | |
+| Metric | mihomo (Go) | mihomo-rust v0.7.6 | Delta |
+|--------|-------------|--------------------|-------|
+| Binary size (stripped) | 30.5 MB | **5.7 MB** | **−81%** |
+| RSS idle | 26.9 MB | **9.0 MB** | **−67%** |
+| RSS under load (peak) | 35.8 MB | **11.7 MB** | **−67%** |
+| TCP throughput, 64 MB×1 | 6.11 Gbps | 5.41 Gbps | −11% |
+| TCP throughput, 1 MB×10 | 6.23 Gbps | 4.61 Gbps | −26% |
+| TCP throughput, 4 KB×10000 | 0.79 Gbps | 0.87 Gbps | **+10%** |
+| Latency p50 (connect + 1 B echo) | 325 µs | **266 µs** | **−18%** |
+| Latency p99 | 583 µs | **339 µs** | **−42%** |
+| Connections/sec (10 s, concurrency 64) | 711 /s | 712 /s | ±0% |
 
-vs the 2026-04-18 M2-open Rust baseline (`docs/benchmarks/baseline-2026-04-18.json`): binary size −53%, throughput +85% to +156% across workloads, p50 latency −40%, idle RSS flat. The p99 latency sample has IQR/median = 47% and is rejected by the ADR-0006 variance gate; a clean reference-host re-run is required to characterise it.
-
-For full methodology, workload definitions (W1–W5), and the Go-comparable gauntlet, see [docs/benchmarks/index.md](docs/benchmarks/index.md).
+Single-run results from `bash bench.sh`; numbers will vary with host load. For the full methodology, three-run-median protocol, and workload definitions (W1–W5), see [ADR-0006](docs/adr/0006-m2-benchmark-methodology.md) and [docs/benchmarks/index.md](docs/benchmarks/index.md).
 
 ## Architecture
 

--- a/crates/mihomo-api/src/routes.rs
+++ b/crates/mihomo-api/src/routes.rs
@@ -115,8 +115,6 @@ async fn require_auth_ws(
     let token_param = query.get("token").map(std::string::String::as_str);
     let provided = bearer.or(token_param);
 
-    // TODO(task#33): apply constant-time comparison here when that task lands,
-    // matching the same fix applied to require_auth above.
     let ok = match provided {
         Some(t) if t.len() == expected.len() => {
             use subtle::ConstantTimeEq;

--- a/crates/mihomo-common/src/adapter.rs
+++ b/crates/mihomo-common/src/adapter.rs
@@ -4,6 +4,7 @@ use crate::error::Result;
 use crate::metadata::Metadata;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
@@ -25,7 +26,7 @@ pub struct ProxyState {
 /// mutability so the trait method can return `&ProxyHealth`.
 pub struct ProxyHealth {
     alive: AtomicBool,
-    history: RwLock<Vec<DelayHistory>>,
+    history: RwLock<VecDeque<DelayHistory>>,
     max_history: usize,
 }
 
@@ -33,7 +34,7 @@ impl ProxyHealth {
     pub fn new() -> Self {
         Self {
             alive: AtomicBool::new(true),
-            history: RwLock::new(Vec::new()),
+            history: RwLock::new(VecDeque::new()),
             max_history: 10,
         }
     }
@@ -49,29 +50,31 @@ impl ProxyHealth {
     pub fn last_delay(&self) -> u16 {
         self.history
             .read()
-            .expect("ProxyHealth history lock poisoned")
-            .last()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .back()
             .map_or(0, |h| h.delay)
     }
 
     pub fn delay_history(&self) -> Vec<DelayHistory> {
         self.history
             .read()
-            .expect("ProxyHealth history lock poisoned")
-            .clone()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .cloned()
+            .collect()
     }
 
     pub fn record_delay(&self, delay: u16) {
         let mut history = self
             .history
             .write()
-            .expect("ProxyHealth history lock poisoned");
-        history.push(DelayHistory {
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        history.push_back(DelayHistory {
             time: SystemTime::now(),
             delay,
         });
         if history.len() > self.max_history {
-            history.remove(0);
+            history.pop_front();
         }
         self.alive.store(delay > 0, Ordering::Relaxed);
     }

--- a/crates/mihomo-dns/src/fakeip.rs
+++ b/crates/mihomo-dns/src/fakeip.rs
@@ -33,7 +33,8 @@ use std::fs;
 use std::io::{self, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::num::NonZeroUsize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::{debug, warn};
 
@@ -133,14 +134,19 @@ struct PersistedSnapshot {
 /// supplies the path (e.g. `<workdir>/fakeip-v4.json`).
 ///
 /// Writes are atomic via `tmp + rename`. The in-memory copy is the source of
-/// truth between flushes; every mutation triggers a save so an unexpected
-/// shutdown loses at most the most recent operation.
+/// truth between flushes; mutations set a dirty flag and a background tokio
+/// task batches the persist after a 1 s debounce so a burst of allocations
+/// from a startup-storm hits the disk once. On `Drop` (process shutdown) we
+/// do one final synchronous flush so SIGTERM during the debounce window
+/// doesn't lose data.
 pub struct FileStore {
     path: PathBuf,
-    state: Mutex<PersistedSnapshot>,
+    state: Arc<Mutex<PersistedSnapshot>>,
     /// In-memory reverse map rebuilt from `state.entries` at load time and
     /// kept in sync on mutation. Kept separate so `Store::get_by_ip` is O(1).
     reverse: Mutex<HashMap<IpAddr, String>>,
+    dirty: Arc<AtomicBool>,
+    notify: Arc<tokio::sync::Notify>,
 }
 
 impl FileStore {
@@ -177,31 +183,83 @@ impl FileStore {
             .iter()
             .map(|(h, ip)| (*ip, h.clone()))
             .collect();
-        Ok(Self {
+
+        let state = Arc::new(Mutex::new(snapshot));
+        let dirty = Arc::new(AtomicBool::new(false));
+        let notify = Arc::new(tokio::sync::Notify::new());
+
+        let store = Self {
             path,
-            state: Mutex::new(snapshot),
+            state,
             reverse: Mutex::new(reverse),
-        })
+            dirty,
+            notify,
+        };
+
+        store.spawn_flush_task();
+        Ok(store)
     }
 
-    fn persist(&self, snap: &PersistedSnapshot) {
-        let tmp = self.path.with_extension("json.tmp");
-        let result = (|| -> io::Result<()> {
-            let bytes = serde_json::to_vec(snap).map_err(io::Error::other)?;
-            if let Some(parent) = self.path.parent() {
-                if !parent.as_os_str().is_empty() {
-                    fs::create_dir_all(parent)?;
+    fn spawn_flush_task(&self) {
+        let path = self.path.clone();
+        let state = Arc::clone(&self.state);
+        let dirty = Arc::clone(&self.dirty);
+        let notify = Arc::clone(&self.notify);
+
+        tokio::spawn(async move {
+            loop {
+                notify.notified().await;
+                // Debounce: wait for more mutations to settle.
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+                if dirty.swap(false, Ordering::SeqCst) {
+                    let snap = {
+                        let s = state.lock();
+                        serialise(&s)
+                    };
+                    persist_to_file(&path, &snap);
                 }
             }
-            let mut f = fs::File::create(&tmp)?;
-            f.write_all(&bytes)?;
-            f.sync_all()?;
-            drop(f);
-            fs::rename(&tmp, &self.path)
-        })();
-        if let Err(e) = result {
-            warn!("fakeip: persist {} failed: {}", self.path.display(), e);
+        });
+    }
+
+    fn mark_dirty(&self) {
+        self.dirty.store(true, Ordering::SeqCst);
+        self.notify.notify_one();
+    }
+}
+
+impl Drop for FileStore {
+    fn drop(&mut self) {
+        // Final synchronous flush so any pending dirty state lands on disk
+        // before the process exits. The background task may have already
+        // cleared `dirty` — in that case this is a no-op. We do not wake the
+        // task because it may be inside its own sleep and there is no
+        // guarantee the runtime is still pumping.
+        if self.dirty.swap(false, Ordering::SeqCst) {
+            let snap = serialise(&self.state.lock());
+            persist_to_file(&self.path, &snap);
         }
+    }
+}
+
+fn persist_to_file(path: &Path, snap: &PersistedSnapshot) {
+    let tmp = path.with_extension("json.tmp");
+    let result = (|| -> io::Result<()> {
+        let bytes = serde_json::to_vec(snap).map_err(io::Error::other)?;
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+        drop(f);
+        fs::rename(&tmp, path)
+    })();
+    if let Err(e) = result {
+        warn!("fakeip: persist {} failed: {}", path.display(), e);
     }
 }
 
@@ -212,9 +270,8 @@ impl Store for FileStore {
     fn put_by_host(&self, host: &str, ip: IpAddr) {
         let mut s = self.state.lock();
         s.entries.insert(host.to_string(), ip);
-        let snap_clone = serialise(&s);
         drop(s);
-        self.persist(&snap_clone);
+        self.mark_dirty();
     }
     fn get_by_ip(&self, ip: IpAddr) -> Option<String> {
         self.reverse.lock().get(&ip).cloned()
@@ -233,9 +290,8 @@ impl Store for FileStore {
         if let Some(host) = host {
             let mut s = self.state.lock();
             s.entries.remove(&host);
-            let snap_clone = serialise(&s);
             drop(s);
-            self.persist(&snap_clone);
+            self.mark_dirty();
         }
     }
     fn exists(&self, ip: IpAddr) -> bool {
@@ -247,17 +303,15 @@ impl Store for FileStore {
         s.entries.clear();
         s.offset = None;
         s.cycle = false;
-        let snap_clone = serialise(&s);
         drop(s);
-        self.persist(&snap_clone);
+        self.mark_dirty();
     }
     fn put_state(&self, offset: IpAddr, cycle: bool) {
         let mut s = self.state.lock();
         s.offset = Some(offset);
         s.cycle = cycle;
-        let snap_clone = serialise(&s);
         drop(s);
-        self.persist(&snap_clone);
+        self.mark_dirty();
     }
     fn get_state(&self) -> Option<(IpAddr, bool)> {
         let s = self.state.lock();
@@ -724,8 +778,8 @@ mod tests {
         assert!(!s.should_skip("foo.test"));
     }
 
-    #[test]
-    fn file_store_roundtrip() {
+    #[tokio::test]
+    async fn file_store_roundtrip() {
         let tmp = tempdir();
         let path = tmp.join("fakeip-v4.json");
         let net = IpNet::from_str("198.18.0.0/16").unwrap();
@@ -734,6 +788,8 @@ mod tests {
             let store = Arc::new(FileStore::open(&path).unwrap());
             let pool = Pool::new(net, store).unwrap();
             ip = pool.lookup("example.com");
+            // Wait for the debounced background persistence to complete.
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
         }
         // Re-open; mapping must survive.
         {

--- a/crates/mihomo-proxy/src/group/load_balance.rs
+++ b/crates/mihomo-proxy/src/group/load_balance.rs
@@ -38,45 +38,73 @@ impl LoadBalanceGroup {
     ///
     /// TODO(perf M2): cache alive-set or use a pre-filtered index if profiling shows this hot
     pub fn select(&self, metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
-        // upstream: adapter/outbound/loadbalance.go::RoundRobin.Addr /
-        //           adapter/outbound/loadbalance.go::ConsistentHashing.Addr
-        let alive: Vec<_> = self.proxies.iter().filter(|p| p.alive()).cloned().collect();
-        if alive.is_empty() {
-            return None;
-        }
-        let idx = match self.strategy {
-            LbStrategy::RoundRobin => self.counter.fetch_add(1, Ordering::Relaxed) % alive.len(),
-            LbStrategy::ConsistentHashing => {
-                // FNV-1a 32-bit, matching upstream adapter/outbound/loadbalance.go hash logic shape.
-                // Note: upstream uses FNV-1 (not FNV-1a); we use FNV-1a which has slightly better
-                // distribution. The hash is stable for a given src IP + proxy list — Class B ADR-0002.
-                let hash = fnv1a(&src_ip_bytes(metadata));
-                (hash as usize) % alive.len()
+        match self.strategy {
+            LbStrategy::RoundRobin => {
+                let alive_count = self.proxies.iter().filter(|p| p.alive()).count();
+                if alive_count == 0 {
+                    return None;
+                }
+                let target_idx = self.counter.fetch_add(1, Ordering::Relaxed) % alive_count;
+                self.proxies
+                    .iter()
+                    .filter(|p| p.alive())
+                    .nth(target_idx)
+                    .cloned()
             }
-        };
-        Some(Arc::clone(&alive[idx]))
+            LbStrategy::ConsistentHashing => {
+                let alive_count = self.proxies.iter().filter(|p| p.alive()).count();
+                if alive_count == 0 {
+                    return None;
+                }
+                let (bytes, len) = src_ip_bytes(metadata);
+                let hash = fnv1a(&bytes[..len]);
+                let target_idx = (hash as usize) % alive_count;
+                self.proxies
+                    .iter()
+                    .filter(|p| p.alive())
+                    .nth(target_idx)
+                    .cloned()
+            }
+        }
     }
 
     fn select_udp(&self, metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
-        let alive_udp: Vec<_> = self
-            .proxies
-            .iter()
-            .filter(|p| p.alive() && p.support_udp())
-            .cloned()
-            .collect();
-        if alive_udp.is_empty() {
-            return None;
-        }
-        let idx = match self.strategy {
+        match self.strategy {
             LbStrategy::RoundRobin => {
-                self.counter.fetch_add(1, Ordering::Relaxed) % alive_udp.len()
+                let alive_count = self
+                    .proxies
+                    .iter()
+                    .filter(|p| p.alive() && p.support_udp())
+                    .count();
+                if alive_count == 0 {
+                    return None;
+                }
+                let target_idx = self.counter.fetch_add(1, Ordering::Relaxed) % alive_count;
+                self.proxies
+                    .iter()
+                    .filter(|p| p.alive() && p.support_udp())
+                    .nth(target_idx)
+                    .cloned()
             }
             LbStrategy::ConsistentHashing => {
-                let hash = fnv1a(&src_ip_bytes(metadata));
-                (hash as usize) % alive_udp.len()
+                let alive_count = self
+                    .proxies
+                    .iter()
+                    .filter(|p| p.alive() && p.support_udp())
+                    .count();
+                if alive_count == 0 {
+                    return None;
+                }
+                let (bytes, len) = src_ip_bytes(metadata);
+                let hash = fnv1a(&bytes[..len]);
+                let target_idx = (hash as usize) % alive_count;
+                self.proxies
+                    .iter()
+                    .filter(|p| p.alive() && p.support_udp())
+                    .nth(target_idx)
+                    .cloned()
             }
-        };
-        Some(Arc::clone(&alive_udp[idx]))
+        }
     }
 }
 
@@ -86,11 +114,19 @@ impl LoadBalanceGroup {
 /// `None` (no src_addr, e.g. local probe) → 4 zero bytes (0.0.0.0 fallback).
 /// Every connection without a src_addr hashes to the same proxy — deterministic,
 /// not random. Upstream: undefined (assumes src always present).
-fn src_ip_bytes(metadata: &Metadata) -> Vec<u8> {
+fn src_ip_bytes(metadata: &Metadata) -> ([u8; 16], usize) {
+    let mut buf = [0u8; 16];
     match metadata.src_ip {
-        Some(IpAddr::V4(v4)) => v4.octets().to_vec(),
-        Some(IpAddr::V6(v6)) => v6.octets().to_vec(),
-        None => vec![0u8; 4],
+        Some(IpAddr::V4(v4)) => {
+            let octets = v4.octets();
+            buf[..4].copy_from_slice(&octets);
+            (buf, 4)
+        }
+        Some(IpAddr::V6(v6)) => {
+            buf.copy_from_slice(&v6.octets());
+            (buf, 16)
+        }
+        None => (buf, 4),
     }
 }
 

--- a/crates/mihomo-tunnel/benches/rules_bench.rs
+++ b/crates/mihomo-tunnel/benches/rules_bench.rs
@@ -80,7 +80,12 @@ fn bench_rules(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("after_indexed", n), &n, |b, _| {
             b.iter(|| {
-                black_box(match_rules(black_box(&meta_hit), black_box(&rules), black_box(&index), false))
+                black_box(match_rules(
+                    black_box(&meta_hit),
+                    black_box(&rules),
+                    black_box(&index),
+                    false,
+                ))
             });
         });
 
@@ -96,7 +101,12 @@ fn bench_rules(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("after_indexed", n), &n, |b, _| {
             b.iter(|| {
-                black_box(match_rules(black_box(&meta_miss), black_box(&rules), black_box(&index), false))
+                black_box(match_rules(
+                    black_box(&meta_miss),
+                    black_box(&rules),
+                    black_box(&index),
+                    false,
+                ))
             });
         });
 

--- a/crates/mihomo-tunnel/src/tunnel.rs
+++ b/crates/mihomo-tunnel/src/tunnel.rs
@@ -235,6 +235,10 @@ impl Tunnel {
         self.inner.proxies.read().clone()
     }
 
+    pub fn proxy(&self, name: &str) -> Option<Arc<dyn Proxy>> {
+        self.inner.proxies.read().get(name).cloned()
+    }
+
     /// Spawn background tasks owned by the tunnel (currently just the UDP NAT
     /// sweeper). Idempotent callers should only invoke this once per process.
     pub fn spawn_background_tasks(&self) {


### PR DESCRIPTION
## Summary

A bundle of in-progress fixes that predate the PR-A / PR-B perf sweep, consolidated and merged with the original review notes addressed.

### fakeip persistence (corrected)

The original WIP introduced a debounced async persist task on `FileStore` (1 s window batches a startup-storm of allocations into one fsync), but the review flagged three concerns:
1. **Data loss** on shutdown — SIGTERM during the debounce window dropped state.
2. **Detached task leak** — no shutdown handle, Arcs kept the state alive forever.
3. **`fn persist_to_file(&PathBuf, …)`** — clippy `ptr_arg` violation.

Fixed (1) by adding a `Drop` impl that does one final synchronous flush if `dirty`. Fixed (3) by switching the signature to `&Path`. (2) is intentional for the singleton process-lifetime case — documented in the FileStore doc-comment which now describes the actual semantics ("debounced + final flush on Drop").

### load_balance.rs

`select` / `select_udp` no longer allocate a `Vec<Arc<dyn Proxy>>` per dial — switched to `filter().count()` + `filter().nth()`. Trade one heap alloc for one extra cache-warm scan. Worth it on typical small groups; for very large lists the cached-selection refactor in T2.1 (a separate planned PR) is the proper fix.

`src_ip_bytes()` now returns `([u8; 16], usize)` on the stack instead of `Vec<u8>` — zero heap alloc per dial. Aligns with ADR-0008.

### ProxyHealth.history

`Vec<DelayHistory>` → `VecDeque<DelayHistory>`. Eliminates the O(n) `remove(0)` on every `record_delay` (it was bounded at 10, so the cost is small but the change is free). Lock poisoning now recovers via `unwrap_or_else(PoisonError::into_inner)` rather than panicking — the history is not safety-critical and stale data is preferable to abort.

### Minor

- `api/routes::require_auth_ws` — stale `TODO(task#33)` removed; the constant-time-comparison fix it pointed at is already in the match arms below.
- `Tunnel::proxy(&str) -> Option<Arc<dyn Proxy>>` — new pub getter. No current caller, but small ergonomic addition.
- `README.md` — replaced misleading "v0.7.0 vs v0.7.6" self-conflicting benchmark table with a clean Go-vs-Rust side-by-side from the actual `bash bench.sh` run. Single-run caveat noted; full ADR-0006 §4 three-run-median methodology pointer restored.
- `mihomo-tunnel/benches/rules_bench.rs` — `cargo fmt` follow-up from PR-B's `, false` arg addition (line length).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (490 passed)
- [x] `cargo test --tests` (all suites passed including fakeip roundtrip with the new Drop-flush)

🤖 Generated with [Claude Code](https://claude.com/claude-code)