### PR TITLE
docs(CLAUDE): add rustdoc to the Regression Bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 cargo clippy --all-targets --no-default-features -- -D warnings
 cargo clippy --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 cargo test --lib
 ```
 


### PR DESCRIPTION
## Summary
- Add `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` to the pre-push Regression Bar so local checks match what CI's `Doc check` step already enforces. PR #104 was the kind of break this would have caught.

## Test plan
- [x] docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)