### PR TITLE
perf: lock-free route table + single-pass proxy-group selection (PR-C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2179,7 @@ dependencies = [
 name = "mihomo-tunnel"
 version = "0.7.6"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "criterion",
  "dashmap",

--- a/crates/mihomo-api/tests/api_test.rs
+++ b/crates/mihomo-api/tests/api_test.rs
@@ -2003,7 +2003,7 @@ async fn e2_group_delay_total_walltime_bounded_by_timeout() {
 
 #[tokio::test]
 async fn e5_group_delay_url_test_no_reselection() {
-    // UrlTestGroup::current() is driven by update_fastest(), which is
+    // UrlTestGroup::current() is driven by pick_for_dial(), which is
     // called only from its own dial_tcp — not from the delay endpoint
     // (which walks members directly). Probing the group must NOT change
     // `current`, even if a later member would win a reselection. Locks in

--- a/crates/mihomo-proxy/src/group/fallback.rs
+++ b/crates/mihomo-proxy/src/group/fallback.rs
@@ -35,20 +35,46 @@ impl FallbackGroup {
         }
     }
 
-    fn effective_proxies(&self) -> Vec<Arc<dyn Proxy>> {
-        let mut all = self.static_proxies.clone();
-        for slot in &self.provider_slots {
-            all.extend(slot.read().iter().cloned());
+    /// Single-pass scan: returns the first alive proxy, or the first
+    /// proxy of any kind if none are alive.  Walks `static_proxies` and
+    /// each provider slot directly without building a unified `Vec`.
+    fn first_alive(&self) -> Option<Arc<dyn Proxy>> {
+        let mut fallback: Option<Arc<dyn Proxy>> = None;
+        for p in &self.static_proxies {
+            if fallback.is_none() {
+                fallback = Some(Arc::clone(p));
+            }
+            if p.alive() {
+                return Some(Arc::clone(p));
+            }
         }
-        all
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            for p in guard.iter() {
+                if fallback.is_none() {
+                    fallback = Some(Arc::clone(p));
+                }
+                if p.alive() {
+                    return Some(Arc::clone(p));
+                }
+            }
+        }
+        fallback
     }
 
-    fn first_alive(&self) -> Option<Arc<dyn Proxy>> {
-        let all = self.effective_proxies();
-        all.iter()
-            .find(|p| p.alive())
-            .cloned()
-            .or_else(|| all.into_iter().next())
+    fn member_names(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .static_proxies
+            .iter()
+            .map(|p| p.name().to_string())
+            .collect();
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            for p in guard.iter() {
+                out.push(p.name().to_string());
+            }
+        }
+        out
     }
 }
 
@@ -117,12 +143,7 @@ impl Proxy for FallbackGroup {
     }
 
     fn members(&self) -> Option<Vec<String>> {
-        Some(
-            self.effective_proxies()
-                .iter()
-                .map(|p| p.name().to_string())
-                .collect(),
-        )
+        Some(self.member_names())
     }
 
     fn current(&self) -> Option<String> {

--- a/crates/mihomo-proxy/src/group/selector.rs
+++ b/crates/mihomo-proxy/src/group/selector.rs
@@ -40,19 +40,23 @@ impl SelectorGroup {
         }
     }
 
-    fn effective_proxies(&self) -> Vec<Arc<dyn Proxy>> {
-        let mut all = self.static_proxies.clone();
-        for slot in &self.provider_slots {
-            all.extend(slot.read().iter().cloned());
+    fn contains_name(&self, name: &str) -> bool {
+        if self.static_proxies.iter().any(|p| p.name() == name) {
+            return true;
         }
-        all
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            if guard.iter().any(|p| p.name() == name) {
+                return true;
+            }
+        }
+        false
     }
 
     /// Select the proxy with the given name. Returns `true` if found.
     /// Selection survives provider refreshes because it is stored by name.
     pub fn select(&self, name: &str) -> bool {
-        let all = self.effective_proxies();
-        if all.iter().any(|p| p.name() == name) {
+        if self.contains_name(name) {
             *self.selected.write() = Some(name.to_string());
             true
         } else {
@@ -60,23 +64,59 @@ impl SelectorGroup {
         }
     }
 
+    /// Resolve `selected` to an `Arc<dyn Proxy>` without allocating a unified
+    /// `Vec`. Walks `static_proxies` then provider slots; falls back to the
+    /// first proxy if `selected` is unset or names something no longer present.
     pub fn selected_proxy(&self) -> Option<Arc<dyn Proxy>> {
-        let all = self.effective_proxies();
-        let sel = self.selected.read();
-        if let Some(name) = sel.as_deref() {
-            if let Some(p) = all.iter().find(|p| p.name() == name) {
+        let sel = self.selected.read().clone();
+        let mut first_any: Option<Arc<dyn Proxy>> = None;
+        if let Some(name) = sel {
+            for p in &self.static_proxies {
+                if first_any.is_none() {
+                    first_any = Some(Arc::clone(p));
+                }
+                if p.name() == name {
+                    return Some(Arc::clone(p));
+                }
+            }
+            for slot in &self.provider_slots {
+                let guard = slot.read();
+                for p in guard.iter() {
+                    if first_any.is_none() {
+                        first_any = Some(Arc::clone(p));
+                    }
+                    if p.name() == name {
+                        return Some(Arc::clone(p));
+                    }
+                }
+            }
+            return first_any;
+        }
+        if let Some(p) = self.static_proxies.first() {
+            return Some(Arc::clone(p));
+        }
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            if let Some(p) = guard.first() {
                 return Some(Arc::clone(p));
             }
         }
-        // Fall back to first proxy in the list
-        all.into_iter().next()
+        None
     }
 
     pub fn proxy_names(&self) -> Vec<String> {
-        self.effective_proxies()
+        let mut out: Vec<String> = self
+            .static_proxies
             .iter()
             .map(|p| p.name().to_string())
-            .collect()
+            .collect();
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            for p in guard.iter() {
+                out.push(p.name().to_string());
+            }
+        }
+        out
     }
 }
 

--- a/crates/mihomo-proxy/src/group/urltest.rs
+++ b/crates/mihomo-proxy/src/group/urltest.rs
@@ -11,7 +11,9 @@ pub struct UrlTestGroup {
     static_proxies: Vec<Arc<dyn Proxy>>,
     provider_slots: Vec<ProviderSlot>,
     tolerance: u16,
-    /// Name of the currently fastest proxy; `None` means use the first.
+    /// Name of the currently selected proxy; `None` means "not yet picked,
+    /// use the first available".  Updated by `pick_for_dial` whenever it
+    /// promotes a new best.
     fastest: RwLock<Option<String>>,
     health: ProxyHealth,
 }
@@ -44,57 +46,127 @@ impl UrlTestGroup {
         }
     }
 
-    fn effective_proxies(&self) -> Vec<Arc<dyn Proxy>> {
-        let mut all = self.static_proxies.clone();
-        for slot in &self.provider_slots {
-            all.extend(slot.read().iter().cloned());
-        }
-        all
-    }
+    /// Single-pass dial-path selector: walks `static_proxies` + provider
+    /// slots once without allocating a unified Vec, updates `self.fastest`
+    /// if a strictly-better-by-tolerance alternative exists (or if the
+    /// current pick has died), and returns the chosen proxy.
+    ///
+    /// Previously this was three separate full scans per dial:
+    /// `update_fastest` cloned the Vec once, scanned to find best, then
+    /// scanned again to read the current proxy's delay/aliveness; then
+    /// `fastest_proxy` cloned the Vec a second time to look up by name.
+    fn pick_for_dial(&self) -> Option<Arc<dyn Proxy>> {
+        let current_name: Option<String> = self.fastest.read().clone();
 
-    pub fn update_fastest(&self) {
-        let all = self.effective_proxies();
-        let mut best_name: Option<String> = None;
-        let mut best_delay = u16::MAX;
+        let mut best_proxy: Option<Arc<dyn Proxy>> = None;
+        let mut best_delay: u16 = u16::MAX;
+        let mut current_proxy: Option<Arc<dyn Proxy>> = None;
+        let mut current_delay: u16 = u16::MAX;
+        let mut current_alive = false;
+        let mut first_any: Option<Arc<dyn Proxy>> = None;
 
-        for proxy in &all {
-            if proxy.alive() {
-                let delay = proxy.last_delay();
-                if delay > 0 && delay < best_delay {
-                    best_delay = delay;
-                    best_name = Some(proxy.name().to_string());
+        // Inline visit logic to avoid an `FnMut` closure that would conflict
+        // with the multiple mutable borrows below.
+        macro_rules! visit {
+            ($p:expr) => {{
+                let p: &Arc<dyn Proxy> = $p;
+                if first_any.is_none() {
+                    first_any = Some(Arc::clone(p));
                 }
+                if p.alive() {
+                    let d = p.last_delay();
+                    if let Some(ref n) = current_name {
+                        if p.name() == n.as_str() {
+                            current_alive = true;
+                            current_delay = d;
+                            current_proxy = Some(Arc::clone(p));
+                        }
+                    }
+                    if d > 0 && d < best_delay {
+                        best_delay = d;
+                        best_proxy = Some(Arc::clone(p));
+                    }
+                }
+            }};
+        }
+
+        for p in &self.static_proxies {
+            visit!(p);
+        }
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            for p in guard.iter() {
+                visit!(p);
             }
         }
 
-        let current_name: Option<String> = self.fastest.read().clone();
-        let current_delay = current_name
-            .as_deref()
-            .and_then(|n| all.iter().find(|p| p.name() == n))
-            .map_or(u16::MAX, |p| p.last_delay());
-        let current_alive = current_name
-            .as_deref()
-            .and_then(|n| all.iter().find(|p| p.name() == n))
-            .is_some_and(|p| p.alive());
-
-        if let Some(ref bname) = best_name {
-            if best_delay + self.tolerance < current_delay || !current_alive {
-                *self.fastest.write() = Some(bname.clone());
+        if let Some(bp) = best_proxy.as_ref() {
+            if best_delay.saturating_add(self.tolerance) < current_delay || !current_alive {
+                *self.fastest.write() = Some(bp.name().to_string());
+                return Some(Arc::clone(bp));
             }
         } else if !current_alive {
-            *self.fastest.write() = all.first().map(|p| p.name().to_string());
+            let fb = first_any.clone();
+            *self.fastest.write() = fb.as_ref().map(|p| p.name().to_string());
+            return fb;
         }
+        current_proxy.or(best_proxy).or(first_any)
     }
 
+    /// Read-only lookup of whatever `fastest` currently points at — used by
+    /// the REST/info methods below.  No Vec allocation; falls back to the
+    /// first proxy if `fastest` is unset or names something no longer present.
     fn fastest_proxy(&self) -> Option<Arc<dyn Proxy>> {
-        let all = self.effective_proxies();
-        let name: Option<String> = self.fastest.read().clone();
+        let name = self.fastest.read().clone();
+        let mut first_any: Option<Arc<dyn Proxy>> = None;
         if let Some(n) = name {
-            if let Some(p) = all.iter().find(|p| p.name() == n) {
+            for p in &self.static_proxies {
+                if first_any.is_none() {
+                    first_any = Some(Arc::clone(p));
+                }
+                if p.name() == n {
+                    return Some(Arc::clone(p));
+                }
+            }
+            for slot in &self.provider_slots {
+                let guard = slot.read();
+                for p in guard.iter() {
+                    if first_any.is_none() {
+                        first_any = Some(Arc::clone(p));
+                    }
+                    if p.name() == n {
+                        return Some(Arc::clone(p));
+                    }
+                }
+            }
+            return first_any;
+        }
+        // No selection yet: return first proxy if any.
+        if let Some(p) = self.static_proxies.first() {
+            return Some(Arc::clone(p));
+        }
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            if let Some(p) = guard.first() {
                 return Some(Arc::clone(p));
             }
         }
-        all.into_iter().next()
+        None
+    }
+
+    fn member_names(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .static_proxies
+            .iter()
+            .map(|p| p.name().to_string())
+            .collect();
+        for slot in &self.provider_slots {
+            let guard = slot.read();
+            for p in guard.iter() {
+                out.push(p.name().to_string());
+            }
+        }
+        out
     }
 }
 
@@ -117,17 +189,15 @@ impl ProxyAdapter for UrlTestGroup {
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
-        self.update_fastest();
         let proxy = self
-            .fastest_proxy()
+            .pick_for_dial()
             .ok_or_else(|| MihomoError::Proxy("no proxy available".into()))?;
         proxy.dial_tcp(metadata).await
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        self.update_fastest();
         let proxy = self
-            .fastest_proxy()
+            .pick_for_dial()
             .ok_or_else(|| MihomoError::Proxy("no proxy available".into()))?;
         proxy.dial_udp(metadata).await
     }
@@ -166,12 +236,7 @@ impl Proxy for UrlTestGroup {
     }
 
     fn members(&self) -> Option<Vec<String>> {
-        Some(
-            self.effective_proxies()
-                .iter()
-                .map(|p| p.name().to_string())
-                .collect(),
-        )
+        Some(self.member_names())
     }
 
     fn current(&self) -> Option<String> {

--- a/crates/mihomo-tunnel/Cargo.toml
+++ b/crates/mihomo-tunnel/Cargo.toml
@@ -15,6 +15,7 @@ dashmap = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 parking_lot = { workspace = true }
+arc-swap = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }
 

--- a/crates/mihomo-tunnel/src/tunnel.rs
+++ b/crates/mihomo-tunnel/src/tunnel.rs
@@ -1,6 +1,7 @@
 use crate::match_engine::{self, DomainIndex};
 use crate::statistics::Statistics;
 use crate::udp::{self, NatTable};
+use arc_swap::ArcSwap;
 use mihomo_common::{Metadata, Proxy, ProxyAdapter, Rule, TunnelMode};
 use mihomo_dns::Resolver;
 use mihomo_proxy::DirectAdapter;
@@ -10,13 +11,36 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::{debug, info};
 
+/// Bundled rules + domain index + proxies map, atomically swapped on config
+/// reload via `ArcSwap`. Reads on the connection-setup hot path are lock-free
+/// — previously each `resolve_proxy` call acquired three `parking_lot::RwLock`
+/// guards (rules, domain_index, proxies). The atomic swap also guarantees
+/// rules + proxies are observed as a consistent snapshot, so a connection
+/// can no longer match a rule that points at a proxy not yet inserted.
+///
+/// `rules` and `domain_index` are themselves `Arc`-wrapped so a partial
+/// update (e.g. `update_proxies` keeping the rules) is a refcount bump
+/// rather than a deep clone — `Box<dyn Rule>` is not `Clone`.
+pub struct RouteTable {
+    pub rules: Arc<Vec<Box<dyn Rule>>>,
+    pub domain_index: Arc<DomainIndex>,
+    pub proxies: HashMap<String, Arc<dyn Proxy>>,
+}
+
+impl RouteTable {
+    fn empty() -> Self {
+        Self {
+            rules: Arc::new(Vec::new()),
+            domain_index: Arc::new(DomainIndex::empty()),
+            proxies: HashMap::new(),
+        }
+    }
+}
+
 pub struct TunnelInner {
     pub mode: RwLock<TunnelMode>,
-    pub rules: RwLock<Vec<Box<dyn Rule>>>,
-    /// Domain trie index for early-exit rule matching (ADR-0008 §7 sub-area 0).
-    /// Rebuilt atomically whenever `update_rules` is called.
-    pub domain_index: RwLock<DomainIndex>,
-    pub proxies: RwLock<HashMap<String, Arc<dyn Proxy>>>,
+    /// Atomically-swapped route table (rules + domain index + proxies).
+    pub route: ArcSwap<RouteTable>,
     pub resolver: Arc<Resolver>,
     /// Fallback DIRECT adapter used when no user-defined rule matches or
     /// when Direct/Global mode bypasses the proxies map. Pre-built with the
@@ -104,8 +128,8 @@ impl TunnelInner {
                 String::new(),
             )),
             TunnelMode::Global => {
-                let proxies = self.proxies.read();
-                if let Some(proxy) = proxies.get("GLOBAL") {
+                let route = self.route.load();
+                if let Some(proxy) = route.proxies.get("GLOBAL") {
                     Some((
                         Arc::clone(proxy) as Arc<dyn ProxyAdapter>,
                         "Global".into(),
@@ -120,10 +144,16 @@ impl TunnelInner {
                 }
             }
             TunnelMode::Rule => {
-                let rules = self.rules.read();
-                let index = self.domain_index.read();
+                // One ArcSwap load — rules + index + proxies all read from a
+                // consistent snapshot. Replaces three RwLock acquisitions.
+                let route = self.route.load();
                 let needs_proc = self.needs_process_lookup.load(Ordering::Relaxed);
-                let result = match_engine::match_rules(metadata, &rules, &index, needs_proc);
+                let result = match_engine::match_rules(
+                    metadata,
+                    route.rules.as_ref(),
+                    route.domain_index.as_ref(),
+                    needs_proc,
+                );
                 match result {
                     Some(m) => {
                         let action = if m.adapter_name == "DIRECT" {
@@ -136,8 +166,7 @@ impl TunnelInner {
                         self.stats
                             .rule_match
                             .increment(m.rule_type.as_str(), action);
-                        let proxies = self.proxies.read();
-                        let proxy = proxies.get(&m.adapter_name).cloned().map_or_else(
+                        let proxy = route.proxies.get(&m.adapter_name).cloned().map_or_else(
                             || {
                                 debug!("proxy '{}' not found, using DIRECT", m.adapter_name);
                                 Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>
@@ -170,9 +199,7 @@ impl Tunnel {
         Self {
             inner: Arc::new(TunnelInner {
                 mode: RwLock::new(TunnelMode::Rule),
-                rules: RwLock::new(Vec::new()),
-                domain_index: RwLock::new(DomainIndex::empty()),
-                proxies: RwLock::new(HashMap::new()),
+                route: ArcSwap::from_pointee(RouteTable::empty()),
                 resolver,
                 direct,
                 nat_table: udp::new_nat_table(),
@@ -200,18 +227,22 @@ impl Tunnel {
         let needs_ip = rules.iter().any(|r| r.should_resolve_ip());
         let needs_proc = rules.iter().any(|r| r.should_find_process());
         let new_index = DomainIndex::build(&rules);
-        {
-            let mut rules_guard = self.inner.rules.write();
-            let mut index_guard = self.inner.domain_index.write();
-            *rules_guard = rules;
-            *index_guard = new_index;
-            self.inner
-                .needs_ip_resolution
-                .store(needs_ip, Ordering::Relaxed);
-            self.inner
-                .needs_process_lookup
-                .store(needs_proc, Ordering::Relaxed);
-        }
+        // Build a new route table on top of the current proxies map. The
+        // current proxies are cloned (Arc bumps for adapter handles, one
+        // HashMap clone) — paid only on config-reload, not the hot path.
+        let current = self.inner.route.load();
+        let new_route = RouteTable {
+            rules: Arc::new(rules),
+            domain_index: Arc::new(new_index),
+            proxies: current.proxies.clone(),
+        };
+        self.inner.route.store(Arc::new(new_route));
+        self.inner
+            .needs_ip_resolution
+            .store(needs_ip, Ordering::Relaxed);
+        self.inner
+            .needs_process_lookup
+            .store(needs_proc, Ordering::Relaxed);
         info!(
             "Rules updated (needs_ip_resolution={}, needs_process_lookup={})",
             needs_ip, needs_proc
@@ -219,7 +250,14 @@ impl Tunnel {
     }
 
     pub fn update_proxies(&self, proxies: HashMap<String, Arc<dyn Proxy>>) {
-        *self.inner.proxies.write() = proxies;
+        // Preserve the current rules + index via Arc refcount bumps.
+        let current = self.inner.route.load();
+        let new_route = RouteTable {
+            rules: Arc::clone(&current.rules),
+            domain_index: Arc::clone(&current.domain_index),
+            proxies,
+        };
+        self.inner.route.store(Arc::new(new_route));
         info!("Proxies updated");
     }
 
@@ -232,11 +270,11 @@ impl Tunnel {
     }
 
     pub fn proxies(&self) -> HashMap<String, Arc<dyn Proxy>> {
-        self.inner.proxies.read().clone()
+        self.inner.route.load().proxies.clone()
     }
 
     pub fn proxy(&self, name: &str) -> Option<Arc<dyn Proxy>> {
-        self.inner.proxies.read().get(name).cloned()
+        self.inner.route.load().proxies.get(name).cloned()
     }
 
     /// Spawn background tasks owned by the tunnel (currently just the UDP NAT
@@ -251,8 +289,9 @@ impl Tunnel {
 
     pub fn rules_info(&self) -> Vec<(String, String, String)> {
         self.inner
+            .route
+            .load()
             .rules
-            .read()
             .iter()
             .map(|r| {
                 (


### PR DESCRIPTION
## Summary

PR-C of the perf-review sweep — Tier-2 items T2.1 (proxy-group selection) and T2.2 (lock-free route table).

### T2.1 — single-pass proxy-group selection

URLTest / Fallback / Selector each previously rebuilt a unified `Vec<Arc<dyn Proxy>>` of (`static_proxies` ++ `provider_slots`) on every dial. UrlTest did it **three times** per dial (in `update_fastest`'s `effective_proxies`, then again inside `update_fastest`, then a third time in `fastest_proxy`), and Selector / Fallback did it twice. Replaced with single-pass selectors that walk `static_proxies` and each provider slot in place — no heap allocations of intermediate Vecs.

- `UrlTestGroup::pick_for_dial` — one pass tracks best, current, and first_any; updates the `fastest` name cache when better-by-tolerance.
- `UrlTestGroup::fastest_proxy`, `FallbackGroup::first_alive`, `SelectorGroup::selected_proxy` — single-walk variants for info/REST paths.

**Did not** add ArcSwap-cached selection across health probes (which the scout suggested) — the codebase has no internal health-probe loop driving selection updates; delays only land via the external REST `/proxies/{name}/delay` endpoint. A cached selection would race with the dial path. The right fix is a background probe loop, out of PR-C scope.

### T2.2 — lock-free route table via ArcSwap

`TunnelInner` previously held three `parking_lot::RwLock`s read on every Rule-mode connection setup (`rules`, `domain_index`, `proxies`). Bundled into a single

```rust
RouteTable { rules: Arc<Vec<Box<dyn Rule>>>, domain_index: Arc<DomainIndex>, proxies: HashMap<String, Arc<dyn Proxy>> }
```

behind `ArcSwap<RouteTable>`. `resolve_proxy` now does one lock-free load. Updates build a new RouteTable and atomically swap; `update_proxies` preserves rules + domain_index via Arc refcount bumps (`Box<dyn Rule>` is not `Clone`).

**Side benefit:** rules and proxies are now observed as a consistent snapshot. A connection can no longer match a rule pointing at a proxy that hasn't been inserted yet — the previous window between `update_rules` and `update_proxies` was benign (graceful DIRECT fallback) but the new model is stricter.

Adds `arc-swap` to mihomo-tunnel deps (already a workspace dep).

## ADR interactions

- **ADR-0006 §1 W3**: removes 3 lock acquisitions + per-dial Vec allocations from the connection-setup path; cumulative win proportional to group size for T2.1.
- **ADR-0008 HP-3**: T2.1 removes per-dial `Vec<Arc<dyn Proxy>>` allocations across all three group types and the inner duplicate name-string scans.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (490 passed)
- [x] `cargo test --tests` (955 passed, 6 ignored — includes `e5_group_delay_url_test_no_reselection` which guards the "delay probe must not change current" contract preserved by the `pick_for_dial` / `fastest_proxy` split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)