### PR TITLE
fix(android): route connect_tcp_host through meow-rs resolver

### DIFF
--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -435,6 +435,21 @@ async fn run(
     // Keep a resolver clone for the auto-update task before it moves into the tunnel.
     let resolver = Arc::clone(&config.dns.resolver);
 
+    // Android: install the resolver as the global host-resolver hook used
+    // by `meow_common::connect_tcp_host` / `resolve_host`. Without this,
+    // proxy adapters dialling by hostname would fall back to libc's
+    // `getaddrinfo`, whose DNS sockets bypass `VpnService.protect(fd)` —
+    // so on a VPN-active device DNS would route through our own tunnel
+    // and loop. See `meow-common/src/socket_protect.rs` for the full
+    // failure mode. The `SocketProtector` itself is installed separately
+    // by the JNI bridge.
+    #[cfg(target_os = "android")]
+    {
+        meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(Arc::clone(
+            &config.dns.resolver,
+        ))));
+    }
+
     // Create the tunnel (core routing engine)
     let tunnel = Tunnel::new(Arc::clone(&config.dns.resolver));
     tunnel.set_mode(config.general.mode);

--- a/crates/meow-common/src/lib.rs
+++ b/crates/meow-common/src/lib.rs
@@ -23,9 +23,10 @@ pub use network::Network;
 pub use process_lookup::{find_process, ProcessInfo};
 pub use rule::{Rule, RuleMatchHelper, RuleType};
 pub use sniffer::SnifferConfig;
-pub use socket_protect::{bind_udp, connect_tcp};
+pub use socket_protect::{bind_udp, connect_tcp, connect_tcp_host, resolve_host};
 #[cfg(target_os = "android")]
 pub use socket_protect::{
-    clear_socket_protector, set_socket_protector, socket_protector, SocketProtector,
+    clear_host_resolver, clear_socket_protector, host_resolver, set_host_resolver,
+    set_socket_protector, socket_protector, HostResolver, SocketProtector,
 };
 pub use tunnel_mode::TunnelMode;

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -5,16 +5,30 @@
 //! loop back into the tunnel and deadlock. Android exposes a per-fd hook
 //! for this: `android.net.VpnService.protect(int fd)`. This module is the
 //! single place the JNI bridge installs that hook; the proxy adapters that
-//! open outbound sockets dial through [`connect_tcp`] / [`bind_udp`], which
-//! call the installed protector before `connect()` / `bind()` so the very
-//! first SYN / UDP packet already bypasses the tunnel.
+//! open outbound sockets dial through [`connect_tcp`] / [`connect_tcp_host`]
+//! / [`bind_udp`], which call the installed protector before `connect()` /
+//! `bind()` so the very first SYN / UDP packet already bypasses the tunnel.
 //!
-//! The protector trait and global setter are compiled only on Android. On
-//! every other target [`connect_tcp`] / [`bind_udp`] degrade to the same
-//! plain tokio code path the adapters used historically — so call sites
-//! need no `cfg` guards.
+//! ## Why the second hook (`HostResolver`)
+//!
+//! `VpnService.protect(fd)` only protects sockets meow-rs creates itself.
+//! Libc's `getaddrinfo` (called by `tokio::net::lookup_host` and
+//! `TcpStream::connect("host:port")`) opens its own DNS sockets that
+//! meow-rs never sees, so on a VPN-active device those DNS queries route
+//! *through* the VPN — i.e. through meow-rs's own tunnel — which then needs
+//! to dial a proxy upstream, which needs DNS, which loops. To break that
+//! loop, [`connect_tcp_host`] consults an optionally-installed
+//! `HostResolver` (typically backed by meow-rs's own `meow_dns::Resolver`
+//! whose upstream sockets *are* protected) before falling back to the
+//! system resolver.
+//!
+//! The hooks are compiled only on Android in production — that's the
+//! platform whose VPN model demands this. For tests we additionally enable
+//! the module on any unix host so CI (which does not target Android) can
+//! actually exercise the hooks against real loopback sockets.
 
 use std::io;
+use std::net::SocketAddr;
 
 use tokio::net::{TcpStream, ToSocketAddrs, UdpSocket};
 
@@ -26,10 +40,11 @@ use tokio::net::{TcpStream, ToSocketAddrs, UdpSocket};
 #[cfg(any(target_os = "android", all(test, unix)))]
 mod android {
     use super::*;
-    use std::net::SocketAddr;
+    use std::net::IpAddr;
     use std::os::fd::{AsRawFd, RawFd};
     use std::sync::Arc;
 
+    use async_trait::async_trait;
     use parking_lot::RwLock;
 
     /// Hook invoked on every outbound socket fd just before `connect()` /
@@ -44,7 +59,20 @@ mod android {
         fn protect(&self, fd: RawFd) -> io::Result<()>;
     }
 
+    /// Hostname → IP resolution hook used by [`connect_tcp_host`] when a
+    /// [`SocketProtector`] is installed. Mirrors the protector registry:
+    /// the JNI bridge / app startup installs an implementation that routes
+    /// queries through meow-rs's own DNS pipeline (whose upstream sockets
+    /// are themselves protected), so the resolution itself bypasses the
+    /// VPN. Without this, `getaddrinfo` would loop DNS through the tunnel.
+    #[async_trait]
+    pub trait HostResolver: Send + Sync {
+        /// Resolve `host` to one `IpAddr`. Returning `Err` aborts the dial.
+        async fn resolve(&self, host: &str) -> io::Result<IpAddr>;
+    }
+
     static PROTECTOR: RwLock<Option<Arc<dyn SocketProtector>>> = RwLock::new(None);
+    static RESOLVER: RwLock<Option<Arc<dyn HostResolver>>> = RwLock::new(None);
 
     /// Install the global socket protector. Call once during VPN startup,
     /// before any proxy adapter dials.
@@ -65,6 +93,27 @@ mod android {
     /// can still apply protect on the fd they own.
     pub fn socket_protector() -> Option<Arc<dyn SocketProtector>> {
         PROTECTOR.read().clone()
+    }
+
+    /// Install the global host resolver used by [`connect_tcp_host`]. Call
+    /// once at startup, right after the meow-rs `Resolver` is built. Safe
+    /// to re-install (e.g. config reload) — the new resolver takes effect
+    /// on the next hostname dial.
+    pub fn set_host_resolver(resolver: Arc<dyn HostResolver>) {
+        *RESOLVER.write() = Some(resolver);
+    }
+
+    /// Remove the currently installed host resolver, if any. With the
+    /// protector still installed, subsequent [`connect_tcp_host`] calls
+    /// will fall back to the system resolver and log a warning — that
+    /// path is known-unsafe when the VPN is active.
+    pub fn clear_host_resolver() {
+        *RESOLVER.write() = None;
+    }
+
+    /// Snapshot of the currently-installed host resolver.
+    pub fn host_resolver() -> Option<Arc<dyn HostResolver>> {
+        RESOLVER.read().clone()
     }
 
     pub(super) async fn connect_tcp_protected(
@@ -121,25 +170,68 @@ mod android {
 
 #[cfg(any(target_os = "android", all(test, unix)))]
 pub use android::{
-    clear_socket_protector, set_socket_protector, socket_protector, SocketProtector,
+    clear_host_resolver, clear_socket_protector, host_resolver, set_host_resolver,
+    set_socket_protector, socket_protector, HostResolver, SocketProtector,
 };
 
-/// Dial an outbound TCP stream. On Android, applies the installed
-/// `SocketProtector` (if any) to the socket fd before `connect()` so the
-/// connection bypasses the VPN. On every other target this is equivalent to
-/// [`TcpStream::connect`].
+/// Dial an outbound TCP stream to an already-resolved [`SocketAddr`]. On
+/// Android, applies the installed `SocketProtector` (if any) to the
+/// socket fd before `connect()` so the connection bypasses the VPN. On
+/// every other target this is equivalent to [`TcpStream::connect`].
 ///
-/// Accepts the same address forms as [`TcpStream::connect`] (a `SocketAddr`,
-/// `(host, port)`, `"host:port"`, etc.). When the Android protector path is
-/// taken, addresses are resolved first via `tokio::net::lookup_host` and each
-/// resolved `SocketAddr` is tried in turn.
-pub async fn connect_tcp<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
+/// Callers that only have a hostname must use [`connect_tcp_host`] —
+/// passing a hostname here is a compile error by construction (the type
+/// is `SocketAddr`, not `ToSocketAddrs`). That split exists to prevent
+/// silent regressions back into the system resolver; see the module docs
+/// for the loop-routing failure mode.
+pub async fn connect_tcp(addr: SocketAddr) -> io::Result<TcpStream> {
     #[cfg(any(target_os = "android", all(test, unix)))]
     {
         if let Some(p) = android::socket_protector() {
+            return android::connect_tcp_protected(addr, p.as_ref()).await;
+        }
+    }
+    TcpStream::connect(addr).await
+}
+
+/// Dial an outbound TCP stream to `host:port`, resolving the hostname
+/// through the installed `HostResolver` when a `SocketProtector` is
+/// also installed. This routes the lookup through meow-rs's own DNS
+/// resolver (whose upstream sockets are themselves protected) instead of
+/// libc's `getaddrinfo`, which on a VPN-active device would loop DNS
+/// queries back through the tunnel.
+///
+/// IP literals short-circuit straight to [`connect_tcp`] — no resolver
+/// hook is needed.
+///
+/// Fallback behaviour (when no `HostResolver` is installed):
+/// * If a `SocketProtector` is installed, falls back to
+///   `tokio::net::lookup_host` and logs a warning — this path is the
+///   exact failure mode the resolver hook exists to prevent, but is kept
+///   so a protector-only configuration still functions (degraded).
+/// * If no `SocketProtector` is installed (i.e. not running inside a
+///   VPN), behaves as a plain `TcpStream::connect((host, port))`.
+pub async fn connect_tcp_host(host: &str, port: u16) -> io::Result<TcpStream> {
+    // IP literal — no DNS needed, regardless of platform.
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return connect_tcp(SocketAddr::new(ip, port)).await;
+    }
+
+    #[cfg(any(target_os = "android", all(test, unix)))]
+    {
+        if let Some(p) = android::socket_protector() {
+            if let Some(r) = android::host_resolver() {
+                let ip = r.resolve(host).await?;
+                return android::connect_tcp_protected(SocketAddr::new(ip, port), p.as_ref()).await;
+            }
+            tracing::warn!(
+                host,
+                "connect_tcp_host: protector installed but no HostResolver — \
+                 falling back to system resolver, which may loop DNS through the VPN"
+            );
             let mut last_err: Option<io::Error> = None;
             let mut any = false;
-            for resolved in tokio::net::lookup_host(addr).await? {
+            for resolved in tokio::net::lookup_host((host, port)).await? {
                 any = true;
                 match android::connect_tcp_protected(resolved, p.as_ref()).await {
                     Ok(s) => return Ok(s),
@@ -150,15 +242,52 @@ pub async fn connect_tcp<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
                     if any {
-                        "connect_tcp: all candidates failed"
+                        "connect_tcp_host: all candidates failed"
                     } else {
-                        "connect_tcp: no addresses resolved"
+                        "connect_tcp_host: no addresses resolved"
                     },
                 )
             }));
         }
     }
-    TcpStream::connect(addr).await
+    TcpStream::connect((host, port)).await
+}
+
+/// Resolve `host` to a single [`SocketAddr`] using the same hook chain
+/// as [`connect_tcp_host`]: IP literals short-circuit, the installed
+/// `HostResolver` is preferred when a `SocketProtector` is present,
+/// and the system resolver is the (warning-logged) fallback. Use this
+/// from call sites that need a `SocketAddr` for a subsequent operation
+/// other than `connect()` — e.g. `UdpSocket::connect(addr)`.
+pub async fn resolve_host(host: &str, port: u16) -> io::Result<SocketAddr> {
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return Ok(SocketAddr::new(ip, port));
+    }
+
+    #[cfg(any(target_os = "android", all(test, unix)))]
+    {
+        if android::socket_protector().is_some() {
+            if let Some(r) = android::host_resolver() {
+                let ip = r.resolve(host).await?;
+                return Ok(SocketAddr::new(ip, port));
+            }
+            tracing::warn!(
+                host,
+                "resolve_host: protector installed but no HostResolver — \
+                 falling back to system resolver, which may loop DNS through the VPN"
+            );
+        }
+    }
+
+    tokio::net::lookup_host((host, port))
+        .await?
+        .next()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("resolve_host: no address for {host}:{port}"),
+            )
+        })
 }
 
 /// Bind an outbound UDP socket. On Android, applies the installed
@@ -183,10 +312,12 @@ pub async fn bind_udp<A: ToSocketAddrs>(local: A) -> io::Result<UdpSocket> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use std::net::SocketAddr;
+    use std::net::{IpAddr, SocketAddr};
     use std::os::fd::RawFd;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+
+    use async_trait::async_trait;
 
     /// Records every fd handed to it; never fails.
     struct Counting {
@@ -217,6 +348,45 @@ mod tests {
     impl SocketProtector for Failing {
         fn protect(&self, _fd: RawFd) -> io::Result<()> {
             Err(io::Error::other("protect denied"))
+        }
+    }
+
+    /// Counts every `resolve` and always returns a fixed `IpAddr`.
+    struct FixedResolver {
+        ip: IpAddr,
+        count: AtomicUsize,
+        last_host: parking_lot::Mutex<Option<String>>,
+    }
+    impl FixedResolver {
+        fn new(ip: IpAddr) -> Arc<Self> {
+            Arc::new(Self {
+                ip,
+                count: AtomicUsize::new(0),
+                last_host: parking_lot::Mutex::new(None),
+            })
+        }
+        fn count(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+        fn last_host(&self) -> Option<String> {
+            self.last_host.lock().clone()
+        }
+    }
+    #[async_trait]
+    impl HostResolver for FixedResolver {
+        async fn resolve(&self, host: &str) -> io::Result<IpAddr> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            *self.last_host.lock() = Some(host.to_string());
+            Ok(self.ip)
+        }
+    }
+
+    /// Errors on every `resolve`.
+    struct FailingResolver;
+    #[async_trait]
+    impl HostResolver for FailingResolver {
+        async fn resolve(&self, _host: &str) -> io::Result<IpAddr> {
+            Err(io::Error::other("resolve denied"))
         }
     }
 
@@ -322,20 +492,82 @@ mod tests {
         clear_socket_protector();
     }
 
+    // ─── connect_tcp_host ────────────────────────────────────────────────────
+
     #[tokio::test]
-    async fn connect_tcp_with_string_addr_resolves_then_protects() {
+    async fn connect_tcp_host_with_ip_literal_skips_resolver() {
+        let _g = LOCK.lock().await;
+        clear_socket_protector();
+        clear_host_resolver();
+        // Install a resolver that would fail if it were called — proving
+        // the IP-literal short-circuit really did skip it.
+        set_host_resolver(Arc::new(FailingResolver) as Arc<dyn HostResolver>);
+        let counter = Counting::new();
+        set_socket_protector(Arc::clone(&counter) as Arc<dyn SocketProtector>);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
+        let _stream = connect_tcp_host("127.0.0.1", port).await.expect("connect");
+        let _ = accept.await.unwrap();
+        assert_eq!(counter.count(), 1, "protector still applies to literal");
+
+        clear_socket_protector();
+        clear_host_resolver();
+    }
+
+    #[tokio::test]
+    async fn connect_tcp_host_uses_installed_resolver_when_protected() {
         let _g = LOCK.lock().await;
         let counter = Counting::new();
         set_socket_protector(Arc::clone(&counter) as Arc<dyn SocketProtector>);
+
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let resolver = FixedResolver::new(IpAddr::from([127, 0, 0, 1]));
+        set_host_resolver(Arc::clone(&resolver) as Arc<dyn HostResolver>);
+
         let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
-        // Pass as "host:port" string — exercises the lookup_host branch.
-        let host_port = format!("127.0.0.1:{}", addr.port());
-        let _stream = connect_tcp(host_port.as_str()).await.expect("connect");
+        let _stream = connect_tcp_host("example.invalid", port)
+            .await
+            .expect("connect");
         let _ = accept.await.unwrap();
-        assert_eq!(counter.count(), 1);
+
+        assert_eq!(resolver.count(), 1, "resolver must be consulted once");
+        assert_eq!(resolver.last_host().as_deref(), Some("example.invalid"));
+        assert_eq!(counter.count(), 1, "protector still applies");
+
+        clear_host_resolver();
         clear_socket_protector();
+    }
+
+    #[tokio::test]
+    async fn connect_tcp_host_propagates_resolver_failure() {
+        let _g = LOCK.lock().await;
+        let counter = Counting::new();
+        set_socket_protector(Arc::clone(&counter) as Arc<dyn SocketProtector>);
+        set_host_resolver(Arc::new(FailingResolver) as Arc<dyn HostResolver>);
+
+        let err = connect_tcp_host("example.invalid", 80)
+            .await
+            .expect_err("resolver should fail");
+        assert!(err.to_string().contains("resolve denied"), "{err}");
+
+        clear_host_resolver();
+        clear_socket_protector();
+    }
+
+    #[tokio::test]
+    async fn connect_tcp_host_without_protector_uses_plain_tokio() {
+        let _g = LOCK.lock().await;
+        clear_socket_protector();
+        clear_host_resolver();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
+        let _stream = connect_tcp_host("127.0.0.1", port).await.expect("connect");
+        let _ = accept.await.unwrap();
     }
 
     // ─── bind_udp ────────────────────────────────────────────────────────────
@@ -407,5 +639,19 @@ mod tests {
         assert_eq!(second.count(), 1, "new protector receives calls");
 
         clear_socket_protector();
+    }
+
+    #[tokio::test]
+    async fn host_resolver_set_get_clear_round_trip() {
+        let _g = LOCK.lock().await;
+        clear_host_resolver();
+        assert!(host_resolver().is_none());
+
+        let r = FixedResolver::new(IpAddr::from([127, 0, 0, 1]));
+        set_host_resolver(Arc::clone(&r) as Arc<dyn HostResolver>);
+        assert!(host_resolver().is_some());
+
+        clear_host_resolver();
+        assert!(host_resolver().is_none());
     }
 }

--- a/crates/meow-dns/src/host_resolver_hook.rs
+++ b/crates/meow-dns/src/host_resolver_hook.rs
@@ -1,0 +1,50 @@
+//! Bridge between [`crate::Resolver`] and the global
+//! [`meow_common::HostResolver`] hook consulted by
+//! [`meow_common::connect_tcp_host`] / [`meow_common::resolve_host`].
+//!
+//! Gated identically to the trait it implements (Android in production,
+//! plus `test/unix` so CI can exercise the wiring) — outside of those
+//! cfgs the hook isn't compiled, so no impl is needed.
+//!
+//! See `meow-common/src/socket_protect.rs` for *why* this hook exists:
+//! `getaddrinfo` queries from libc bypass `VpnService.protect(fd)` and
+//! therefore route back through meow-rs's own tunnel, looping. Routing
+//! the lookup through `Resolver::resolve_ip` instead breaks that loop
+//! because the resolver's upstream sockets are themselves protected.
+
+#![cfg(target_os = "android")]
+
+use std::io;
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use meow_common::HostResolver;
+
+use crate::Resolver;
+
+/// Adapter that implements `meow_common::HostResolver` by delegating to
+/// `Resolver::resolve_ip` — i.e. the same path `DirectAdapter` uses, so
+/// hosts file entries and fake-IP rules behave consistently between the
+/// direct outbound and the socket-protect dial path.
+pub struct ResolverHostHook {
+    resolver: Arc<Resolver>,
+}
+
+impl ResolverHostHook {
+    pub fn new(resolver: Arc<Resolver>) -> Self {
+        Self { resolver }
+    }
+}
+
+#[async_trait]
+impl HostResolver for ResolverHostHook {
+    async fn resolve(&self, host: &str) -> io::Result<IpAddr> {
+        self.resolver.resolve_ip(host).await.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("meow-dns resolver: no address for {host}"),
+            )
+        })
+    }
+}

--- a/crates/meow-dns/src/lib.rs
+++ b/crates/meow-dns/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cache;
 pub mod client;
 pub mod fakeip;
+pub mod host_resolver_hook;
 pub mod resolver;
 pub mod server;
 pub mod upstream;
@@ -8,6 +9,8 @@ pub mod upstream;
 pub use cache::DnsCache;
 pub use client::{set_socket_factory, ClientError, DnsClient, SocketFactory};
 pub use fakeip::{FileStore, MemoryStore, Pool, PoolError, Skipper, SkipperMode, Store};
+#[cfg(target_os = "android")]
+pub use host_resolver_hook::ResolverHostHook;
 pub use resolver::{BootstrapError, FallbackFilter, NameserverPolicy, PolicyEntry, Resolver};
 pub use server::DnsServer;
 pub use upstream::{HostOrIp, NameServerEntry, NameServerParseError, NameServerUrl};

--- a/crates/meow-proxy/src/ech_tls_tunnel.rs
+++ b/crates/meow-proxy/src/ech_tls_tunnel.rs
@@ -137,7 +137,7 @@ pub async fn dial(
     );
 
     // 1) Raw TCP.
-    let tcp = meow_common::connect_tcp((server_host, server_port))
+    let tcp = meow_common::connect_tcp_host(server_host, server_port)
         .await
         .map_err(MeowError::Io)?;
     let _ = tcp.set_nodelay(true);

--- a/crates/meow-proxy/src/http_adapter.rs
+++ b/crates/meow-proxy/src/http_adapter.rs
@@ -80,7 +80,7 @@ impl HttpAdapter {
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = meow_common::connect_tcp(format!("{}:{}", self.server, self.port))
+        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
 

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -325,7 +325,7 @@ impl ProxyAdapter for ShadowsocksAdapter {
             PluginKind::Obfs(obfs) => {
                 // Open a raw TCP connection to the SS server, wrap it in the
                 // simple-obfs codec, then layer the SS crypto stream on top.
-                let tcp = meow_common::connect_tcp((self.server.as_str(), self.port))
+                let tcp = meow_common::connect_tcp_host(&self.server, self.port)
                     .await
                     .map_err(|e| MeowError::Proxy(format!("ss obfs tcp connect: {e}")))?;
                 let _ = tcp.set_nodelay(true);
@@ -384,11 +384,17 @@ impl ProxyAdapter for ShadowsocksAdapter {
                 // For `PluginKind::External`, `tcp_external_addr` returns the
                 // SIP003 plugin's local listener (typically 127.0.0.1:<port>),
                 // so the connect is loopback and `protect()` is harmless;
-                // for `PluginKind::None` it's the remote SS server.
-                let server_addr = self.server_config.tcp_external_addr().to_string();
-                let tcp = meow_common::connect_tcp(&server_addr)
-                    .await
-                    .map_err(|e| MeowError::Proxy(format!("ss tcp connect: {e}")))?;
+                // for `PluginKind::None` it's the remote SS server. Dispatch
+                // on the variant so domain-name servers also go through the
+                // installed `HostResolver` (system DNS would loop the
+                // lookup through the VPN on Android).
+                let tcp = match self.server_config.tcp_external_addr() {
+                    ServerAddr::SocketAddr(sa) => meow_common::connect_tcp(*sa).await,
+                    ServerAddr::DomainName(host, port) => {
+                        meow_common::connect_tcp_host(host, *port).await
+                    }
+                }
+                .map_err(|e| MeowError::Proxy(format!("ss tcp connect: {e}")))?;
                 let stream = ProxyClientStream::from_stream(
                     Arc::clone(&self.context),
                     tcp,
@@ -424,11 +430,9 @@ impl ProxyAdapter for ShadowsocksAdapter {
         // (where the connect is loopback — protect is harmless).
         let remote = match self.server_config.udp_external_addr() {
             ServerAddr::SocketAddr(sa) => *sa,
-            ServerAddr::DomainName(host, port) => tokio::net::lookup_host((host.as_str(), *port))
+            ServerAddr::DomainName(host, port) => meow_common::resolve_host(host, *port)
                 .await
-                .map_err(|e| MeowError::Proxy(format!("ss udp lookup: {e}")))?
-                .next()
-                .ok_or_else(|| MeowError::Proxy(format!("ss udp: no address for {host}:{port}")))?,
+                .map_err(|e| MeowError::Proxy(format!("ss udp lookup {host}:{port}: {e}")))?,
         };
         let bind_addr: SocketAddr = if remote.is_ipv4() {
             "0.0.0.0:0".parse().expect("static")

--- a/crates/meow-proxy/src/socks5_adapter.rs
+++ b/crates/meow-proxy/src/socks5_adapter.rs
@@ -88,7 +88,7 @@ impl Socks5Adapter {
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = meow_common::connect_tcp(format!("{}:{}", self.server, self.port))
+        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
 

--- a/crates/meow-proxy/src/trojan.rs
+++ b/crates/meow-proxy/src/trojan.rs
@@ -37,6 +37,8 @@ const ATYP_IPV6: u8 = 0x04;
 
 pub struct TrojanAdapter {
     name: String,
+    server: String,
+    port: u16,
     addr_str: String,
     hex_password: String,
     support_udp: bool,
@@ -76,6 +78,8 @@ impl TrojanAdapter {
 
         Self {
             name: name.to_string(),
+            server: server.to_string(),
+            port,
             addr_str: format!("{server}:{port}"),
             hex_password,
             support_udp: udp,
@@ -105,7 +109,7 @@ impl TrojanAdapter {
         metadata: &Metadata,
         cmd: u8,
     ) -> Result<Box<dyn TransportStream>> {
-        let tcp = meow_common::connect_tcp(self.addr_str.as_str())
+        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
 

--- a/crates/meow-proxy/src/v2ray_plugin.rs
+++ b/crates/meow-proxy/src/v2ray_plugin.rs
@@ -136,7 +136,7 @@ pub async fn dial(
     );
 
     // 1) Raw TCP.
-    let tcp = meow_common::connect_tcp((server_host, server_port))
+    let tcp = meow_common::connect_tcp_host(server_host, server_port)
         .await
         .map_err(MeowError::Io)?;
 

--- a/crates/meow-proxy/src/vless_adapter.rs
+++ b/crates/meow-proxy/src/vless_adapter.rs
@@ -44,6 +44,8 @@ pub enum VlessFlow {
 /// VLESS outbound proxy adapter.
 pub struct VlessAdapter {
     name: String,
+    server: String,
+    port: u16,
     addr_str: String,
     uuid_bytes: [u8; 16],
     flow: Option<VlessFlow>,
@@ -69,6 +71,8 @@ impl VlessAdapter {
     ) -> Self {
         Self {
             name: name.to_string(),
+            server: server.to_string(),
+            port,
             addr_str: format!("{server}:{port}"),
             uuid_bytes,
             flow,
@@ -80,7 +84,7 @@ impl VlessAdapter {
 
     /// Dial a raw TCP + transport-chain stream to the VLESS server.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = meow_common::connect_tcp(self.addr_str.as_str())
+        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
         self.transport.connect(Box::new(tcp)).await


### PR DESCRIPTION
## Summary
- On Android with the VPN active, `tokio::net::lookup_host` / `TcpStream::connect(\"host:port\")` use libc's `getaddrinfo`, whose DNS sockets bypass `VpnService.protect(fd)` and therefore route through our own tunnel — which then needs to dial a proxy upstream, which needs DNS. Hard loop. `DirectAdapter` already side-stepped this by pre-resolving through `meow_dns::Resolver`; every other outbound (trojan, vless, ss tcp+udp, http, socks5, v2ray-plugin, ech-tls-tunnel) handed a hostname straight to `connect_tcp` and loop-routed.
- Mirrors the existing `SocketProtector` registry in `meow-common/src/socket_protect.rs` with a `HostResolver` hook, and splits `connect_tcp<A: ToSocketAddrs>` into `connect_tcp(SocketAddr)` + `connect_tcp_host(&str, u16)`. The signature change prevents silent regressions back to the system resolver by construction. Also adds `resolve_host(&str, u16) -> SocketAddr` for the SS UDP path that needs a `SocketAddr` for `UdpSocket::connect`.
- `meow-dns` adds `ResolverHostHook` (`cfg(target_os = \"android\")`) that delegates to `Resolver::resolve_ip`, so hosts-file / fake-IP behave consistently with the Direct path. `meow-app` installs it at startup right after the resolver is built; the JNI bridge still owns `SocketProtector` setup. When a protector is installed but no `HostResolver` is, we warn-log and fall back to `lookup_host` (degraded, but functional).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` — 594 passed
- [x] `cargo test --test rules_test` — 100 passed
- [x] `cargo test --test trojan_integration` — 5 passed
- [x] `cargo test --test shadowsocks_integration` — 5 passed
- [x] New `socket_protect` unit tests: IP-literal short-circuit, resolver consulted under protector, resolver-error propagates, no-protector plain-tokio fallback, registry round-trip
- [x] `cargo check -p meow-common --target aarch64-linux-android` (NDK-dependent crates like ring/aws-lc-sys fail environmentally, unrelated to this PR)
- [ ] On-device: run inside meow-android JNI bridge, confirm hostname-only proxy upstreams dial without DNS looping through the tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)