### PR TITLE
test(proxy/group): unit tests for selector, urltest, fallback

### DIFF
--- a/crates/meow-proxy/src/group/fallback.rs
+++ b/crates/meow-proxy/src/group/fallback.rs
@@ -150,3 +150,88 @@ impl Proxy for FallbackGroup {
         self.first_alive().map(|p| p.name().to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::test_support::MockProxy;
+    use meow_common::Metadata;
+
+    #[test]
+    fn picks_first_when_all_alive() {
+        let g = FallbackGroup::new("fb", vec![MockProxy::new("a"), MockProxy::new("b")]);
+        assert_eq!(g.first_alive().unwrap().name(), "a");
+    }
+
+    #[test]
+    fn skips_dead_to_next_alive() {
+        let a = MockProxy::new("a");
+        a.set_alive(false);
+        let g = FallbackGroup::new("fb", vec![a, MockProxy::new("b"), MockProxy::new("c")]);
+        assert_eq!(g.first_alive().unwrap().name(), "b");
+    }
+
+    #[test]
+    fn all_dead_returns_first_proxy_as_last_resort() {
+        // Upstream behaviour: when every member is dead, still return *something*
+        // (the first proxy) so the caller can attempt the dial and surface a
+        // real network error rather than a "no proxy" config error.
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        a.set_alive(false);
+        b.set_alive(false);
+        let g = FallbackGroup::new("fb", vec![a, b]);
+        assert_eq!(g.first_alive().unwrap().name(), "a");
+    }
+
+    #[test]
+    fn recovery_promotes_revived_member_back_to_head() {
+        let a = MockProxy::new("a");
+        a.set_alive(false);
+        let a_ref = Arc::clone(&a);
+        let g = FallbackGroup::new("fb", vec![a, MockProxy::new("b")]);
+        assert_eq!(g.first_alive().unwrap().name(), "b");
+        a_ref.set_alive(true);
+        assert_eq!(
+            g.first_alive().unwrap().name(),
+            "a",
+            "head proxy regaining health must reclaim primary slot"
+        );
+    }
+
+    #[test]
+    fn member_names_preserve_declaration_order() {
+        let g = FallbackGroup::new(
+            "fb",
+            vec![
+                MockProxy::new("a"),
+                MockProxy::new("b"),
+                MockProxy::new("c"),
+            ],
+        );
+        assert_eq!(g.member_names(), vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn dial_tcp_routes_through_first_alive() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        a.set_alive(false);
+        let a_ref = Arc::clone(&a);
+        let b_ref = Arc::clone(&b);
+        let g = FallbackGroup::new("fb", vec![a, b]);
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert_eq!(a_ref.dials(), 0);
+        assert_eq!(b_ref.dials(), 1);
+    }
+
+    #[test]
+    fn support_udp_reflects_first_alive() {
+        let a = MockProxy::new("a"); // tcp-only
+        let a_ref = Arc::clone(&a);
+        let g = FallbackGroup::new("fb", vec![a, MockProxy::new_udp("b")]);
+        assert!(!g.support_udp(), "a is alive and tcp-only");
+        a_ref.set_alive(false);
+        assert!(g.support_udp(), "fallback to udp-capable b");
+    }
+}

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -4,3 +4,6 @@ pub mod relay;
 pub mod selector;
 pub mod selector_store;
 pub mod urltest;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/crates/meow-proxy/src/group/selector.rs
+++ b/crates/meow-proxy/src/group/selector.rs
@@ -217,3 +217,87 @@ impl Proxy for SelectorGroup {
         self.selected_proxy().map(|p| p.name().to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::test_support::MockProxy;
+    use meow_common::Metadata;
+
+    #[test]
+    fn unselected_falls_back_to_first_static() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        let g = SelectorGroup::new("sel", vec![a, b]);
+        assert_eq!(g.selected_proxy().unwrap().name(), "a");
+        assert_eq!(g.proxy_names(), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn select_changes_target_and_returns_true_only_when_present() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        let g = SelectorGroup::new("sel", vec![a, b]);
+        assert!(g.select("b"));
+        assert_eq!(g.selected_proxy().unwrap().name(), "b");
+        assert!(!g.select("nope"));
+        // Unknown name must not clobber the previous choice.
+        assert_eq!(g.selected_proxy().unwrap().name(), "b");
+    }
+
+    #[test]
+    fn selection_falls_back_when_named_proxy_disappears() {
+        // Simulates a provider refresh that removed the previously-selected
+        // node. Manually poke the selection to a missing name (the public
+        // `select` would reject it; this mirrors the post-refresh state).
+        let a = MockProxy::new("a");
+        let g = SelectorGroup::new("sel", vec![a]);
+        *g.selected.write() = Some("ghost".into());
+        assert_eq!(g.selected_proxy().unwrap().name(), "a");
+    }
+
+    #[test]
+    fn store_primes_initial_selection_and_persists_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sel.json");
+        let store = crate::group::selector_store::SelectorStore::open(path.clone());
+        store.set("sel", "b");
+
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        let g = SelectorGroup::new("sel", vec![a, b]).with_store(Arc::clone(&store));
+        assert_eq!(
+            g.selected_proxy().unwrap().name(),
+            "b",
+            "primed selection should load from store"
+        );
+
+        assert!(g.select("a"));
+        drop(store);
+        let store2 = crate::group::selector_store::SelectorStore::open(path);
+        assert_eq!(store2.get("sel").as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn support_udp_reflects_selected_target() {
+        let tcp = MockProxy::new("tcp-only");
+        let udp = MockProxy::new_udp("udp-able");
+        let g = SelectorGroup::new("sel", vec![tcp, udp]);
+        assert!(!g.support_udp(), "default selection is tcp-only");
+        assert!(g.select("udp-able"));
+        assert!(g.support_udp(), "switching selection updates udp support");
+    }
+
+    #[tokio::test]
+    async fn dial_tcp_routes_to_selected_member() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        let a_ref = Arc::clone(&a);
+        let b_ref = Arc::clone(&b);
+        let g = SelectorGroup::new("sel", vec![a, b]);
+        assert!(g.select("b"));
+        let _ = g.dial_tcp(&Metadata::default()).await; // mock returns Err
+        assert_eq!(a_ref.dials(), 0);
+        assert_eq!(b_ref.dials(), 1);
+    }
+}

--- a/crates/meow-proxy/src/group/test_support.rs
+++ b/crates/meow-proxy/src/group/test_support.rs
@@ -1,0 +1,106 @@
+//! Test-only fakes for proxy-group unit tests.
+//!
+//! Shared across `selector`, `urltest`, and `fallback` so each module can
+//! exercise its routing logic without standing up real adapters.
+
+use async_trait::async_trait;
+use meow_common::{
+    AdapterType, DelayHistory, MeowError, Metadata, Proxy, ProxyAdapter, ProxyConn, ProxyHealth,
+    ProxyPacketConn, Result,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Minimal `Proxy` impl that records dial attempts and reflects whatever
+/// alive / delay the test wires up via [`set_alive`](Self::set_alive) and
+/// [`set_delay`](Self::set_delay).
+///
+/// `dial_tcp` / `dial_udp` deliberately return an error — the group tests
+/// only care about *which* member the group selected, not about completing
+/// the dial.
+pub struct MockProxy {
+    name: String,
+    health: ProxyHealth,
+    udp: bool,
+    pub dial_count: AtomicUsize,
+}
+
+impl MockProxy {
+    pub fn new(name: &str) -> Arc<Self> {
+        Arc::new(Self {
+            name: name.to_string(),
+            health: ProxyHealth::new(),
+            udp: false,
+            dial_count: AtomicUsize::new(0),
+        })
+    }
+
+    pub fn new_udp(name: &str) -> Arc<Self> {
+        Arc::new(Self {
+            name: name.to_string(),
+            health: ProxyHealth::new(),
+            udp: true,
+            dial_count: AtomicUsize::new(0),
+        })
+    }
+
+    pub fn set_alive(&self, alive: bool) {
+        self.health.set_alive(alive);
+    }
+
+    /// Drives `last_delay` via the underlying history. `0` would flip the
+    /// proxy to dead because `ProxyHealth::record_delay` interprets 0 as
+    /// "down" — pass at least 1.
+    pub fn set_delay(&self, delay: u16) {
+        self.health.record_delay(delay);
+    }
+
+    pub fn dials(&self) -> usize {
+        self.dial_count.load(Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl ProxyAdapter for MockProxy {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn adapter_type(&self) -> AdapterType {
+        AdapterType::Direct
+    }
+    fn addr(&self) -> &str {
+        ""
+    }
+    fn support_udp(&self) -> bool {
+        self.udp
+    }
+    async fn dial_tcp(&self, _m: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        self.dial_count.fetch_add(1, Ordering::Relaxed);
+        Err(MeowError::Proxy(format!("mock {} dial_tcp", self.name)))
+    }
+    async fn dial_udp(&self, _m: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        self.dial_count.fetch_add(1, Ordering::Relaxed);
+        Err(MeowError::Proxy(format!("mock {} dial_udp", self.name)))
+    }
+    fn health(&self) -> &ProxyHealth {
+        &self.health
+    }
+}
+
+impl Proxy for MockProxy {
+    fn alive(&self) -> bool {
+        self.health.alive()
+    }
+    fn alive_for_url(&self, _url: &str) -> bool {
+        self.health.alive()
+    }
+    fn last_delay(&self) -> u16 {
+        self.health.last_delay()
+    }
+    fn last_delay_for_url(&self, _url: &str) -> u16 {
+        self.health.last_delay()
+    }
+    fn delay_history(&self) -> Vec<DelayHistory> {
+        self.health.delay_history()
+    }
+}

--- a/crates/meow-proxy/src/group/urltest.rs
+++ b/crates/meow-proxy/src/group/urltest.rs
@@ -243,3 +243,102 @@ impl Proxy for UrlTestGroup {
         self.fastest_proxy().map(|p| p.name().to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::test_support::MockProxy;
+    use meow_common::Metadata;
+
+    fn pick(g: &UrlTestGroup) -> String {
+        g.pick_for_dial().unwrap().name().to_string()
+    }
+
+    #[test]
+    fn first_pick_chooses_lowest_delay_among_alive() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        let c = MockProxy::new("c");
+        a.set_delay(120);
+        b.set_delay(30);
+        c.set_delay(60);
+        let g = UrlTestGroup::new("ut", vec![a, b, c], 0);
+        assert_eq!(pick(&g), "b");
+    }
+
+    #[test]
+    fn tolerance_keeps_current_pick_until_strictly_better() {
+        // tolerance = 50: once an incumbent exists, a challenger must beat
+        // it by MORE than 50 ms before the selection flips.
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        a.set_delay(100);
+        b.set_delay(80);
+        let a_ref = Arc::clone(&a);
+        let g = UrlTestGroup::new("ut", vec![a, b], 50);
+        // First pick has no incumbent → goes to the lowest-delay member.
+        assert_eq!(pick(&g), "b");
+
+        // a comes in just inside the tolerance band — must stick with b.
+        a_ref.set_delay(40);
+        assert_eq!(pick(&g), "b", "tolerance prevents flapping");
+
+        // a improves enough to clear the band → must promote.
+        a_ref.set_delay(20);
+        assert_eq!(pick(&g), "a");
+    }
+
+    #[test]
+    fn dead_current_forces_repick_even_inside_tolerance() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        a.set_delay(50);
+        b.set_delay(80);
+        let a_ref = Arc::clone(&a);
+        let g = UrlTestGroup::new("ut", vec![a, b], 100);
+        assert_eq!(pick(&g), "a");
+        a_ref.set_alive(false);
+        assert_eq!(pick(&g), "b", "current died -> must promote next best");
+    }
+
+    #[test]
+    fn no_alive_members_returns_first_proxy_as_fallback() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        a.set_alive(false);
+        b.set_alive(false);
+        let g = UrlTestGroup::new("ut", vec![a, b], 0);
+        assert_eq!(
+            g.pick_for_dial().unwrap().name(),
+            "a",
+            "graceful degradation: surface a real network error from a, \
+             not a 'no proxy' config error"
+        );
+    }
+
+    #[test]
+    fn zero_delay_is_treated_as_unknown_not_best() {
+        // last_delay == 0 means "never probed / dead"; the picker must NOT
+        // consider it the lowest delay.
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        // a has no recorded delay (last_delay=0), b has 100.
+        b.set_delay(100);
+        let g = UrlTestGroup::new("ut", vec![a, b], 0);
+        assert_eq!(pick(&g), "b", "0-delay proxy must not win");
+    }
+
+    #[tokio::test]
+    async fn dial_tcp_routes_through_pick() {
+        let a = MockProxy::new("a");
+        let b = MockProxy::new("b");
+        a.set_delay(100);
+        b.set_delay(20);
+        let a_ref = Arc::clone(&a);
+        let b_ref = Arc::clone(&b);
+        let g = UrlTestGroup::new("ut", vec![a, b], 0);
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert_eq!(a_ref.dials(), 0);
+        assert_eq!(b_ref.dials(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
Three proxy groups had zero unit coverage. Failover, alive-transition, URLTest tolerance / flap-prevention, and selector-store persistence were only visible through full integration paths that didn't isolate the group logic.

Add a shared \`MockProxy\` fixture (mirroring the existing one in \`load_balance\`) and 19 focused unit tests covering:
- **SelectorGroup** — unselected fallback, reject-unknown-name, post-refresh ghost selection, store priming + persistence, UDP support reflection, dial dispatch.
- **FallbackGroup** — skip-dead, recovery-promotes-head, all-dead-still-returns-first, member-order, dial routing, UDP reflection.
- **UrlTestGroup** — first-pick is lowest delay, tolerance band prevents flap, clearing band promotes, dead incumbent forces repick, all-dead fallback, \`delay==0\` (unprobed) cannot win.

Full suite: **491 → 510 passing**.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo clippy --all-targets --no-default-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo test --lib\` (510 passed, 2 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)