### PR TITLE
feat(snell): add Snell v4/v5 outbound adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -174,6 +174,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
 ]
 
 [[package]]
@@ -401,6 +413,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "blake3"
@@ -997,7 +1018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1468,7 +1489,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1687,7 +1708,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2155,6 +2176,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "anytls-rs",
+ "argon2",
  "async-trait",
  "base64",
  "bytes",
@@ -2356,7 +2378,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2471,6 +2493,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2692,7 +2725,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2729,7 +2762,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3036,7 +3069,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3400,7 +3433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3495,7 +3528,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4227,7 +4260,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ chacha20poly1305 = "0.10"
 crc32fast = "1"
 hex = "0.4"
 subtle = "2"
+# Snell uses Argon2id (t=3, m=8 KiB, p=1) as its KDF and AES-128-GCM
+# (the `aes-gcm` entry above) as its AEAD; both are pure-Rust RustCrypto
+# crates sharing the AES backend with the existing crypto stack.
+argon2 = { version = "0.5", default-features = false, features = ["alloc"] }
 
 # Logging
 tracing = "0.1"

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -16,6 +16,7 @@ trojan = ["meow-config/trojan", "meow-proxy/trojan"]
 vless = ["meow-config/vless", "meow-proxy/vless"]
 vless-vision = ["vless", "meow-config/vless-vision", "meow-proxy/vless-vision"]
 vmess = ["meow-config/vmess", "meow-proxy/vmess"]
+snell = ["meow-config/snell", "meow-proxy/snell"]
 ech-tls-tunnel = [
     "ss",
     "meow-config/ech-tls-tunnel",
@@ -35,7 +36,7 @@ listener-mixed = ["meow-listener/listener-mixed"]
 # Convenience bundles
 minimal = ["ss", "trojan", "dns-server", "listener-mixed"]
 full = [
-    "ss", "trojan", "vless", "vless-vision", "vmess", "ech-tls-tunnel",
+    "ss", "trojan", "vless", "vless-vision", "vmess", "snell", "ech-tls-tunnel",
     "dns-server", "dns-encrypted",
     "listener-http", "listener-socks5", "listener-tproxy", "listener-mixed",
 ]

--- a/crates/meow-common/src/adapter_type.rs
+++ b/crates/meow-common/src/adapter_type.rs
@@ -19,6 +19,7 @@ pub enum AdapterType {
     Trojan,
     Hysteria2,
     Anytls,
+    Snell,
 }
 
 impl fmt::Display for AdapterType {
@@ -40,6 +41,7 @@ impl fmt::Display for AdapterType {
             AdapterType::Trojan => write!(f, "Trojan"),
             AdapterType::Hysteria2 => write!(f, "Hysteria2"),
             AdapterType::Anytls => write!(f, "AnyTLS"),
+            AdapterType::Snell => write!(f, "Snell"),
         }
     }
 }

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess"]
+default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell"]
 ss = ["meow-proxy/ss"]
 trojan = ["meow-proxy/trojan"]
 vless = ["meow-proxy/vless"]
@@ -13,6 +13,7 @@ vless-vision = ["vless", "meow-proxy/vless-vision"]
 vmess = ["meow-proxy/vmess"]
 anytls = ["meow-proxy/anytls"]
 hysteria2 = ["meow-proxy/hysteria2"]
+snell = ["meow-proxy/snell"]
 boring-tls = ["meow-transport/boring-tls"]
 ech = ["meow-transport/ech"]
 ech-tls-tunnel = ["ss", "meow-proxy/ech-tls-tunnel"]

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -189,8 +189,136 @@ pub fn parse_proxy(
             let adapter = parse_vmess(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
+        #[cfg(feature = "snell")]
+        "snell" => {
+            let adapter = parse_snell(name, config)?;
+            Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
+        }
         _ => Err(format!("unsupported proxy type: {proxy_type}")),
     }
+}
+
+/// Parse a `type: snell` proxy block.
+///
+/// Aligned with opensnell's client-side surface — v4 / v5 wire only (older
+/// v1/v2/v3 are hard-rejected, mirroring opensnell's own scope decision).
+///
+/// YAML schema (mihomo-compatible):
+///
+/// ```yaml
+/// - name: my-snell
+///   type: snell
+///   server: 1.2.3.4
+///   port: 443
+///   psk: shared-secret
+///   version: 4         # optional; default 4. Accepts 4, 5, "v4", "v5".
+///   udp: true          # optional; UDP-over-TCP relay.
+///   reuse: true        # optional; CommandConnectV2 + connection pool.
+///   obfs-opts:         # optional
+///     mode: http       # off (default) | http | tls
+///     host: bing.com   # falls back to server when missing
+/// ```
+///
+/// # Hard errors (Class A per ADR-0002)
+///
+/// - missing `server`, `port`, or `psk` — required by the protocol.
+/// - `port == 0` — never a valid endpoint.
+/// - empty `psk` — caught by [`meow_proxy::SnellAdapter::new`].
+/// - `version` ∈ {1, 2, 3} — opensnell does not implement those wires.
+/// - `obfs-opts.mode` is not one of off / http / tls.
+#[cfg(feature = "snell")]
+fn parse_snell(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<meow_proxy::SnellAdapter, String> {
+    use meow_proxy::{SnellAdapter, SnellObfs, SnellVersion};
+
+    let server = config
+        .get("server")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("snell[{name}]: missing server"))?;
+    let port = config
+        .get("port")
+        .and_then(serde_yaml::Value::as_u64)
+        .ok_or_else(|| format!("snell[{name}]: missing port"))? as u16;
+    if port == 0 {
+        return Err(format!("snell[{name}]: port must be non-zero"));
+    }
+    let psk = config
+        .get("psk")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("snell[{name}]: missing psk"))?;
+
+    let udp = config
+        .get("udp")
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(false);
+    let reuse = config
+        .get("reuse")
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(false);
+
+    // ── Version parsing ──────────────────────────────────────────────────
+    let version = match config.get("version") {
+        None => SnellVersion::V4,
+        Some(v) => {
+            // Accept ints (1..=5) or strings ("v4", "5", ...).
+            let label = if let Some(n) = v.as_u64() {
+                n.to_string()
+            } else if let Some(s) = v.as_str() {
+                s.to_string()
+            } else {
+                return Err(format!(
+                    "snell[{name}]: version must be an integer or string (4 or 5)"
+                ));
+            };
+            match label.trim().to_ascii_lowercase().as_str() {
+                "" | "4" | "v4" => SnellVersion::V4,
+                "5" | "v5" => SnellVersion::V5,
+                "1" | "2" | "3" | "v1" | "v2" | "v3" => {
+                    return Err(format!(
+                        "snell[{name}]: version '{label}' is not supported; \
+                         this adapter implements the v4 / v5 wire only \
+                         (mihomo's older v1/v2/v3 are deprecated)"
+                    ));
+                }
+                other => {
+                    return Err(format!(
+                        "snell[{name}]: unknown version '{other}'; valid: 4, 5"
+                    ));
+                }
+            }
+        }
+    };
+
+    // ── Obfs opts ────────────────────────────────────────────────────────
+    let obfs = if let Some(opts) = config.get("obfs-opts") {
+        let mode = opts
+            .get("mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("off")
+            .to_ascii_lowercase();
+        let host = opts
+            .get("host")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map_or_else(|| server.to_string(), std::string::ToString::to_string);
+        match mode.as_str() {
+            "off" | "none" | "" => SnellObfs::None,
+            "http" => SnellObfs::Http { host },
+            "tls" => SnellObfs::Tls { server: host },
+            other => {
+                return Err(format!(
+                    "snell[{name}]: obfs-opts.mode '{other}' invalid; expected one of off, http, tls"
+                ));
+            }
+        }
+    } else {
+        SnellObfs::None
+    };
+
+    SnellAdapter::new(name, server, port, psk, obfs, version, udp, reuse)
+        .map_err(|e| format!("snell[{name}]: {e}"))
 }
 
 /// Parse a `type: http` proxy config block into an `HttpAdapter`.

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -5,12 +5,16 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess"]
+default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell"]
 ss = ["dep:shadowsocks"]
 trojan = []
 vless = []
 vmess = ["dep:md-5", "dep:hmac", "dep:aes", "dep:aes-gcm", "dep:chacha20poly1305", "dep:crc32fast"]
 vless-vision = ["vless"]
+# Snell v4/v5 outbound — argon2id KDF + AES-128-GCM AEAD frames,
+# optional http/tls obfs (reused from the SS simple-obfs module),
+# UDP-over-TCP, and an opt-in reuse pool (CommandConnectV2).
+snell = ["dep:argon2", "dep:aes-gcm"]
 # Opt-in anytls outbound (uses the `anytls-rs` crate). Adds ~one extra TLS
 # provider to the binary because the upstream crate pins default rustls
 # features — accept the bloat in exchange for not re-implementing the
@@ -33,6 +37,7 @@ tokio = { workspace = true }
 anytls-rs = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 shadowsocks = { workspace = true, optional = true }
+argon2 = { workspace = true, optional = true }
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }
 webpki-roots = { workspace = true }

--- a/crates/meow-proxy/src/lib.rs
+++ b/crates/meow-proxy/src/lib.rs
@@ -11,13 +11,20 @@ pub mod transport_chain;
 pub mod ech_tls_tunnel;
 #[cfg(feature = "ss")]
 pub mod shadowsocks_adapter;
-#[cfg(feature = "ss")]
+// simple-obfs is shared with the snell adapter (which reuses the
+// http / tls obfuscation codecs verbatim).
+#[cfg(any(feature = "ss", feature = "snell"))]
 pub mod simple_obfs;
 #[cfg(feature = "ss")]
 pub mod v2ray_plugin;
 
 #[cfg(feature = "trojan")]
 pub mod trojan;
+
+#[cfg(feature = "snell")]
+pub mod snell;
+#[cfg(feature = "snell")]
+pub use snell::{SnellAdapter, SnellObfs, SnellVersion};
 
 #[cfg(feature = "anytls")]
 pub mod anytls_adapter;

--- a/crates/meow-proxy/src/snell/adapter.rs
+++ b/crates/meow-proxy/src/snell/adapter.rs
@@ -1,0 +1,340 @@
+//! Snell outbound adapter — implements `ProxyAdapter` for `type: snell`.
+//!
+//! Wires together the v4 AEAD codec, the optional simple-obfs (http/tls)
+//! layer, the snell request/response framing, and the optional reuse pool
+//! (`CommandConnectV2`).
+//!
+//! Version handling: opensnell's wire is v4 / v5 (both share the same TCP
+//! framing — v5 is identical on the client side, the difference is the
+//! server's optional QUIC mode). Older v1 / v2 / v3 wires are *not*
+//! supported (different AEAD and frame layout); the YAML parser hard-errors
+//! on those values.
+
+use async_trait::async_trait;
+use meow_common::{
+    AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
+};
+use meow_transport::Stream as TransportStream;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tracing::debug;
+
+use crate::simple_obfs::{HttpObfs, TlsObfs};
+
+use super::pool::{drain_for_reuse, Pool, PoolStream};
+use super::protocol::{write_header, write_udp_header, Snell};
+use super::udp::SnellPacketConn;
+
+/// What snell version label the adapter announces. Today both labels
+/// produce identical wire framing — Snell v4 == v5 on the TCP side. The
+/// value is stored so future v5 QUIC support can switch on it without
+/// breaking config compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnellVersion {
+    V4,
+    V5,
+}
+
+impl SnellVersion {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SnellVersion::V4 => "v4",
+            SnellVersion::V5 => "v5",
+        }
+    }
+}
+
+/// Optional simple-obfs wrapping the underlying TCP. Mirrors the SS adapter's
+/// `BuiltinObfs` enum, but kept private to the snell module so the two
+/// adapters stay independent at the type level.
+#[derive(Debug, Clone)]
+pub enum SnellObfs {
+    None,
+    Http { host: String },
+    Tls { server: String },
+}
+
+pub struct SnellAdapter {
+    name: String,
+    server: String,
+    port: u16,
+    addr_str: String,
+    psk: Arc<[u8]>,
+    obfs: SnellObfs,
+    support_udp: bool,
+    pool: Option<Arc<Pool>>,
+    /// Currently informational — v4 and v5 share the same TCP wire. Stashed
+    /// so a future v5 QUIC outbound can branch on it without breaking config
+    /// compatibility.
+    #[allow(dead_code, reason = "reserved for v5 QUIC support")]
+    version: SnellVersion,
+    health: ProxyHealth,
+}
+
+impl SnellAdapter {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "snell config surface is wide; struct-of-args adds no clarity here"
+    )]
+    pub fn new(
+        name: &str,
+        server: &str,
+        port: u16,
+        psk: &str,
+        obfs: SnellObfs,
+        version: SnellVersion,
+        udp: bool,
+        reuse: bool,
+    ) -> Result<Self> {
+        if psk.is_empty() {
+            return Err(MeowError::Config(format!(
+                "snell[{name}]: psk must not be empty"
+            )));
+        }
+        if port == 0 {
+            return Err(MeowError::Config(format!(
+                "snell[{name}]: port must be non-zero"
+            )));
+        }
+        if server.is_empty() {
+            return Err(MeowError::Config(format!(
+                "snell[{name}]: server must not be empty"
+            )));
+        }
+        let psk_bytes: Arc<[u8]> = Arc::from(psk.as_bytes());
+        debug!(
+            "snell '{}' configured: version={} reuse={} udp={} obfs={}",
+            name,
+            version.as_str(),
+            reuse,
+            udp,
+            match &obfs {
+                SnellObfs::None => "off",
+                SnellObfs::Http { .. } => "http",
+                SnellObfs::Tls { .. } => "tls",
+            }
+        );
+        Ok(Self {
+            name: name.to_string(),
+            server: server.to_string(),
+            port,
+            addr_str: format!("{server}:{port}"),
+            psk: psk_bytes,
+            obfs,
+            support_udp: udp,
+            pool: if reuse {
+                Some(Arc::new(Pool::new()))
+            } else {
+                None
+            },
+            version,
+            health: ProxyHealth::new(),
+        })
+    }
+
+    /// Open a fresh underlying byte stream (TCP, optionally wrapped in obfs)
+    /// and Snell-wrap it. No CONNECT header is sent yet.
+    async fn dial_fresh(&self) -> Result<PoolStream> {
+        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+            .await
+            .map_err(MeowError::Io)?;
+        let _ = tcp.set_nodelay(true);
+        let inner: Box<dyn TransportStream> = match &self.obfs {
+            SnellObfs::None => Box::new(tcp),
+            SnellObfs::Http { host } => Box::new(HttpObfs::new(tcp, host.clone(), self.port)),
+            SnellObfs::Tls { server } => Box::new(TlsObfs::new(tcp, server.clone())),
+        };
+        Ok(Snell::new(inner, Arc::clone(&self.psk)))
+    }
+
+    fn extract_dest(metadata: &Metadata) -> Result<(String, u16)> {
+        let port = metadata.dst_port;
+        if !metadata.host.is_empty() {
+            return Ok((metadata.host.to_string(), port));
+        }
+        if let Some(ip) = metadata.dst_ip {
+            return Ok((ip.to_string(), port));
+        }
+        Err(MeowError::Proxy(
+            "snell: metadata has neither host nor dst_ip".into(),
+        ))
+    }
+}
+
+#[async_trait]
+impl ProxyAdapter for SnellAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn adapter_type(&self) -> AdapterType {
+        AdapterType::Snell
+    }
+    fn addr(&self) -> &str {
+        &self.addr_str
+    }
+    fn support_udp(&self) -> bool {
+        self.support_udp
+    }
+
+    async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        let (host, port) = Self::extract_dest(metadata)?;
+        debug!(
+            "snell connecting to {}:{} via {} (reuse={})",
+            host,
+            port,
+            self.addr_str,
+            self.pool.is_some()
+        );
+
+        // Pool-first path — opensnell client.go DialTCP semantics.
+        if let Some(pool) = &self.pool {
+            // Two tries: a pooled conn may have been silently closed by the
+            // server between sessions, in which case the header write fails
+            // and we try the next/dial fresh.
+            for attempt in 0..2u32 {
+                let Some((mut snell, prev_uses)) = pool.take_idle() else {
+                    break;
+                };
+                snell.reset_reply_state();
+                if let Err(e) = write_header(&mut snell, &host, port, true).await {
+                    debug!("snell pool conn write failed (attempt {attempt}): {e}");
+                    continue;
+                }
+                return Ok(Box::new(PooledConn::new(
+                    snell,
+                    Some(Arc::clone(pool)),
+                    prev_uses + 1,
+                )));
+            }
+        }
+
+        let mut snell = self.dial_fresh().await?;
+        let reuse = self.pool.is_some();
+        write_header(&mut snell, &host, port, reuse)
+            .await
+            .map_err(MeowError::Io)?;
+        Ok(Box::new(PooledConn::new(
+            snell,
+            self.pool.as_ref().map(Arc::clone),
+            1,
+        )))
+    }
+
+    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        if !self.support_udp {
+            return Err(MeowError::NotSupported(
+                "snell UDP is disabled for this proxy (set `udp: true`)".into(),
+            ));
+        }
+        let mut snell = self.dial_fresh().await?;
+        write_udp_header(&mut snell).await.map_err(MeowError::Io)?;
+        snell.read_reply().await.map_err(MeowError::Io)?;
+        Ok(Box::new(SnellPacketConn::new(snell)))
+    }
+
+    fn health(&self) -> &ProxyHealth {
+        &self.health
+    }
+}
+
+// ─── PooledConn ──────────────────────────────────────────────────────────────
+
+/// `ProxyConn` that returns its underlying snell stream to a pool on drop
+/// (when the pool is configured). Behaves as a transparent passthrough
+/// otherwise — the v4 zero-chunk → EOF mapping happens inside `Snell` itself.
+struct PooledConn {
+    inner: Option<PoolStream>,
+    pool: Option<Arc<Pool>>,
+    uses: u32,
+}
+
+impl PooledConn {
+    fn new(snell: PoolStream, pool: Option<Arc<Pool>>, uses: u32) -> Self {
+        Self {
+            inner: Some(snell),
+            pool,
+            uses,
+        }
+    }
+}
+
+impl AsyncRead for PooledConn {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let inner = self
+            .inner
+            .as_mut()
+            .expect("PooledConn::poll_read after take");
+        Pin::new(inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for PooledConn {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let inner = self
+            .inner
+            .as_mut()
+            .expect("PooledConn::poll_write after take");
+        Pin::new(inner).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let inner = self
+            .inner
+            .as_mut()
+            .expect("PooledConn::poll_flush after take");
+        Pin::new(inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let inner = self
+            .inner
+            .as_mut()
+            .expect("PooledConn::poll_shutdown after take");
+        // Send the half-close zero chunk via the v4 codec (empty write =>
+        // zero-chunk frame). After the frame drains we report Ready, and
+        // the pool-return logic runs in `Drop`.
+        match Pin::new(inner).poll_write(cx, &[]) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
+        }
+    }
+}
+
+impl Unpin for PooledConn {}
+impl ProxyConn for PooledConn {}
+
+impl Drop for PooledConn {
+    fn drop(&mut self) {
+        let (Some(snell), Some(pool)) = (self.inner.take(), self.pool.take()) else {
+            return;
+        };
+        let uses = self.uses;
+        // Spawn a background task to drain the server's tail bytes + the
+        // zero-chunk half-close, then push the conn back. Failures simply
+        // drop the conn — its underlying TCP is closed by `Snell`'s drop.
+        //
+        // Requires an active tokio runtime; the meow-rs binary always runs
+        // inside #[tokio::main], so this is safe in production. In unit
+        // tests that drop a PooledConn outside any runtime, `tokio::spawn`
+        // panics — those tests should use a #[tokio::test] runtime.
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        tokio::spawn(async move {
+            let mut snell = snell;
+            if drain_for_reuse(&mut snell).await {
+                snell.reset_reply_state();
+                pool.put(snell, uses);
+            }
+        });
+    }
+}

--- a/crates/meow-proxy/src/snell/cipher.rs
+++ b/crates/meow-proxy/src/snell/cipher.rs
@@ -1,0 +1,57 @@
+//! Snell KDF and AEAD helpers.
+//!
+//! Port of opensnell `components/snell/cipher.go`. The Snell-specific KDF is
+//! Argon2id with t=3, m=8 KiB, p=1, 32-byte output; the first `key_size`
+//! bytes are used as the AEAD key (AES-128-GCM uses 16).
+
+use aes_gcm::aead::KeyInit;
+use aes_gcm::Aes128Gcm;
+use argon2::{Algorithm, Argon2, Params, Version};
+
+/// Snell KDF — Argon2id(t=3, m=8 KiB, p=1) → 32 bytes; first `key_size`
+/// bytes are the AEAD key.
+///
+/// The 8 KiB memory and 3 passes mirror the official server's
+/// `argon2.IDKey(psk, salt, 3, 8, 1, 32)` call exactly. Mismatching either
+/// parameter produces a different key and the AEAD handshake silently fails
+/// with "snell v4 invalid frame header".
+pub fn snell_kdf(psk: &[u8], salt: &[u8], key_size: usize) -> Vec<u8> {
+    debug_assert!(key_size <= 32, "snell KDF caller asked for >32 B");
+    let params = Params::new(8, 3, 1, Some(32)).expect("static snell KDF params are valid");
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let mut out = vec![0u8; 32];
+    argon2
+        .hash_password_into(psk, salt, &mut out)
+        .expect("argon2 hash_password_into never fails with valid params + output len 32");
+    out.truncate(key_size);
+    out
+}
+
+/// Build an AES-128-GCM cipher from a 16-byte key.
+pub fn aes_gcm(key: &[u8]) -> Aes128Gcm {
+    debug_assert_eq!(key.len(), 16, "snell AEAD requires a 16-byte AES-128 key");
+    Aes128Gcm::new_from_slice(key).expect("16-byte key is valid for AES-128-GCM")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kdf_is_deterministic_for_same_inputs() {
+        let psk = b"shared-secret";
+        let salt = [7u8; 16];
+        let a = snell_kdf(psk, &salt, 16);
+        let b = snell_kdf(psk, &salt, 16);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 16);
+    }
+
+    #[test]
+    fn kdf_differs_on_different_salt() {
+        let psk = b"shared-secret";
+        let a = snell_kdf(psk, &[0u8; 16], 16);
+        let b = snell_kdf(psk, &[1u8; 16], 16);
+        assert_ne!(a, b);
+    }
+}

--- a/crates/meow-proxy/src/snell/mod.rs
+++ b/crates/meow-proxy/src/snell/mod.rs
@@ -1,0 +1,22 @@
+//! Snell v4 / v5 outbound proxy adapter.
+//!
+//! Port of the client side of [opensnell](https://github.com/missuo/opensnell):
+//!
+//! * [`cipher`] — Argon2id KDF + AES-128-GCM helpers.
+//! * [`v4`]    — AEAD frame codec (`v4Conn`) with padding interleave and
+//!   payload-limit ramp-up.
+//! * [`protocol`] — `Snell` stream wrapper with request/response handling.
+//! * [`udp`]   — UDP-over-TCP datagram framing exposed as `ProxyPacketConn`.
+//! * [`pool`]  — bounded LIFO reuse pool for `CommandConnectV2` sessions.
+//! * [`adapter`] — `SnellAdapter` implementing [`meow_common::ProxyAdapter`].
+//!
+//! Older snell v1 / v2 / v3 wires are intentionally unsupported.
+
+pub mod adapter;
+pub mod cipher;
+pub mod pool;
+pub mod protocol;
+pub mod udp;
+pub mod v4;
+
+pub use adapter::{SnellAdapter, SnellObfs, SnellVersion};

--- a/crates/meow-proxy/src/snell/pool.rs
+++ b/crates/meow-proxy/src/snell/pool.rs
@@ -1,0 +1,130 @@
+//! Reuse pool for snell `CommandConnectV2` sessions.
+//!
+//! Port of opensnell `components/snell/pool.go`. The Surge `snell-server`
+//! v5.0.1 implementation closes a reuse-mode TCP connection after the second
+//! session (one fresh CONNECT + one reuse), so this pool caps `uses_per_conn`
+//! at 2 and discards beyond that. Idle entries also age out after 15 s.
+//!
+//! Lifecycle of a pooled session:
+//!
+//! 1. `Pool::get` either pops the most-recently-returned idle conn (LIFO,
+//!    warmest cache) or asks the factory to dial a fresh one.
+//! 2. The caller writes the snell `CommandConnectV2` header, relays data,
+//!    and on success calls `PooledConn::into_returnable(...)` to send a
+//!    zero-chunk half-close and put the conn back.
+//! 3. On error the caller drops the `PooledConn` and the underlying TCP is
+//!    closed.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use meow_transport::Stream as TransportStream;
+
+use super::protocol::Snell;
+use super::v4::is_zero_chunk;
+use tokio::io::AsyncReadExt;
+
+/// Type-erased snell stream used inside the pool. The underlying byte
+/// stream may be a plain TCP connection or an obfs-wrapped one — the pool
+/// doesn't care.
+pub type PoolStream = Snell<Box<dyn TransportStream>>;
+
+const DEFAULT_MAX_SIZE: usize = 10;
+const DEFAULT_MAX_AGE: Duration = Duration::from_secs(15);
+const DEFAULT_MAX_USES_PER_CONN: u32 = 2;
+/// Time budget for draining the server's trailing zero-chunk before
+/// returning a conn to the pool. Mirrors opensnell's 500ms.
+const DRAIN_DEADLINE: Duration = Duration::from_millis(500);
+
+struct PooledEntry {
+    conn: PoolStream,
+    expires_at: Instant,
+    /// CONNECT sessions already served by this TCP stream.
+    uses: u32,
+}
+
+/// Bounded LIFO pool of warm snell streams.
+pub struct Pool {
+    max_size: usize,
+    max_age: Duration,
+    max_uses_per_conn: u32,
+    items: Mutex<Vec<PooledEntry>>,
+}
+
+impl Pool {
+    pub fn new() -> Self {
+        Self {
+            max_size: DEFAULT_MAX_SIZE,
+            max_age: DEFAULT_MAX_AGE,
+            max_uses_per_conn: DEFAULT_MAX_USES_PER_CONN,
+            items: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Try to take a still-fresh idle entry off the pool. Returns `None` if
+    /// the pool is empty or every entry has expired.
+    pub fn take_idle(&self) -> Option<(PoolStream, u32)> {
+        let now = Instant::now();
+        let mut items = self
+            .items
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while let Some(entry) = items.pop() {
+            if now < entry.expires_at {
+                return Some((entry.conn, entry.uses));
+            }
+            // Expired — drop on the floor; the underlying TCP will close
+            // when the Snell wrapper is dropped.
+        }
+        None
+    }
+
+    /// Re-insert a conn that has just finished a session. Drops the conn if
+    /// the pool is full or the conn has reached its session cap.
+    pub fn put(&self, conn: PoolStream, uses: u32) {
+        if uses >= self.max_uses_per_conn {
+            return;
+        }
+        let mut items = self
+            .items
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if items.len() >= self.max_size {
+            return;
+        }
+        items.push(PooledEntry {
+            conn,
+            expires_at: Instant::now() + self.max_age,
+            uses,
+        });
+    }
+}
+
+impl Default for Pool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Drain trailing data + the server's zero-chunk so the conn is clean for
+/// reuse. Returns `true` when the zero-chunk was observed within
+/// `DRAIN_DEADLINE`, `false` otherwise (caller should discard the conn).
+pub async fn drain_for_reuse(conn: &mut PoolStream) -> bool {
+    let mut scratch = [0u8; 4096];
+    let deadline = tokio::time::sleep(DRAIN_DEADLINE);
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            biased;
+            () = &mut deadline => return false,
+            res = conn.read(&mut scratch) => {
+                match res {
+                    Ok(0) => return false, // peer closed underlying TCP
+                    Ok(_) => continue,
+                    Err(e) if is_zero_chunk(&e) => return true,
+                    Err(_) => return false,
+                }
+            }
+        }
+    }
+}

--- a/crates/meow-proxy/src/snell/protocol.rs
+++ b/crates/meow-proxy/src/snell/protocol.rs
@@ -1,0 +1,289 @@
+//! Snell protocol constants and the high-level `Snell` stream wrapper.
+//!
+//! Port of opensnell `components/snell/protocol.go` + `conn.go`. Bridges the
+//! v4 AEAD codec to the snell request/response semantics:
+//!
+//! * The client writes a 5-byte `[ver | cmd | client-id-len=0 | host-len |
+//!   host... | port:u16 BE]` connect request after the salt is in flight.
+//! * The server replies with a status byte (Tunnel/Pong/Error). Error
+//!   responses carry `[code, msg-len, msg...]`.
+//! * Either side may send a zero-payload frame to signal half-close; in
+//!   reuse mode the client emits a zero chunk after each session so the
+//!   connection can be returned to the pool and reused for the next request.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
+
+use super::v4::{is_zero_chunk, V4Conn, MAX_PAYLOAD_LENGTH};
+
+/// First byte of every Snell request — `0x01` since v1.
+pub const HEADER_VERSION: u8 = 1;
+
+pub const COMMAND_CONNECT: u8 = 1;
+/// Reuse-capable TCP connect; used when the client maintains a pool.
+pub const COMMAND_CONNECT_V2: u8 = 5;
+pub const COMMAND_UDP: u8 = 6;
+/// First byte of each UDP-over-TCP request frame.
+pub const COMMAND_UDP_FORWARD: u8 = 1;
+
+pub const RESPONSE_TUNNEL: u8 = 0;
+pub const RESPONSE_PONG: u8 = 1;
+pub const RESPONSE_ERROR: u8 = 2;
+
+/// Application-layer error returned by the snell peer.
+#[derive(Debug, Clone)]
+pub struct AppError {
+    pub code: u8,
+    pub message: String,
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "snell server error code={} msg={}",
+            self.code, self.message
+        )
+    }
+}
+
+impl std::error::Error for AppError {}
+
+/// Encode a TCP CONNECT request header. The bytes are written through the
+/// caller's stream (typically a `V4Conn`).
+pub async fn write_header<W: AsyncWrite + Unpin>(
+    stream: &mut W,
+    host: &str,
+    port: u16,
+    reuse: bool,
+) -> io::Result<()> {
+    if host.len() > 255 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "snell: host name too long",
+        ));
+    }
+    let mut buf = Vec::with_capacity(5 + host.len() + 2);
+    buf.push(HEADER_VERSION);
+    buf.push(if reuse {
+        COMMAND_CONNECT_V2
+    } else {
+        COMMAND_CONNECT
+    });
+    buf.push(0); // empty client ID
+    buf.push(host.len() as u8);
+    buf.extend_from_slice(host.as_bytes());
+    buf.extend_from_slice(&port.to_be_bytes());
+    stream.write_all(&buf).await
+}
+
+/// Encode a UDP-ASSOCIATE request header.
+pub async fn write_udp_header<W: AsyncWrite + Unpin>(stream: &mut W) -> io::Result<()> {
+    stream.write_all(&[HEADER_VERSION, COMMAND_UDP, 0x00]).await
+}
+
+/// Emit a zero-chunk (`payload_len == 0 && padding_len == 0`) — the
+/// half-close signal recognized by the peer. The v4 codec turns a zero-byte
+/// `poll_write` into a zero-chunk frame, so this is a thin wrapper.
+pub async fn write_zero_chunk<W: AsyncWrite + Unpin>(stream: &mut W) -> io::Result<()> {
+    stream.write_all(&[]).await
+}
+
+// ─── Snell stream wrapper ────────────────────────────────────────────────────
+
+/// AEAD-wrapped stream with snell request/response semantics.
+///
+/// On the first `poll_read`, the wrapper consumes the server's status byte
+/// before yielding any relay bytes (`read_reply`). Subsequent reads pass
+/// through directly. The wrapper exposes [`Snell::write_packet_frame`] so
+/// the UDP relay can emit datagram-sized frames atomically.
+pub struct Snell<S> {
+    inner: V4Conn<S>,
+    /// Set to `true` after the reply byte has been consumed once. Reset to
+    /// `false` by [`Snell::reset_reply_state`] when a pooled connection is
+    /// re-used for a fresh request.
+    reply_consumed: bool,
+}
+
+impl<S> Snell<S> {
+    pub fn from_v4(inner: V4Conn<S>) -> Self {
+        Self {
+            inner,
+            reply_consumed: false,
+        }
+    }
+
+    pub fn new(inner: S, psk: Arc<[u8]>) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        Self {
+            inner: V4Conn::new(inner, psk),
+            reply_consumed: false,
+        }
+    }
+
+    /// After a successful pool reuse the next request's reply byte is
+    /// pending again — reset the flag so the next `read` consumes it.
+    pub fn reset_reply_state(&mut self) {
+        self.reply_consumed = false;
+    }
+
+    pub fn mark_reply_consumed(&mut self) {
+        self.reply_consumed = true;
+    }
+
+    /// Stage a single frame carrying `buf` verbatim as a UDP datagram
+    /// payload. The frame is written via the underlying `V4Conn` so the
+    /// codec keeps producing valid AEAD frames.
+    pub async fn write_packet_frame(&mut self, buf: &[u8]) -> io::Result<usize>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        if buf.len() > MAX_PAYLOAD_LENGTH {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snell: packet frame too large",
+            ));
+        }
+        self.inner.stage_packet_frame(buf)?;
+        // Drain the staged frame to completion.
+        std::future::poll_fn(|cx| {
+            if self.inner.has_pending_write() {
+                Pin::new(&mut self.inner).poll_flush(cx)
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        })
+        .await?;
+        Ok(buf.len())
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> Snell<S> {
+    /// Consume the server's status byte. Idempotent — calls after the first
+    /// successful invocation are no-ops until [`Snell::reset_reply_state`].
+    pub async fn read_reply(&mut self) -> io::Result<()> {
+        if self.reply_consumed {
+            return Ok(());
+        }
+        let mut byte = [0u8; 1];
+        self.read_exact_underlying(&mut byte).await?;
+        self.reply_consumed = true;
+        match byte[0] {
+            RESPONSE_TUNNEL | RESPONSE_PONG => Ok(()),
+            RESPONSE_ERROR => {
+                let mut buf = [0u8; 1];
+                self.read_exact_underlying(&mut buf).await?;
+                let code = buf[0];
+                self.read_exact_underlying(&mut buf).await?;
+                let len = buf[0] as usize;
+                let mut msg = vec![0u8; len];
+                if len > 0 {
+                    self.read_exact_underlying(&mut msg).await?;
+                }
+                let message = String::from_utf8_lossy(&msg).into_owned();
+                Err(io::Error::other(AppError { code, message }))
+            }
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("snell: unknown response code 0x{other:x}"),
+            )),
+        }
+    }
+
+    async fn read_exact_underlying(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        // Read directly from the AEAD-decoded stream, bypassing the reply
+        // guard (otherwise we'd recurse).
+        let mut filled = 0;
+        while filled < buf.len() {
+            let mut rb = ReadBuf::new(&mut buf[filled..]);
+            std::future::poll_fn(|cx| Pin::new(&mut self.inner).poll_read(cx, &mut rb)).await?;
+            let n = rb.filled().len();
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "snell: unexpected EOF reading reply",
+                ));
+            }
+            filled += n;
+        }
+        Ok(())
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for Snell<S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        out: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        // First-read reply handshake. Implemented as a hand-rolled state
+        // machine: the byte is read via `poll_read` on the inner stream into
+        // a tiny scratch buffer, then we recurse on the body read in the
+        // same poll once the reply is consumed.
+        let this = &mut *self;
+        if !this.reply_consumed {
+            let mut buf = [0u8; 1];
+            let mut rb = ReadBuf::new(&mut buf);
+            match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {}
+            }
+            if rb.filled().is_empty() {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "snell: EOF before reply byte",
+                )));
+            }
+            this.reply_consumed = true;
+            match buf[0] {
+                RESPONSE_TUNNEL | RESPONSE_PONG => {}
+                RESPONSE_ERROR => {
+                    // We're inside poll_read — surface the error rather than
+                    // trying to read the error tail synchronously. The caller
+                    // will report it; for richer messages the explicit
+                    // `read_reply` path is preferred (the adapter calls it for
+                    // UDP, and on TCP the next byte is data, so any error is
+                    // surfaced as an io::Error here).
+                    return Poll::Ready(Err(io::Error::other(
+                        "snell: server returned error response (use read_reply for details)",
+                    )));
+                }
+                other => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("snell: unknown response code 0x{other:x}"),
+                    )));
+                }
+            }
+        }
+        // Map the v4 zero-chunk into a clean EOF for the caller.
+        match Pin::new(&mut this.inner).poll_read(cx, out) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) if is_zero_chunk(&e) => Poll::Ready(Ok(())),
+            other => other,
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for Snell<S> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}

--- a/crates/meow-proxy/src/snell/udp.rs
+++ b/crates/meow-proxy/src/snell/udp.rs
@@ -1,0 +1,168 @@
+//! Snell UDP-over-TCP framing.
+//!
+//! Port of opensnell `components/snell/udp.go`. Each datagram is sent as a
+//! single snell AEAD frame whose body is
+//! `[CommandUDPForward=0x01][addr][payload]`. The address encoding mirrors
+//! SOCKS5 except IPv6 is signaled by `0x06` (not 0x04 of SOCKS5).
+//!
+//! Server → client frames use a slightly different address layout:
+//! `[0x04|0x06][ip-bytes][port:u16 BE][payload]`. The `read_packet` parser
+//! handles both ipv4 (`0x04`) and ipv6 (`0x06`); domain-name replies are not
+//! emitted by official servers.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use meow_common::{MeowError, ProxyPacketConn, Result};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use tokio::sync::Mutex;
+
+use super::protocol::{Snell, COMMAND_UDP_FORWARD};
+
+/// Build the `[CommandUDPForward][addr-encoding][payload]` frame payload for a
+/// snell UDP request.
+fn build_request_frame(addr: &SocketAddr, payload: &[u8]) -> Vec<u8> {
+    // Header is encoded as if the client always sent an IP target; that
+    // matches what opensnell's PacketConn does after the DNS resolve
+    // shortcut in the SOCKS5 path.
+    let mut buf = Vec::with_capacity(1 + 1 + 16 + 2 + payload.len());
+    buf.push(COMMAND_UDP_FORWARD);
+    // host-length 0 means "address follows as raw IP" with a one-byte family
+    // marker.
+    buf.push(0);
+    match addr.ip() {
+        IpAddr::V4(v4) => {
+            buf.push(0x04);
+            buf.extend_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            buf.push(0x06);
+            buf.extend_from_slice(&v6.octets());
+        }
+    }
+    buf.extend_from_slice(&addr.port().to_be_bytes());
+    buf.extend_from_slice(payload);
+    buf
+}
+
+/// Parse a server-to-client snell UDP response frame, writing the payload
+/// into `out` and returning (bytes copied, source address).
+async fn read_response_frame<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    out: &mut [u8],
+) -> io::Result<(usize, SocketAddr)> {
+    let mut family = [0u8; 1];
+    reader.read_exact(&mut family).await?;
+    let addr = match family[0] {
+        0x04 => {
+            let mut ip = [0u8; 4];
+            reader.read_exact(&mut ip).await?;
+            let mut port = [0u8; 2];
+            reader.read_exact(&mut port).await?;
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::from(ip)), u16::from_be_bytes(port))
+        }
+        0x06 => {
+            let mut ip = [0u8; 16];
+            reader.read_exact(&mut ip).await?;
+            let mut port = [0u8; 2];
+            reader.read_exact(&mut port).await?;
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::from(ip)), u16::from_be_bytes(port))
+        }
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("snell udp: unknown address family 0x{other:x}"),
+            ));
+        }
+    };
+    // The remainder of the snell frame is the payload. The v4 codec already
+    // re-assembles a frame's payload into a contiguous read, but the snell
+    // AEAD frame is sized to hold exactly one datagram, so a single
+    // `read` returns the entire payload. Pull until we observe the end.
+    //
+    // We can't know the payload length from the snell frame header alone
+    // (it's been consumed by the v4 codec). Instead we keep reading into
+    // `out` until the next read would block — but we have no zero-frame
+    // sentinel here. opensnell's PacketConn.ReadFrom does a single Read
+    // call and relies on the snell frame == one datagram invariant. We do
+    // the same: one `read` gives us the payload up to `out.len()`, and any
+    // extra is dropped (datagram-truncation semantics matching net.UDPConn).
+    let n = reader.read(out).await?;
+    Ok((n, addr))
+}
+
+/// Per-connection snell UDP relay. Multiplexes datagrams over a single AEAD
+/// stream guarded by a `Mutex`. The lock is held only during one
+/// frame-sized read or write, so reads and writes serialise but never block
+/// each other for long.
+pub struct SnellPacketConn<S> {
+    inner: Arc<Mutex<Snell<S>>>,
+}
+
+impl<S> SnellPacketConn<S> {
+    pub fn new(snell: Snell<S>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(snell)),
+        }
+    }
+}
+
+#[async_trait]
+impl<S> ProxyPacketConn for SnellPacketConn<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+{
+    async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        let mut guard = self.inner.lock().await;
+        read_response_frame(&mut *guard, buf)
+            .await
+            .map_err(MeowError::Io)
+    }
+
+    async fn write_packet(&self, buf: &[u8], addr: &SocketAddr) -> Result<usize> {
+        let frame = build_request_frame(addr, buf);
+        let mut guard = self.inner.lock().await;
+        guard
+            .write_packet_frame(&frame)
+            .await
+            .map_err(MeowError::Io)?;
+        Ok(buf.len())
+    }
+
+    fn local_addr(&self) -> Result<SocketAddr> {
+        // Datagrams ride on a TCP stream — no real local UDP socket exists.
+        Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
+    }
+
+    fn close(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_frame_ipv4_layout() {
+        let frame = build_request_frame(&"1.2.3.4:5353".parse().unwrap(), b"\x00\x01");
+        assert_eq!(frame[0], COMMAND_UDP_FORWARD);
+        assert_eq!(frame[1], 0); // host-length 0 → IP follows
+        assert_eq!(frame[2], 0x04);
+        assert_eq!(&frame[3..7], &[1, 2, 3, 4]);
+        assert_eq!(&frame[7..9], &5353u16.to_be_bytes());
+        assert_eq!(&frame[9..], b"\x00\x01");
+    }
+
+    #[test]
+    fn request_frame_ipv6_layout() {
+        let frame = build_request_frame(&"[::1]:53".parse().unwrap(), b"abc");
+        assert_eq!(frame[0], COMMAND_UDP_FORWARD);
+        assert_eq!(frame[1], 0);
+        assert_eq!(frame[2], 0x06);
+        assert_eq!(frame.len(), 1 + 1 + 1 + 16 + 2 + 3);
+        assert_eq!(&frame[frame.len() - 3..], b"abc");
+    }
+}

--- a/crates/meow-proxy/src/snell/v4.rs
+++ b/crates/meow-proxy/src/snell/v4.rs
@@ -31,7 +31,7 @@ use aes_gcm::aead::generic_array::GenericArray;
 use aes_gcm::aead::AeadInPlace;
 use aes_gcm::Aes128Gcm;
 use rand::RngCore;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, BufReader, ReadBuf};
 
 use super::cipher::{aes_gcm, snell_kdf};
 
@@ -48,6 +48,12 @@ const V4_BURST_RESET_AFTER: std::time::Duration = std::time::Duration::from_secs
 
 /// Largest snell frame payload — matches mihomo's `maxLength` (0x3FFF).
 pub const MAX_PAYLOAD_LENGTH: usize = 0x3FFF;
+
+/// Userspace read buffer on the underlying stream. Without it, every frame
+/// costs two `recv()` syscalls (23-byte sealed header + body); 64 KiB holds
+/// ~40 max-size frames per `recv()`. Mirrors mihomo PR #2821. Writes are
+/// unaffected — `BufReader` passes `AsyncWrite` straight through.
+const V4_READ_BUFFER_SIZE: usize = 64 * 1024;
 
 const ZERO_CHUNK_KIND: io::ErrorKind = io::ErrorKind::UnexpectedEof;
 const ZERO_CHUNK_MSG: &str = "snell: zero chunk";
@@ -336,17 +342,17 @@ fn open_in_place(
 
 /// AEAD frame wrapper around an `AsyncRead + AsyncWrite` byte stream.
 pub struct V4Conn<S> {
-    inner: S,
+    inner: BufReader<S>,
     psk: Arc<[u8]>,
     writer: Writer,
     reader: ReaderState,
 }
 
-impl<S> V4Conn<S> {
+impl<S: AsyncRead> V4Conn<S> {
     pub fn new(inner: S, psk: Arc<[u8]>) -> Self {
         let writer = Writer::new(&psk);
         Self {
-            inner,
+            inner: BufReader::with_capacity(V4_READ_BUFFER_SIZE, inner),
             psk,
             writer,
             reader: ReaderState::NeedSalt {
@@ -355,7 +361,9 @@ impl<S> V4Conn<S> {
             },
         }
     }
+}
 
+impl<S> V4Conn<S> {
     /// Stage a single frame carrying `buf` as a UDP datagram payload. The
     /// caller is responsible for draining the stream (calling `poll_write`
     /// with an empty buf is a no-op here; the higher-level

--- a/crates/meow-proxy/src/snell/v4.rs
+++ b/crates/meow-proxy/src/snell/v4.rs
@@ -1,0 +1,765 @@
+//! Snell v4 AEAD frame codec.
+//!
+//! Port of opensnell `components/snell/v4.go` (which itself ports mihomo's
+//! `transport/snell/v4.go`). Wraps an existing `AsyncRead + AsyncWrite`
+//! stream with the v4 frame format:
+//!
+//! 1. The first write emits a 16-byte random salt, then frame(s); reader
+//!    consumes the salt before its first frame.
+//! 2. Each frame is `[AEAD-sealed 7-byte header][padding (interleaved with
+//!    payload's even bytes)][AEAD-sealed payload]`.
+//! 3. Header layout (plaintext, 7 B): `[ver=4][0][0][padding_len:u16
+//!    BE][payload_len:u16 BE]`.
+//! 4. Nonce: 12-byte little-endian counter incremented after every Seal/Open.
+//! 5. A frame with `payload_len == 0 && padding_len == 0` signals the peer's
+//!    half-close (`ErrZeroChunk`, surfaced as a tagged `io::Error`).
+//!
+//! The writer also implements opensnell's payload-limit ramp-up: the first
+//! frame fits within one MTU (1460 B), then each subsequent frame in a burst
+//! grows up to `MAX_PAYLOAD_LENGTH` (16383 B). After 30 s of inactivity the
+//! ramp restarts. Initial-burst padding is bit-balanced against the payload
+//! cipher's `popcount` to defeat the trivial entropy fingerprint of AEAD-only
+//! traffic.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use aes_gcm::aead::generic_array::GenericArray;
+use aes_gcm::aead::AeadInPlace;
+use aes_gcm::Aes128Gcm;
+use rand::RngCore;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use super::cipher::{aes_gcm, snell_kdf};
+
+pub const V4_SALT_SIZE: usize = 16;
+pub const V4_NONCE_SIZE: usize = 12;
+pub const V4_HEADER_PLAIN_SIZE: usize = 7;
+pub const V4_GCM_TAG: usize = 16;
+pub const V4_HEADER_CIPHER_SIZE: usize = V4_HEADER_PLAIN_SIZE + V4_GCM_TAG;
+
+const V4_FRAME_SIZE: usize = 1460;
+const V4_INITIAL_PADDING_MIN: u16 = 0x100;
+const V4_INITIAL_PADDING_SPAN: u16 = 0x100;
+const V4_BURST_RESET_AFTER: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Largest snell frame payload — matches mihomo's `maxLength` (0x3FFF).
+pub const MAX_PAYLOAD_LENGTH: usize = 0x3FFF;
+
+const ZERO_CHUNK_KIND: io::ErrorKind = io::ErrorKind::UnexpectedEof;
+const ZERO_CHUNK_MSG: &str = "snell: zero chunk";
+
+/// True iff the I/O error is the v4 zero-chunk half-close signal.
+pub fn is_zero_chunk(err: &io::Error) -> bool {
+    err.kind() == ZERO_CHUNK_KIND
+        && err
+            .get_ref()
+            .is_some_and(|e| e.to_string() == ZERO_CHUNK_MSG)
+}
+
+fn zero_chunk_err() -> io::Error {
+    io::Error::new(ZERO_CHUNK_KIND, ZERO_CHUNK_MSG)
+}
+
+fn increment_nonce(nonce: &mut [u8; V4_NONCE_SIZE]) {
+    for byte in nonce.iter_mut() {
+        *byte = byte.wrapping_add(1);
+        if *byte != 0 {
+            return;
+        }
+    }
+}
+
+fn swap_padding(padding: &mut [u8], payload_cipher: &mut [u8]) {
+    let limit = padding.len().min(payload_cipher.len());
+    let mut i = 0;
+    while i < limit {
+        std::mem::swap(&mut padding[i], &mut payload_cipher[i]);
+        i += 2;
+    }
+}
+
+fn make_v4_bit_count_padding(length: usize, one_bits: usize) -> io::Result<Vec<u8>> {
+    let total_bits = 8 * length;
+    if one_bits > total_bits {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "snell v4 invalid padding bit count",
+        ));
+    }
+    let mut bitset = vec![0u8; total_bits];
+    for slot in bitset.iter_mut().take(one_bits) {
+        *slot = 1;
+    }
+    let mut rng = rand::rng();
+    for i in (1..total_bits).rev() {
+        let j = (rng.next_u64() % (i as u64 + 1)) as usize;
+        bitset.swap(i, j);
+    }
+    let mut padding = vec![0u8; length];
+    for (i, bit) in bitset.into_iter().enumerate() {
+        if bit == 1 {
+            padding[i / 8] |= 1 << (i % 8);
+        }
+    }
+    Ok(padding)
+}
+
+fn make_v4_random_padding(length: usize) -> Vec<u8> {
+    let mut padding = vec![0u8; length];
+    rand::rng().fill_bytes(&mut padding);
+    padding
+}
+
+fn count_v4_payload_ones(payload_cipher: &[u8]) -> usize {
+    let limit = payload_cipher.len() & !3;
+    payload_cipher[..limit]
+        .iter()
+        .map(|b| b.count_ones() as usize)
+        .sum()
+}
+
+fn random_unit_f64() -> f64 {
+    (rand::rng().next_u64() % (1u64 << 53)) as f64 / 2f64.powi(53)
+}
+
+fn make_v4_padding(payload_cipher: &[u8], padding_length: usize) -> io::Result<Vec<u8>> {
+    if padding_length == 0 {
+        return Ok(Vec::new());
+    }
+    let payload_ones = count_v4_payload_ones(payload_cipher);
+    let payload_zeros = 8 * payload_cipher.len() - payload_ones;
+    if payload_zeros == 0 {
+        return Ok(make_v4_random_padding(padding_length));
+    }
+    let ratio = payload_ones as f64 / payload_zeros as f64;
+    if ratio <= 0.5 || ratio >= 1.6 {
+        return Ok(make_v4_random_padding(padding_length));
+    }
+    let target_base = if payload_zeros < payload_ones {
+        0.4
+    } else {
+        1.6
+    };
+    let target_ratio = target_base + random_unit_f64() / 10.0;
+    let total_bits = 8 * (padding_length + payload_cipher.len());
+    let target_ones_f =
+        total_bits as f64 * (target_ratio / (target_ratio + 1.0)) - payload_ones as f64;
+    if !target_ones_f.is_finite() || target_ones_f < 0.0 {
+        return Ok(make_v4_random_padding(padding_length));
+    }
+    let target_ones = target_ones_f as usize;
+    if target_ones > 8 * padding_length {
+        return Ok(make_v4_random_padding(padding_length));
+    }
+    make_v4_bit_count_padding(padding_length, target_ones)
+}
+
+// ─── Reader state machine ────────────────────────────────────────────────────
+
+enum ReaderState {
+    /// Consuming the peer's 16-byte salt; once full, derive the AEAD via PSK.
+    NeedSalt {
+        salt_buf: [u8; V4_SALT_SIZE],
+        salt_progress: usize,
+    },
+    /// Reading the next frame's 23-byte sealed header.
+    ReadingHeader {
+        aead: Arc<Aes128Gcm>,
+        nonce: [u8; V4_NONCE_SIZE],
+        header_buf: [u8; V4_HEADER_CIPHER_SIZE],
+        header_progress: usize,
+    },
+    /// Reading `padding_len + payload_len + 16` body bytes.
+    ReadingBody {
+        aead: Arc<Aes128Gcm>,
+        nonce: [u8; V4_NONCE_SIZE],
+        padding_len: usize,
+        payload_len: usize,
+        body_buf: Vec<u8>,
+        body_progress: usize,
+    },
+    /// Decrypted payload pending — drain into caller before next frame.
+    Drain {
+        aead: Arc<Aes128Gcm>,
+        nonce: [u8; V4_NONCE_SIZE],
+        payload: Vec<u8>,
+        payload_off: usize,
+    },
+}
+
+// ─── Writer state ────────────────────────────────────────────────────────────
+
+struct Writer {
+    aead: Arc<Aes128Gcm>,
+    nonce: [u8; V4_NONCE_SIZE],
+    salt: [u8; V4_SALT_SIZE],
+    salt_sent: bool,
+    initial_padding_length: u16,
+    payload_limit: u16,
+    last_write: Option<Instant>,
+    /// Bytes already pushed downstream from the in-flight frame.
+    pending: Vec<u8>,
+    pending_off: usize,
+    /// Number of caller bytes the in-flight frame represents (reported on
+    /// successful drain).
+    pending_input: usize,
+}
+
+impl Writer {
+    fn new(psk: &[u8]) -> Self {
+        let mut salt = [0u8; V4_SALT_SIZE];
+        rand::rng().fill_bytes(&mut salt);
+        let aead = aes_gcm(&snell_kdf(psk, &salt, 16));
+        let padding_delta = (rand::rng().next_u32() % u32::from(V4_INITIAL_PADDING_SPAN)) as u16;
+        Self {
+            aead: Arc::new(aead),
+            nonce: [0u8; V4_NONCE_SIZE],
+            salt,
+            salt_sent: false,
+            initial_padding_length: V4_INITIAL_PADDING_MIN + padding_delta,
+            payload_limit: 0,
+            last_write: None,
+            pending: Vec::new(),
+            pending_off: 0,
+            pending_input: 0,
+        }
+    }
+
+    fn next_payload_limit(&mut self) -> u16 {
+        let now = Instant::now();
+        let limit = match self.last_write {
+            None => V4_FRAME_SIZE as u16 - 55 - self.initial_padding_length,
+            Some(t) if now.duration_since(t) > V4_BURST_RESET_AFTER => V4_FRAME_SIZE as u16 - 39,
+            Some(_) => self.payload_limit,
+        };
+        self.last_write = Some(now);
+        if limit < MAX_PAYLOAD_LENGTH as u16 {
+            let next = limit as usize + V4_FRAME_SIZE - 39;
+            self.payload_limit = next.min(MAX_PAYLOAD_LENGTH) as u16;
+        } else {
+            self.payload_limit = MAX_PAYLOAD_LENGTH as u16;
+        }
+        limit
+    }
+
+    fn next_frame_padding_length(&self, payload_length: usize) -> usize {
+        if self.salt_sent || payload_length == 0 {
+            0
+        } else {
+            self.initial_padding_length as usize
+        }
+    }
+
+    fn stage_frame(&mut self, payload: &[u8], padding_length: usize) -> io::Result<()> {
+        if payload.len() > MAX_PAYLOAD_LENGTH || padding_length > MAX_PAYLOAD_LENGTH {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snell v4 frame too large",
+            ));
+        }
+        if payload.is_empty() && padding_length != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snell v4 zero chunk with padding",
+            ));
+        }
+
+        let mut header = [0u8; V4_HEADER_PLAIN_SIZE];
+        header[0] = 4;
+        header[3..5].copy_from_slice(&(padding_length as u16).to_be_bytes());
+        header[5..7].copy_from_slice(&(payload.len() as u16).to_be_bytes());
+
+        let mut header_buf: Vec<u8> = Vec::with_capacity(V4_HEADER_CIPHER_SIZE);
+        header_buf.extend_from_slice(&header);
+        seal_in_place(&self.aead, &self.nonce, &mut header_buf)?;
+        increment_nonce(&mut self.nonce);
+
+        let mut payload_buf: Vec<u8> = Vec::new();
+        if !payload.is_empty() {
+            payload_buf.extend_from_slice(payload);
+            seal_in_place(&self.aead, &self.nonce, &mut payload_buf)?;
+            increment_nonce(&mut self.nonce);
+        }
+
+        let mut padding = if padding_length > 0 {
+            make_v4_padding(&payload_buf, padding_length)?
+        } else {
+            Vec::new()
+        };
+        if padding_length > 0 {
+            swap_padding(&mut padding, &mut payload_buf);
+        }
+
+        let mut frame: Vec<u8> = Vec::with_capacity(
+            if self.salt_sent { 0 } else { V4_SALT_SIZE }
+                + header_buf.len()
+                + padding.len()
+                + payload_buf.len(),
+        );
+        if !self.salt_sent {
+            frame.extend_from_slice(&self.salt);
+            self.salt_sent = true;
+        }
+        frame.extend_from_slice(&header_buf);
+        frame.extend_from_slice(&padding);
+        frame.extend_from_slice(&payload_buf);
+
+        self.pending = frame;
+        self.pending_off = 0;
+        Ok(())
+    }
+}
+
+fn seal_in_place(
+    aead: &Aes128Gcm,
+    nonce: &[u8; V4_NONCE_SIZE],
+    buf: &mut Vec<u8>,
+) -> io::Result<()> {
+    aead.encrypt_in_place(GenericArray::from_slice(nonce), b"", buf)
+        .map_err(|_| io::Error::other("snell v4 encrypt failed"))
+}
+
+fn open_in_place(
+    aead: &Aes128Gcm,
+    nonce: &[u8; V4_NONCE_SIZE],
+    buf: &mut Vec<u8>,
+) -> io::Result<()> {
+    aead.decrypt_in_place(GenericArray::from_slice(nonce), b"", buf)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "snell v4 decrypt failed"))
+}
+
+// ─── V4Conn ──────────────────────────────────────────────────────────────────
+
+/// AEAD frame wrapper around an `AsyncRead + AsyncWrite` byte stream.
+pub struct V4Conn<S> {
+    inner: S,
+    psk: Arc<[u8]>,
+    writer: Writer,
+    reader: ReaderState,
+}
+
+impl<S> V4Conn<S> {
+    pub fn new(inner: S, psk: Arc<[u8]>) -> Self {
+        let writer = Writer::new(&psk);
+        Self {
+            inner,
+            psk,
+            writer,
+            reader: ReaderState::NeedSalt {
+                salt_buf: [0u8; V4_SALT_SIZE],
+                salt_progress: 0,
+            },
+        }
+    }
+
+    /// Stage a single frame carrying `buf` as a UDP datagram payload. The
+    /// caller is responsible for draining the stream (calling `poll_write`
+    /// with an empty buf is a no-op here; the higher-level
+    /// `SnellPacketConn::write_packet` uses a dedicated path that owns the
+    /// stream mutex and drives the drain to completion).
+    pub fn stage_packet_frame(&mut self, buf: &[u8]) -> io::Result<()> {
+        if buf.len() > MAX_PAYLOAD_LENGTH {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snell v4 packet frame too large",
+            ));
+        }
+        let padding_length = self.writer.next_frame_padding_length(buf.len());
+        self.writer.pending_input = buf.len();
+        self.writer.stage_frame(buf, padding_length)
+    }
+
+    pub fn has_pending_write(&self) -> bool {
+        self.writer.pending_off < self.writer.pending.len()
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for V4Conn<S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        out: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        loop {
+            match &mut this.reader {
+                ReaderState::NeedSalt {
+                    salt_buf,
+                    salt_progress,
+                } => {
+                    let mut tmp = [0u8; V4_SALT_SIZE];
+                    let need = V4_SALT_SIZE - *salt_progress;
+                    let mut rb = ReadBuf::new(&mut tmp[..need]);
+                    match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Ready(Ok(())) => {}
+                    }
+                    let n = rb.filled().len();
+                    if n == 0 {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "snell v4 EOF before salt",
+                        )));
+                    }
+                    salt_buf[*salt_progress..*salt_progress + n].copy_from_slice(&tmp[..n]);
+                    *salt_progress += n;
+                    if *salt_progress < V4_SALT_SIZE {
+                        continue;
+                    }
+                    let aead = Arc::new(aes_gcm(&snell_kdf(&this.psk, &salt_buf[..], 16)));
+                    this.reader = ReaderState::ReadingHeader {
+                        aead,
+                        nonce: [0u8; V4_NONCE_SIZE],
+                        header_buf: [0u8; V4_HEADER_CIPHER_SIZE],
+                        header_progress: 0,
+                    };
+                }
+                ReaderState::Drain {
+                    aead,
+                    nonce,
+                    payload,
+                    payload_off,
+                } => {
+                    let avail = &payload[*payload_off..];
+                    if avail.is_empty() {
+                        let aead = Arc::clone(aead);
+                        let nonce = *nonce;
+                        this.reader = ReaderState::ReadingHeader {
+                            aead,
+                            nonce,
+                            header_buf: [0u8; V4_HEADER_CIPHER_SIZE],
+                            header_progress: 0,
+                        };
+                        continue;
+                    }
+                    let take = avail.len().min(out.remaining());
+                    out.put_slice(&avail[..take]);
+                    *payload_off += take;
+                    return Poll::Ready(Ok(()));
+                }
+                ReaderState::ReadingHeader {
+                    aead,
+                    nonce,
+                    header_buf,
+                    header_progress,
+                } => {
+                    let need = V4_HEADER_CIPHER_SIZE - *header_progress;
+                    let mut tmp = [0u8; V4_HEADER_CIPHER_SIZE];
+                    let mut rb = ReadBuf::new(&mut tmp[..need]);
+                    match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Ready(Ok(())) => {}
+                    }
+                    let n = rb.filled().len();
+                    if n == 0 {
+                        // Clean EOF on a frame boundary: the peer closed the
+                        // TCP without sending the zero-chunk half-close.
+                        // Treat it as a normal EOF for the caller (matches
+                        // io.EOF semantics in opensnell's Reader). Mid-header
+                        // partial reads, however, are protocol errors.
+                        if *header_progress == 0 {
+                            return Poll::Ready(Ok(()));
+                        }
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "snell v4 EOF mid-header",
+                        )));
+                    }
+                    header_buf[*header_progress..*header_progress + n].copy_from_slice(&tmp[..n]);
+                    *header_progress += n;
+                    if *header_progress < V4_HEADER_CIPHER_SIZE {
+                        continue;
+                    }
+                    let mut sealed = header_buf.to_vec();
+                    if let Err(e) = open_in_place(aead, nonce, &mut sealed) {
+                        return Poll::Ready(Err(e));
+                    }
+                    increment_nonce(nonce);
+                    if sealed.len() != V4_HEADER_PLAIN_SIZE || sealed[0] != 4 {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "snell v4 invalid frame header",
+                        )));
+                    }
+                    let padding_len = u16::from_be_bytes([sealed[3], sealed[4]]) as usize;
+                    let payload_len = u16::from_be_bytes([sealed[5], sealed[6]]) as usize;
+                    if payload_len == 0 {
+                        if padding_len != 0 {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "snell v4 zero chunk with padding",
+                            )));
+                        }
+                        let aead_keep = Arc::clone(aead);
+                        let nonce_keep = *nonce;
+                        this.reader = ReaderState::ReadingHeader {
+                            aead: aead_keep,
+                            nonce: nonce_keep,
+                            header_buf: [0u8; V4_HEADER_CIPHER_SIZE],
+                            header_progress: 0,
+                        };
+                        return Poll::Ready(Err(zero_chunk_err()));
+                    }
+                    if payload_len > MAX_PAYLOAD_LENGTH || padding_len > MAX_PAYLOAD_LENGTH {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "snell v4 frame too large",
+                        )));
+                    }
+                    let body_size = padding_len + payload_len + V4_GCM_TAG;
+                    let aead = Arc::clone(aead);
+                    let nonce = *nonce;
+                    this.reader = ReaderState::ReadingBody {
+                        aead,
+                        nonce,
+                        padding_len,
+                        payload_len,
+                        body_buf: vec![0u8; body_size],
+                        body_progress: 0,
+                    };
+                }
+                ReaderState::ReadingBody {
+                    aead,
+                    nonce,
+                    padding_len,
+                    payload_len,
+                    body_buf,
+                    body_progress,
+                } => {
+                    if *body_progress < body_buf.len() {
+                        let mut rb = ReadBuf::new(&mut body_buf[*body_progress..]);
+                        match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+                            Poll::Pending => return Poll::Pending,
+                            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                            Poll::Ready(Ok(())) => {}
+                        }
+                        let n = rb.filled().len();
+                        if n == 0 {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "snell v4 EOF mid-body",
+                            )));
+                        }
+                        *body_progress += n;
+                        if *body_progress < body_buf.len() {
+                            continue;
+                        }
+                    }
+                    let (padding_part, payload_part) = body_buf.split_at_mut(*padding_len);
+                    if *padding_len > 0 {
+                        swap_padding(padding_part, payload_part);
+                    }
+                    let mut payload_cipher = payload_part.to_vec();
+                    if let Err(e) = open_in_place(aead, nonce, &mut payload_cipher) {
+                        return Poll::Ready(Err(e));
+                    }
+                    increment_nonce(nonce);
+                    debug_assert_eq!(payload_cipher.len(), *payload_len);
+                    let aead = Arc::clone(aead);
+                    let nonce = *nonce;
+                    this.reader = ReaderState::Drain {
+                        aead,
+                        nonce,
+                        payload: payload_cipher,
+                        payload_off: 0,
+                    };
+                }
+            }
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for V4Conn<S> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = &mut *self;
+        if this.writer.pending_off < this.writer.pending.len() {
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {
+                    let consumed = std::mem::take(&mut this.writer.pending_input);
+                    return Poll::Ready(Ok(consumed));
+                }
+            }
+        }
+
+        if buf.is_empty() {
+            this.writer.pending_input = 0;
+            this.writer.stage_frame(&[], 0)?;
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(0)),
+            }
+        } else {
+            let limit = this.writer.next_payload_limit() as usize;
+            let limit = if limit == 0 || limit > MAX_PAYLOAD_LENGTH {
+                MAX_PAYLOAD_LENGTH
+            } else {
+                limit
+            };
+            let take = buf.len().min(limit);
+            let chunk = &buf[..take];
+            let padding_length = this.writer.next_frame_padding_length(chunk.len());
+            this.writer.pending_input = take;
+            this.writer.stage_frame(chunk, padding_length)?;
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {
+                    let consumed = std::mem::take(&mut this.writer.pending_input);
+                    Poll::Ready(Ok(consumed))
+                }
+            }
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        if this.writer.pending_off < this.writer.pending.len() {
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {}
+            }
+        }
+        Pin::new(&mut this.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        if this.writer.pending_off < this.writer.pending.len() {
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {}
+            }
+        }
+        Pin::new(&mut this.inner).poll_shutdown(cx)
+    }
+}
+
+fn drain_writer<S: AsyncWrite + Unpin>(
+    writer: &mut Writer,
+    inner: &mut S,
+    cx: &mut Context<'_>,
+) -> Poll<io::Result<()>> {
+    while writer.pending_off < writer.pending.len() {
+        let slice = &writer.pending[writer.pending_off..];
+        match Pin::new(&mut *inner).poll_write(cx, slice) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Ready(Ok(0)) => {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "snell v4: short write",
+                )));
+            }
+            Poll::Ready(Ok(n)) => writer.pending_off += n,
+        }
+    }
+    writer.pending.clear();
+    writer.pending_off = 0;
+    Poll::Ready(Ok(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn increment_nonce_wraps() {
+        let mut n = [0xFFu8; V4_NONCE_SIZE];
+        increment_nonce(&mut n);
+        assert_eq!(n, [0u8; V4_NONCE_SIZE]);
+    }
+
+    #[test]
+    fn swap_padding_round_trips() {
+        let mut p = vec![1u8, 2, 3, 4, 5, 6];
+        let mut c = vec![10u8, 20, 30, 40, 50, 60];
+        let (orig_p, orig_c) = (p.clone(), c.clone());
+        swap_padding(&mut p, &mut c);
+        swap_padding(&mut p, &mut c);
+        assert_eq!(p, orig_p);
+        assert_eq!(c, orig_c);
+    }
+
+    #[test]
+    fn bit_count_padding_has_requested_ones() {
+        let pad = make_v4_bit_count_padding(16, 40).unwrap();
+        let ones: u32 = pad.iter().map(|b| b.count_ones()).sum();
+        assert_eq!(ones, 40);
+    }
+
+    /// End-to-end: two V4Conn instances over a duplex stream should round-trip
+    /// arbitrary payloads, including bursts that overflow the first-frame limit.
+    #[tokio::test]
+    async fn v4_round_trip_through_duplex() {
+        let (a, b) = tokio::io::duplex(1 << 18);
+        let psk: Arc<[u8]> = Arc::from(b"shared-secret".as_slice());
+        let mut alice = V4Conn::new(a, Arc::clone(&psk));
+        let mut bob = V4Conn::new(b, psk);
+
+        // Alice writes a small payload, then a large burst.
+        let small = b"hello-world";
+        let large: Vec<u8> = (0..32_000u32).map(|i| (i % 251) as u8).collect();
+
+        let writer = tokio::spawn(async move {
+            alice.write_all(small).await.unwrap();
+            alice.write_all(&large).await.unwrap();
+            alice.flush().await.unwrap();
+            // Keep alice alive for the read side to consume everything.
+            alice
+        });
+
+        let mut got_small = vec![0u8; small.len()];
+        bob.read_exact(&mut got_small).await.unwrap();
+        assert_eq!(got_small, small);
+
+        let mut got_large = vec![0u8; 32_000];
+        bob.read_exact(&mut got_large).await.unwrap();
+        let expected: Vec<u8> = (0..32_000u32).map(|i| (i % 251) as u8).collect();
+        assert_eq!(got_large, expected);
+
+        drop(writer.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn v4_zero_chunk_surfaces_as_tagged_error() {
+        let (a, b) = tokio::io::duplex(8192);
+        let psk: Arc<[u8]> = Arc::from(b"k".as_slice());
+        let mut alice = V4Conn::new(a, Arc::clone(&psk));
+        let mut bob = V4Conn::new(b, psk);
+
+        // Alice sends one real frame, then a zero chunk. `write_all(&[])`
+        // is a no-op in tokio because the future short-circuits on empty
+        // input, so we drive `poll_write(&[])` by hand to actually emit
+        // the zero-chunk frame.
+        alice.write_all(b"abc").await.unwrap();
+        alice.flush().await.unwrap();
+        std::future::poll_fn(|cx| Pin::new(&mut alice).poll_write(cx, &[]))
+            .await
+            .unwrap();
+        alice.flush().await.unwrap();
+
+        let mut buf = [0u8; 3];
+        bob.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"abc");
+
+        let mut more = [0u8; 1];
+        let err = bob.read_exact(&mut more).await.unwrap_err();
+        assert!(is_zero_chunk(&err), "expected zero-chunk tag, got {err:?}");
+    }
+}

--- a/crates/meow-proxy/tests/snell_smoke.rs
+++ b/crates/meow-proxy/tests/snell_smoke.rs
@@ -1,0 +1,173 @@
+//! End-to-end smoke test against a real Snell server.
+//!
+//! Gated behind the `SNELL_SMOKE` env var so CI doesn't dial anyone.
+//! Example:
+//!
+//! ```bash
+//! SNELL_SMOKE=1 SNELL_SERVER=82.40.35.29:63689 SNELL_PSK=... \
+//!     cargo test -p meow-proxy --features snell --test snell_smoke -- --nocapture
+//! ```
+
+#![cfg(feature = "snell")]
+
+use meow_proxy::snell::protocol::{write_header, Snell};
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::net::TcpStream;
+
+fn opt_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+/// Transparent wrapper that prints every chunk of bytes that flows across
+/// the TCP stream in both directions. Useful for spotting wire-format bugs.
+struct Sniffer {
+    inner: TcpStream,
+    label: &'static str,
+}
+
+impl AsyncRead for Sniffer {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        match Pin::new(&mut self.inner).poll_read(cx, buf) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => {
+                eprintln!("[{}] READ ERR: {e}", self.label);
+                Poll::Ready(Err(e))
+            }
+            Poll::Ready(Ok(())) => {
+                let n = buf.filled().len() - before;
+                if n > 0 {
+                    let slice = &buf.filled()[before..];
+                    eprintln!(
+                        "[{}] READ {} bytes: {}",
+                        self.label,
+                        n,
+                        hex::encode(&slice[..slice.len().min(64)])
+                    );
+                } else {
+                    eprintln!("[{}] READ 0 (EOF)", self.label);
+                }
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+}
+
+impl AsyncWrite for Sniffer {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match Pin::new(&mut self.inner).poll_write(cx, buf) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(n)) => {
+                eprintln!(
+                    "[{}] WRITE {} bytes: {}",
+                    self.label,
+                    n,
+                    hex::encode(&buf[..n.min(64)])
+                );
+                Poll::Ready(Ok(n))
+            }
+        }
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snell_dial_real_server() {
+    if opt_env("SNELL_SMOKE").is_none() {
+        eprintln!("SNELL_SMOKE not set; skipping. Set it to run this test.");
+        return;
+    }
+    let server_addr =
+        opt_env("SNELL_SERVER").expect("SNELL_SERVER (host:port) required when SNELL_SMOKE=1");
+    let psk = opt_env("SNELL_PSK").expect("SNELL_PSK required when SNELL_SMOKE=1");
+
+    let target_host = opt_env("SNELL_TARGET_HOST").unwrap_or_else(|| "httpbin.org".to_string());
+    let target_port: u16 = opt_env("SNELL_TARGET_PORT")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(80);
+    let target_path = opt_env("SNELL_TARGET_PATH").unwrap_or_else(|| "/ip".to_string());
+
+    eprintln!("snell smoke: dialing {target_host}:{target_port} via {server_addr} (reuse=false)");
+
+    let tcp = tokio::time::timeout(Duration::from_secs(8), TcpStream::connect(&server_addr))
+        .await
+        .expect("tcp connect timeout")
+        .expect("tcp connect ok");
+    tcp.set_nodelay(true).ok();
+    let sniffer = Sniffer {
+        inner: tcp,
+        label: "snell-tcp",
+    };
+
+    let mut snell = Snell::new(sniffer, Arc::from(psk.as_bytes()));
+
+    // Snell CONNECT request (reuse=false).
+    write_header(&mut snell, &target_host, target_port, false)
+        .await
+        .expect("write snell header");
+    snell.flush().await.expect("flush snell header");
+
+    // HTTP/1.0 GET.
+    let request =
+        format!("GET {target_path} HTTP/1.0\r\nHost: {target_host}\r\nConnection: close\r\n\r\n");
+    snell
+        .write_all(request.as_bytes())
+        .await
+        .expect("write http req");
+    snell.flush().await.expect("flush http req");
+
+    // Read up to 4 KiB; we read in a loop so a mid-stream snell error
+    // doesn't discard the bytes we already have.
+    let mut buf = Vec::with_capacity(4096);
+    let mut scratch = [0u8; 1024];
+    loop {
+        let n = match tokio::time::timeout(Duration::from_secs(10), snell.read(&mut scratch)).await
+        {
+            Err(_) => {
+                eprintln!("read timed out after {} bytes", buf.len());
+                break;
+            }
+            Ok(Err(e)) => {
+                eprintln!("read error after {} bytes: {e}", buf.len());
+                break;
+            }
+            Ok(Ok(0)) => {
+                eprintln!("read EOF (snell zero-chunk) after {} bytes", buf.len());
+                break;
+            }
+            Ok(Ok(n)) => n,
+        };
+        buf.extend_from_slice(&scratch[..n]);
+        if buf.len() >= 4096 {
+            break;
+        }
+    }
+    let head = String::from_utf8_lossy(&buf);
+    eprintln!("--- decoded server response (first 400 B) ---");
+    eprintln!("{}", &head[..head.len().min(400)]);
+    eprintln!("--- end ({} B total) ---", buf.len());
+    assert!(
+        head.starts_with("HTTP/1."),
+        "expected HTTP response head, got: {:?}",
+        &head[..head.len().min(80)]
+    );
+}


### PR DESCRIPTION
## Summary

- New `meow-proxy::snell` module porting the client side of [missuo/opensnell](https://github.com/missuo/opensnell): Argon2id KDF + AES-128-GCM AEAD framing with padding interleave and burst-aware payload-limit ramp-up, optional http/tls simple-obfs (reusing the SS codec), UDP-over-TCP datagram framing exposed as a `ProxyPacketConn`, and a bounded LIFO reuse pool for `CommandConnectV2` sessions (10 idle / 15 s max age / 2 uses per conn / 500 ms tail drain).
- YAML parser accepts mihomo-compatible `type: snell` blocks (`server`, `port`, `psk`, `version`, `udp`, `reuse`, `obfs-opts.{mode,host}`).
- New `snell` cargo feature on `meow-proxy` + `meow-config`, enabled by default.

Wire format implemented = snell v4 / v5 (client-side identical, matching opensnell's scope). Mihomo's legacy v1 / v2 / v3 wires are intentionally rejected at parse time with a Class-A error per ADR-0002.

Closes the Snell row in `docs/gap-analysis.md` (was "Medium priority Gap").

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings` — default features, `--no-default-features --features snell`, and the touched-crate set all clean.
- [x] `cargo test -p meow-proxy --features snell --lib snell::` — 9 unit tests pass (KDF determinism, AEAD frame round-trip through a duplex, bit-balanced padding, padding swap reversibility, nonce wrap, zero-chunk half-close detection, UDP request frame layout v4/v6).
- [x] Live end-to-end smoke test (`crates/meow-proxy/tests/snell_smoke.rs`, gated behind `SNELL_SMOKE=1` so CI never dials anyone): `SNELL_SMOKE=1 SNELL_SERVER=… SNELL_PSK=… cargo test -p meow-proxy --features snell --test snell_smoke -- --nocapture` — proxied `GET /ip` to `httpbin.org` and got back `HTTP/1.1 200 OK` with the `origin` field showing the proxy's IP, confirming the full handshake / AEAD / response-decode path is correct.

## Reference

Built by porting [`missuo/opensnell`](https://github.com/missuo/opensnell)'s `components/snell` client package to Rust + tokio. The reuse-pool semantics (max 2 sessions per TCP, 500 ms drain-before-reuse) and the v4 payload-limit ramp + padding-interleave specifics all follow that reference verbatim.