### PR TITLE
chore: gitignore local-state files

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8d3504e3-e6c2-4ad6-8768-36ddb23cf1cb","pid":66868,"procStart":"Sun May 17 06:38:17 2026","acquiredAt":1779002623464}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Dockerfile.debug
 dhat-heap.json
 dhat-ad-hoc.json
 dh_out.json
+.claude/scheduled_tasks.lock
+.antigravitycli/


### PR DESCRIPTION
## Summary
- Adds \`.claude/scheduled_tasks.lock\` and \`.antigravitycli/\` to \`.gitignore\`.
- Untracks the lock file (it was accidentally committed earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)