### PR TITLE
feat(common): Android VpnService.protect(fd) integration hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
+ "socket2 0.5.10",
  "subtle",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/meow-common/Cargo.toml
+++ b/crates/meow-common/Cargo.toml
@@ -18,11 +18,15 @@ httparse = { version = "1", default-features = false }
 ipnet = { workspace = true }
 subtle = { workspace = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-libproc = "0.14"
+[target.'cfg(target_os = "android")'.dependencies]
+socket2 = { workspace = true }
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libproc = "0.14"
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/meow-common/src/lib.rs
+++ b/crates/meow-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod network;
 pub mod process_lookup;
 pub mod rule;
 pub mod sniffer;
+pub mod socket_protect;
 pub mod tunnel_mode;
 
 pub use adapter::{DelayHistory, ProviderSlot, Proxy, ProxyAdapter, ProxyHealth, ProxyState};
@@ -22,4 +23,9 @@ pub use network::Network;
 pub use process_lookup::{find_process, ProcessInfo};
 pub use rule::{Rule, RuleMatchHelper, RuleType};
 pub use sniffer::SnifferConfig;
+pub use socket_protect::{bind_udp, connect_tcp};
+#[cfg(target_os = "android")]
+pub use socket_protect::{
+    clear_socket_protector, set_socket_protector, socket_protector, SocketProtector,
+};
 pub use tunnel_mode::TunnelMode;

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -1,0 +1,238 @@
+//! Outbound-socket protector hook for Android `VpnService.protect(fd)`.
+//!
+//! When meow-rs runs *inside* an Android VPN app, every outbound socket it
+//! opens must bypass the VPN itself — otherwise packets to proxy upstreams
+//! loop back into the tunnel and deadlock. Android exposes a per-fd hook
+//! for this: `android.net.VpnService.protect(int fd)`. This module is the
+//! single place the JNI bridge installs that hook; the proxy adapters that
+//! open outbound sockets dial through [`connect_tcp`] / [`bind_udp`], which
+//! call the installed protector before `connect()` / `bind()` so the very
+//! first SYN / UDP packet already bypasses the tunnel.
+//!
+//! The protector trait and global setter are compiled only on Android. On
+//! every other target [`connect_tcp`] / [`bind_udp`] degrade to the same
+//! plain tokio code path the adapters used historically — so call sites
+//! need no `cfg` guards.
+
+use std::io;
+
+use tokio::net::{TcpStream, ToSocketAddrs, UdpSocket};
+
+#[cfg(target_os = "android")]
+mod android {
+    use super::*;
+    use std::net::SocketAddr;
+    use std::os::fd::{AsRawFd, RawFd};
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+
+    /// Hook invoked on every outbound socket fd just before `connect()` /
+    /// `bind()`. Typically a thin JNI shim around
+    /// `android.net.VpnService.protect(int)`.
+    ///
+    /// Implementations must not block — the call runs on the async runtime
+    /// worker that is dialing the socket.
+    pub trait SocketProtector: Send + Sync {
+        /// Protect `fd`. Returning `Err` aborts the connect/bind and the
+        /// error propagates back to the caller.
+        fn protect(&self, fd: RawFd) -> io::Result<()>;
+    }
+
+    static PROTECTOR: RwLock<Option<Arc<dyn SocketProtector>>> = RwLock::new(None);
+
+    /// Install the global socket protector. Call once during VPN startup,
+    /// before any proxy adapter dials.
+    ///
+    /// Re-installing is allowed (e.g. VPN tear-down / re-create); the new
+    /// protector takes effect on the next outbound socket.
+    pub fn set_socket_protector(protector: Arc<dyn SocketProtector>) {
+        *PROTECTOR.write() = Some(protector);
+    }
+
+    /// Remove the currently installed protector, if any.
+    pub fn clear_socket_protector() {
+        *PROTECTOR.write() = None;
+    }
+
+    /// Snapshot of the currently-installed protector. Exposed so callers
+    /// that build sockets through `socket2` directly (e.g. for `SO_MARK`)
+    /// can still apply protect on the fd they own.
+    pub fn socket_protector() -> Option<Arc<dyn SocketProtector>> {
+        PROTECTOR.read().clone()
+    }
+
+    pub(super) async fn connect_tcp_protected(
+        dest: SocketAddr,
+        protector: &dyn SocketProtector,
+    ) -> io::Result<TcpStream> {
+        use socket2::{Domain, Protocol, Socket, Type};
+
+        let domain = if dest.is_ipv4() {
+            Domain::IPV4
+        } else {
+            Domain::IPV6
+        };
+        let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+        protector.protect(socket.as_raw_fd())?;
+        socket.set_nonblocking(true)?;
+
+        match socket.connect(&dest.into()) {
+            Ok(()) => {}
+            Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+            Err(e) => return Err(e),
+        }
+
+        let std_stream: std::net::TcpStream = socket.into();
+        let stream = TcpStream::from_std(std_stream)?;
+        stream.writable().await?;
+        if let Some(err) = stream.take_error()? {
+            return Err(err);
+        }
+        Ok(stream)
+    }
+
+    pub(super) fn bind_udp_protected(
+        local: SocketAddr,
+        protector: &dyn SocketProtector,
+    ) -> io::Result<UdpSocket> {
+        use socket2::{Domain, Protocol, Socket, Type};
+
+        let domain = if local.is_ipv4() {
+            Domain::IPV4
+        } else {
+            Domain::IPV6
+        };
+        let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+        protector.protect(socket.as_raw_fd())?;
+        socket.set_nonblocking(true)?;
+        socket.bind(&local.into())?;
+
+        let std_socket: std::net::UdpSocket = socket.into();
+        UdpSocket::from_std(std_socket)
+    }
+}
+
+#[cfg(target_os = "android")]
+pub use android::{
+    clear_socket_protector, set_socket_protector, socket_protector, SocketProtector,
+};
+
+/// Dial an outbound TCP stream. On Android, applies the installed
+/// `SocketProtector` (if any) to the socket fd before `connect()` so the
+/// connection bypasses the VPN. On every other target this is equivalent to
+/// [`TcpStream::connect`].
+///
+/// Accepts the same address forms as [`TcpStream::connect`] (a `SocketAddr`,
+/// `(host, port)`, `"host:port"`, etc.). When the Android protector path is
+/// taken, addresses are resolved first via `tokio::net::lookup_host` and each
+/// resolved `SocketAddr` is tried in turn.
+pub async fn connect_tcp<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
+    #[cfg(target_os = "android")]
+    {
+        if let Some(p) = android::socket_protector() {
+            let mut last_err: Option<io::Error> = None;
+            let mut any = false;
+            for resolved in tokio::net::lookup_host(addr).await? {
+                any = true;
+                match android::connect_tcp_protected(resolved, p.as_ref()).await {
+                    Ok(s) => return Ok(s),
+                    Err(e) => last_err = Some(e),
+                }
+            }
+            return Err(last_err.unwrap_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    if any {
+                        "connect_tcp: all candidates failed"
+                    } else {
+                        "connect_tcp: no addresses resolved"
+                    },
+                )
+            }));
+        }
+    }
+    TcpStream::connect(addr).await
+}
+
+/// Bind an outbound UDP socket. On Android, applies the installed
+/// `SocketProtector` (if any) to the socket fd before `bind()`. On every
+/// other target this is equivalent to [`UdpSocket::bind`].
+pub async fn bind_udp<A: ToSocketAddrs>(local: A) -> io::Result<UdpSocket> {
+    #[cfg(target_os = "android")]
+    {
+        if let Some(p) = android::socket_protector() {
+            let resolved = tokio::net::lookup_host(local)
+                .await?
+                .next()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "bind_udp: no address resolved")
+                })?;
+            return android::bind_udp_protected(resolved, p.as_ref());
+        }
+    }
+    UdpSocket::bind(local).await
+}
+
+#[cfg(all(test, target_os = "android"))]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+    use std::os::fd::RawFd;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct Counting(AtomicUsize);
+    impl SocketProtector for Counting {
+        fn protect(&self, _fd: RawFd) -> io::Result<()> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct Failing;
+    impl SocketProtector for Failing {
+        fn protect(&self, _fd: RawFd) -> io::Result<()> {
+            Err(io::Error::other("protect denied"))
+        }
+    }
+
+    static LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    #[tokio::test]
+    async fn connect_tcp_invokes_protector() {
+        let _g = LOCK.lock();
+        let counter = Arc::new(Counting(AtomicUsize::new(0)));
+        set_socket_protector(counter.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
+        let _stream = connect_tcp(addr).await.expect("connect");
+        let _ = accept.await.unwrap();
+        assert_eq!(counter.0.load(Ordering::SeqCst), 1);
+        clear_socket_protector();
+    }
+
+    #[tokio::test]
+    async fn connect_tcp_propagates_protector_failure() {
+        let _g = LOCK.lock();
+        set_socket_protector(Arc::new(Failing));
+        let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let err = connect_tcp(addr).await.expect_err("protect should fail");
+        assert!(err.to_string().contains("protect denied"), "{err}");
+        clear_socket_protector();
+    }
+
+    #[tokio::test]
+    async fn bind_udp_invokes_protector() {
+        let _g = LOCK.lock();
+        let counter = Arc::new(Counting(AtomicUsize::new(0)));
+        set_socket_protector(counter.clone());
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let sock = bind_udp(addr).await.expect("bind");
+        assert!(sock.local_addr().unwrap().port() != 0);
+        assert_eq!(counter.0.load(Ordering::SeqCst), 1);
+        clear_socket_protector();
+    }
+}

--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -40,7 +40,9 @@ pub trait SocketFactory: Send + Sync + 'static {
     fn connect_tcp(&self, addr: SocketAddr) -> BoxFuture<'_, io::Result<TcpStream>>;
 }
 
-/// Tokio default factory: plain `UdpSocket::bind` / `TcpStream::connect`.
+/// Tokio default factory: routes through [`meow_common::bind_udp`] /
+/// [`meow_common::connect_tcp`] so the Android `VpnService.protect(fd)`
+/// hook (when installed) covers DNS upstream sockets too.
 struct DefaultSocketFactory;
 
 impl SocketFactory for DefaultSocketFactory {
@@ -49,12 +51,12 @@ impl SocketFactory for DefaultSocketFactory {
             // Bind to v4 unspecified; this is fine because we always
             // `connect()` the socket before sending, and connect() will
             // re-resolve the local address family.
-            UdpSocket::bind(SocketAddr::from(([0u8; 4], 0))).await
+            meow_common::bind_udp(SocketAddr::from(([0u8; 4], 0))).await
         })
     }
 
     fn connect_tcp(&self, addr: SocketAddr) -> BoxFuture<'_, io::Result<TcpStream>> {
-        Box::pin(async move { TcpStream::connect(addr).await })
+        Box::pin(async move { meow_common::connect_tcp(addr).await })
     }
 }
 

--- a/crates/meow-proxy/src/direct.rs
+++ b/crates/meow-proxy/src/direct.rs
@@ -171,7 +171,10 @@ impl ProxyPacketConn for DirectPacketConn {
 }
 
 /// Create a TCP socket with an optional routing mark (SO_MARK on Linux)
-/// set BEFORE connecting, so the SYN packet is already marked.
+/// set BEFORE connecting, so the SYN packet is already marked. On Android
+/// the installed `meow_common::SocketProtector` is applied to the socket
+/// fd (also pre-connect) so the dial bypasses VpnService when meow-rs runs
+/// inside a VPN app.
 async fn connect_with_mark(
     dest: SocketAddr,
     routing_mark: Option<u32>,
@@ -203,7 +206,7 @@ async fn connect_with_mark(
     #[cfg(not(target_os = "linux"))]
     let _ = routing_mark;
 
-    TcpStream::connect(dest).await
+    meow_common::connect_tcp(dest).await
 }
 
 #[async_trait]
@@ -243,7 +246,9 @@ impl ProxyAdapter for DirectAdapter {
     }
 
     async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        let socket = UdpSocket::bind("0.0.0.0:0").await.map_err(MeowError::Io)?;
+        let socket = meow_common::bind_udp("0.0.0.0:0")
+            .await
+            .map_err(MeowError::Io)?;
         Ok(Box::new(DirectPacketConn(socket)))
     }
 

--- a/crates/meow-proxy/src/ech_tls_tunnel.rs
+++ b/crates/meow-proxy/src/ech_tls_tunnel.rs
@@ -27,7 +27,6 @@ use meow_transport::{
     ws::{WsConfig, WsLayer},
     Transport,
 };
-use tokio::net::TcpStream;
 use tracing::{debug, warn};
 
 use crate::transport_to_proxy_err;
@@ -138,7 +137,7 @@ pub async fn dial(
     );
 
     // 1) Raw TCP.
-    let tcp = TcpStream::connect((server_host, server_port))
+    let tcp = meow_common::connect_tcp((server_host, server_port))
         .await
         .map_err(MeowError::Io)?;
     let _ = tcp.set_nodelay(true);

--- a/crates/meow-proxy/src/http_adapter.rs
+++ b/crates/meow-proxy/src/http_adapter.rs
@@ -27,7 +27,6 @@ use meow_common::{
 };
 use std::fmt::Write as _;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
 use tracing::debug;
 
 use crate::stream_conn::StreamConn;
@@ -81,7 +80,7 @@ impl HttpAdapter {
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = TcpStream::connect(format!("{}:{}", self.server, self.port))
+        let tcp = meow_common::connect_tcp(format!("{}:{}", self.server, self.port))
             .await
             .map_err(MeowError::Io)?;
 
@@ -549,7 +548,7 @@ mod tests {
     #[tokio::test]
     async fn http_connect_over_relay() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        use tokio::net::TcpListener;
+        use tokio::net::{TcpListener, TcpStream};
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -15,7 +15,6 @@ use shadowsocks::relay::Address;
 use shadowsocks::ProxyClientStream;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::net::TcpStream;
 use tracing::debug;
 
 /// Built-in (native, no external process) simple-obfs configuration.
@@ -325,7 +324,7 @@ impl ProxyAdapter for ShadowsocksAdapter {
             PluginKind::Obfs(obfs) => {
                 // Open a raw TCP connection to the SS server, wrap it in the
                 // simple-obfs codec, then layer the SS crypto stream on top.
-                let tcp = TcpStream::connect((self.server.as_str(), self.port))
+                let tcp = meow_common::connect_tcp((self.server.as_str(), self.port))
                     .await
                     .map_err(|e| MeowError::Proxy(format!("ss obfs tcp connect: {e}")))?;
                 let _ = tcp.set_nodelay(true);
@@ -374,6 +373,14 @@ impl ProxyAdapter for ShadowsocksAdapter {
                 Ok(Box::new(SsConn(stream)))
             }
             PluginKind::None | PluginKind::External(_) => {
+                // NOTE: Android VpnService.protect integration — the upstream
+                // `shadowsocks` crate dials this stream internally via tokio,
+                // bypassing our `meow_common::connect_tcp` helper, so the
+                // installed `meow_common::SocketProtector` does NOT see the
+                // fd. To protect SS standard-path outbound sockets on Android,
+                // plumb `ConnectOpts.vpn_protect_path` (Unix domain socket
+                // implementing shadowsocks-android's protect-fd cmsg protocol)
+                // — tracked as a follow-up.
                 let stream = ProxyClientStream::connect(
                     Arc::clone(&self.context),
                     &self.server_config,

--- a/crates/meow-proxy/src/socks5_adapter.rs
+++ b/crates/meow-proxy/src/socks5_adapter.rs
@@ -24,7 +24,6 @@ use meow_common::{
     AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
 use tracing::debug;
 
 use crate::stream_conn::StreamConn;
@@ -89,7 +88,7 @@ impl Socks5Adapter {
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = TcpStream::connect(format!("{}:{}", self.server, self.port))
+        let tcp = meow_common::connect_tcp(format!("{}:{}", self.server, self.port))
             .await
             .map_err(MeowError::Io)?;
 

--- a/crates/meow-proxy/src/trojan.rs
+++ b/crates/meow-proxy/src/trojan.rs
@@ -20,7 +20,6 @@ use meow_transport::{
 use sha2::{Digest, Sha224};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
-use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -106,7 +105,7 @@ impl TrojanAdapter {
         metadata: &Metadata,
         cmd: u8,
     ) -> Result<Box<dyn TransportStream>> {
-        let tcp = TcpStream::connect(&self.addr_str)
+        let tcp = meow_common::connect_tcp(self.addr_str.as_str())
             .await
             .map_err(MeowError::Io)?;
 

--- a/crates/meow-proxy/src/v2ray_plugin.rs
+++ b/crates/meow-proxy/src/v2ray_plugin.rs
@@ -22,7 +22,6 @@ use meow_transport::{
     ws::{WsConfig, WsLayer},
     Transport,
 };
-use tokio::net::TcpStream;
 use tracing::{debug, warn};
 
 use crate::transport_to_proxy_err;
@@ -137,7 +136,7 @@ pub async fn dial(
     );
 
     // 1) Raw TCP.
-    let tcp = TcpStream::connect((server_host, server_port))
+    let tcp = meow_common::connect_tcp((server_host, server_port))
         .await
         .map_err(MeowError::Io)?;
 

--- a/crates/meow-proxy/src/vless_adapter.rs
+++ b/crates/meow-proxy/src/vless_adapter.rs
@@ -20,7 +20,6 @@ use async_trait::async_trait;
 use meow_common::{
     AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
 };
-use tokio::net::TcpStream;
 use tracing::debug;
 
 use crate::stream_conn::StreamConn;
@@ -81,7 +80,7 @@ impl VlessAdapter {
 
     /// Dial a raw TCP + transport-chain stream to the VLESS server.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = TcpStream::connect(&self.addr_str)
+        let tcp = meow_common::connect_tcp(self.addr_str.as_str())
             .await
             .map_err(MeowError::Io)?;
         self.transport.connect(Box::new(tcp)).await


### PR DESCRIPTION
## Summary
- Add \`meow_common::SocketProtector\` (\`target_os = \"android\"\` only) — trait the JNI bridge implements, plus \`set_socket_protector\` / \`clear_socket_protector\` / \`socket_protector\` global registry. Zero footprint on non-Android builds.
- Add \`meow_common::connect_tcp\` and \`meow_common::bind_udp\` (always available) — on Android they create the socket via socket2, invoke the installed protector on the fd, then connect/bind; everywhere else they degrade to plain tokio. First SYN / UDP packet bypasses the VPN.
- Migrate every outbound socket call site we own (direct + SO_MARK path, trojan, vless, http, socks5, v2ray-plugin, ech-tls-tunnel, ss-obfs, DNS default SocketFactory) to dial through the helpers.

## Known gap
The shadowsocks **standard** path goes through the upstream \`shadowsocks\` crate's own tokio dial — our helper cannot intercept it. An inline \`NOTE\` in \`shadowsocks_adapter.rs\` flags this and points at \`ConnectOpts.vpn_protect_path\` (shadowsocks-android's cmsg-over-UDS protocol) as the follow-up.

## Android integration sketch
\`\`\`rust
struct JniProtect { /* JavaVM, global ref to VpnService */ }
impl meow_common::SocketProtector for JniProtect {
    fn protect(&self, fd: std::os::fd::RawFd) -> std::io::Result<()> {
        // JNI call: vpnService.protect(fd) → bool; map false to Err
    }
}
meow_common::set_socket_protector(Arc::new(JniProtect { .. }));
\`\`\`

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo clippy --all-targets --no-default-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo test --lib\` (491 passed)
- [x] \`cargo check --target aarch64-linux-android -p meow-common\` (Android-gated code compiles cleanly)
- [ ] Manual on-device: install protector, observe traffic on tcpdump of \`tun0\` vs \`wlan0\` — proxy/DIRECT TCP/UDP must appear on \`wlan0\` only (bypassing the tunnel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)