### PR TITLE
feat(config): route rule-provider and geodata fetches through first proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ dependencies = [
  "async-trait",
  "base64",
  "hickory-proto",
+ "httparse",
  "ipnet",
  "libc",
  "maxminddb",
@@ -2040,12 +2041,17 @@ dependencies = [
  "parking_lot",
  "regex",
  "reqwest",
+ "rustls",
  "serde",
  "serde_yaml",
+ "smol_str",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/crates/mihomo-app/src/main.rs
+++ b/crates/mihomo-app/src/main.rs
@@ -708,19 +708,33 @@ async fn geodata_auto_update_loop(
 
         let mut any_updated = false;
 
-        if let Err(e) = download_and_replace(&geo.mmdb_url, &mmdb_target).await {
+        // Look up the first upstream proxy on each tick — captures any
+        // selector/group changes since startup.
+        let proxies = tunnel.proxies();
+        let download_proxy = mihomo_config::internal_http::first_named_proxy(
+            raw_config.read().proxies.as_deref(),
+            &proxies,
+        );
+
+        if let Err(e) =
+            download_and_replace(&geo.mmdb_url, &mmdb_target, download_proxy.as_ref()).await
+        {
             warn!("geodata auto-update: GeoIP MMDB download failed: {:#}", e);
         } else {
             any_updated = true;
         }
 
-        if let Err(e) = download_and_replace(&geo.asn_url, &asn_target).await {
+        if let Err(e) =
+            download_and_replace(&geo.asn_url, &asn_target, download_proxy.as_ref()).await
+        {
             warn!("geodata auto-update: ASN MMDB download failed: {:#}", e);
         } else {
             any_updated = true;
         }
 
-        if let Err(e) = download_and_replace(&geo.geosite_url, &geosite_target).await {
+        if let Err(e) =
+            download_and_replace(&geo.geosite_url, &geosite_target, download_proxy.as_ref()).await
+        {
             warn!("geodata auto-update: geosite download failed: {:#}", e);
         } else {
             any_updated = true;

--- a/crates/mihomo-config/Cargo.toml
+++ b/crates/mihomo-config/Cargo.toml
@@ -35,6 +35,12 @@ base64 = { workspace = true }
 regex = { workspace = true }
 parking_lot = { workspace = true }
 hickory-proto = { workspace = true }
+smol_str = { workspace = true }
+tokio-rustls = { workspace = true }
+rustls = { workspace = true }
+webpki-roots = { workspace = true }
+url = "2"
+httparse = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/mihomo-config/src/geodata.rs
+++ b/crates/mihomo-config/src/geodata.rs
@@ -1,6 +1,9 @@
+use crate::internal_http;
 use crate::raw::RawGeoDataConfig;
 use anyhow::anyhow;
+use mihomo_common::adapter::Proxy;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
 
@@ -90,24 +93,44 @@ pub fn parse_geodata(raw: Option<&RawGeoDataConfig>) -> Result<GeoDataConfig, an
 
 /// Download `url` and atomically replace `dest` via a `.tmp` sibling.
 ///
+/// When `proxy` is `Some`, the HTTP fetch is tunneled through that proxy
+/// adapter (used so GFW-blocked CDNs stay reachable on background refresh);
+/// otherwise the OS handles connectivity directly.
+///
 /// Returns `Ok(())` on success. On failure the temp file is removed (best-
 /// effort) and the original `dest` is untouched.
-pub async fn download_and_replace(url: &str, dest: &Path) -> Result<(), anyhow::Error> {
+pub async fn download_and_replace(
+    url: &str,
+    dest: &Path,
+    proxy: Option<&Arc<dyn Proxy>>,
+) -> Result<(), anyhow::Error> {
     let tmp = dest.with_extension("tmp");
 
-    info!("auto-update: downloading {} from {}", dest.display(), url);
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(60))
-        .user_agent(concat!("clash.meta/", env!("CARGO_PKG_VERSION")))
-        .build()?;
-
-    let resp = client.get(url).send().await?;
-    let status = resp.status();
-    if !status.is_success() {
-        return Err(anyhow!("HTTP {status} fetching {url}"));
+    if let Some(p) = proxy {
+        info!(
+            "auto-update: downloading {} from {} via proxy '{}'",
+            dest.display(),
+            url,
+            p.name()
+        );
+    } else {
+        info!("auto-update: downloading {} from {}", dest.display(), url);
     }
-    let bytes = resp.bytes().await?;
+
+    let bytes = if let Some(p) = proxy {
+        internal_http::fetch_via_proxy(url, p).await?
+    } else {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60))
+            .user_agent(concat!("clash.meta/", env!("CARGO_PKG_VERSION")))
+            .build()?;
+        let resp = client.get(url).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(anyhow!("HTTP {status} fetching {url}"));
+        }
+        resp.bytes().await?.to_vec()
+    };
 
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/mihomo-config/src/internal_http.rs
+++ b/crates/mihomo-config/src/internal_http.rs
@@ -1,0 +1,207 @@
+//! Tiny HTTP/1.1 GET client that tunnels through a mihomo `Proxy` adapter.
+//!
+//! Used by rule-provider and geodata downloaders so that internal HTTP fetches
+//! (which often target GFW-blocked hosts like `raw.githubusercontent.com` and
+//! `github.com` release assets) can route through one of the user's configured
+//! upstream nodes instead of going direct.
+//!
+//! Scope is intentionally minimal:
+//!   * `GET` only.
+//!   * HTTP/1.1, `Connection: close`, `Accept-Encoding: identity`.
+//!   * Follows up to 5 redirects (`3xx` with `Location`).
+//!   * No streaming — full body buffered in memory (matches the existing
+//!     `reqwest::bytes()` semantics on every call site).
+
+use anyhow::{anyhow, bail, Result};
+use mihomo_common::adapter::Proxy;
+use mihomo_common::metadata::Metadata;
+use mihomo_common::{ConnType, Network};
+use smol_str::SmolStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use url::Url;
+
+const MAX_REDIRECTS: u8 = 5;
+const READ_TIMEOUT: Duration = Duration::from_secs(60);
+const USER_AGENT: &str = concat!("clash.meta/", env!("CARGO_PKG_VERSION"));
+const MAX_BODY_BYTES: usize = 256 * 1024 * 1024; // 256 MiB hard ceiling
+
+/// Fetch `url` via `proxy` and return the response body.
+///
+/// Follows up to [`MAX_REDIRECTS`] redirects (302/301/307/308). Returns an
+/// error for non-2xx terminal responses, oversize bodies, or transport errors.
+pub async fn fetch_via_proxy(url: &str, proxy: &Arc<dyn Proxy>) -> Result<Vec<u8>> {
+    let mut current = Url::parse(url).map_err(|e| anyhow!("invalid URL '{url}': {e}"))?;
+    for _ in 0..=MAX_REDIRECTS {
+        match fetch_one(&current, proxy).await? {
+            Outcome::Body(bytes) => return Ok(bytes),
+            Outcome::Redirect(next) => {
+                current = current
+                    .join(&next)
+                    .map_err(|e| anyhow!("bad redirect Location '{next}': {e}"))?;
+            }
+        }
+    }
+    bail!("too many redirects (> {MAX_REDIRECTS}) starting from {url}")
+}
+
+enum Outcome {
+    Body(Vec<u8>),
+    Redirect(String),
+}
+
+async fn fetch_one(url: &Url, proxy: &Arc<dyn Proxy>) -> Result<Outcome> {
+    let scheme = url.scheme();
+    let is_https = match scheme {
+        "https" => true,
+        "http" => false,
+        other => bail!("unsupported URL scheme '{other}': {url}"),
+    };
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("URL has no host: {url}"))?
+        .to_string();
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| anyhow!("URL has no port: {url}"))?;
+    let path_and_query = match url.query() {
+        Some(q) => format!("{}?{q}", url.path()),
+        None => url.path().to_string(),
+    };
+
+    let metadata = Metadata {
+        network: Network::Tcp,
+        conn_type: ConnType::Http,
+        host: SmolStr::from(&host),
+        dst_port: port,
+        ..Metadata::default()
+    };
+
+    let conn = proxy
+        .dial_tcp(&metadata)
+        .await
+        .map_err(|e| anyhow!("dial via proxy '{}': {e}", proxy.name()))?;
+
+    let request = format!(
+        "GET {path} HTTP/1.1\r\n\
+         Host: {host_header}\r\n\
+         User-Agent: {ua}\r\n\
+         Accept: */*\r\n\
+         Accept-Encoding: identity\r\n\
+         Connection: close\r\n\
+         \r\n",
+        path = path_and_query,
+        host_header = host_header(&host, port, is_https),
+        ua = USER_AGENT,
+    );
+
+    if is_https {
+        let tls = tls_connector();
+        let server_name = rustls::pki_types::ServerName::try_from(host.clone())
+            .map_err(|e| anyhow!("invalid TLS server name '{host}': {e}"))?;
+        let mut stream = tls
+            .connect(server_name, conn)
+            .await
+            .map_err(|e| anyhow!("TLS handshake to {host}: {e}"))?;
+        stream.write_all(request.as_bytes()).await?;
+        stream.flush().await?;
+        read_response(&mut stream).await
+    } else {
+        let mut stream = conn;
+        stream.write_all(request.as_bytes()).await?;
+        stream.flush().await?;
+        read_response(&mut stream).await
+    }
+}
+
+fn host_header(host: &str, port: u16, is_https: bool) -> String {
+    let default_port = if is_https { 443 } else { 80 };
+    if port == default_port {
+        host.to_string()
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+async fn read_response<S>(stream: &mut S) -> Result<Outcome>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    // Read until EOF with a wall-clock timeout. Connection: close means
+    // the server signals end-of-body by closing the socket.
+    let mut buf = Vec::with_capacity(64 * 1024);
+    let read = async {
+        let mut tmp = [0u8; 16 * 1024];
+        loop {
+            let n = stream.read(&mut tmp).await?;
+            if n == 0 {
+                break;
+            }
+            if buf.len() + n > MAX_BODY_BYTES {
+                bail!("response exceeds max body size ({MAX_BODY_BYTES} bytes)");
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        Result::<()>::Ok(())
+    };
+    tokio::time::timeout(READ_TIMEOUT, read)
+        .await
+        .map_err(|_| anyhow!("response read timed out after {READ_TIMEOUT:?}"))??;
+
+    parse_response(&buf)
+}
+
+fn parse_response(buf: &[u8]) -> Result<Outcome> {
+    let mut headers = [httparse::EMPTY_HEADER; 64];
+    let mut resp = httparse::Response::new(&mut headers);
+    let parsed = resp
+        .parse(buf)
+        .map_err(|e| anyhow!("response parse error: {e}"))?;
+    let body_start = match parsed {
+        httparse::Status::Complete(n) => n,
+        httparse::Status::Partial => bail!("incomplete HTTP response (no header terminator)"),
+    };
+    let status = resp
+        .code
+        .ok_or_else(|| anyhow!("response missing status code"))?;
+
+    if (300..400).contains(&status) {
+        for h in resp.headers.iter() {
+            if h.name.eq_ignore_ascii_case("location") {
+                let loc = std::str::from_utf8(h.value)
+                    .map_err(|e| anyhow!("non-UTF-8 Location header: {e}"))?;
+                return Ok(Outcome::Redirect(loc.to_string()));
+            }
+        }
+        bail!("HTTP {status} redirect without Location header");
+    }
+    if !(200..300).contains(&status) {
+        bail!("HTTP {status}");
+    }
+    Ok(Outcome::Body(buf[body_start..].to_vec()))
+}
+
+fn tls_connector() -> tokio_rustls::TlsConnector {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    tokio_rustls::TlsConnector::from(Arc::new(config))
+}
+
+/// Pick the first proxy named in the user's `proxies:` config block and look
+/// it up in the live proxy registry.
+///
+/// Returns `None` if there are no `proxies:` entries, if the first entry has
+/// no `name:` field, or if that name isn't in the registry (e.g. it failed to
+/// load during proxy construction).
+pub fn first_named_proxy(
+    raw_proxies: Option<&[std::collections::HashMap<String, serde_yaml::Value>]>,
+    proxies: &std::collections::HashMap<String, Arc<dyn Proxy>>,
+) -> Option<Arc<dyn Proxy>> {
+    let entry = raw_proxies?.first()?;
+    let name = entry.get("name")?.as_str()?;
+    proxies.get(name).cloned()
+}

--- a/crates/mihomo-config/src/lib.rs
+++ b/crates/mihomo-config/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod dns_parser;
 pub mod ech_dns;
 pub mod geodata;
+pub mod internal_http;
 pub mod proxy_parser;
 pub mod proxy_provider;
 pub mod raw;
@@ -293,9 +294,14 @@ fn rebuild_from_raw_impl(
     let ctx = build_parser_context_from_raw(raw)?;
 
     // Load rule-providers before rule parsing so RULE-SET entries can
-    // resolve their named sets.
+    // resolve their named sets. Route HTTP fetches through the first
+    // upstream proxy from `proxies:` (if any) so providers hosted on
+    // GFW-blocked domains stay reachable.
+    let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     let providers = match raw.rule_providers.as_ref() {
-        Some(map) if !map.is_empty() => rule_provider::load_providers(map, cache_dir, &ctx),
+        Some(map) if !map.is_empty() => {
+            rule_provider::load_providers(map, cache_dir, &ctx, download_proxy.as_ref())
+        }
         _ => HashMap::new(),
     };
     let ruleset_map = rule_provider::snapshot_ruleset_map(&providers);
@@ -829,10 +835,14 @@ async fn build_config(
     )?;
 
     // Rule providers share the same ParserContext as the top-level rules
-    // (same geodata paths, same lazy-loaded readers).
+    // (same geodata paths, same lazy-loaded readers). HTTP fetches route
+    // through the first upstream proxy from `proxies:` (if any).
     let ctx = build_parser_context_with_geo(&raw, &geodata)?;
+    let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     let rule_providers = match raw.rule_providers.as_ref() {
-        Some(map) if !map.is_empty() => rule_provider::load_providers(map, cache_dir, &ctx),
+        Some(map) if !map.is_empty() => {
+            rule_provider::load_providers(map, cache_dir, &ctx, download_proxy.as_ref())
+        }
         _ => HashMap::new(),
     };
 

--- a/crates/mihomo-config/src/rule_provider.rs
+++ b/crates/mihomo-config/src/rule_provider.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context, Result};
+use mihomo_common::adapter::Proxy;
 use mihomo_rules::{
     build_rule_set, build_rule_set_from_mrs, is_mrs_bytes, ParserContext, RuleSet, RuleSetBehavior,
     RuleSetFormat,
@@ -19,6 +20,7 @@ use parking_lot::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{info, warn};
 
+use crate::internal_http;
 use crate::raw::RawRuleProvider;
 
 // ---------------------------------------------------------------------------
@@ -56,6 +58,9 @@ pub struct RuleProvider {
     /// Unix timestamp (seconds) of last successful load/refresh.
     updated_at: AtomicU64,
     rules: RwLock<Arc<dyn RuleSet>>,
+    /// Upstream proxy to route HTTP fetches through. `None` = direct.
+    /// Captured at load time; reused on every periodic `refresh()`.
+    download_proxy: Option<Arc<dyn Proxy>>,
 }
 
 impl std::fmt::Debug for RuleProvider {
@@ -89,7 +94,7 @@ impl RuleProvider {
         if self.provider_type != ProviderType::Http {
             return Ok(());
         }
-        let bytes = fetch_http_async(&self.vehicle).await?;
+        let bytes = fetch_http_async(&self.vehicle, self.download_proxy.as_ref()).await?;
         let behavior = self.behavior;
         let ctx_clone = ctx.clone();
         let boxed: Box<dyn RuleSet> = tokio::task::spawn_blocking(move || {
@@ -126,13 +131,14 @@ pub fn load_providers(
     raw_providers: &HashMap<String, RawRuleProvider>,
     cache_dir: Option<&Path>,
     ctx: &ParserContext,
+    download_proxy: Option<&Arc<dyn Proxy>>,
 ) -> HashMap<String, Arc<RuleProvider>> {
     let mut out = HashMap::new();
     if raw_providers.is_empty() {
         return out;
     }
     for (name, cfg) in raw_providers {
-        match load_one(name, cfg, cache_dir, ctx) {
+        match load_one(name, cfg, cache_dir, ctx, download_proxy) {
             Ok(provider) => {
                 info!(
                     "Loaded rule-provider '{}' ({}/{}): {} entries",
@@ -168,12 +174,13 @@ fn load_one(
     cfg: &RawRuleProvider,
     cache_dir: Option<&Path>,
     ctx: &ParserContext,
+    download_proxy: Option<&Arc<dyn Proxy>>,
 ) -> Result<RuleProvider> {
     let behavior: RuleSetBehavior = cfg.behavior.parse().map_err(|e: String| anyhow!("{e}"))?;
     match cfg.provider_type.as_str() {
         "inline" => load_inline(name, cfg, behavior, ctx),
         "file" => load_file(name, cfg, cache_dir, behavior, ctx),
-        "http" => load_http(name, cfg, cache_dir, behavior, ctx),
+        "http" => load_http(name, cfg, cache_dir, behavior, ctx, download_proxy),
         other => Err(anyhow!("unknown rule-provider type: {other}")),
     }
 }
@@ -202,6 +209,7 @@ fn load_inline(
         String::new(),
         0,
         rules,
+        None,
     ))
 }
 
@@ -233,6 +241,7 @@ fn load_file(
         vehicle,
         0,
         rules,
+        None,
     ))
 }
 
@@ -242,13 +251,14 @@ fn load_http(
     cache_dir: Option<&Path>,
     behavior: RuleSetBehavior,
     ctx: &ParserContext,
+    download_proxy: Option<&Arc<dyn Proxy>>,
 ) -> Result<RuleProvider> {
     let url = cfg
         .url
         .as_deref()
         .ok_or_else(|| anyhow!("http provider '{name}' requires a 'url'"))?;
     let cache_path = resolve_path(cfg, cache_dir, name);
-    let bytes = fetch_http_blocking_with_cache(url, cache_path.as_deref())?;
+    let bytes = fetch_http_blocking_with_cache(url, cache_path.as_deref(), download_proxy)?;
     let explicit_format = parse_explicit_format(cfg)?;
     let rules = parse_bytes_to_ruleset_with_format(&bytes, behavior, explicit_format, ctx)?;
     let interval = cfg.interval.unwrap_or(0);
@@ -259,6 +269,7 @@ fn load_http(
         url.to_string(),
         interval,
         rules,
+        download_proxy.cloned(),
     ))
 }
 
@@ -269,6 +280,7 @@ fn make_provider(
     vehicle: String,
     interval: u64,
     rules: Box<dyn RuleSet>,
+    download_proxy: Option<Arc<dyn Proxy>>,
 ) -> RuleProvider {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -283,6 +295,7 @@ fn make_provider(
         interval,
         updated_at: AtomicU64::new(now),
         rules: RwLock::new(rules_arc),
+        download_proxy,
     }
 }
 
@@ -369,8 +382,12 @@ fn resolve_path(cfg: &RawRuleProvider, cache_dir: Option<&Path>, name: &str) -> 
 // HTTP fetch
 // ---------------------------------------------------------------------------
 
-fn fetch_http_blocking_with_cache(url: &str, cache_path: Option<&Path>) -> Result<Vec<u8>> {
-    match fetch_http_blocking(url) {
+fn fetch_http_blocking_with_cache(
+    url: &str,
+    cache_path: Option<&Path>,
+    proxy: Option<&Arc<dyn Proxy>>,
+) -> Result<Vec<u8>> {
+    match fetch_http_blocking(url, proxy) {
         Ok(bytes) => {
             if let Some(path) = cache_path {
                 write_cache(path, &bytes);
@@ -394,15 +411,18 @@ fn fetch_http_blocking_with_cache(url: &str, cache_path: Option<&Path>) -> Resul
     }
 }
 
-fn fetch_http_blocking(url: &str) -> Result<Vec<u8>> {
+fn fetch_http_blocking(url: &str, proxy: Option<&Arc<dyn Proxy>>) -> Result<Vec<u8>> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .context("building temporary tokio runtime for rule-provider fetch")?;
-    rt.block_on(fetch_http_async(url))
+    rt.block_on(fetch_http_async(url, proxy))
 }
 
-pub(crate) async fn fetch_http_async(url: &str) -> Result<Vec<u8>> {
+pub(crate) async fn fetch_http_async(url: &str, proxy: Option<&Arc<dyn Proxy>>) -> Result<Vec<u8>> {
+    if let Some(p) = proxy {
+        return internal_http::fetch_via_proxy(url, p).await;
+    }
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .user_agent(concat!("clash.meta/", env!("CARGO_PKG_VERSION")))
@@ -476,7 +496,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, Some(dir.path()), &ctx());
+        let out = load_providers(&providers, Some(dir.path()), &ctx(), None);
         assert_eq!(out.len(), 1);
         let p = out.get("test").unwrap();
         assert_eq!(p.behavior, RuleSetBehavior::Domain);
@@ -498,7 +518,7 @@ mod tests {
                 payload: Some(vec!["example.com".to_string(), "+.foo.com".to_string()]),
             },
         );
-        let out = load_providers(&providers, None, &ctx());
+        let out = load_providers(&providers, None, &ctx(), None);
         assert_eq!(out.len(), 1);
         let p = out.get("my-rules").unwrap();
         assert_eq!(p.provider_type, ProviderType::Inline);
@@ -543,7 +563,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, None, &ctx());
+        let out = load_providers(&providers, None, &ctx(), None);
         let p = out.get("mrs-test").expect("provider should load");
         assert_eq!(p.rule_count(), 2);
     }
@@ -567,7 +587,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, None, &ctx());
+        let out = load_providers(&providers, None, &ctx(), None);
         assert_eq!(out.get("x").unwrap().rule_count(), 1);
     }
 
@@ -586,7 +606,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, None, &ctx());
+        let out = load_providers(&providers, None, &ctx(), None);
         assert!(out.is_empty());
     }
 
@@ -608,7 +628,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, None, &ctx());
+        let out = load_providers(&providers, None, &ctx(), None);
         assert_eq!(out.len(), 1);
     }
 
@@ -639,7 +659,7 @@ mod tests {
                 payload: Some(vec!["10.0.0.0/8".to_string()]),
             },
         );
-        let out = load_providers(&providers, None, &ctx());
+        let out = load_providers(&providers, None, &ctx(), None);
         let ruleset_map = snapshot_ruleset_map(&out);
         assert_eq!(ruleset_map.len(), 2);
         assert!(ruleset_map.contains_key("p1"));


### PR DESCRIPTION
## Summary
- Rule-provider and geodata-auto-update HTTP fetches previously used a default \`reqwest::Client\` with no proxy. On hosts behind a censoring network (e.g. a Raspberry Pi in mainland China), the GitHub-hosted MMDB / geosite / rule-set URLs were unreachable.
- This PR adds a small \`tokio + tokio-rustls\` HTTP/1.1 GET client that dials via a \`ProxyAdapter\` and uses the **first entry of the user's \`proxies:\` list** as the download proxy automatically. No new config knob.
- Falls back to the existing reqwest path when no upstream proxy is configured (e.g. \`proxies:\` is empty or the first entry has no \`name:\`).

## Implementation
- \`crates/mihomo-config/src/internal_http.rs\` (new, ~200 LOC) — HTTP/1.1 \`GET\`, up to 5 redirects (needed for GitHub release-asset → CDN), 60 s read timeout, 256 MiB body cap. TLS via \`tokio-rustls\` + \`webpki-roots\`.
- \`first_named_proxy(raw.proxies, &live_proxies)\` resolves the first proxy at config-build time (for initial provider load) and at every auto-update tick (so it tracks live group changes).
- \`rule_provider::{load_providers, RuleProvider, refresh}\` now thread \`Option<Arc<dyn Proxy>>\` so periodic refresh reuses the same proxy.
- \`geodata::download_and_replace\` accepts an optional proxy; \`main.rs::geodata_auto_update_loop\` re-resolves the first proxy per tick.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (default / no-default / all-features)
- [x] \`cargo test --lib\` — 491 passed
- [x] \`cargo test -p mihomo-config\` — 196 passed
- [x] Cross-built \`aarch64-unknown-linux-musl\` via \`cargo zigbuild\` and deployed to a Raspberry Pi; service healthy on the new binary.
- [ ] **Functional verification still pending** — the deploy target currently has \`rule-providers: null\` and \`geodata: null\`, so the new path is dormant in production. Verified compile/lint only; will add an integration test against a loopback HTTP server + Direct adapter in a follow-up if reviewers want belt-and-braces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)