### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meow-api"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "libc",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anytls-rs",
  "async-trait",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.8.0 to 0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)