### PR TITLE
feat(ech-tls-tunnel): honor fingerprint opt, default to chrome

### DIFF
--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -438,6 +438,7 @@ async fn doh_exchange(
     Ok(body.to_vec())
 }
 
+#[cfg(feature = "encrypted")]
 fn find_subseq(hay: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() || hay.len() < needle.len() {
         return None;
@@ -480,6 +481,7 @@ fn tls_client_config(alpn: &str) -> Arc<rustls::ClientConfig> {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "encrypted")]
     #[test]
     fn find_subseq_basic() {
         assert_eq!(find_subseq(b"abc\r\n\r\nbody", b"\r\n\r\n"), Some(3));

--- a/crates/meow-dns/src/upstream.rs
+++ b/crates/meow-dns/src/upstream.rs
@@ -196,25 +196,24 @@ impl NameServerUrl {
         Ok(NameServerUrl::Udp { addr, port })
     }
 
+    #[cfg(feature = "encrypted")]
     fn parse_tls(rest: &str, fragment: Option<&str>) -> Result<Self, NameServerParseError> {
-        #[cfg(not(feature = "encrypted"))]
-        return Err(NameServerParseError::EncryptedFeatureDisabled);
-
-        #[cfg(feature = "encrypted")]
-        {
-            let (addr, port) = parse_host_port(rest, 853)?;
-            let sni = match fragment {
-                Some(f) if !f.is_empty() => f.to_string(),
-                // Default SNI = the host string (IP or hostname)
-                _ => addr.to_string(),
-            };
-            Ok(NameServerUrl::Tls { addr, port, sni })
-        }
+        let (addr, port) = parse_host_port(rest, 853)?;
+        let sni = match fragment {
+            Some(f) if !f.is_empty() => f.to_string(),
+            // Default SNI = the host string (IP or hostname)
+            _ => addr.to_string(),
+        };
+        Ok(NameServerUrl::Tls { addr, port, sni })
     }
 
+    #[cfg(not(feature = "encrypted"))]
+    fn parse_tls(_rest: &str, _fragment: Option<&str>) -> Result<Self, NameServerParseError> {
+        Err(NameServerParseError::EncryptedFeatureDisabled)
+    }
+
+    #[cfg(feature = "encrypted")]
     fn parse_https(rest: &str, fragment: Option<&str>) -> Result<Self, NameServerParseError> {
-        #[cfg(not(feature = "encrypted"))]
-        return Err(NameServerParseError::EncryptedFeatureDisabled);
         // Split path off the host[:port] portion. Path starts at first '/' after host.
         let (hostport, path) = match rest.find('/') {
             Some(idx) => (&rest[..idx], rest[idx..].to_string()),
@@ -238,6 +237,11 @@ impl NameServerUrl {
             path,
             sni,
         })
+    }
+
+    #[cfg(not(feature = "encrypted"))]
+    fn parse_https(_rest: &str, _fragment: Option<&str>) -> Result<Self, NameServerParseError> {
+        Err(NameServerParseError::EncryptedFeatureDisabled)
     }
 }
 

--- a/crates/meow-proxy/src/ech_tls_tunnel.rs
+++ b/crates/meow-proxy/src/ech_tls_tunnel.rs
@@ -40,6 +40,9 @@ pub struct EchTlsTunnelConfig {
     pub path: String,
     /// Wire-format `ECHConfigList`, base64-decoded. Required.
     pub ech_config: Vec<u8>,
+    /// Optional uTLS client-fingerprint (e.g. `chrome`). When set, the TLS
+    /// backend routing prefers BoringSSL.
+    pub fingerprint: Option<String>,
 }
 
 fn parse_bool(s: &str) -> bool {
@@ -53,6 +56,10 @@ fn parse_bool(s: &str) -> bool {
 /// * `sni`    — REQUIRED, inner SNI / cert name / Host header.
 /// * `path`   — REQUIRED, must start with `/`.
 /// * `ech_config` — REQUIRED, base64-encoded `ECHConfigList`.
+/// * `fingerprint` — OPTIONAL, uTLS client-fingerprint (e.g. `chrome`).
+///   Routes the TLS handshake through the BoringSSL backend. Defaults to
+///   `chrome` when the opt is absent (so ECH traffic mimics a real browser
+///   by default). Pass `fingerprint=none` to opt out.
 /// * `fast_open` — accepted, ignored (we don't TFO outbound today).
 ///
 /// Unknown keys are warned and ignored to stay forward-compatible.
@@ -61,6 +68,7 @@ pub fn parse_opts(s: &str) -> Result<EchTlsTunnelConfig> {
     let mut sni: Option<String> = None;
     let mut path: Option<String> = None;
     let mut ech_b64: Option<String> = None;
+    let mut fingerprint: Option<String> = Some("chrome".to_string());
 
     for token in s.split(';').map(str::trim).filter(|t| !t.is_empty()) {
         let (key, value) = match token.split_once('=') {
@@ -72,6 +80,12 @@ pub fn parse_opts(s: &str) -> Result<EchTlsTunnelConfig> {
             "sni" => sni = Some(value),
             "path" => path = Some(value),
             "ech_config" | "ech-config" => ech_b64 = Some(value),
+            "fingerprint" | "client-fingerprint" | "client_fingerprint" => {
+                fingerprint = match value.as_str() {
+                    "" | "none" | "off" | "disable" | "disabled" => None,
+                    _ => Some(value),
+                };
+            }
             "fast_open" | "fast-open" => {
                 let _ = parse_bool(&value);
             }
@@ -117,6 +131,7 @@ pub fn parse_opts(s: &str) -> Result<EchTlsTunnelConfig> {
         sni,
         path,
         ech_config,
+        fingerprint,
     })
 }
 
@@ -148,6 +163,7 @@ pub async fn dial(
     let mut tls_config = TlsConfig::new(cfg.sni.clone());
     tls_config.alpn = vec!["http/1.1".to_string()];
     tls_config.ech = Some(EchOpts::Config(cfg.ech_config.clone()));
+    tls_config.fingerprint = cfg.fingerprint.clone();
     let tls_layer = TlsLayer::new(&tls_config).map_err(transport_to_proxy_err)?;
     let tls_stream = tls_layer
         .connect(Box::new(tcp))
@@ -240,6 +256,33 @@ mod tests {
         ))
         .expect("ok");
         assert_eq!(cfg.sni, "t.example");
+    }
+
+    #[test]
+    fn parse_fingerprint_chrome() {
+        let cfg = parse_opts(&format!(
+            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64};fingerprint=chrome"
+        ))
+        .expect("ok");
+        assert_eq!(cfg.fingerprint.as_deref(), Some("chrome"));
+    }
+
+    #[test]
+    fn parse_fingerprint_defaults_to_chrome() {
+        let cfg = parse_opts(&format!(
+            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64}"
+        ))
+        .expect("ok");
+        assert_eq!(cfg.fingerprint.as_deref(), Some("chrome"));
+    }
+
+    #[test]
+    fn parse_fingerprint_none_opts_out() {
+        let cfg = parse_opts(&format!(
+            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64};fingerprint=none"
+        ))
+        .expect("ok");
+        assert!(cfg.fingerprint.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `meow-proxy/src/ech_tls_tunnel.rs::parse_opts` now reads a `fingerprint=<value>` SIP003 opt (aliases: `client-fingerprint`, `client_fingerprint`) and plumbs it into `TlsConfig.fingerprint` in `dial()`. Default is `chrome` so ECH traffic mimics a real browser by default; `fingerprint=none` (or `off`/`disable[d]`/empty) opts out.
- Because `fingerprint.is_some()` is now true by default, the TLS-backend tiebreaker in `meow-transport::tls` flips to BoringSSL for ECH dials — the only backend with real uTLS fingerprint support.
- Drive-by: fixed pre-existing `meow-dns` clippy failures under `--no-default-features` (the `encrypted` feature off): gated `find_subseq` + test, and split `parse_tls`/`parse_https` into paired `cfg` definitions instead of the unreachable early-return idiom.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` (593 passed)
- [x] New unit tests in `ech_tls_tunnel.rs` cover the default-to-chrome, explicit-value, and opt-out paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)