### PR TITLE
test(config): real-world Clash Meta smoke test + fix custom direct-proxy names

### DIFF
--- a/crates/mihomo-app/tests/config_smoke.rs
+++ b/crates/mihomo-app/tests/config_smoke.rs
@@ -5,6 +5,7 @@
 // refactors before the full integration test suite runs.
 
 const MINIMAL_YAML: &str = include_str!("fixtures/minimal.yaml");
+const REALWORLD_YAML: &str = include_str!("fixtures/realworld_clash_meta.yaml");
 
 #[tokio::test]
 async fn load_minimal_config_parses_without_error() {
@@ -41,5 +42,63 @@ async fn load_minimal_config_parses_without_error() {
         config.listeners.mixed_port,
         Some(7890),
         "expected mixed-port 7890 from fixture"
+    );
+}
+
+/// Real-world community Clash Meta config — exercises proxy-providers, many
+/// selector groups with `include-all`/`filter`/`exclude-type`, a `url-test`
+/// auto-group, fake-IP DNS, and the GEOIP/GEOSITE rule set. Guards against
+/// parser regressions that would break a typical end-user config.
+///
+/// See the fixture header for the three patches against the original.
+#[tokio::test]
+async fn load_realworld_config_parses_without_error() {
+    let config = mihomo_config::load_config_from_str(REALWORLD_YAML)
+        .await
+        .expect("realworld_clash_meta.yaml must parse cleanly");
+
+    // 1 direct adapter + 3 built-ins + 20 proxy-groups = 24 entries.
+    assert!(
+        config.proxies.contains_key("直连"),
+        "named direct proxy '直连' must be parsed"
+    );
+    for group in [
+        "默认",
+        "Google",
+        "Telegram",
+        "Twitter",
+        "哔哩哔哩",
+        "巴哈姆特",
+        "YouTube",
+        "NETFLIX",
+        "Spotify",
+        "Github",
+        "国内",
+        "其他",
+        "香港",
+        "台湾",
+        "日本",
+        "美国",
+        "新加坡",
+        "其它地区",
+        "全部节点",
+        "自动选择",
+    ] {
+        assert!(
+            config.proxies.contains_key(group),
+            "proxy-group '{group}' must be parsed; keys: {:?}",
+            config.proxies.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // Mixed listener on 7890.
+    assert_eq!(config.listeners.mixed_port, Some(7890));
+
+    // All 18 rules parsed (12 GEOSITE + 5 GEOIP + 1 MATCH).
+    assert_eq!(
+        config.rules.len(),
+        18,
+        "expected 18 parsed rules, got {}",
+        config.rules.len()
     );
 }

--- a/crates/mihomo-app/tests/fixtures/realworld_clash_meta.yaml
+++ b/crates/mihomo-app/tests/fixtures/realworld_clash_meta.yaml
@@ -1,0 +1,214 @@
+# Real-world Clash Meta config (community template, anonymised subscription URLs).
+# Exercises proxy-providers, multi-region selector groups with `include-all` +
+# `filter`, a `url-test` auto-group, fake-IP DNS with TLS-bootstrap, sniffer
+# (TLS/HTTP/QUIC), and the full GEOIP/GEOSITE rule set used by typical CN users.
+#
+# Three patches vs. the original to satisfy the current parser:
+#   1. `sniffer.sniff.HTTP.ports: [80, "8080-8880"]` → `[80, 8080]`
+#      (port-range strings not supported; tracked as a parser gap).
+#   2. `exclude-type: direct` → `exclude-type: [direct]` on every geo group
+#      (scalar form not supported; tracked as a parser gap).
+#   3. `default-nameserver: tls://223.5.5.5` → `udp://223.5.5.5`
+#      (TLS in default-nameserver intentionally rejected per ADR-0002 to
+#      avoid a bootstrap loop — Class A divergence, no fix planned).
+proxy-providers:
+  provider1:
+    url: ""
+    type: http
+    interval: 86400
+    health-check: {enable: true, url: "https://www.gstatic.com/generate_204", interval: 300}
+    override:
+      additional-prefix: "[provider1]"
+
+  provider2:
+    url: ""
+    type: http
+    interval: 86400
+    health-check: {enable: true, url: "https://www.gstatic.com/generate_204", interval: 300}
+    override:
+      additional-prefix: "[provider2]"
+
+proxies:
+  - name: "直连"
+    type: direct
+    udp: true
+
+mixed-port: 7890
+ipv6: true
+allow-lan: true
+unified-delay: false
+tcp-concurrent: true
+external-controller: 127.0.0.1:9090
+external-ui: ui
+external-ui-url: "https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip"
+
+geodata-mode: true
+geox-url:
+  geoip: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip-lite.dat"
+  geosite: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+  mmdb: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country-lite.mmdb"
+  asn: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+
+find-process-mode: strict
+global-client-fingerprint: chrome
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80, 8080]
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+    QUIC:
+      ports: [443, 8443]
+  skip-domain:
+    - "Mijia Cloud"
+    - "+.push.apple.com"
+
+tun:
+  enable: true
+  stack: mixed
+  dns-hijack:
+    - "any:53"
+    - "tcp://any:53"
+  auto-route: true
+  auto-redirect: true
+  auto-detect-interface: true
+
+dns:
+  enable: true
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-filter:
+    - "*"
+    - "+.lan"
+    - "+.local"
+    - "+.market.xiaomi.com"
+  default-nameserver:
+    - udp://223.5.5.5
+    - udp://223.6.6.6
+  nameserver:
+    - https://doh.pub/dns-query
+    - https://dns.alidns.com/dns-query
+
+proxy-groups:
+  - name: 默认
+    type: select
+    proxies: [自动选择, 直连, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点]
+
+  - name: Google
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Telegram
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Twitter
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 哔哩哔哩
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 巴哈姆特
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: YouTube
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: NETFLIX
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Spotify
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Github
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 国内
+    type: select
+    proxies: [直连, 默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择]
+
+  - name: 其他
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 香港
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)港|hk|hongkong|hong kong"
+
+  - name: 台湾
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)台|tw|taiwan"
+
+  - name: 日本
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)日|jp|japan"
+
+  - name: 美国
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)美|us|unitedstates|united states"
+
+  - name: 新加坡
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)(新|sg|singapore)"
+
+  - name: 其它地区
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)^(?!.*(?:🇭🇰|🇯🇵|🇺🇸|🇸🇬|🇨🇳|港|hk|hongkong|台|tw|taiwan|日|jp|japan|新|sg|singapore|美|us|unitedstates)).*"
+
+  - name: 全部节点
+    type: select
+    include-all: true
+    exclude-type: [direct]
+
+  - name: 自动选择
+    type: url-test
+    include-all: true
+    exclude-type: [direct]
+    tolerance: 10
+
+rules:
+  - GEOIP,lan,直连,no-resolve
+  - GEOSITE,github,Github
+  - GEOSITE,twitter,Twitter
+  - GEOSITE,youtube,YouTube
+  - GEOSITE,google,Google
+  - GEOSITE,telegram,Telegram
+  - GEOSITE,netflix,NETFLIX
+  - GEOSITE,bilibili,哔哩哔哩
+  - GEOSITE,bahamut,巴哈姆特
+  - GEOSITE,spotify,Spotify
+  - GEOSITE,CN,国内
+  - GEOSITE,geolocation-!cn,其他
+
+  - GEOIP,google,Google
+  - GEOIP,netflix,NETFLIX
+  - GEOIP,telegram,Telegram
+  - GEOIP,twitter,Twitter
+  - GEOIP,CN,国内
+  - MATCH,其他

--- a/crates/mihomo-config/src/lib.rs
+++ b/crates/mihomo-config/src/lib.rs
@@ -233,8 +233,16 @@ fn rebuild_from_raw_impl(
     for raw_proxy in raw.proxies.as_deref().unwrap_or(&[]) {
         match proxy_parser::parse_proxy(raw_proxy) {
             Ok(proxy) => {
-                let name = proxy.name().to_string();
-                proxies.insert(name, proxy);
+                // Prefer the YAML `name:` as the registry key. `proxy.name()`
+                // is fine for SS/Trojan/VLESS (their parsers thread the name
+                // into the adapter) but `DirectAdapter::name()` is hardcoded
+                // to "DIRECT" and would overwrite the built-in, hiding any
+                // user-named direct proxy (e.g. `name: "直连"`) from groups.
+                let key = raw_proxy
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .map_or_else(|| proxy.name().to_string(), str::to_string);
+                proxies.insert(key, proxy);
             }
             Err(e) => warn!("Failed to parse proxy: {}", e),
         }


### PR DESCRIPTION
## Summary
- Adds \`crates/mihomo-app/tests/fixtures/realworld_clash_meta.yaml\` — a representative community Clash Meta config (2 proxy-providers, 20 selector/url-test groups across 6 regions, fake-IP DNS, full GEOIP/GEOSITE rule set).
- New test \`load_realworld_config_parses_without_error\` in \`config_smoke.rs\` asserts the fixture parses and every named group/proxy lands in the registry.
- Fixes a bug uncovered while wiring this up: a user-named direct proxy (\`- name: \"直连\", type: direct\`) was being silently overwritten by the built-in \`DIRECT\` entry, so groups referencing \"直连\" all logged \"not found\" warnings and ran without the direct option.

## The bug
\`DirectAdapter::name()\` returns the hardcoded string \`\"DIRECT\"\`, regardless of the YAML \`name:\`. \`lib.rs\` was using \`proxy.name()\` as the registry key:

\`\`\`rust
let name = proxy.name().to_string();
proxies.insert(name, proxy);
\`\`\`

So a user block

\`\`\`yaml
- name: \"直连\"
  type: direct
\`\`\`

ended up keyed under \`\"DIRECT\"\` instead of \`\"直连\"\`, overwriting the built-in. SS/Trojan/VLESS aren't affected because their parsers thread the user-given name into the adapter constructor.

**Fix:** key the registry entry by the YAML \`name:\` field directly (with \`proxy.name()\` as a fallback). Observable no-op for adapters that already carry a user-set name.

## Known divergences surfaced by the fixture
Three patches were applied to the original community config to satisfy the current parser. The first two are parser gaps worth fixing in follow-ups; the third is intentional policy.

| Original | Patched | Status |
|---|---|---|
| \`sniffer.sniff.HTTP.ports: [80, \"8080-8880\"]\` | \`[80, 8080]\` | parser gap — port-range strings not yet supported |
| \`exclude-type: direct\` | \`exclude-type: [direct]\` | parser gap — scalar form not accepted on geo groups |
| \`default-nameserver: tls://223.5.5.5\` | \`udp://223.5.5.5\` | intentional, Class A per ADR-0002 (anti-bootstrap-loop) |

The fixture header documents each patch for future readers.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (default / no-default / all-features)
- [x] \`cargo test --lib\` — 491 passed
- [x] \`cargo test -p mihomo-app --test config_smoke\` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)