### PR TITLE
fix(transport): seed boring's X509Store with webpki-roots Mozilla CAs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,7 @@ dependencies = [
  "tokio-tungstenite 0.24.0",
  "tracing",
  "tracing-subscriber",
+ "webpki-root-certs",
  "webpki-roots 0.26.11",
 ]
 
@@ -4183,6 +4184,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/meow-transport/Cargo.toml
+++ b/crates/meow-transport/Cargo.toml
@@ -27,6 +27,7 @@ boring-tls = [
     "dep:tokio-boring",
     "dep:boring-sys",
     "dep:rand",
+    "dep:webpki-root-certs",
 ]
 ws = [
     "dep:tokio-tungstenite",
@@ -81,9 +82,20 @@ rand = { workspace = true, optional = true }
 httparse = { version = "1", optional = true }
 
 # boring-tls feature
-boring       = { workspace = true, optional = true }
-tokio-boring = { workspace = true, optional = true }
-boring-sys   = { version = "5.0.2", optional = true }
+boring             = { workspace = true, optional = true }
+tokio-boring       = { workspace = true, optional = true }
+boring-sys         = { version = "5.0.2", optional = true }
+# Mozilla CA bundle for boring's X509Store. The BoringSSL connector
+# starts with an *empty* trust store; sandboxed runtimes (iOS
+# NetworkExtension, sealed app extensions) don't pick up system roots
+# the way `boring-sys`'s vendored BoringSSL falls back to on a plain
+# macOS process, so peer-cert verification fails with
+# `unable to get local issuer certificate` for every proxy that uses
+# TLS (ech-tls-tunnel, trojan, vless+tls, ss-plugin v2ray, …).
+# Seeding the same Mozilla root list rustls uses gives the boring path
+# parity with rustls and makes verification work uniformly across
+# platforms. Adds ~150 KB of DER blobs to the .rlib.
+webpki-root-certs  = { version = "1", optional = true }
 
 [dev-dependencies]
 tokio        = { workspace = true }

--- a/crates/meow-transport/src/tls.rs
+++ b/crates/meow-transport/src/tls.rs
@@ -795,8 +795,26 @@ impl BoringInner {
             b.set_verify(boring::ssl::SslVerifyMode::NONE);
         } else {
             b.set_verify(boring::ssl::SslVerifyMode::PEER);
-            if !config.additional_roots.is_empty() {
+            // Seed Mozilla's CA bundle so peer verification has a trust
+            // root to chase, even in sandboxed runtimes (iOS NE
+            // extensions, sealed app extensions) where boring-sys's
+            // vendored BoringSSL can't reach any system trust store.
+            // This matches what rustls does by default and gives the
+            // boring backend the same baseline. User-supplied
+            // `additional_roots` are added afterwards so they take
+            // precedence on conflicts.
+            {
                 let cert_store = b.cert_store_mut();
+                for cert in webpki_root_certs::TLS_SERVER_ROOT_CERTS {
+                    let x509 = boring::x509::X509::from_der(cert.as_ref()).map_err(|e| {
+                        TransportError::Config(format!(
+                            "webpki_root_certs: invalid CA cert (boring): {e}"
+                        ))
+                    })?;
+                    cert_store.add_cert(x509).map_err(|e| {
+                        TransportError::Config(format!("webpki_root_certs: add_cert (boring): {e}"))
+                    })?;
+                }
                 for der in &config.additional_roots {
                     let x509 = boring::x509::X509::from_der(der).map_err(|e| {
                         TransportError::Config(format!(


### PR DESCRIPTION
## Problem

`BoringInner::new` was starting the `SslConnectorBuilder` with an empty `X509Store`. The only certs ever loaded were `config.additional_roots`, but every shipping proxy in this tree builds its `TlsConfig` via `TlsConfig::new(sni)` and leaves `additional_roots` at its default `Vec::new()`.

On a regular macOS process boring-sys's vendored BoringSSL happens to verify anyway (some host-side fallback I didn't fully track down). Inside an iOS **NetworkExtension extension sandbox** there's no equivalent — the handshake on every TLS-using proxy fails:

```
cert verification failed - unable to get local issuer certificate [CERTIFICATE_VERIFY_FAILED]
```

…and the ECH retry-config codepath then logs the BoringSSL `fe0dffffff` sentinel as `"ECH rejected by server; rotated to retry_configs"`, sending the operator chasing the wrong layer.

## Fix

Seed the X509Store with the same Mozilla CA bundle rustls uses by default. Pulled via [`webpki-root-certs`](https://crates.io/crates/webpki-root-certs) — the DER-only sibling of `webpki-roots` (which exposes parsed `TrustAnchor` structs and is therefore unusable with boring's `X509::from_der`). User-supplied `additional_roots` are still added afterwards so they keep precedence on conflicts.

Cost: ~150 KB of DER blobs in the boring-tls-enabled `.rlib`. The existing doc comment on `TlsConfig.additional_roots` already described this behaviour (\"in addition to `webpki-roots`\") — this brings the implementation in line with the contract.

## Verification

On iOS PacketTunnel against a live ss + ech-tls-tunnel server (`tyo.maxlv.net:443`, ech_config_len=75):

**Pre-patch** (every dial through ech-sgp/ech-tyo failed with the same line):

```
ech-tls-tunnel: dialing tyo.maxlv.net:443 sni=tyo.maxlv.net path=/ws-… ech_config_len=75
ECH rejected by server; rotated to retry_configs — next connect will use the new key
dial error: Proxy error: tls handshake: boring TLS handshake (ECH rejected; retry_configs=fe0dffffff):
            TLS handshake failed: cert verification failed -
            unable to get local issuer certificate [CERTIFICATE_VERIFY_FAILED]
```

**Post-patch** — same dial:

```
boring TLS handshake complete sni=tyo.maxlv.net ech_requested=true ech_accepted=true tls_version=TLSv1.3
```

(`cargo build -p meow-transport --features boring-tls,ech` clean; `cargo clippy --features boring-tls,ech --all-targets -- -D warnings` clean; `cargo fmt --check` clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)