### PR TITLE
feat(listener): configurable max-connections (default unlimited)

### DIFF
--- a/crates/mihomo-app/src/main.rs
+++ b/crates/mihomo-app/src/main.rs
@@ -544,7 +544,8 @@ async fn run(
                 {
                     let listener = MixedListener::new(tunnel.clone(), addr, nl.name.clone())
                         .with_sniffer(Arc::clone(&sniffer_runtime))
-                        .with_auth(Arc::clone(&auth));
+                        .with_auth(Arc::clone(&auth))
+                        .with_max_connections(nl.max_connections);
                     tokio::spawn(async move {
                         if let Err(e) = listener.run().await {
                             error!("Listener error: {}", e);

--- a/crates/mihomo-config/src/lib.rs
+++ b/crates/mihomo-config/src/lib.rs
@@ -81,6 +81,11 @@ pub struct NamedListener {
     pub port: u16,
     pub listen: String,
     pub tproxy_sni: bool,
+    /// Cap on concurrent in-flight inbound connections for this listener.
+    /// `0` (default) disables the cap. Resolved from the per-listener
+    /// `max-connections` field, falling back to the global `max-connections`.
+    #[serde(default)]
+    pub max_connections: usize,
 }
 
 pub struct ListenerConfig {
@@ -638,12 +643,14 @@ fn build_named_listeners(
     let mut result: Vec<NamedListener> = Vec::new();
     let mut used_ports: HashMap<u16, String> = HashMap::new();
     let mut used_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let global_max_conns = raw.max_connections.unwrap_or(0);
 
     let mut add = |name: &str,
                    ltype: ListenerType,
                    port: u16,
                    listen: &str,
-                   tproxy_sni: bool|
+                   tproxy_sni: bool,
+                   max_connections: usize|
      -> Result<(), anyhow::Error> {
         if let Some(existing) = used_ports.get(&port) {
             anyhow::bail!(
@@ -662,19 +669,41 @@ fn build_named_listeners(
             port,
             listen: listen.to_string(),
             tproxy_sni,
+            max_connections,
         });
         Ok(())
     };
 
-    // Shorthand fields → auto-named listeners
+    // Shorthand fields → auto-named listeners (inherit global max-connections)
     if let Some(port) = raw.mixed_port {
-        add("mixed", ListenerType::Mixed, port, default_bind, false)?;
+        add(
+            "mixed",
+            ListenerType::Mixed,
+            port,
+            default_bind,
+            false,
+            global_max_conns,
+        )?;
     }
     if let Some(port) = raw.socks_port {
-        add("socks", ListenerType::Socks5, port, default_bind, false)?;
+        add(
+            "socks",
+            ListenerType::Socks5,
+            port,
+            default_bind,
+            false,
+            global_max_conns,
+        )?;
     }
     if let Some(port) = raw.port {
-        add("http", ListenerType::Http, port, default_bind, false)?;
+        add(
+            "http",
+            ListenerType::Http,
+            port,
+            default_bind,
+            false,
+            global_max_conns,
+        )?;
     }
     if let Some(port) = raw.tproxy_port {
         add(
@@ -683,6 +712,7 @@ fn build_named_listeners(
             port,
             "127.0.0.1",
             global_tproxy_sni,
+            global_max_conns,
         )?;
     }
 
@@ -698,7 +728,15 @@ fn build_named_listeners(
                 default_bind
             });
         let tproxy_sni = raw_l.tproxy_sni.unwrap_or(global_tproxy_sni);
-        add(&raw_l.name, ltype, raw_l.port, listen, tproxy_sni)?;
+        let max_connections = raw_l.max_connections.unwrap_or(global_max_conns);
+        add(
+            &raw_l.name,
+            ltype,
+            raw_l.port,
+            listen,
+            tproxy_sni,
+            max_connections,
+        )?;
     }
 
     Ok(result)

--- a/crates/mihomo-config/src/raw.rs
+++ b/crates/mihomo-config/src/raw.rs
@@ -75,6 +75,10 @@ pub struct RawConfig {
     pub authentication: Option<Vec<String>>,
     pub skip_auth_prefixes: Option<Vec<String>>,
     pub geodata: Option<RawGeoDataConfig>,
+    /// Global default cap on concurrent in-flight inbound connections per
+    /// listener. `0` (the default) disables the cap. Individual `listeners:`
+    /// entries can override this with their own `max-connections` field.
+    pub max_connections: Option<usize>,
 }
 
 /// A `hosts:` map value: either a single IP address or a list of addresses.
@@ -104,6 +108,9 @@ pub struct RawListener {
     pub port: u16,
     pub listen: Option<String>,
     pub tproxy_sni: Option<bool>,
+    /// Per-listener override of the global `max-connections` cap. `0`
+    /// disables the cap for this listener.
+    pub max_connections: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/mihomo-listener/src/mixed.rs
+++ b/crates/mihomo-listener/src/mixed.rs
@@ -10,12 +10,13 @@ use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
 /// Default cap on in-flight inbound connections per listener.
-/// Empirically, each live VLESS+WS+TLS+ECH tunnel costs ~90 KB of userland
-/// memory (rustls/BoringSSL state + WS framer + tokio future heap + relay
-/// buffers). 256 caps load RSS at ~50 MB on top of an ~18 MB idle baseline —
-/// the documented footprint cap. Excess clients block on `accept()` rather
-/// than driving RSS unbounded.
-pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
+/// `0` means no cap — the listener accepts as many concurrent connections as
+/// the kernel and tokio runtime can hold. Set a positive value (via the
+/// `max-connections` config key, top-level or per-listener) to back-pressure
+/// the TCP listen queue and bound RSS under burst load: each live
+/// VLESS+WS+TLS+ECH tunnel costs ~90 KB of userland memory, so a cap of 256
+/// holds RSS to ~50 MB on top of an ~18 MB idle baseline.
+pub const DEFAULT_MAX_CONNECTIONS: usize = 0;
 
 pub struct MixedListener {
     tunnel: Tunnel,
@@ -61,10 +62,17 @@ impl MixedListener {
 
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let listener = TcpListener::bind(self.listen_addr).await?;
-        info!(
-            "Mixed listener '{}' on {} (max_connections={})",
-            self.name, self.listen_addr, self.max_connections
-        );
+        if self.max_connections == 0 {
+            info!(
+                "Mixed listener '{}' on {} (max_connections=unlimited)",
+                self.name, self.listen_addr
+            );
+        } else {
+            info!(
+                "Mixed listener '{}' on {} (max_connections={})",
+                self.name, self.listen_addr, self.max_connections
+            );
+        }
 
         // Bound the number of in-flight connection-handler tasks so RSS stays
         // capped under burst load. The semaphore is None when max=0


### PR DESCRIPTION
## Summary
- Removes the hardcoded 256 in-flight semaphore cap on the Mixed listener. The cap caused client-side hangs in production when upstream proxy nodes stalled — connections accumulated faster than they could drain, the listener back-pressured the TCP accept queue, and new clients sat in the kernel backlog.
- Default is now `0` (unlimited). A new top-level `max-connections` YAML field sets a global cap; per-listener `max-connections` overrides it on `listeners:` entries.

## Files
- `crates/mihomo-listener/src/mixed.rs` — `DEFAULT_MAX_CONNECTIONS = 0`, startup log now says `max_connections=unlimited` when 0.
- `crates/mihomo-config/src/{raw,lib}.rs` — wire the new field through `RawConfig` / `RawListener` → `NamedListener` (per-listener falls back to global, which falls back to 0).
- `crates/mihomo-app/src/main.rs` — chain `.with_max_connections(nl.max_connections)` onto the listener builder.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default / no-default / all-features)
- [x] `cargo test --lib` — 491 passed
- [x] `cargo test -p mihomo-config` — 196 passed
- [x] Cross-built for `aarch64-unknown-linux-musl` via `cargo zigbuild` and deployed to a Raspberry Pi running the prior 256-cap binary; saturation warnings stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)