### PR TITLE
test(meow-app): unit + integration tests for geodata startup-fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "dhat",
  "libc",
  "meow-api",
+ "meow-common",
  "meow-config",
  "meow-dns",
  "meow-listener",

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -50,6 +50,7 @@ path = "src/main.rs"
 ignored = ["meow-proxy"]
 
 [dependencies]
+meow-common = { workspace = true }
 meow-config = { workspace = true, default-features = false }
 meow-rules = { workspace = true }
 meow-tunnel = { workspace = true }

--- a/crates/meow-app/src/geodata_fetch.rs
+++ b/crates/meow-app/src/geodata_fetch.rs
@@ -1,0 +1,166 @@
+//! On-startup geodata DB download (independent of `geodata.auto-update`).
+//!
+//! Extracted from `main.rs` so the path-resolution and download orchestration
+//! can be unit/integration tested without standing up a real `Tunnel`.
+
+use meow_common::adapter::Proxy;
+use meow_config::geodata::download_and_replace;
+use meow_config::GeoDataConfig;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+/// One geodata DB to consider on startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeoTarget {
+    pub label: &'static str,
+    pub path: PathBuf,
+    pub url: String,
+}
+
+/// Resolve the three geodata target paths (mmdb / asn / geosite) from `geo`,
+/// applying the project-wide defaults when an explicit path was not set.
+pub fn compute_targets(geo: &GeoDataConfig) -> [GeoTarget; 3] {
+    let mmdb = geo
+        .mmdb_path
+        .clone()
+        .unwrap_or_else(meow_config::default_geoip_path);
+    let asn = geo
+        .asn_path
+        .clone()
+        .unwrap_or_else(meow_config::default_asn_path);
+    let geosite = geo
+        .geosite_path
+        .clone()
+        .unwrap_or_else(meow_config::default_geosite_path);
+    [
+        GeoTarget {
+            label: "GeoIP MMDB",
+            path: mmdb,
+            url: geo.mmdb_url.clone(),
+        },
+        GeoTarget {
+            label: "ASN MMDB",
+            path: asn,
+            url: geo.asn_url.clone(),
+        },
+        GeoTarget {
+            label: "geosite",
+            path: geosite,
+            url: geo.geosite_url.clone(),
+        },
+    ]
+}
+
+/// Download each target whose `path` does not yet exist. Returns the list of
+/// labels that were successfully fetched (empty if nothing was missing or
+/// every fetch failed). Each target is attempted independently — one failure
+/// does not skip the others.
+pub async fn fetch_missing(
+    targets: &[GeoTarget],
+    download_proxy: Option<&Arc<dyn Proxy>>,
+) -> Vec<&'static str> {
+    let mut downloaded = Vec::new();
+    for t in targets {
+        if t.path.exists() {
+            continue;
+        }
+        info!(
+            "geodata startup-fetch: {} missing at {}, downloading",
+            t.label,
+            t.path.display()
+        );
+        match download_and_replace(&t.url, &t.path, download_proxy).await {
+            Ok(()) => downloaded.push(t.label),
+            Err(e) => warn!(
+                "geodata startup-fetch: {} download failed: {:#}",
+                t.label, e
+            ),
+        }
+    }
+    downloaded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with_paths(
+        mmdb: Option<&str>,
+        asn: Option<&str>,
+        geosite: Option<&str>,
+    ) -> GeoDataConfig {
+        GeoDataConfig {
+            mmdb_path: mmdb.map(PathBuf::from),
+            asn_path: asn.map(PathBuf::from),
+            geosite_path: geosite.map(PathBuf::from),
+            mmdb_url: "https://example.test/country.mmdb".into(),
+            asn_url: "https://example.test/asn.mmdb".into(),
+            geosite_url: "https://example.test/geosite.mrs".into(),
+            ..GeoDataConfig::default()
+        }
+    }
+
+    #[test]
+    fn compute_targets_uses_explicit_paths_when_set() {
+        let cfg = cfg_with_paths(
+            Some("/tmp/explicit/country.mmdb"),
+            Some("/tmp/explicit/asn.mmdb"),
+            Some("/tmp/explicit/geosite.mrs"),
+        );
+        let t = compute_targets(&cfg);
+        assert_eq!(t[0].label, "GeoIP MMDB");
+        assert_eq!(t[0].path, PathBuf::from("/tmp/explicit/country.mmdb"));
+        assert_eq!(t[1].label, "ASN MMDB");
+        assert_eq!(t[1].path, PathBuf::from("/tmp/explicit/asn.mmdb"));
+        assert_eq!(t[2].label, "geosite");
+        assert_eq!(t[2].path, PathBuf::from("/tmp/explicit/geosite.mrs"));
+    }
+
+    #[test]
+    fn compute_targets_falls_back_to_defaults_when_unset() {
+        let cfg = cfg_with_paths(None, None, None);
+        let t = compute_targets(&cfg);
+        // Defaults are project-defined; we just assert non-empty + matching
+        // file basenames so the test isn't tied to the user's home dir.
+        assert_eq!(t[0].path, meow_config::default_geoip_path());
+        assert_eq!(t[1].path, meow_config::default_asn_path());
+        assert_eq!(t[2].path, meow_config::default_geosite_path());
+    }
+
+    #[test]
+    fn compute_targets_carries_urls() {
+        let cfg = cfg_with_paths(None, None, None);
+        let t = compute_targets(&cfg);
+        assert_eq!(t[0].url, "https://example.test/country.mmdb");
+        assert_eq!(t[1].url, "https://example.test/asn.mmdb");
+        assert_eq!(t[2].url, "https://example.test/geosite.mrs");
+    }
+
+    #[tokio::test]
+    async fn fetch_missing_skips_existing_files() {
+        // All three targets point at files that already exist → returns empty
+        // and never touches the network (the URLs are unreachable).
+        let dir = tempfile::tempdir().unwrap();
+        let mmdb = dir.path().join("country.mmdb");
+        let asn = dir.path().join("asn.mmdb");
+        let geosite = dir.path().join("geosite.mrs");
+        std::fs::write(&mmdb, b"existing-mmdb").unwrap();
+        std::fs::write(&asn, b"existing-asn").unwrap();
+        std::fs::write(&geosite, b"existing-geosite").unwrap();
+
+        let cfg = cfg_with_paths(
+            Some(mmdb.to_str().unwrap()),
+            Some(asn.to_str().unwrap()),
+            Some(geosite.to_str().unwrap()),
+        );
+        let targets = compute_targets(&cfg);
+        let downloaded = fetch_missing(&targets, None).await;
+        assert!(
+            downloaded.is_empty(),
+            "no file is missing → no download attempt"
+        );
+        // Files are unchanged.
+        assert_eq!(std::fs::read(&mmdb).unwrap(), b"existing-mmdb");
+    }
+}

--- a/crates/meow-app/src/lib.rs
+++ b/crates/meow-app/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod geodata_fetch;
+
 /// Generate a systemd unit file for the meow service.
 ///
 /// Returns the unit file content as a string.

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -698,26 +698,7 @@ async fn geodata_fetch_missing_on_startup(
     raw_config: Arc<RwLock<RawConfig>>,
     resolver: Arc<Resolver>,
 ) {
-    use meow_config::geodata::download_and_replace;
-
-    let mmdb_target = geo
-        .mmdb_path
-        .clone()
-        .unwrap_or_else(meow_config::default_geoip_path);
-    let asn_target = geo
-        .asn_path
-        .clone()
-        .unwrap_or_else(meow_config::default_asn_path);
-    let geosite_target = geo
-        .geosite_path
-        .clone()
-        .unwrap_or_else(meow_config::default_geosite_path);
-
-    let targets: [(&str, &std::path::Path, &str); 3] = [
-        ("GeoIP MMDB", &mmdb_target, &geo.mmdb_url),
-        ("ASN MMDB", &asn_target, &geo.asn_url),
-        ("geosite", &geosite_target, &geo.geosite_url),
-    ];
+    let targets = meow_app::geodata_fetch::compute_targets(&geo);
 
     let proxies = tunnel.proxies();
     let download_proxy = meow_config::internal_http::first_named_proxy(
@@ -725,22 +706,9 @@ async fn geodata_fetch_missing_on_startup(
         &proxies,
     );
 
-    let mut any_downloaded = false;
-    for (label, path, url) in targets {
-        if path.exists() {
-            continue;
-        }
-        info!(
-            "geodata startup-fetch: {label} missing at {}, downloading",
-            path.display()
-        );
-        match download_and_replace(url, path, download_proxy.as_ref()).await {
-            Ok(()) => any_downloaded = true,
-            Err(e) => warn!("geodata startup-fetch: {label} download failed: {:#}", e),
-        }
-    }
-
-    if !any_downloaded {
+    let downloaded =
+        meow_app::geodata_fetch::fetch_missing(&targets, download_proxy.as_ref()).await;
+    if downloaded.is_empty() {
         return;
     }
 

--- a/crates/meow-app/tests/geodata_fetch_test.rs
+++ b/crates/meow-app/tests/geodata_fetch_test.rs
@@ -1,0 +1,161 @@
+//! Integration tests for [`meow_app::geodata_fetch::fetch_missing`].
+//!
+//! Stands up a hand-rolled HTTP/1.1 server on `127.0.0.1:0` that serves
+//! canned bytes per path, then asserts the helper writes the expected
+//! file contents (and skips targets whose paths already exist).
+
+use meow_app::geodata_fetch::{fetch_missing, GeoTarget};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const MMDB_BYTES: &[u8] = b"FAKE-MMDB-CONTENTS-1";
+const ASN_BYTES: &[u8] = b"FAKE-ASN-CONTENTS-2";
+const GEOSITE_BYTES: &[u8] = b"FAKE-GEOSITE-CONTENTS-3";
+
+/// Spawn a minimal HTTP/1.1 server that responds to `GET <path>` with
+/// `routes[path]`. Returns the bound socket address.
+async fn spawn_origin(routes: HashMap<&'static str, &'static [u8]>) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let routes = Arc::new(routes);
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let routes = Arc::clone(&routes);
+            tokio::spawn(async move {
+                let mut buf = [0u8; 2048];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let path = req.split_whitespace().nth(1).unwrap_or("/").to_string();
+                let (status, body): (&str, &[u8]) = match routes.get(path.as_str()) {
+                    Some(b) => ("200 OK", b),
+                    None => ("404 Not Found", b""),
+                };
+                let headers = format!(
+                    "HTTP/1.1 {status}\r\n\
+                     Content-Length: {}\r\n\
+                     Connection: close\r\n\
+                     \r\n",
+                    body.len()
+                );
+                let _ = sock.write_all(headers.as_bytes()).await;
+                let _ = sock.write_all(body).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    addr
+}
+
+fn targets_for(dir: &std::path::Path, base_url: &str) -> [GeoTarget; 3] {
+    [
+        GeoTarget {
+            label: "GeoIP MMDB",
+            path: dir.join("country.mmdb"),
+            url: format!("{base_url}/country.mmdb"),
+        },
+        GeoTarget {
+            label: "ASN MMDB",
+            path: dir.join("asn.mmdb"),
+            url: format!("{base_url}/asn.mmdb"),
+        },
+        GeoTarget {
+            label: "geosite",
+            path: dir.join("geosite.mrs"),
+            url: format!("{base_url}/geosite.mrs"),
+        },
+    ]
+}
+
+#[tokio::test]
+async fn downloads_all_missing_targets_and_writes_to_disk() {
+    let mut routes = HashMap::new();
+    routes.insert("/country.mmdb", MMDB_BYTES);
+    routes.insert("/asn.mmdb", ASN_BYTES);
+    routes.insert("/geosite.mrs", GEOSITE_BYTES);
+    let addr = spawn_origin(routes).await;
+    let base = format!("http://{addr}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let targets = targets_for(dir.path(), &base);
+    let downloaded = fetch_missing(&targets, None).await;
+
+    assert_eq!(downloaded.len(), 3, "all three targets must be fetched");
+    assert_eq!(std::fs::read(&targets[0].path).unwrap(), MMDB_BYTES);
+    assert_eq!(std::fs::read(&targets[1].path).unwrap(), ASN_BYTES);
+    assert_eq!(std::fs::read(&targets[2].path).unwrap(), GEOSITE_BYTES);
+}
+
+#[tokio::test]
+async fn skips_targets_already_present() {
+    let mut routes = HashMap::new();
+    routes.insert("/country.mmdb", MMDB_BYTES);
+    routes.insert("/asn.mmdb", ASN_BYTES);
+    routes.insert("/geosite.mrs", GEOSITE_BYTES);
+    let addr = spawn_origin(routes).await;
+    let base = format!("http://{addr}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let targets = targets_for(dir.path(), &base);
+    // Pre-create the geosite file with sentinel contents.
+    std::fs::write(&targets[2].path, b"SENTINEL-DO-NOT-OVERWRITE").unwrap();
+
+    let downloaded = fetch_missing(&targets, None).await;
+    assert_eq!(downloaded.len(), 2, "should fetch only the missing two");
+    assert!(downloaded.contains(&"GeoIP MMDB"));
+    assert!(downloaded.contains(&"ASN MMDB"));
+
+    assert_eq!(
+        std::fs::read(&targets[2].path).unwrap(),
+        b"SENTINEL-DO-NOT-OVERWRITE",
+        "pre-existing file must not be touched"
+    );
+}
+
+#[tokio::test]
+async fn one_failed_target_does_not_block_the_others() {
+    // ASN route returns 404 → expected to be reported as failed but the
+    // other two still complete.
+    let mut routes = HashMap::new();
+    routes.insert("/country.mmdb", MMDB_BYTES);
+    routes.insert("/geosite.mrs", GEOSITE_BYTES);
+    // intentionally no /asn.mmdb
+    let addr = spawn_origin(routes).await;
+    let base = format!("http://{addr}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let targets = targets_for(dir.path(), &base);
+    let downloaded = fetch_missing(&targets, None).await;
+
+    assert_eq!(downloaded.len(), 2);
+    assert!(downloaded.contains(&"GeoIP MMDB"));
+    assert!(downloaded.contains(&"geosite"));
+    assert!(!downloaded.contains(&"ASN MMDB"));
+
+    assert!(targets[0].path.exists(), "mmdb should be written");
+    assert!(!targets[1].path.exists(), "asn (404) must not be written");
+    assert!(targets[2].path.exists(), "geosite should be written");
+}
+
+#[tokio::test]
+async fn empty_target_list_returns_empty() {
+    let downloaded = fetch_missing(&[] as &[GeoTarget], None).await;
+    assert!(downloaded.is_empty());
+}
+
+#[test]
+fn geo_target_is_constructible_for_callers() {
+    // The public type is what main.rs hands to fetch_missing — guard the
+    // shape so a future refactor that flips a field private breaks here.
+    let t = GeoTarget {
+        label: "GeoIP MMDB",
+        path: PathBuf::from("/tmp/x.mmdb"),
+        url: "http://example.test/x.mmdb".into(),
+    };
+    assert_eq!(t.label, "GeoIP MMDB");
+}


### PR DESCRIPTION
## Summary
PR #107's \`geodata_fetch_missing_on_startup\` landed in \`main.rs\` with zero tests — the orchestrator pulled in a real \`Tunnel\` + \`Resolver\` and wasn't unit-testable.

Extract the testable core into a new \`meow_app::geodata_fetch\` module:

\`\`\`rust
pub fn compute_targets(&GeoDataConfig) -> [GeoTarget; 3]
pub async fn fetch_missing(&[GeoTarget], Option<&Arc<dyn Proxy>>) -> Vec<&'static str>
\`\`\`

\`main.rs\` now calls these and only owns the rule-rebuild step. **No behaviour change.**

## Coverage added
- **4 unit tests** for \`compute_targets\` (explicit overrides, default fallback, URL carry) and \`fetch_missing\` no-op-when-all-present.
- **5 integration tests** (\`tests/geodata_fetch_test.rs\`) standing up a hand-rolled HTTP/1.1 server on \`127.0.0.1:0\`:
  - all three missing targets fetched + persisted with expected bytes
  - skips targets whose paths already exist (sentinel preserved)
  - 404 on one target does NOT block the others (each is independent)
  - empty list returns empty
  - \`GeoTarget\` constructible by external callers

Full suite: 510 → 514 unit-passing; +5 integration.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (all 3 feature flavours)
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo test --lib\`
- [x] \`cargo test -p meow-app --test geodata_fetch_test\` (5 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)