### PR TITLE
perf(config): mmap GeoIP MMDB to reclaim 8 MB on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "ipnetwork",
  "log",
  "memchr",
+ "memmap2",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -1953,6 +1954,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "meow-api"
@@ -2211,6 +2221,7 @@ version = "0.9.0"
 dependencies = [
  "criterion",
  "proptest",
+ "regex",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 
 # GeoIP
-maxminddb = "0.27"
+maxminddb = { version = "0.27", features = ["mmap"] }
 
 # Concurrency
 dashmap = "6"

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -484,13 +484,11 @@ fn build_parser_context_at(
     let geoip_trigger = lines.iter().find(|l| line_is_geoip_rule(l));
     let geoip = match geoip_trigger {
         Some(trigger) => {
-            let reader = load_mmdb(geoip_path, "GeoIP", trigger)?;
+            let reader = load_mmdb_mmap(geoip_path, "GeoIP", trigger)?;
             let allowed = collect_geoip_countries(lines);
             let index = meow_rules::country_index::CountryIndex::build(&reader, &allowed)
                 .map_err(|e| anyhow::anyhow!("failed to build GeoIP country index: {e}"))?;
-            // Drop the MMDB reader — the index now holds the per-country
-            // ranges we need and per-rule matches go through
-            // `IpRange::contains`, not MMDB.
+            // reader is mmap-backed — pages are returned to the OS on drop.
             drop(reader);
             Some(Arc::new(index))
         }
@@ -547,6 +545,28 @@ fn load_mmdb(
         )
     })?;
     info!("Loaded {} database from {}", kind, path.display());
+    Ok(reader)
+}
+
+/// Memory-map an MMDB file. The OS reclaims pages immediately on drop,
+/// unlike `Vec<u8>` where the allocator retains the freed block.
+fn load_mmdb_mmap(
+    path: &Path,
+    kind: &str,
+    trigger: &str,
+) -> Result<maxminddb::Reader<maxminddb::Mmap>, anyhow::Error> {
+    // Safety: the file is read-only and not modified during the reader's
+    // lifetime (dropped before the function returns to the caller).
+    let reader = unsafe { maxminddb::Reader::open_mmap(path) }.map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to load {} database at {}\n  required by rule: {}\n  underlying error: {}",
+            kind,
+            path.display(),
+            trigger.trim(),
+            e
+        )
+    })?;
+    info!("Loaded {} database from {} (mmap)", kind, path.display());
     Ok(reader)
 }
 

--- a/crates/meow-rules/src/country_index.rs
+++ b/crates/meow-rules/src/country_index.rs
@@ -95,8 +95,8 @@ impl CountryIndex {
     /// about. Codes are matched case-insensitively (the allowlist is
     /// internally uppercased). Networks without an `iso_code` are skipped
     /// silently — they cannot drive any rule.
-    pub fn build(
-        reader: &maxminddb::Reader<Vec<u8>>,
+    pub fn build<S: AsRef<[u8]>>(
+        reader: &maxminddb::Reader<S>,
         allowed: &HashSet<String>,
     ) -> Result<Self, String> {
         if allowed.is_empty() {


### PR DESCRIPTION
## Summary
- Switch GeoIP `Reader<Vec<u8>>` to `Reader<Mmap>` so the OS reclaims the 8.1 MB MMDB pages immediately on drop, instead of macOS's allocator retaining them as `MALLOC_LARGE (empty)`
- Make `CountryIndex::build` generic over `AsRef<[u8]>` so it accepts both `Vec<u8>` and `Mmap` readers
- Enable `mmap` feature on `maxminddb` workspace dependency

**RSS: 28.6 MB → 19.0 MB (-34%)**
**Physical footprint: 20.5 MB → 12.0 MB (-41%)**

## Test plan
- [x] All 603 unit tests pass
- [x] Three-way clippy clean (default / no-default-features / all-features)
- [x] RSS verified at 19.0 MB with Nexitally config (7,745 rules, 1 GEOIP)
- [x] vmmap confirms MALLOC_LARGE (empty) 8.3 MB block is eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)