### PR TITLE
feat(geodata): default geosite to .dat (upstream dropped .mrs)

### DIFF
--- a/crates/meow-config/src/geodata.rs
+++ b/crates/meow-config/src/geodata.rs
@@ -12,7 +12,7 @@ const DEFAULT_MMDB_URL: &str =
 const DEFAULT_ASN_URL: &str =
     "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-ASN.mmdb";
 const DEFAULT_GEOSITE_URL: &str =
-    "https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geosite.mrs";
+    "https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geosite.dat";
 
 /// Validated `geodata:` config, produced by [`parse_geodata`].
 #[derive(Debug, Clone)]
@@ -174,7 +174,7 @@ mod tests {
         assert!(cfg.geosite_path.is_none());
         assert!(cfg.mmdb_url.contains("country.mmdb"));
         assert!(cfg.asn_url.contains("GeoLite2-ASN"));
-        assert!(cfg.geosite_url.contains("geosite.mrs"));
+        assert!(cfg.geosite_url.contains("geosite.dat"));
     }
 
     #[test]

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -618,9 +618,11 @@ pub fn default_asn_path() -> PathBuf {
     meow_config_dir().join("GeoLite2-ASN.mmdb")
 }
 
-/// Default path for geosite.mrs (first candidate in the discovery chain).
+/// Default on-disk path for the geosite DB used by the geodata downloader.
+/// Uses `geosite.dat` since upstream MetaCubeX stopped publishing the `.mrs`
+/// release artifact; the loader transparently accepts either format.
 pub fn default_geosite_path() -> PathBuf {
-    meow_config_dir().join("geosite.mrs")
+    meow_config_dir().join("geosite.dat")
 }
 
 pub fn meow_config_dir() -> PathBuf {


### PR DESCRIPTION
## Summary
MetaCubeX no longer publishes the `geosite.mrs` release artifact — `https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geosite.mrs` returns **404** since the .dat → .mrs build was discontinued upstream. The native `.dat` loader added in 8f9f80d (#125) lets us switch the default URL and on-disk filename without dropping support for users who already have `geosite.mrs` on disk.

- `DEFAULT_GEOSITE_URL` → `…/geosite.dat`
- `default_geosite_path()` → `…/meow/geosite.dat`
- Discovery still lists `geosite.mrs` first, so users with a manually-placed `.mrs` are unaffected.

## Verification
- `curl -I .../geosite.mrs` → 404
- `curl -I .../geosite.dat` → 200

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (590 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)