### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,7 +1929,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meow-api"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "base64",
  "libc",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anytls-rs",
  "async-trait",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.7.6"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
Workspace package version \`0.7.6\` → \`0.8.0\`. All 12 workspace crates inherit via \`version.workspace = true\`, so this PR only touches \`Cargo.toml\` + \`Cargo.lock\`.

Merging this and pushing tag \`v0.8.0\` will trigger the release workflow (cargo-zigbuild for x86_64- and aarch64-musl, size gate on aarch64, signed tarball + sha256 uploaded to the GitHub release).

## Highlights since 0.7.6
- **feat(geodata)**: on-startup fetch of any missing DBs (#107)
- **feat(common)**: Android \`VpnService.protect(fd)\` integration hook (#108)
- **test**: lib suite **491 → 573 (+82, +16.7%)**; ignored tests **2 → 0**.
  - New integration suites: \`http_adapter\` (#117), \`socks5_adapter\` (#118), \`anytls\` expansion (#120)
  - Proxy groups gained unit tests (#109)
  - \`DIRECT\` timeout regression made deterministic (#115)
  - Newly-tested: \`dns/cache\`, \`dns/server\` wire builders (#114), \`log_stream\` (#116), \`reject\` (#119), \`socket_protect\` (CI-runnable on any unix, #113), tproxy firewall rule generation (\`edddb53\`).

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (all three feature flavours)
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo test --lib\` (573 passed, 0 ignored)
- [x] \`./target/release/meow --version\` → \`meow 0.8.0\`
- [ ] Post-merge: tag \`v0.8.0\` on main; release workflow builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)