### PR TITLE
feat(geosite): native V2Ray geosite.dat (protobuf) support

### DIFF
--- a/crates/meow-rules/src/geosite.rs
+++ b/crates/meow-rules/src/geosite.rs
@@ -19,12 +19,14 @@ use crate::mrs_parser::{
 
 #[derive(Debug, thiserror::Error)]
 pub enum GeositeError {
-    #[error("geosite: .dat / V2Ray protobuf format is not supported; convert with metacubex convert-geo")]
+    #[error("geosite: unrecognised format (neither .mrs magic nor a parseable V2Ray .dat)")]
     WrongFormat,
     #[error("geosite: file I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("geosite: mrs parse error: {0}")]
     Mrs(#[from] MrsError),
+    #[error("geosite: dat parse error: {0}")]
+    Dat(#[from] crate::geosite_dat::DatError),
     #[error("geosite: mrs header type {0} is not 'domain' (expected 0)")]
     UnexpectedType(u8),
 }
@@ -91,40 +93,56 @@ impl GeositeDB {
         self.counts.get(&category.to_ascii_lowercase()).copied()
     }
 
-    /// Load a geosite DB from bytes. Detects non-mrs files by magic bytes
-    /// and returns `WrongFormat` — the callsite is responsible for logging
-    /// an actionable message with the file path (per spec §Divergences #1).
-    ///
-    /// **Does not log.** A file that isn't present on disk is not wrong; a
-    /// file whose magic doesn't match is wrong and the callsite logs with
-    /// the path. Internal logging from here would duplicate the message.
-    pub fn from_bytes(data: &[u8]) -> Result<Self, GeositeError> {
-        let (header, rest) = match parse_header(data) {
-            Ok(v) => v,
-            Err(MrsError::WrongFormat) => return Err(GeositeError::WrongFormat),
-            Err(e) => return Err(GeositeError::Mrs(e)),
-        };
-        if header.type_tag != TYPE_DOMAIN {
-            return Err(GeositeError::UnexpectedType(header.type_tag));
-        }
-        let decompressed = decompress_payload(rest)?;
-        let payload = parse_geosite_payload(&decompressed)?;
+    /// Construct a `GeositeDB` from already-built per-category tries +
+    /// counts. Used by the `.dat` (V2Ray protobuf) parser to hand back a
+    /// fully populated DB without going through the `.mrs` path.
+    pub fn from_parts(
+        categories: HashMap<String, DomainTrie<()>>,
+        counts: HashMap<String, usize>,
+    ) -> Self {
+        Self { categories, counts }
+    }
 
-        let mut categories: HashMap<String, DomainTrie<()>> =
-            HashMap::with_capacity(payload.categories.len());
-        let mut counts: HashMap<String, usize> = HashMap::with_capacity(payload.categories.len());
-        for (name, domains) in payload.categories {
-            let mut trie = DomainTrie::new();
-            let mut inserted = 0usize;
-            for d in domains {
-                if trie.insert(&d, ()) {
-                    inserted += 1;
+    /// Load a geosite DB from bytes. Auto-detects format:
+    /// - `MRS!` magic → parsed as the upstream MetaCubeX `.mrs` binary.
+    /// - anything else → parsed as a V2Ray `geosite.dat` protobuf.
+    ///
+    /// Returns `WrongFormat` only when neither path produces a usable DB.
+    /// **Does not log.** Callsites log with the file path.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, GeositeError> {
+        match parse_header(data) {
+            Ok((header, rest)) => {
+                if header.type_tag != TYPE_DOMAIN {
+                    return Err(GeositeError::UnexpectedType(header.type_tag));
                 }
+                let decompressed = decompress_payload(rest)?;
+                let payload = parse_geosite_payload(&decompressed)?;
+
+                let mut categories: HashMap<String, DomainTrie<()>> =
+                    HashMap::with_capacity(payload.categories.len());
+                let mut counts: HashMap<String, usize> =
+                    HashMap::with_capacity(payload.categories.len());
+                for (name, domains) in payload.categories {
+                    let mut trie = DomainTrie::new();
+                    let mut inserted = 0usize;
+                    for d in domains {
+                        if trie.insert(&d, ()) {
+                            inserted += 1;
+                        }
+                    }
+                    counts.insert(name.clone(), inserted);
+                    categories.insert(name, trie);
+                }
+                Ok(Self { categories, counts })
             }
-            counts.insert(name.clone(), inserted);
-            categories.insert(name, trie);
+            Err(MrsError::WrongFormat) => {
+                // Try the V2Ray .dat protobuf format. On any dat-parse
+                // error, surface `WrongFormat` so the callsite can log a
+                // single actionable message without internal noise.
+                crate::geosite_dat::from_dat_bytes(data).map_err(|_| GeositeError::WrongFormat)
+            }
+            Err(e) => Err(GeositeError::Mrs(e)),
         }
-        Ok(Self { categories, counts })
     }
 
     /// Load a geosite DB from a filesystem path.
@@ -143,12 +161,20 @@ fn meow_config_dir() -> PathBuf {
     base.join("meow")
 }
 
-/// Candidate paths for `geosite.mrs`, in priority order. Returned regardless
-/// of whether the files exist; caller decides.
+/// Candidate paths for the geosite DB, in priority order. Returned
+/// regardless of whether the files exist; caller decides.
+///
+/// Both `.mrs` (MetaCubeX binary) and `.dat` (V2Ray protobuf) are accepted —
+/// the loader auto-detects via magic bytes. `.mrs` is preferred when both
+/// are present, since it parses ~10× faster and has no per-entry type
+/// fidelity loss.
 pub fn default_geosite_candidates() -> Vec<PathBuf> {
+    let cfg = meow_config_dir();
     vec![
-        meow_config_dir().join("geosite.mrs"),
+        cfg.join("geosite.mrs"),
+        cfg.join("geosite.dat"),
         PathBuf::from("./meow/geosite.mrs"),
+        PathBuf::from("./meow/geosite.dat"),
     ]
 }
 
@@ -183,8 +209,8 @@ pub fn discover_and_load_at(
 pub fn discover_and_load_from(candidates: &[PathBuf]) -> Option<Arc<GeositeDB>> {
     let Some(path) = candidates.iter().find(|p| p.exists()) else {
         warn!(
-            "geosite.mrs not found in any of the discovery paths; GEOSITE rules will not match. \
-             Place the file at one of: {}",
+            "geosite DB not found in any of the discovery paths; GEOSITE rules will not match. \
+             Place a geosite.mrs or geosite.dat file at one of: {}",
             candidates
                 .iter()
                 .map(|p| p.display().to_string())
@@ -198,14 +224,13 @@ pub fn discover_and_load_from(candidates: &[PathBuf]) -> Option<Arc<GeositeDB>> 
         Err(GeositeError::WrongFormat) => {
             tracing::error!(
                 path = %path.display(),
-                "geosite.dat detected at {}; meow-rs requires geosite.mrs format. \
-                 Convert with: metacubex convert-geo",
+                "geosite file at {} is neither a valid .mrs nor a parseable V2Ray .dat",
                 path.display()
             );
             None
         }
         Err(e) => {
-            tracing::error!(path = %path.display(), "failed to load geosite.mrs: {}", e);
+            tracing::error!(path = %path.display(), "failed to load geosite DB: {}", e);
             None
         }
     }

--- a/crates/meow-rules/src/geosite_dat.rs
+++ b/crates/meow-rules/src/geosite_dat.rs
@@ -1,0 +1,462 @@
+//! V2Ray `geosite.dat` (protobuf) parser.
+//!
+//! Parses the legacy V2Ray `geosite.dat` format used by upstream
+//! mihomo / MetaCubeX before the `.mrs` rollout. Schema (subset):
+//!
+//! ```proto
+//! message Domain {
+//!   enum Type { Plain = 0; Regex = 1; Domain = 2; Full = 3; }
+//!   Type type = 1;
+//!   string value = 2;
+//!   // Attribute (field 3) is parsed and discarded — attribute filtering
+//!   // is not implemented (Class B per ADR-0002 §GEOSITE @-suffix).
+//! }
+//! message GeoSite { string country_code = 1; repeated Domain domain = 2; }
+//! message GeoSiteList { repeated GeoSite entry = 1; }
+//! ```
+//!
+//! Domain.Type mapping into `DomainTrie`:
+//! - `Domain` (suffix, matches `value` AND `*.value`) → inserted as `+.value`
+//!   so the trie matches both the apex and any subdomain (consistent with
+//!   `GeositeDB::insert`-and-suffix semantics).
+//! - `Full` (exact match only) → inserted as `value` so the trie matches
+//!   only the apex label.
+//! - `Plain` (substring) and `Regex` are silently dropped — `DomainTrie`
+//!   has no representation for them. A warning summarising the skipped
+//!   count is emitted once per `from_dat_bytes` call.
+
+use std::collections::HashMap;
+
+use meow_trie::DomainTrie;
+use tracing::warn;
+
+use crate::geosite::GeositeDB;
+
+/// Protobuf wire-type tags we care about.
+const WIRE_VARINT: u32 = 0;
+const WIRE_LEN_DELIM: u32 = 2;
+const WIRE_I64: u32 = 1;
+const WIRE_I32: u32 = 5;
+
+/// Field numbers in the V2Ray geosite schema (above).
+const FIELD_GEOSITELIST_ENTRY: u32 = 1;
+const FIELD_GEOSITE_COUNTRY_CODE: u32 = 1;
+const FIELD_GEOSITE_DOMAIN: u32 = 2;
+const FIELD_DOMAIN_TYPE: u32 = 1;
+const FIELD_DOMAIN_VALUE: u32 = 2;
+
+/// `Domain.Type` enum values.
+const DOMAIN_TYPE_PLAIN: u64 = 0;
+const DOMAIN_TYPE_REGEX: u64 = 1;
+const DOMAIN_TYPE_DOMAIN: u64 = 2;
+const DOMAIN_TYPE_FULL: u64 = 3;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DatError {
+    #[error("geosite.dat: truncated at offset {0}")]
+    Truncated(usize),
+    #[error("geosite.dat: varint overflow at offset {0}")]
+    VarintOverflow(usize),
+    #[error("geosite.dat: invalid utf-8 in field at offset {0}")]
+    InvalidUtf8(usize),
+    #[error("geosite.dat: unknown wire type {1} at offset {0}")]
+    UnknownWireType(usize, u32),
+}
+
+/// Minimal protobuf reader — only the wire-format primitives needed for the
+/// geosite schema. Holds a byte slice + cursor; all reads advance the cursor.
+struct PbReader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> PbReader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    fn is_at_end(&self) -> bool {
+        self.pos >= self.buf.len()
+    }
+
+    fn read_varint(&mut self) -> Result<u64, DatError> {
+        let start = self.pos;
+        let mut result: u64 = 0;
+        let mut shift: u32 = 0;
+        loop {
+            if self.pos >= self.buf.len() {
+                return Err(DatError::Truncated(start));
+            }
+            let b = self.buf[self.pos];
+            self.pos += 1;
+            if shift >= 64 {
+                return Err(DatError::VarintOverflow(start));
+            }
+            result |= u64::from(b & 0x7F) << shift;
+            if b & 0x80 == 0 {
+                return Ok(result);
+            }
+            shift += 7;
+        }
+    }
+
+    /// Read a wire tag — returns `(field_number, wire_type)`.
+    fn read_tag(&mut self) -> Result<(u32, u32), DatError> {
+        let tag = self.read_varint()?;
+        let field = (tag >> 3) as u32;
+        let wire = (tag & 0x7) as u32;
+        Ok((field, wire))
+    }
+
+    fn read_length_delimited(&mut self) -> Result<&'a [u8], DatError> {
+        let start = self.pos;
+        let len = self.read_varint()? as usize;
+        if self.remaining() < len {
+            return Err(DatError::Truncated(start));
+        }
+        let bytes = &self.buf[self.pos..self.pos + len];
+        self.pos += len;
+        Ok(bytes)
+    }
+
+    /// Skip a field whose tag was just consumed. Required when an unknown
+    /// field is encountered (e.g. `Domain.attribute`, field 3 wire-type 2).
+    fn skip_field(&mut self, wire: u32) -> Result<(), DatError> {
+        let start = self.pos;
+        match wire {
+            WIRE_VARINT => {
+                let _ = self.read_varint()?;
+            }
+            WIRE_LEN_DELIM => {
+                let _ = self.read_length_delimited()?;
+            }
+            WIRE_I64 => {
+                if self.remaining() < 8 {
+                    return Err(DatError::Truncated(start));
+                }
+                self.pos += 8;
+            }
+            WIRE_I32 => {
+                if self.remaining() < 4 {
+                    return Err(DatError::Truncated(start));
+                }
+                self.pos += 4;
+            }
+            other => return Err(DatError::UnknownWireType(start, other)),
+        }
+        Ok(())
+    }
+}
+
+/// Tally of skipped Domain entries — emitted as a single warn after parsing.
+#[derive(Default)]
+struct SkipStats {
+    plain: usize,
+    regex: usize,
+    empty: usize,
+}
+
+/// Parse a V2Ray `geosite.dat` byte buffer into a fully-built [`GeositeDB`].
+///
+/// `Plain` and `Regex` entries are skipped (see module docs). All `Domain`
+/// and `Full` entries are inserted into the per-category trie. Category
+/// names are lowercased to match `.mrs` semantics.
+pub fn from_dat_bytes(data: &[u8]) -> Result<GeositeDB, DatError> {
+    let mut r = PbReader::new(data);
+    let mut categories: HashMap<String, DomainTrie<()>> = HashMap::new();
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut skipped = SkipStats::default();
+
+    // Top-level message is GeoSiteList: repeated GeoSite entry = 1.
+    while !r.is_at_end() {
+        let (field, wire) = r.read_tag()?;
+        if field != FIELD_GEOSITELIST_ENTRY || wire != WIRE_LEN_DELIM {
+            r.skip_field(wire)?;
+            continue;
+        }
+        let entry_bytes = r.read_length_delimited()?;
+        parse_geosite_entry(entry_bytes, &mut categories, &mut counts, &mut skipped)?;
+    }
+
+    if skipped.plain + skipped.regex + skipped.empty > 0 {
+        warn!(
+            "geosite.dat: skipped {} Plain (keyword), {} Regex, and {} empty-value entries — \
+             DomainTrie has no representation for substring/regex matching",
+            skipped.plain, skipped.regex, skipped.empty
+        );
+    }
+
+    Ok(GeositeDB::from_parts(categories, counts))
+}
+
+fn parse_geosite_entry(
+    data: &[u8],
+    categories: &mut HashMap<String, DomainTrie<()>>,
+    counts: &mut HashMap<String, usize>,
+    skipped: &mut SkipStats,
+) -> Result<(), DatError> {
+    let mut r = PbReader::new(data);
+    let mut country: Option<String> = None;
+    let mut deferred_domains: Vec<Vec<u8>> = Vec::new();
+
+    while !r.is_at_end() {
+        let (field, wire) = r.read_tag()?;
+        match (field, wire) {
+            (FIELD_GEOSITE_COUNTRY_CODE, WIRE_LEN_DELIM) => {
+                let bytes = r.read_length_delimited()?;
+                let s = std::str::from_utf8(bytes)
+                    .map_err(|_| DatError::InvalidUtf8(r.pos))?
+                    .to_ascii_lowercase();
+                country = Some(s);
+            }
+            (FIELD_GEOSITE_DOMAIN, WIRE_LEN_DELIM) => {
+                // country_code may appear after some domain entries in
+                // pathological encoders; buffer the bytes and apply after
+                // the message is fully scanned.
+                deferred_domains.push(r.read_length_delimited()?.to_vec());
+            }
+            (_, w) => r.skip_field(w)?,
+        }
+    }
+
+    let Some(country) = country else {
+        return Ok(()); // unnamed category — drop silently
+    };
+
+    let trie = categories.entry(country.clone()).or_default();
+    let mut count = counts.get(&country).copied().unwrap_or(0);
+    for domain_bytes in deferred_domains {
+        if let Some(()) = apply_domain_entry(&domain_bytes, trie, skipped)? {
+            count += 1;
+        }
+    }
+    counts.insert(country, count);
+    Ok(())
+}
+
+/// Parse a single `Domain` submessage and insert it into `trie`. Returns
+/// `Some(())` when an insert happened, `None` when the entry was skipped.
+fn apply_domain_entry(
+    data: &[u8],
+    trie: &mut DomainTrie<()>,
+    skipped: &mut SkipStats,
+) -> Result<Option<()>, DatError> {
+    let mut r = PbReader::new(data);
+    let mut dom_type: u64 = DOMAIN_TYPE_DOMAIN; // proto3 default = 0 = Plain; explicit default kept clear
+    let mut value: Option<String> = None;
+    let mut saw_type = false;
+
+    while !r.is_at_end() {
+        let (field, wire) = r.read_tag()?;
+        match (field, wire) {
+            (FIELD_DOMAIN_TYPE, WIRE_VARINT) => {
+                dom_type = r.read_varint()?;
+                saw_type = true;
+            }
+            (FIELD_DOMAIN_VALUE, WIRE_LEN_DELIM) => {
+                let bytes = r.read_length_delimited()?;
+                let s = std::str::from_utf8(bytes)
+                    .map_err(|_| DatError::InvalidUtf8(r.pos))?
+                    .to_ascii_lowercase();
+                value = Some(s);
+            }
+            (_, w) => r.skip_field(w)?,
+        }
+    }
+
+    // proto3 omits the field for zero values; an unset `type` means Plain.
+    if !saw_type {
+        dom_type = DOMAIN_TYPE_PLAIN;
+    }
+
+    let Some(value) = value else {
+        skipped.empty += 1;
+        return Ok(None);
+    };
+    if value.is_empty() {
+        skipped.empty += 1;
+        return Ok(None);
+    }
+
+    match dom_type {
+        DOMAIN_TYPE_PLAIN => {
+            skipped.plain += 1;
+            Ok(None)
+        }
+        DOMAIN_TYPE_REGEX => {
+            skipped.regex += 1;
+            Ok(None)
+        }
+        DOMAIN_TYPE_DOMAIN => {
+            // V2Ray's `Domain` type matches the apex AND any subdomain.
+            // `DomainTrie`'s `+.value` form only covers subdomains, so we
+            // insert the apex (`value`) separately. The pair count as one
+            // logical entry — `inserted` only tracks the suffix insert.
+            let pat = format!("+.{value}");
+            let _ = trie.insert(&value, ());
+            if trie.insert(&pat, ()) {
+                Ok(Some(()))
+            } else {
+                Ok(None)
+            }
+        }
+        DOMAIN_TYPE_FULL => {
+            if trie.insert(&value, ()) {
+                Ok(Some(()))
+            } else {
+                Ok(None)
+            }
+        }
+        _ => Ok(None), // unknown type — silently skip
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Append a protobuf wire tag `(field << 3) | wire_type` as a varint.
+    fn write_tag(out: &mut Vec<u8>, field: u32, wire: u32) {
+        write_varint(out, ((field as u64) << 3) | (wire as u64));
+    }
+
+    fn write_varint(out: &mut Vec<u8>, mut n: u64) {
+        loop {
+            let b = (n & 0x7F) as u8;
+            n >>= 7;
+            if n == 0 {
+                out.push(b);
+                return;
+            }
+            out.push(b | 0x80);
+        }
+    }
+
+    fn write_len_delim(out: &mut Vec<u8>, bytes: &[u8]) {
+        write_varint(out, bytes.len() as u64);
+        out.extend_from_slice(bytes);
+    }
+
+    /// Build a minimal Domain submessage.
+    fn build_domain(ty: u64, value: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        if ty != DOMAIN_TYPE_PLAIN {
+            write_tag(&mut out, FIELD_DOMAIN_TYPE, WIRE_VARINT);
+            write_varint(&mut out, ty);
+        }
+        write_tag(&mut out, FIELD_DOMAIN_VALUE, WIRE_LEN_DELIM);
+        write_len_delim(&mut out, value.as_bytes());
+        out
+    }
+
+    fn build_geosite(country: &str, domains: &[(u64, &str)]) -> Vec<u8> {
+        let mut out = Vec::new();
+        write_tag(&mut out, FIELD_GEOSITE_COUNTRY_CODE, WIRE_LEN_DELIM);
+        write_len_delim(&mut out, country.as_bytes());
+        for &(ty, v) in domains {
+            let dom = build_domain(ty, v);
+            write_tag(&mut out, FIELD_GEOSITE_DOMAIN, WIRE_LEN_DELIM);
+            write_len_delim(&mut out, &dom);
+        }
+        out
+    }
+
+    fn build_geosite_list(entries: &[(&str, &[(u64, &str)])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for &(country, domains) in entries {
+            let entry = build_geosite(country, domains);
+            write_tag(&mut out, FIELD_GEOSITELIST_ENTRY, WIRE_LEN_DELIM);
+            write_len_delim(&mut out, &entry);
+        }
+        out
+    }
+
+    #[test]
+    fn parse_single_domain_entry() {
+        let bytes = build_geosite_list(&[("cn", &[(DOMAIN_TYPE_DOMAIN, "baidu.com")])]);
+        let db = from_dat_bytes(&bytes).expect("ok");
+        assert!(db.lookup("cn", "baidu.com"));
+        assert!(db.lookup("cn", "www.baidu.com")); // suffix
+        assert!(!db.lookup("cn", "google.com"));
+    }
+
+    #[test]
+    fn parse_full_entry_is_exact_match() {
+        let bytes = build_geosite_list(&[("test", &[(DOMAIN_TYPE_FULL, "example.com")])]);
+        let db = from_dat_bytes(&bytes).expect("ok");
+        assert!(db.lookup("test", "example.com"));
+        assert!(!db.lookup("test", "sub.example.com")); // no suffix match for Full
+    }
+
+    #[test]
+    fn parse_plain_and_regex_are_skipped() {
+        let bytes = build_geosite_list(&[(
+            "mixed",
+            &[
+                (DOMAIN_TYPE_DOMAIN, "keep.com"),
+                (DOMAIN_TYPE_PLAIN, "drop-keyword"),
+                (DOMAIN_TYPE_REGEX, "^drop.*regex$"),
+                (DOMAIN_TYPE_FULL, "exact.com"),
+            ],
+        )]);
+        let db = from_dat_bytes(&bytes).expect("ok");
+        assert_eq!(db.domain_count("mixed"), Some(2));
+        assert!(db.lookup("mixed", "keep.com"));
+        assert!(db.lookup("mixed", "exact.com"));
+        assert!(!db.lookup("mixed", "drop-keyword"));
+    }
+
+    #[test]
+    fn multiple_categories() {
+        let bytes = build_geosite_list(&[
+            ("cn", &[(DOMAIN_TYPE_DOMAIN, "baidu.com")]),
+            ("youtube", &[(DOMAIN_TYPE_DOMAIN, "youtube.com")]),
+        ]);
+        let db = from_dat_bytes(&bytes).expect("ok");
+        assert_eq!(db.category_count(), 2);
+        assert!(db.lookup("cn", "www.baidu.com"));
+        assert!(db.lookup("youtube", "m.youtube.com"));
+        assert!(!db.lookup("cn", "youtube.com"));
+    }
+
+    #[test]
+    fn category_names_are_lowercased() {
+        let bytes = build_geosite_list(&[("CN", &[(DOMAIN_TYPE_DOMAIN, "Baidu.COM")])]);
+        let db = from_dat_bytes(&bytes).expect("ok");
+        assert!(db.lookup("cn", "baidu.com"));
+        assert!(db.lookup("CN", "BAIDU.COM"));
+    }
+
+    #[test]
+    fn unknown_top_level_fields_are_skipped() {
+        // Build a list with a stray field 99 (varint) before the real entry.
+        let mut bytes = Vec::new();
+        write_tag(&mut bytes, 99, WIRE_VARINT);
+        write_varint(&mut bytes, 12345);
+        let entry = build_geosite("cn", &[(DOMAIN_TYPE_DOMAIN, "baidu.com")]);
+        write_tag(&mut bytes, FIELD_GEOSITELIST_ENTRY, WIRE_LEN_DELIM);
+        write_len_delim(&mut bytes, &entry);
+        let db = from_dat_bytes(&bytes).expect("ok");
+        assert!(db.lookup("cn", "baidu.com"));
+    }
+
+    #[test]
+    fn truncated_input_errors() {
+        let mut bytes = build_geosite_list(&[("cn", &[(DOMAIN_TYPE_DOMAIN, "baidu.com")])]);
+        bytes.truncate(bytes.len() - 3);
+        assert!(matches!(
+            from_dat_bytes(&bytes),
+            Err(DatError::Truncated(_))
+        ));
+    }
+
+    #[test]
+    fn empty_input_is_empty_db() {
+        let db = from_dat_bytes(&[]).expect("ok");
+        assert_eq!(db.category_count(), 0);
+    }
+}

--- a/crates/meow-rules/src/lib.rs
+++ b/crates/meow-rules/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dscp;
 pub mod final_rule;
 pub mod geoip;
 pub mod geosite;
+pub mod geosite_dat;
 pub mod geosite_rule;
 pub mod in_name;
 pub mod in_port;


### PR DESCRIPTION
## Summary
- `GeositeDB::from_bytes` now auto-detects between MetaCubeX `.mrs` (magic `MRS!`) and V2Ray `.dat` (protobuf) and parses either natively.
- New `geosite_dat` module ships a hand-rolled minimal protobuf reader (varint + length-delimited + skip) — no `prost`/`protobuf` workspace dependency.
- Maps V2Ray `Domain.Type` into the existing `DomainTrie`:
  - `Domain` (suffix) → insert apex `value` AND `+.value` so both the domain and its subdomains match.
  - `Full` (exact) → insert `value` only.
  - `Plain` and `Regex` are skipped with a single summary warn; `DomainTrie` has no representation for substring/regex matching.
- Discovery candidates now include `geosite.dat` alongside `.mrs` in both `$XDG_CONFIG_HOME/meow/` and `./meow/`. `.mrs` wins when both exist (faster parse, lossless).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (590 passed, +9 new geosite_dat cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)