### PR TITLE
test(reject): unit tests for REJECT and REJECT-DROP adapters

### DIFF
--- a/crates/meow-proxy/src/reject.rs
+++ b/crates/meow-proxy/src/reject.rs
@@ -133,3 +133,106 @@ impl ProxyAdapter for RejectAdapter {
         &self.health
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn naming_reflects_drop_mode() {
+        assert_eq!(RejectAdapter::new(false).name(), "REJECT");
+        assert_eq!(RejectAdapter::new(true).name(), "REJECT-DROP");
+        assert_eq!(
+            RejectAdapter::new(false).adapter_type(),
+            AdapterType::Reject
+        );
+        assert_eq!(
+            RejectAdapter::new(true).adapter_type(),
+            AdapterType::RejectDrop
+        );
+    }
+
+    #[test]
+    fn empty_addr_and_supports_udp() {
+        let a = RejectAdapter::new(false);
+        assert_eq!(a.addr(), "");
+        assert!(
+            a.support_udp(),
+            "reject claims UDP so rules don't bypass it"
+        );
+    }
+
+    #[tokio::test]
+    async fn dial_tcp_reject_returns_eof_stream_immediately() {
+        let a = RejectAdapter::new(false);
+        let mut conn = a
+            .dial_tcp(&Metadata::default())
+            .await
+            .expect("REJECT must produce a connection (not error)");
+        // Read returns 0 (EOF) without blocking.
+        let mut buf = [0u8; 8];
+        let n = conn.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0, "REJECT stream is EOF on read");
+    }
+
+    #[tokio::test]
+    async fn dial_tcp_reject_silently_discards_writes() {
+        let a = RejectAdapter::new(false);
+        let mut conn = a.dial_tcp(&Metadata::default()).await.unwrap();
+        // Writes report success but go nowhere.
+        let n = conn.write(b"discarded").await.unwrap();
+        assert_eq!(n, b"discarded".len());
+        conn.flush().await.unwrap();
+        conn.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dial_tcp_reject_drop_hangs_then_yields_eof() {
+        // RejectDrop simulates a black-hole by sleeping ~60 s before yielding
+        // the same EOF stream. Under paused tokio time we can advance past
+        // that without wall-clock waiting.
+        let a = std::sync::Arc::new(RejectAdapter::new(true));
+        let a2 = std::sync::Arc::clone(&a);
+        let task = tokio::spawn(async move { a2.dial_tcp(&Metadata::default()).await });
+        tokio::task::yield_now().await;
+        assert!(!task.is_finished(), "dial must not return before sleep");
+        tokio::time::advance(std::time::Duration::from_secs(61)).await;
+        let mut conn = task.await.unwrap().expect("eventual EOF stream");
+        let mut buf = [0u8; 4];
+        let n = conn.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn dial_udp_returns_writeonly_packet_conn() {
+        let a = RejectAdapter::new(false);
+        let conn = a.dial_udp(&Metadata::default()).await.expect("packet conn");
+        let dst: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let n = conn.write_packet(b"x", &dst).await.unwrap();
+        assert_eq!(n, 1);
+        let mut buf = [0u8; 16];
+        let err = conn.read_packet(&mut buf).await.err();
+        assert!(err.is_some(), "REJECT UDP read must error, not block");
+        assert!(conn.local_addr().is_err());
+        assert!(conn.close().is_ok());
+    }
+
+    #[tokio::test]
+    async fn connect_over_refuses_relay_insertion() {
+        let a = RejectAdapter::new(false);
+        let upstream = a.dial_tcp(&Metadata::default()).await.unwrap();
+        let err = a
+            .connect_over(upstream, &Metadata::default())
+            .await
+            .err()
+            .expect("relay through REJECT must be a hard error");
+        match err {
+            MeowError::Proxy(msg) => assert!(
+                msg.to_lowercase().contains("reject"),
+                "error message should name 'reject': {msg}"
+            ),
+            other => panic!("expected MeowError::Proxy, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The REJECT adapter had zero unit tests. Simple but load-bearing — every blocked-by-rule connection lands here, and the contract (EOF-on-read, silent-discard-on-write, refuses relay-chain insertion, REJECT-DROP simulates black-hole) was easy to regress.

## 7 tests
- Naming + adapter_type reflect drop mode (\`REJECT\` vs \`REJECT-DROP\`)
- Empty \`addr\`; \`support_udp\` claims true so rules don't bypass
- \`REJECT::dial_tcp\` returns a stream that's EOF on read
- \`REJECT::dial_tcp\` silently accepts writes / flush / shutdown
- \`REJECT-DROP::dial_tcp\` sleeps ~60 s then yields EOF — verified under \`#[tokio::test(start_paused = true)]\` so we exercise the hang without wall-clock waiting
- UDP path: read errors (no data), write accepts, local_addr errors, close succeeds
- \`connect_over\` (relay chain) returns \`MeowError::Proxy(\"reject\")\` — relay through REJECT is a hard error, NOT a silent byte-drop

Full suite: 558 → 565 passing.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (all 3 feature flavours)
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo test --lib\` (565 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)