### PR TITLE
test(api): unit tests for log_stream

### DIFF
--- a/crates/meow-api/src/log_stream.rs
+++ b/crates/meow-api/src/log_stream.rs
@@ -99,3 +99,128 @@ pub fn parse_log_level(s: &str) -> LogLevel {
         _ => LogLevel::Info,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::subscriber;
+    use tracing_subscriber::prelude::*;
+
+    #[test]
+    fn log_level_str_round_trip_via_parse() {
+        for (s, lvl) in [
+            ("debug", LogLevel::Debug),
+            ("info", LogLevel::Info),
+            ("warning", LogLevel::Warning),
+            ("error", LogLevel::Error),
+            ("silent", LogLevel::Silent),
+        ] {
+            assert_eq!(parse_log_level(s), lvl);
+            assert_eq!(lvl.as_str(), s);
+        }
+    }
+
+    #[test]
+    fn parse_log_level_accepts_warn_alias() {
+        assert_eq!(parse_log_level("warn"), LogLevel::Warning);
+        assert_eq!(parse_log_level("WARN"), LogLevel::Warning);
+    }
+
+    #[test]
+    fn parse_log_level_is_case_insensitive() {
+        assert_eq!(parse_log_level("DEBUG"), LogLevel::Debug);
+        assert_eq!(parse_log_level("Info"), LogLevel::Info);
+        assert_eq!(parse_log_level("Error"), LogLevel::Error);
+    }
+
+    #[test]
+    fn parse_log_level_unknown_input_defaults_to_info() {
+        // Documented behaviour: an unrecognised level → fall back to Info
+        // rather than rejecting the request.
+        assert_eq!(parse_log_level(""), LogLevel::Info);
+        assert_eq!(parse_log_level("nonsense"), LogLevel::Info);
+        assert_eq!(parse_log_level("trace"), LogLevel::Info);
+    }
+
+    #[test]
+    fn log_level_ord_matches_severity_increasing() {
+        // The WS handler filters with `level >= request_level`. The enum
+        // ordering must therefore be Debug < Info < Warning < Error < Silent
+        // (where Silent is the strictest filter — nothing passes).
+        assert!(LogLevel::Debug < LogLevel::Info);
+        assert!(LogLevel::Info < LogLevel::Warning);
+        assert!(LogLevel::Warning < LogLevel::Error);
+        assert!(LogLevel::Error < LogLevel::Silent);
+    }
+
+    #[test]
+    fn log_message_serializes_three_fields() {
+        // 2026-01-02 03:04:05 UTC = 1767322945 seconds since unix epoch.
+        let ts = time::OffsetDateTime::from_unix_timestamp(1_767_322_945).unwrap();
+        let msg = LogMessage {
+            level: LogLevel::Warning,
+            payload: "alerts: thing happened".into(),
+            time: ts,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["type"], "warning");
+        assert_eq!(json["payload"], "alerts: thing happened");
+        assert_eq!(json["time"], "2026-01-02T03:02:25Z");
+    }
+
+    #[test]
+    fn layer_forwards_string_message_event() {
+        let (tx, mut rx) = broadcast::channel(8);
+        let layer = LogBroadcastLayer { tx };
+        let registry = tracing_subscriber::registry().with(layer);
+        subscriber::with_default(registry, || {
+            tracing::warn!("hello-world");
+        });
+        let got = rx.try_recv().expect("event must be forwarded");
+        assert_eq!(got.level, LogLevel::Warning);
+        assert!(
+            got.payload.contains("hello-world"),
+            "payload: {}",
+            got.payload
+        );
+    }
+
+    #[test]
+    fn layer_maps_tracing_levels_to_log_levels() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let layer = LogBroadcastLayer { tx };
+        let registry = tracing_subscriber::registry().with(layer);
+        subscriber::with_default(registry, || {
+            tracing::error!("e");
+            tracing::warn!("w");
+            tracing::info!("i");
+            tracing::debug!("d"); // collapses to Debug
+            tracing::trace!("t"); // collapses to Debug
+        });
+        let levels: Vec<LogLevel> = std::iter::from_fn(|| rx.try_recv().ok())
+            .map(|m| m.level)
+            .collect();
+        // Trace+debug both map to Debug; default filter may drop them at the
+        // subscriber level, so accept either {Error, Warning, Info} only or
+        // the full set.
+        assert!(levels.starts_with(&[LogLevel::Error, LogLevel::Warning, LogLevel::Info]));
+        for extra in &levels[3..] {
+            assert_eq!(*extra, LogLevel::Debug);
+        }
+    }
+
+    #[test]
+    fn layer_send_with_no_subscribers_does_not_panic() {
+        // Documented contract: a send Err (no subscribers / channel full) is
+        // acceptable — verify we don't regress to a panicking `.unwrap()`.
+        let (tx, rx) = broadcast::channel(1);
+        drop(rx);
+        let layer = LogBroadcastLayer { tx };
+        let registry = tracing_subscriber::registry().with(layer);
+        subscriber::with_default(registry, || {
+            tracing::info!("payload");
+            tracing::error!("oh no");
+        });
+        // No panic = pass.
+    }
+}


### PR DESCRIPTION
## Summary
\`log_stream.rs\` exposes \`LogBroadcastLayer\` (forwards every tracing event into the WS log channel) and \`parse_log_level\` (client filter parser). Both were only exercised through the \`api_logs_ws_test\` integration; source-level coverage was zero.

## Coverage added (9 tests)
- \`parse_log_level\`: round-trip vs \`as_str\`, \`warn\`/\`WARN\` alias, case-insensitive, unknown/empty/unrecognised → Info fallback
- \`LogLevel\` ordering — the WS handler filters with \`level >= request_level\`, so the Ord must match severity (Debug < Info < Warning < Error < Silent)
- \`LogMessage\` serializes \`{type, payload, time}\` with RFC3339 time
- \`LogBroadcastLayer\` forwards a string-message event end-to-end through a real tracing registry
- \`LogBroadcastLayer\` maps tracing Level → LogLevel correctly (trace+debug both collapse to Debug)
- send-with-no-subscribers does not panic (the documented \"Err is acceptable\" contract)

Full suite: 549 → 558 passing.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (all 3 feature flavours)
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo test -p meow-api --lib log_stream\` (9 passed)
- [x] \`cargo test --lib\` (558 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)