### PR TITLE
feat(geodata): re-enable geosite refresh in auto-update loop

### DIFF
--- a/crates/meow-app/src/geodata_fetch.rs
+++ b/crates/meow-app/src/geodata_fetch.rs
@@ -125,15 +125,15 @@ pub async fn run_on_startup(
     }
 }
 
-/// Background task that periodically re-downloads the ASN DB when
-/// `geodata.auto-update: true`. After a successful download the DB file is
-/// atomically replaced on disk, then rules are rebuilt in memory without
-/// restart. Runs forever; spawn as a background task.
+/// Background task that periodically re-downloads the ASN and geosite DBs
+/// when `geodata.auto-update: true`. After each successful download the DB
+/// file is atomically replaced on disk, then rules are rebuilt in memory
+/// without restart. Runs forever; spawn as a background task.
 ///
-/// GeoIP MMDB and geosite are intentionally NOT refreshed here — their data
-/// changes infrequently, and skipping the rebuild lets the parser-built
-/// `CountryIndex` / geosite DB stay live without churn. Operators who need
-/// to update them should replace the files on disk and restart.
+/// The GeoIP MMDB is intentionally NOT refreshed here — country-code → CIDR
+/// mappings change infrequently and skipping the rebuild keeps the
+/// parser-built `CountryIndex` alive without churn. Operators who need to
+/// update GeoIP should replace `Country.mmdb` on disk and restart.
 pub async fn auto_update_loop(
     geo: GeoDataConfig,
     tunnel: Tunnel,
@@ -148,9 +148,15 @@ pub async fn auto_update_loop(
         .asn_path
         .clone()
         .unwrap_or_else(meow_config::default_asn_path);
+    let geosite_target = geo
+        .geosite_path
+        .clone()
+        .unwrap_or_else(meow_config::default_geosite_path);
 
     loop {
         ticker.tick().await;
+
+        let mut any_updated = false;
 
         let proxies = tunnel.proxies();
         let download_proxy = meow_config::internal_http::first_named_proxy(
@@ -162,6 +168,20 @@ pub async fn auto_update_loop(
             download_and_replace(&geo.asn_url, &asn_target, download_proxy.as_ref()).await
         {
             warn!("geodata auto-update: ASN MMDB download failed: {:#}", e);
+        } else {
+            any_updated = true;
+        }
+
+        if let Err(e) =
+            download_and_replace(&geo.geosite_url, &geosite_target, download_proxy.as_ref()).await
+        {
+            warn!("geodata auto-update: geosite download failed: {:#}", e);
+        } else {
+            any_updated = true;
+        }
+
+        if !any_updated {
+            warn!("geodata auto-update: all downloads failed; rules not reloaded");
             continue;
         }
 


### PR DESCRIPTION
## Summary
Add geosite back to `auto_update_loop` alongside ASN. The earlier removal (e5493ca) was driven by the upstream 404 on `geosite.mrs` and the desire to avoid churn on the parser-built `GeositeDB`. Now that:

- meow-rs natively parses `geosite.dat` (#125 / 8f9f80d), and
- the default URL points at the upstream-200 `.dat` artifact (#126 / 2702052),

the refresh path works end-to-end again. GeoIP MMDB stays out — country-code → CIDR mappings change rarely and skipping the rebuild keeps `CountryIndex` alive without churn.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (590 passed)
- [x] `cargo test -p meow-app` (21 passed, 1 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)