### PR TITLE
fix(config): repair broken rustdoc intra-doc links

### DIFF
--- a/crates/mihomo-config/src/internal_http.rs
+++ b/crates/mihomo-config/src/internal_http.rs
@@ -29,7 +29,7 @@ const MAX_BODY_BYTES: usize = 256 * 1024 * 1024; // 256 MiB hard ceiling
 
 /// Fetch `url` via `proxy` and return the response body.
 ///
-/// Follows up to [`MAX_REDIRECTS`] redirects (302/301/307/308). Returns an
+/// Follows up to 5 redirects (302/301/307/308). Returns an
 /// error for non-2xx terminal responses, oversize bodies, or transport errors.
 pub async fn fetch_via_proxy(url: &str, proxy: &Arc<dyn Proxy>) -> Result<Vec<u8>> {
     let mut current = Url::parse(url).map_err(|e| anyhow!("invalid URL '{url}': {e}"))?;

--- a/crates/mihomo-config/src/proxy_parser.rs
+++ b/crates/mihomo-config/src/proxy_parser.rs
@@ -931,7 +931,7 @@ pub fn parse_proxy_group(
     parse_proxy_group_inner(config, existing_proxies, true, providers, None)
 }
 
-/// Variant of [`parse_proxy_group`] that wires a persistent [`SelectorStore`]
+/// Variant of [`parse_proxy_group`] that wires a persistent [`mihomo_proxy::SelectorStore`]
 /// into any `type: select` group it builds, so user picks survive restart.
 pub fn parse_proxy_group_with_store(
     config: &crate::raw::RawProxyGroup,


### PR DESCRIPTION
## Summary
- `fetch_via_proxy` doc linked to private const `MAX_REDIRECTS` → replaced with literal "5"
- `parse_proxy_group_with_store` linked to unqualified `SelectorStore` → fully qualified as `mihomo_proxy::SelectorStore`

Unblocks the `lint` CI job, which runs rustdoc with `-D warnings` and was failing on main (867be0e).

## Test plan
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p mihomo-config` passes
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (491 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)