### PR TITLE
Replace bloom filters with prefix trie for ZST domain matching

### DIFF
--- a/crates/meow-rules/tests/geosite_rss_test.rs
+++ b/crates/meow-rules/tests/geosite_rss_test.rs
@@ -1,0 +1,334 @@
+//! RSS measurement for GeositeDB loading with the prefix-trie domain engine.
+//!
+//! Builds synthetic geosite MRS payloads at realistic scale (matching the
+//! MetaCubeX wiki config categories), loads them into `GeositeDB`, forces
+//! trie compilation via lookups, and reports before/after RSS.
+//!
+//! `#[ignore]`-gated so it does not run in normal `cargo test`. Invoke with:
+//!
+//!     cargo test -p meow-rules --test geosite_rss_test --release -- --ignored --nocapture
+
+use meow_rules::geosite::GeositeDB;
+use meow_rules::mrs_parser::{write_geosite_mrs, GeositePayload};
+
+fn rss_kb() -> u64 {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            let s = rest.trim().trim_end_matches(" kB").trim();
+            return s.parse().unwrap_or(0);
+        }
+    }
+    0
+}
+
+fn generate_cn_domains(count: usize) -> Vec<String> {
+    let tlds = [
+        "baidu.com",
+        "qq.com",
+        "taobao.com",
+        "jd.com",
+        "163.com",
+        "sina.com.cn",
+        "weibo.com",
+        "sohu.com",
+        "ifeng.com",
+        "zhihu.com",
+        "douyin.com",
+        "toutiao.com",
+        "bytedance.com",
+        "alibaba.com",
+        "alipay.com",
+        "tmall.com",
+        "meituan.com",
+        "dianping.com",
+        "xiaomi.com",
+        "huawei.com",
+        "oppo.com",
+        "vivo.com",
+        "pinduoduo.com",
+        "kuaishou.com",
+        "bilibili.com",
+        "iqiyi.com",
+        "youku.com",
+        "ctrip.com",
+        "suning.com",
+        "ele.me",
+        "csdn.net",
+        "cnbeta.com",
+        "segmentfault.com",
+        "oschina.net",
+        "zhimg.com",
+        "douban.com",
+        "jianshu.com",
+        "qcloud.com",
+        "tencent.com",
+        "netease.com",
+    ];
+    let prefixes = [
+        "+.",
+        "*.api.",
+        "*.cdn.",
+        "*.static.",
+        "*.m.",
+        "*.www.",
+        "*.app.",
+    ];
+    let mut domains = Vec::with_capacity(count);
+    let mut i = 0;
+    'outer: loop {
+        for tld in &tlds {
+            if i >= count {
+                break 'outer;
+            }
+            domains.push(tld.to_string());
+            i += 1;
+            for prefix in &prefixes {
+                if i >= count {
+                    break 'outer;
+                }
+                domains.push(format!("{prefix}{tld}"));
+                i += 1;
+            }
+            for j in 0..20 {
+                if i >= count {
+                    break 'outer;
+                }
+                domains.push(format!("service{j}-{}.{tld}", i % 100));
+                i += 1;
+            }
+        }
+    }
+    domains
+}
+
+fn generate_google_domains() -> Vec<String> {
+    let mut domains = vec![
+        "google-ohttp-relay-safebrowsing.fastly-edge.com".into(),
+        "publicca.googleapis.com".into(),
+        "clients1.google.com".into(),
+        "ai.google.dev".into(),
+        "notebooklm.googleapis.com".into(),
+        "yt3.googleusercontent.com".into(),
+    ];
+    let ccodes = [
+        "ae", "at", "be", "bg", "ca", "ch", "cl", "cn", "cz", "de", "dk", "es", "fi", "fr", "gr",
+        "hu", "is", "it", "lt", "lu", "lv", "nl", "no", "pl", "pt", "ro", "rs", "ru", "se", "sk",
+    ];
+    for cc in &ccodes {
+        domains.push(format!("+.google.{cc}"));
+    }
+    let suffixes = [
+        "googleapis.com",
+        "googleusercontent.com",
+        "googlevideo.com",
+        "gstatic.com",
+        "googletagmanager.com",
+        "googleadservices.com",
+        "googlesyndication.com",
+        "googleanalytics.com",
+        "google-analytics.com",
+        "googleoptimize.com",
+        "doubleclick.net",
+        "googlesource.com",
+        "chromium.org",
+    ];
+    for s in &suffixes {
+        domains.push(format!("+.{s}"));
+    }
+    domains.push("+.google.com".into());
+    for i in 0..200 {
+        domains.push(format!("extra-svc{i}.googleapis.com"));
+    }
+    domains
+}
+
+fn generate_twitter_domains() -> Vec<String> {
+    vec![
+        ".twitter.jp",
+        ".x.com",
+        ".t.co",
+        ".twimg.com",
+        ".twitpic.com",
+        ".twitter.com",
+        ".twittercommunity.com",
+        ".twtrdns.net",
+        ".twttr.com",
+        ".twttr.net",
+        ".vine.co",
+        ".ads-twitter.com",
+        ".pscp.tv",
+        ".periscope.tv",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+fn generate_youtube_domains() -> Vec<String> {
+    let mut domains = vec![
+        "yt3.googleusercontent.com".to_string(),
+        "+.ytimg.com".into(),
+        "+.youtu.be".into(),
+        "+.youtube-nocookie.com".into(),
+        "+.yt.be".into(),
+        "+.ggpht.com".into(),
+        "+.youtube.com".into(),
+        "+.googlevideo.com".into(),
+    ];
+    let ccodes = [
+        "ae", "al", "am", "at", "az", "ba", "be", "bg", "bh", "bo", "by", "ca", "ch", "cl", "co",
+        "cr", "cz", "de", "dk", "ee", "es", "fi", "fr", "ge", "gr", "gt", "hk", "hr", "hu", "ie",
+        "in", "iq", "is", "it", "jo", "jp", "kr", "kz", "la", "lk", "lt", "lu", "lv", "ly", "ma",
+        "md", "me", "mk", "mn", "mx", "my", "ng", "ni", "nl", "no", "pa", "pe", "ph", "pk", "pl",
+        "pr", "pt", "qa", "ro", "rs", "ru", "sa", "se", "sg", "si", "sk", "sn", "sv", "tn", "tv",
+        "ua", "ug", "uy", "vn",
+    ];
+    for cc in &ccodes {
+        domains.push(format!("+.youtube.{cc}"));
+    }
+    domains
+}
+
+fn generate_netflix_domains() -> Vec<String> {
+    vec![
+        "netflix.com.edgesuite.net",
+        "+.fast.com",
+        "+.netflix.com",
+        "+.netflix.net",
+        "+.nflxext.com",
+        "+.nflximg.com",
+        "+.nflximg.net",
+        "+.nflxsearch.net",
+        "+.nflxso.net",
+        "+.nflxvideo.net",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+fn generate_telegram_domains() -> Vec<String> {
+    vec![
+        ".cdn-telegram.org",
+        ".t.me",
+        ".telegram.org",
+        ".telegram.me",
+        ".telegra.ph",
+        ".telegram-cdn.org",
+        ".tg.dev",
+        ".ton.org",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+fn build_geosite_payload(cn_count: usize) -> GeositePayload {
+    GeositePayload {
+        categories: vec![
+            ("cn".into(), generate_cn_domains(cn_count)),
+            ("google".into(), generate_google_domains()),
+            ("twitter".into(), generate_twitter_domains()),
+            ("youtube".into(), generate_youtube_domains()),
+            ("netflix".into(), generate_netflix_domains()),
+            ("telegram".into(), generate_telegram_domains()),
+        ],
+    }
+}
+
+fn force_compile(db: &GeositeDB, categories: &[&str]) {
+    for cat in categories {
+        db.lookup(cat, "nonexistent-probe.test.invalid");
+    }
+}
+
+#[test]
+#[ignore = "RSS measurement; opt in with --ignored --nocapture"]
+fn geosite_rss_scaling() {
+    let cats = ["cn", "google", "twitter", "youtube", "netflix", "telegram"];
+    let cn_sizes = [1_000, 5_000, 10_000, 30_000, 50_000];
+
+    println!();
+    println!("=== GeositeDB RSS scaling (prefix trie) ===");
+    println!(
+        "{:<12} {:<12} {:<12} {:<12} {:<14} {:<12}",
+        "cn_domains", "total_doms", "mrs_bytes", "rss_before", "rss_after(kB)", "delta(kB)"
+    );
+    println!("{}", "-".repeat(78));
+
+    for &cn_count in &cn_sizes {
+        let payload = build_geosite_payload(cn_count);
+        let total_domains: usize = payload.categories.iter().map(|(_, d)| d.len()).sum();
+        let mrs_bytes = write_geosite_mrs(&payload).unwrap();
+        let mrs_len = mrs_bytes.len();
+
+        // Force GC / stabilize
+        drop(payload);
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        let rss_before = rss_kb();
+
+        let db = GeositeDB::from_bytes(&mrs_bytes, None).unwrap();
+        force_compile(&db, &cats);
+
+        let rss_after = rss_kb();
+        let delta = rss_after.saturating_sub(rss_before);
+
+        println!(
+            "{cn_count:<12} {total_domains:<12} {mrs_len:<12} {rss_before:<14} {rss_after:<14} {delta:<12}"
+        );
+
+        // Keep db alive until after measurement
+        std::hint::black_box(&db);
+        drop(db);
+    }
+
+    // Final run: full-scale with 50k CN + all categories, verify RSS delta
+    println!();
+    println!("--- Full-scale validation (50k CN domains) ---");
+
+    let payload = build_geosite_payload(50_000);
+    let total: usize = payload.categories.iter().map(|(_, d)| d.len()).sum();
+    let mrs_bytes = write_geosite_mrs(&payload).unwrap();
+
+    drop(payload);
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let rss_before = rss_kb();
+
+    let db = GeositeDB::from_bytes(&mrs_bytes, None).unwrap();
+    force_compile(&db, &cats);
+
+    // Verify all categories loaded
+    assert_eq!(db.category_count(), 6);
+    assert!(db.lookup("google", "clients1.google.com"));
+    assert!(db.lookup("google", "www.googleapis.com"));
+    assert!(db.lookup("twitter", "api.twitter.com"));
+    assert!(db.lookup("youtube", "www.youtube.com"));
+    assert!(db.lookup("netflix", "api.netflix.com"));
+    assert!(db.lookup("telegram", "web.telegram.org"));
+
+    // Verify no false positives
+    assert!(!db.lookup("google", "notgoogle.example.com"));
+    assert!(!db.lookup("cn", "random.example.org"));
+    assert!(!db.lookup("twitter", "api.facebook.com"));
+
+    let rss_after = rss_kb();
+    let delta_kb = rss_after.saturating_sub(rss_before);
+    let delta_mb = delta_kb as f64 / 1024.0;
+
+    println!("total domains: {total}");
+    println!("mrs file size: {} bytes", mrs_bytes.len());
+    println!("rss before:    {rss_before} kB");
+    println!("rss after:     {rss_after} kB");
+    println!("rss delta:     {delta_kb} kB ({delta_mb:.1} MB)");
+
+    std::hint::black_box(&db);
+
+    // Sanity: 50k domains should not consume more than 50 MB
+    assert!(
+        delta_mb < 50.0,
+        "RSS delta {delta_mb:.1} MB exceeds 50 MB budget for {total} domains"
+    );
+}

--- a/crates/meow-trie/src/trie.rs
+++ b/crates/meow-trie/src/trie.rs
@@ -21,26 +21,38 @@ enum MatchKind {
     Dot,
 }
 
+// ---------------------------------------------------------------------------
+// Prefix trie node for the ZST path (0% false-positive rate).
+// Labels are stored in reverse order (TLD first): com → google → www.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct TrieNode {
+    children: HashMap<Box<str>, TrieNode>,
+    exact: bool,
+    star: bool,
+    dot: bool,
+}
+
 enum Compiled<T> {
     Empty,
-    /// ZST path: pure Bloom filters (~0.1% FPR). Filter size is dynamic,
-    /// computed as `n * 14.4` bits for `n` items to guarantee <0.1% FPR.
-    BloomCheck {
-        exact: BloomFilter,
-        star: BloomFilter,
-        dot: BloomFilter,
+    /// ZST path: real prefix trie — 0% false-positive rate.
+    TrieCheck {
+        root: TrieNode,
         value: T,
     },
     /// Value-bearing path: Bloom filters for fast rejection, HashMaps for
     /// exact value retrieval on hits (effective FPR = 0%).
-    BloomMap {
-        exact_bloom: BloomFilter,
-        star_bloom: BloomFilter,
-        dot_bloom: BloomFilter,
-        exact: HashMap<String, T>,
-        star: HashMap<String, T>,
-        dot: HashMap<String, T>,
-    },
+    BloomMap(Box<BloomMapData<T>>),
+}
+
+struct BloomMapData<T> {
+    exact_bloom: BloomFilter,
+    star_bloom: BloomFilter,
+    dot_bloom: BloomFilter,
+    exact: HashMap<String, T>,
+    star: HashMap<String, T>,
+    dot: HashMap<String, T>,
 }
 
 impl<T: Clone + 'static> DomainTrie<T> {
@@ -138,50 +150,47 @@ impl<T: Clone + 'static> DomainTrie<T> {
 
         match compiled {
             Compiled::Empty => None,
-            Compiled::BloomCheck {
-                exact,
-                star,
-                dot,
-                value,
-            } => {
-                if exact.maybe_contains(query) {
-                    return Some(value);
-                }
-                for (i, _) in query.match_indices('.') {
-                    let suffix = &query[i..];
-                    let prefix = &query[..i];
-                    if star.maybe_contains(suffix) && !prefix.contains('.') {
-                        return Some(value);
-                    }
-                    if dot.maybe_contains(suffix) {
-                        return Some(value);
+            Compiled::TrieCheck { root, value } => {
+                let labels: smallvec::SmallVec<[&str; 8]> = query.rsplit('.').collect();
+                let n = labels.len();
+                let mut node = root;
+
+                for (d, label) in labels.iter().enumerate() {
+                    match node.children.get(*label) {
+                        None => return None,
+                        Some(child) => {
+                            node = child;
+                            let remaining = n - d - 1;
+                            if remaining == 0 && node.exact {
+                                return Some(value);
+                            }
+                            if remaining == 1 && node.star {
+                                return Some(value);
+                            }
+                            if remaining > 0 && node.dot {
+                                return Some(value);
+                            }
+                        }
                     }
                 }
                 None
             }
-            Compiled::BloomMap {
-                exact_bloom,
-                star_bloom,
-                dot_bloom,
-                exact,
-                star,
-                dot,
-            } => {
-                if exact_bloom.maybe_contains(query) {
-                    if let Some(v) = exact.get(query) {
+            Compiled::BloomMap(data) => {
+                if data.exact_bloom.maybe_contains(query) {
+                    if let Some(v) = data.exact.get(query) {
                         return Some(v);
                     }
                 }
                 for (i, _) in query.match_indices('.') {
                     let suffix = &query[i..];
                     let prefix = &query[..i];
-                    if !prefix.contains('.') && star_bloom.maybe_contains(suffix) {
-                        if let Some(v) = star.get(suffix) {
+                    if !prefix.contains('.') && data.star_bloom.maybe_contains(suffix) {
+                        if let Some(v) = data.star.get(suffix) {
                             return Some(v);
                         }
                     }
-                    if dot_bloom.maybe_contains(suffix) {
-                        if let Some(v) = dot.get(suffix) {
+                    if data.dot_bloom.maybe_contains(suffix) {
+                        if let Some(v) = data.dot.get(suffix) {
                             return Some(v);
                         }
                     }
@@ -206,7 +215,7 @@ impl<T: Clone + 'static> DomainTrie<T> {
         }
 
         if std::mem::size_of::<T>() == 0 {
-            Self::compile_bloom(&entries)
+            Self::compile_trie(&entries)
         } else {
             Self::compile_bloom_map(entries)
         }
@@ -239,26 +248,28 @@ impl<T: Clone + 'static> DomainTrie<T> {
             }
         }
 
-        Compiled::BloomMap {
+        Compiled::BloomMap(Box::new(BloomMapData {
             exact_bloom: BloomFilter::from_items(&exact_items),
             star_bloom: BloomFilter::from_items(&star_items),
             dot_bloom: BloomFilter::from_items(&dot_items),
             exact: exact_map,
             star: star_map,
             dot: dot_map,
-        }
+        }))
     }
 
-    fn compile_bloom(entries: &[Entry<T>]) -> Compiled<T> {
-        let mut exact_items: Vec<String> = Vec::new();
-        let mut star_items: Vec<String> = Vec::new();
-        let mut dot_items: Vec<String> = Vec::new();
+    fn compile_trie(entries: &[Entry<T>]) -> Compiled<T> {
+        let mut root = TrieNode::default();
 
         for e in entries {
+            let mut node = &mut root;
+            for label in e.base_domain.rsplit('.') {
+                node = node.children.entry(label.into()).or_default();
+            }
             match e.kind {
-                MatchKind::Exact => exact_items.push(e.base_domain.clone()),
-                MatchKind::Star => star_items.push(format!(".{}", e.base_domain)),
-                MatchKind::Dot => dot_items.push(format!(".{}", e.base_domain)),
+                MatchKind::Exact => node.exact = true,
+                MatchKind::Star => node.star = true,
+                MatchKind::Dot => node.dot = true,
             }
         }
 
@@ -268,12 +279,7 @@ impl<T: Clone + 'static> DomainTrie<T> {
             std::mem::MaybeUninit::<T>::uninit().assume_init()
         };
 
-        Compiled::BloomCheck {
-            exact: BloomFilter::from_items(&exact_items),
-            star: BloomFilter::from_items(&star_items),
-            dot: BloomFilter::from_items(&dot_items),
-            value,
-        }
+        Compiled::TrieCheck { root, value }
     }
 }
 
@@ -425,6 +431,35 @@ mod proptests {
                     trie_hit,
                     naive_hit,
                     "divergence on query {:?} with patterns {:?}",
+                    q,
+                    patterns
+                );
+            }
+        }
+
+        #[test]
+        fn matches_naive_reference_zst(
+            patterns in proptest::collection::vec(
+                "[a-z]{1,5}(\\.[a-z]{1,5}){0,3}|\\*\\.[a-z]{1,5}(\\.[a-z]{1,5}){0,2}",
+                1..=20,
+            ),
+            queries in proptest::collection::vec(
+                "[a-z]{1,5}(\\.[a-z]{1,5}){0,4}",
+                1..=10,
+            ),
+        ) {
+            let mut trie: DomainTrie<()> = DomainTrie::new();
+            for p in &patterns {
+                trie.insert(p, ());
+            }
+            let naive = NaiveMatcher::new(&patterns);
+            for q in &queries {
+                let trie_hit = trie.search(q).is_some();
+                let naive_hit = naive.matches(q);
+                prop_assert_eq!(
+                    trie_hit,
+                    naive_hit,
+                    "ZST divergence on query {:?} with patterns {:?}",
                     q,
                     patterns
                 );

--- a/crates/meow-trie/tests/bloom_mismatch_test.rs
+++ b/crates/meow-trie/tests/bloom_mismatch_test.rs
@@ -1,0 +1,977 @@
+//! Bloom-filter mismatch-rate tests using realistic domain rule-sets from
+//! MetaCubeX geosite categories (google, twitter, youtube, telegram, netflix,
+//! github, bilibili, spotify). Verifies the DomainTrie<()> BloomCheck path
+//! does not exceed a 1% false-positive rate for unrelated probe domains.
+
+use meow_trie::DomainTrie;
+
+// ---------------------------------------------------------------------------
+// Realistic domain lists sourced from:
+// https://github.com/MetaCubeX/meta-rules-dat (geo/geosite/*.list)
+// Format matches the wiki example configuration at:
+// https://wiki.metacubex.one/example/conf/#__tabbed_3_1
+// ---------------------------------------------------------------------------
+
+fn google_domains() -> Vec<&'static str> {
+    vec![
+        "google-ohttp-relay-safebrowsing.fastly-edge.com",
+        "publicca.googleapis.com",
+        "preprod-publicca.googleapis.com",
+        "clients1.google.com",
+        "pki.google.com",
+        "android.googlesource.com",
+        "ai.google.dev",
+        "alkalicore-pa.clients6.google.com",
+        "alkalimakersuite-pa.clients6.google.com",
+        "webchannel-alkalimakersuite-pa.clients6.google.com",
+        "cloudaicompanion.googleapis.com",
+        "cloudcode-pa.googleapis.com",
+        "daily-cloudcode-pa.googleapis.com",
+        "notebooklm-pa.googleapis.com",
+        "notebooklm.googleapis.com",
+        "antigravity-pa.googleapis.com",
+        "antigravity.googleapis.com",
+        "alt7-mtalk.google.com",
+        "alt8-mtalk.google.com",
+        "mtalk-dev.google.com",
+        "mtalk-staging.google.com",
+        "mtalk4.google.com",
+        "yt3.googleusercontent.com",
+        "+.google.com",
+        "+.google.ae",
+        "+.google.at",
+        "+.google.be",
+        "+.google.bg",
+        "+.google.ca",
+        "+.google.ch",
+        "+.google.cl",
+        "+.google.cn",
+        "+.google.co.id",
+        "+.google.co.il",
+        "+.google.co.in",
+        "+.google.co.jp",
+        "+.google.co.kr",
+        "+.google.co.nz",
+        "+.google.co.th",
+        "+.google.co.uk",
+        "+.google.co.ve",
+        "+.google.co.za",
+        "+.google.com.ar",
+        "+.google.com.au",
+        "+.google.com.br",
+        "+.google.com.co",
+        "+.google.com.eg",
+        "+.google.com.hk",
+        "+.google.com.mx",
+        "+.google.com.my",
+        "+.google.com.pe",
+        "+.google.com.ph",
+        "+.google.com.pk",
+        "+.google.com.sg",
+        "+.google.com.tr",
+        "+.google.com.tw",
+        "+.google.com.ua",
+        "+.google.com.vn",
+        "+.google.cz",
+        "+.google.de",
+        "+.google.dk",
+        "+.google.es",
+        "+.google.fi",
+        "+.google.fr",
+        "+.google.gr",
+        "+.google.hu",
+        "+.google.is",
+        "+.google.it",
+        "+.google.lt",
+        "+.google.lu",
+        "+.google.lv",
+        "+.google.nl",
+        "+.google.no",
+        "+.google.pl",
+        "+.google.pt",
+        "+.google.ro",
+        "+.google.rs",
+        "+.google.ru",
+        "+.google.se",
+        "+.google.sk",
+        "+.googleapis.com",
+        "+.googleusercontent.com",
+        "+.googlevideo.com",
+        "+.gstatic.com",
+        "+.googletagmanager.com",
+        "+.googleadservices.com",
+        "+.googlesyndication.com",
+        "+.googleanalytics.com",
+        "+.google-analytics.com",
+        "+.googleoptimize.com",
+        "+.doubleclick.net",
+        "+.googlesource.com",
+        "+.chromium.org",
+    ]
+}
+
+fn twitter_domains() -> Vec<&'static str> {
+    vec![
+        ".twitter.jp",
+        ".x.com",
+        ".cms-twdigitalassets.com",
+        ".t.co",
+        ".tellapart.com",
+        ".tweetdeck.com",
+        ".twimg.com",
+        ".twitpic.com",
+        ".twitter.biz",
+        ".twittercommunity.com",
+        ".pscp.tv",
+        ".periscope.tv",
+        ".twitter.com",
+        ".twitterflightschool.com",
+        ".twitterinc.com",
+        ".twitteroauth.com",
+        ".twitterstat.us",
+        ".twtrdns.net",
+        ".twttr.com",
+        ".twttr.net",
+        ".twvid.com",
+        ".vine.co",
+        ".twitter.map.fastly.net",
+        ".ads-twitter.com",
+    ]
+}
+
+fn youtube_domains() -> Vec<&'static str> {
+    vec![
+        "yt3.googleusercontent.com",
+        "+.youtube",
+        "+.youtube.ru",
+        "+.youtube.az",
+        "+.ytimg.com",
+        "+.withyoutube.com",
+        "+.youtu.be",
+        "+.youtube-nocookie.com",
+        "+.yt.be",
+        "+.youtube.ae",
+        "+.youtube.al",
+        "+.youtube.am",
+        "+.youtube.at",
+        "+.youtube.ro",
+        "+.youtube.ba",
+        "+.youtube.be",
+        "+.youtube.bg",
+        "+.youtube.bh",
+        "+.youtube.bo",
+        "+.youtube.by",
+        "+.youtube.ca",
+        "+.youtube.cat",
+        "+.youtube.ch",
+        "+.youtube.qa",
+        "+.youtube.co",
+        "+.youtubemobilesupport.com",
+        "+.youtubekids.com",
+        "+.youtubego.in",
+        "+.youtubego.id",
+        "+.youtubego.com",
+        "+.youtubegaming.com",
+        "+.youtubefanfest.com",
+        "+.youtubeeducation.com",
+        "+.youtube.vn",
+        "+.youtube.uy",
+        "+.youtube.ug",
+        "+.youtube.ua",
+        "+.youtube.tv",
+        "+.youtube.tn",
+        "+.youtube.sv",
+        "+.youtube.soy",
+        "+.youtube.rs",
+        "+.youtube.sk",
+        "+.ggpht.com",
+        "+.youtube.com",
+        "+.youtube.si",
+        "+.youtube.sg",
+        "+.youtube.se",
+        "+.youtube.sa",
+        "+.youtube.ee",
+        "+.youtube.sn",
+        "+.googlevideo.com",
+        "+.youtube.cl",
+        "+.youtube.pt",
+        "+.youtube.pr",
+        "+.youtube.pl",
+        "+.youtube.pk",
+        "+.youtube.ph",
+        "+.youtube.pe",
+        "+.youtube.pa",
+        "+.youtube.no",
+        "+.youtube.nl",
+        "+.youtube.ni",
+        "+.youtube.ng",
+        "+.youtube.my",
+        "+.youtube.mx",
+        "+.youtube.mn",
+        "+.youtube.mk",
+        "+.youtube.me",
+        "+.youtube.md",
+        "+.youtube.ma",
+        "+.youtube.ly",
+        "+.youtube.lv",
+        "+.youtube.lu",
+        "+.youtube.lt",
+        "+.youtube.lk",
+        "+.youtube.la",
+        "+.youtube.kz",
+        "+.youtube.kr",
+        "+.youtube.jp",
+        "+.youtube.jo",
+        "+.youtube.it",
+        "+.youtube.is",
+        "+.youtube.iq",
+        "+.youtube.in",
+        "+.youtube.ie",
+        "+.youtube.hu",
+        "+.youtube.hr",
+        "+.youtube.hk",
+        "+.youtube.gt",
+        "+.youtube.gr",
+        "+.youtube.ge",
+        "+.youtube.fr",
+        "+.youtube.fi",
+        "+.youtube.es",
+        "+.youtube.cr",
+        "+.youtube.cz",
+        "+.youtube.de",
+        "+.youtube.dk",
+        "+.youtube.co.zw",
+        "+.youtube.com.ve",
+        "+.youtube.com.uy",
+        "+.youtube.com.ua",
+        "+.youtube.com.tw",
+        "+.youtube.googleapis.com",
+        "+.youtube.com.tr",
+        "+.youtube.com.tn",
+        "+.youtube.com.sv",
+        "+.youtube.com.sg",
+        "+.youtube.com.sa",
+        "+.youtube.com.ro",
+        "+.youtube.com.qa",
+        "+.youtube.com.py",
+        "+.youtube.com.pt",
+        "+.youtube.com.pk",
+        "+.youtube.com.ph",
+        "+.youtube.com.pe",
+        "+.youtube.com.pa",
+        "+.youtube.com.om",
+        "+.youtube.com.ni",
+        "+.youtube.com.ng",
+        "+.youtube.com.my",
+        "+.youtube.com.mx",
+        "+.youtube.com.mt",
+        "+.youtube.com.mk",
+        "+.youtube.com.ly",
+        "+.youtube.com.lv",
+        "+.youtube.com.lb",
+        "+.youtube.com.kw",
+        "+.youtube.com.jo",
+        "+.youtube.com.jm",
+        "+.youtube.com.hr",
+        "+.youtube.com.hn",
+        "+.youtube.com.hk",
+        "+.youtube.com.gt",
+        "+.youtube.com.gr",
+        "+.youtube.com.gh",
+        "+.youtube.com.es",
+        "+.youtube.com.eg",
+        "+.youtube.com.ee",
+        "+.youtube.com.ec",
+        "+.youtube.com.do",
+        "+.youtube.com.co",
+        "+.youtube.com.by",
+        "+.youtube.com.br",
+        "+.youtube.com.bo",
+        "+.youtube.com.bh",
+        "+.youtube.com.bd",
+        "+.youtube.com.az",
+        "+.youtube.com.au",
+        "+.youtube.com.ar",
+        "+.youtube.co.za",
+        "+.youtube.co.ve",
+        "+.youtube.co.uk",
+        "+.youtube.co.ug",
+        "+.youtube.co.tz",
+        "+.youtube.co.th",
+        "+.youtube.co.nz",
+        "+.youtube.co.ma",
+        "+.youtube.co.kr",
+        "+.youtube.co.ke",
+        "+.youtube.co.jp",
+        "+.youtubeembeddedplayer.googleapis.com",
+        "+.youtube.co.in",
+        "+.youtube.co.il",
+        "+.youtubego.co.id",
+        "+.youtubego.co.in",
+        "+.youtube.co.id",
+        "+.youtubego.com.br",
+        "+.youtube.co.hu",
+        "+.youtube.co.cr",
+        "+.youtubei.googleapis.com",
+        "+.youtube.co.at",
+        "+.youtube.co.ae",
+        "+.youtube-ui.l.google.com",
+        "+.wide-youtube.l.google.com",
+        "+.ggpht.cn",
+    ]
+}
+
+fn telegram_domains() -> Vec<&'static str> {
+    vec![
+        ".cdn-telegram.org",
+        ".comments.app",
+        ".contest.com",
+        ".fragment.com",
+        ".graph.org",
+        ".quiz.directory",
+        ".t.me",
+        ".tdesktop.com",
+        ".telega.one",
+        ".telegra.ph",
+        ".telegram-cdn.org",
+        ".telegram.dog",
+        ".telegram.me",
+        ".telegram.org",
+        ".telegram.space",
+        ".telesco.pe",
+        ".tg.dev",
+        ".ton.org",
+        ".tx.me",
+        ".usercontent.dev",
+    ]
+}
+
+fn netflix_domains() -> Vec<&'static str> {
+    vec![
+        "netflix.com.edgesuite.net",
+        "+.fast.com",
+        "+.netflix.ca",
+        "+.netflix.com",
+        "+.netflix.net",
+        "+.netflixinvestor.com",
+        "+.netflixtechblog.com",
+        "+.nflxext.com",
+        "+.nflximg.com",
+        "+.nflximg.net",
+        "+.nflxsearch.net",
+        "+.nflxso.net",
+        "+.nflxvideo.net",
+        "+.netflixdnstest0.com",
+        "+.netflixdnstest1.com",
+        "+.netflixdnstest2.com",
+        "+.netflixdnstest3.com",
+        "+.netflixdnstest4.com",
+        "+.netflixdnstest5.com",
+        "+.netflixdnstest6.com",
+        "+.netflixdnstest7.com",
+        "+.netflixdnstest8.com",
+        "+.netflixdnstest9.com",
+        "+.netflixdnstest10.com",
+    ]
+}
+
+fn github_domains() -> Vec<&'static str> {
+    vec![
+        "github-api.arkoselabs.com",
+        "github-cloud.s3.amazonaws.com",
+        "github-production-release-asset-2e65be.s3.amazonaws.com",
+        "github-production-repository-file-5c1aeb.s3.amazonaws.com",
+        "github-production-repository-image-32fea6.s3.amazonaws.com",
+        "github-production-upload-manifest-file-7fdce7.s3.amazonaws.com",
+        "github-production-user-asset-6210df.s3.amazonaws.com",
+        "productionresultssa0.blob.core.windows.net",
+        "productionresultssa1.blob.core.windows.net",
+        "productionresultssa2.blob.core.windows.net",
+        "productionresultssa3.blob.core.windows.net",
+        "productionresultssa4.blob.core.windows.net",
+        "productionresultssa5.blob.core.windows.net",
+        "productionresultssa6.blob.core.windows.net",
+        "productionresultssa7.blob.core.windows.net",
+        "productionresultssa8.blob.core.windows.net",
+        "productionresultssa9.blob.core.windows.net",
+        "productionresultssa10.blob.core.windows.net",
+        "productionresultssa11.blob.core.windows.net",
+        "productionresultssa12.blob.core.windows.net",
+        "productionresultssa13.blob.core.windows.net",
+        "productionresultssa14.blob.core.windows.net",
+        "productionresultssa15.blob.core.windows.net",
+        "productionresultssa16.blob.core.windows.net",
+        "productionresultssa17.blob.core.windows.net",
+        "productionresultssa18.blob.core.windows.net",
+        "productionresultssa19.blob.core.windows.net",
+        "copilot-proxy.githubusercontent.com",
+        "copilot-workspace.githubnext.com",
+        "copilotprodattachments.blob.core.windows.net",
+        "+.atom.io",
+        "+.dependabot.com",
+        "+.gh.io",
+        "+.ghcr.io",
+        "+.git.io",
+        "+.github.ai",
+        "+.github.blog",
+        "+.github.com",
+        "+.github.community",
+        "+.github.dev",
+        "+.github.io",
+        "+.githubapp.com",
+        "+.githubassets.com",
+        "+.githubhackathon.com",
+        "+.githubnext.com",
+        "+.githubpreview.dev",
+        "+.githubstatus.com",
+        "+.githubuniverse.com",
+        "+.githubusercontent.com",
+        "+.myoctocat.com",
+        "+.octocaptcha.com",
+        "+.opensource.guide",
+        "+.repo.new",
+        "+.thegithubshop.com",
+        "+.githubcopilot.com",
+        "+.npm.community",
+        "+.npmjs.com",
+        "+.npmjs.org",
+        "+.collector.github.com",
+        "copilot-telemetry-service.githubusercontent.com",
+        "copilot-telemetry.githubusercontent.com",
+    ]
+}
+
+fn bilibili_domains() -> Vec<&'static str> {
+    vec![
+        "+.bilicomic.com",
+        "+.bilicomics.com",
+        "+.acg.tv",
+        "+.acgvideo.com",
+        "+.animetamashi.cn",
+        "+.animetamashi.com",
+        "+.anitama.cn",
+        "+.anitama.net",
+        "+.b23.tv",
+        "+.bigfun.cn",
+        "+.bigfunapp.cn",
+        "+.bili22.cn",
+        "+.bili2233.cn",
+        "+.bili23.cn",
+        "+.bili33.cn",
+        "+.biliapi.com",
+        "+.biliapi.net",
+        "+.bilibili.cc",
+        "+.bilibili.cn",
+        "+.bilibili.com",
+        "+.bilibili.net",
+        "+.bilibilipay.cn",
+        "+.bilibilipay.com",
+        "+.biligo.com",
+        "+.huasheng.cn",
+        "+.im9.com",
+        "+.yo9.com",
+        "+.bilicdn1.com",
+        "+.bilicdn2.com",
+        "+.bilicdn3.com",
+        "+.bilicdn4.com",
+        "+.bilicdn5.com",
+        "+.biliimg.com",
+        "+.bilivideo.cn",
+        "+.bilivideo.com",
+        "+.bilivideo.net",
+        "+.hdslb.com",
+        "+.hdslb.org",
+        "+.maoercdn.com",
+        "+.mincdn.com",
+        "+.bilibiligame.cn",
+        "+.bilibiligame.co",
+        "+.bilibiligame.net",
+        "+.biligame.co",
+        "+.biligame.com",
+        "+.biligame.net",
+        "+.bilibili.tv",
+        "+.biliintl.com",
+        "+.dreamcast.hk",
+        "upos-hz-mirrorakam.akamaized.net",
+    ]
+}
+
+fn spotify_domains() -> Vec<&'static str> {
+    vec![
+        "audio-ak-spotify-com.akamaized.net",
+        "audio4-ak-spotify-com.akamaized.net",
+        "cdn-spotify-experiments.conductrics.com",
+        "heads-ak-spotify-com.akamaized.net",
+        "heads4-ak-spotify-com.akamaized.net",
+        "spotify.com.edgesuite.net",
+        "spotify.map.fastly.net",
+        "spotify.map.fastlylb.net",
+        "+.byspotify.com",
+        "+.pscdn.co",
+        "+.scdn.co",
+        "+.spoti.fi",
+        "+.spotify-everywhere.com",
+        "+.spotify.com",
+        "+.spotify.design",
+        "+.spotifycdn.com",
+        "+.spotifycdn.net",
+        "+.spotifycharts.com",
+        "+.spotifycodes.com",
+        "+.spotifyforbrands.com",
+        "+.spotifyjobs.com",
+        "+.spotify.link",
+        "+.tospotify.com",
+    ]
+}
+
+/// Synthetic CN-like domains to simulate the large `geosite:cn` category
+/// (typically 10,000+ entries).
+fn cn_domains() -> Vec<String> {
+    let cn_tlds = [
+        "baidu.com",
+        "qq.com",
+        "taobao.com",
+        "jd.com",
+        "163.com",
+        "sina.com.cn",
+        "weibo.com",
+        "sohu.com",
+        "ifeng.com",
+        "zhihu.com",
+        "douyin.com",
+        "toutiao.com",
+        "bytedance.com",
+        "alibaba.com",
+        "alipay.com",
+        "tmall.com",
+        "meituan.com",
+        "dianping.com",
+        "xiaomi.com",
+        "huawei.com",
+        "oppo.com",
+        "vivo.com",
+        "pinduoduo.com",
+        "kuaishou.com",
+        "bilibili.com",
+        "iqiyi.com",
+        "youku.com",
+        "ctrip.com",
+        "suning.com",
+        "ele.me",
+    ];
+    let prefixes = [
+        "+.",
+        "*.api.",
+        "*.cdn.",
+        "*.static.",
+        "*.m.",
+        "*.www.",
+        "*.app.",
+        "*.open.",
+        "*.cloud.",
+        "*.data.",
+    ];
+    let mut domains = Vec::new();
+    for tld in &cn_tlds {
+        for prefix in &prefixes {
+            domains.push(format!("{prefix}{tld}"));
+        }
+        // Also add exact domains
+        domains.push(tld.to_string());
+        for i in 0..30 {
+            domains.push(format!("service{i}.{tld}"));
+        }
+    }
+    domains
+}
+
+/// Build combined trie from all geosite categories, matching the wiki config.
+fn build_combined_trie() -> DomainTrie<()> {
+    let mut trie: DomainTrie<()> = DomainTrie::new();
+
+    let all_lists: Vec<&str> = google_domains()
+        .into_iter()
+        .chain(twitter_domains())
+        .chain(youtube_domains())
+        .chain(telegram_domains())
+        .chain(netflix_domains())
+        .chain(github_domains())
+        .chain(bilibili_domains())
+        .chain(spotify_domains())
+        .collect();
+
+    for domain in &all_lists {
+        trie.insert(domain, ());
+    }
+
+    let cn = cn_domains();
+    for domain in &cn {
+        trie.insert(domain, ());
+    }
+
+    // Also insert bare domains for +. entries (mihomo semantics)
+    for domain in &all_lists {
+        if let Some(rest) = domain.strip_prefix("+.") {
+            trie.insert(rest, ());
+        }
+    }
+    for domain in &cn {
+        if let Some(rest) = domain.strip_prefix("+.") {
+            trie.insert(rest, ());
+        }
+    }
+
+    trie
+}
+
+/// Generate probe domains that should NOT match any rule in the combined trie.
+fn unrelated_probes(count: usize) -> Vec<String> {
+    let unrelated_tlds = [
+        "randomsite.xyz",
+        "mywebsite.org",
+        "example.net",
+        "testdomain.info",
+        "foobar.dev",
+        "whatever.app",
+        "notgoogle.io",
+        "unmatched.club",
+        "private.network",
+        "localhost.test",
+        "corporate.internal",
+        "enterprise.solutions",
+        "academic.edu",
+        "healthcare.med",
+        "finance.bank",
+        "shopping.store",
+        "travel.agency",
+        "gaming.gg",
+        "music.fm",
+        "news.press",
+    ];
+    let subdomains = [
+        "www",
+        "api",
+        "cdn",
+        "static",
+        "m",
+        "app",
+        "mail",
+        "login",
+        "auth",
+        "dashboard",
+        "portal",
+        "admin",
+        "dev",
+        "staging",
+        "test",
+        "beta",
+        "alpha",
+        "prod",
+        "ops",
+        "monitor",
+    ];
+
+    let mut probes = Vec::with_capacity(count);
+    for i in 0..count {
+        let tld = unrelated_tlds[i % unrelated_tlds.len()];
+        let sub = subdomains[i / unrelated_tlds.len() % subdomains.len()];
+        let unique = i / (unrelated_tlds.len() * subdomains.len());
+        if unique == 0 {
+            probes.push(format!("{sub}.{tld}"));
+        } else {
+            probes.push(format!("{sub}{unique}.{tld}"));
+        }
+    }
+    probes
+}
+
+/// Probe domains that look similar to rule-set domains but are NOT in the set.
+/// These stress the bloom filter more than purely random domains.
+fn adversarial_probes(count: usize) -> Vec<String> {
+    let near_miss_patterns = [
+        "googl.com",
+        "gogle.com",
+        "google.org",
+        "twiter.com",
+        "twtter.com",
+        "twitter.info",
+        "youtube.org",
+        "youttube.com",
+        "netflixx.com",
+        "netlfix.com",
+        "githb.com",
+        "github.org",
+        "bilibil.com",
+        "bilbili.com",
+        "spotfy.com",
+        "sptify.com",
+        "telegramm.org",
+        "telegam.org",
+        "googlevideo.org",
+        "googleapi.net",
+    ];
+    let subdomains = [
+        "www", "api", "cdn", "static", "m", "app", "service", "proxy", "edge", "node", "cluster",
+        "pod", "svc", "internal", "private", "secure", "fast", "cache", "lb", "gw",
+    ];
+
+    let mut probes = Vec::with_capacity(count);
+    for i in 0..count {
+        let pat = near_miss_patterns[i % near_miss_patterns.len()];
+        let sub = subdomains[i / near_miss_patterns.len() % subdomains.len()];
+        let unique = i / (near_miss_patterns.len() * subdomains.len());
+        if unique == 0 {
+            probes.push(format!("{sub}.{pat}"));
+        } else {
+            probes.push(format!("{sub}{unique}.{pat}"));
+        }
+    }
+    probes
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Verify zero false negatives: every inserted domain must match.
+#[test]
+fn bloom_rules_no_false_negatives() {
+    let trie = build_combined_trie();
+
+    // Test exact domains
+    for domain in google_domains() {
+        if domain.starts_with("+.") || domain.starts_with("*.") || domain.starts_with('.') {
+            continue;
+        }
+        assert!(
+            trie.search(domain).is_some(),
+            "false negative for exact domain: {domain}"
+        );
+    }
+
+    // Test wildcard matches
+    let wildcard_checks = [
+        ("sub.google.com", true),
+        ("deep.sub.google.com", true),
+        ("www.youtube.com", true),
+        ("api.github.com", true),
+        ("cdn.netflix.com", true),
+        ("app.spotify.com", true),
+        ("live.bilibili.com", true),
+        ("web.telegram.org", true),
+    ];
+    for (domain, expected) in wildcard_checks {
+        let result = trie.search(domain).is_some();
+        assert_eq!(
+            result, expected,
+            "unexpected result for {domain}: got {result}, expected {expected}"
+        );
+    }
+}
+
+/// Core mismatch rate test: unrelated domains must not exceed 1% FPR.
+#[test]
+fn bloom_rules_mismatch_rate_unrelated_below_1_percent() {
+    let trie = build_combined_trie();
+    let probes = unrelated_probes(10_000);
+
+    let mut false_positives = 0u64;
+    let mut fp_examples: Vec<String> = Vec::new();
+
+    for probe in &probes {
+        if trie.search(probe).is_some() {
+            false_positives += 1;
+            if fp_examples.len() < 10 {
+                fp_examples.push(probe.clone());
+            }
+        }
+    }
+
+    let fpr = false_positives as f64 / probes.len() as f64;
+    assert!(
+        fpr < 0.01,
+        "bloom filter mismatch rate {:.2}% exceeds 1% threshold \
+         ({false_positives}/{} false positives)\nexamples: {fp_examples:?}",
+        fpr * 100.0,
+        probes.len()
+    );
+}
+
+/// Adversarial probe test: near-miss domains must not exceed 1% FPR.
+#[test]
+fn bloom_rules_mismatch_rate_adversarial_below_1_percent() {
+    let trie = build_combined_trie();
+    let probes = adversarial_probes(10_000);
+
+    let mut false_positives = 0u64;
+    let mut fp_examples: Vec<String> = Vec::new();
+
+    for probe in &probes {
+        if trie.search(probe).is_some() {
+            false_positives += 1;
+            if fp_examples.len() < 10 {
+                fp_examples.push(probe.clone());
+            }
+        }
+    }
+
+    let fpr = false_positives as f64 / probes.len() as f64;
+    assert!(
+        fpr < 0.01,
+        "bloom filter adversarial mismatch rate {:.2}% exceeds 1% threshold \
+         ({false_positives}/{} false positives)\nexamples: {fp_examples:?}",
+        fpr * 100.0,
+        probes.len()
+    );
+}
+
+/// Per-category isolation test: each geosite category individually should have
+/// < 1% FPR against 5000 unrelated probes.
+#[test]
+fn bloom_rules_per_category_mismatch_below_1_percent() {
+    let categories: &[(&str, Vec<&str>)] = &[
+        ("google", google_domains()),
+        ("twitter", twitter_domains()),
+        ("youtube", youtube_domains()),
+        ("telegram", telegram_domains()),
+        ("netflix", netflix_domains()),
+        ("github", github_domains()),
+        ("bilibili", bilibili_domains()),
+        ("spotify", spotify_domains()),
+    ];
+
+    let probes = unrelated_probes(5_000);
+
+    for (name, domains) in categories {
+        let mut trie: DomainTrie<()> = DomainTrie::new();
+        for domain in domains {
+            trie.insert(domain, ());
+            if let Some(rest) = domain.strip_prefix("+.") {
+                trie.insert(rest, ());
+            }
+        }
+
+        let mut false_positives = 0u64;
+        for probe in &probes {
+            if trie.search(probe).is_some() {
+                false_positives += 1;
+            }
+        }
+
+        let fpr = false_positives as f64 / probes.len() as f64;
+        assert!(
+            fpr < 0.01,
+            "category '{name}' bloom mismatch rate {:.2}% exceeds 1% \
+             ({false_positives}/{} false positives)",
+            fpr * 100.0,
+            probes.len()
+        );
+    }
+}
+
+/// Large-scale test simulating full CN geosite (~1200 entries with wildcards)
+/// combined with all other categories. Total ~2000+ unique bloom entries.
+/// Tests 50,000 probes for statistical confidence.
+#[test]
+fn bloom_rules_large_scale_50k_probes_below_1_percent() {
+    let trie = build_combined_trie();
+
+    let mut false_positives = 0u64;
+    let total_probes = 50_000u64;
+
+    // Generate diverse probes: mix of structured and semi-random
+    for i in 0..total_probes {
+        let probe = format!(
+            "host{}.zone{}.region{}.unrelated{}.example.net",
+            i % 100,
+            i % 50,
+            i % 20,
+            i / 1000
+        );
+        if trie.search(&probe).is_some() {
+            false_positives += 1;
+        }
+    }
+
+    let fpr = false_positives as f64 / total_probes as f64;
+    assert!(
+        fpr < 0.01,
+        "large-scale bloom mismatch rate {:.2}% exceeds 1% \
+         ({false_positives}/{total_probes} false positives)",
+        fpr * 100.0,
+    );
+}
+
+/// Regression test: single-label subdomains queried against wildcard rules
+/// (the star filter) should not produce spurious matches.
+#[test]
+fn bloom_rules_star_wildcard_no_cross_category_leakage() {
+    let trie = build_combined_trie();
+
+    // These are single-label.unrelated-tld queries that should NOT match
+    // star filters for google.com, youtube.com, etc.
+    let non_matching_star_probes = [
+        "randomsub.amazon.com",
+        "frontend.vercel.app",
+        "api.stripe.com",
+        "cdn.cloudflare.com",
+        "static.facebook.com",
+        "media.instagram.com",
+        "edge.microsoft.com",
+        "api.openai.com",
+        "cdn.apple.com",
+        "auth.okta.com",
+        "api.slack.com",
+        "webhook.discord.com",
+        "api.twilio.com",
+        "cdn.jsdelivr.net",
+        "fonts.bunny.net",
+        "images.unsplash.com",
+        "api.anthropic.com",
+        "status.datadog.com",
+        "logs.sentry.io",
+        "metrics.grafana.com",
+    ];
+
+    let mut false_positives = 0u64;
+    for probe in &non_matching_star_probes {
+        if trie.search(probe).is_some() {
+            false_positives += 1;
+        }
+    }
+
+    assert_eq!(
+        false_positives,
+        0,
+        "star wildcard cross-category leakage: {false_positives}/{} false positives",
+        non_matching_star_probes.len()
+    );
+}
+
+/// Test that multi-level subdomain queries don't false-match on star filters.
+/// Star patterns (*.example.com) only match single-label prefixes.
+#[test]
+fn bloom_rules_deep_subdomains_no_star_leakage() {
+    let trie = build_combined_trie();
+
+    // Multi-level subdomains of unrelated TLDs
+    let deep_probes: Vec<String> = (0..1000)
+        .map(|i| format!("level3.level2.level1.unrelated{}.example.org", i % 100))
+        .collect();
+
+    let mut false_positives = 0u64;
+    for probe in &deep_probes {
+        if trie.search(probe).is_some() {
+            false_positives += 1;
+        }
+    }
+
+    let fpr = false_positives as f64 / deep_probes.len() as f64;
+    assert!(
+        fpr < 0.01,
+        "deep subdomain bloom mismatch rate {:.2}% exceeds 1% \
+         ({false_positives}/{} false positives)",
+        fpr * 100.0,
+        deep_probes.len()
+    );
+}

--- a/crates/meow-trie/tests/bloom_mismatch_test.rs
+++ b/crates/meow-trie/tests/bloom_mismatch_test.rs
@@ -975,3 +975,976 @@ fn bloom_rules_deep_subdomains_no_star_leakage() {
         deep_probes.len()
     );
 }
+
+// ===========================================================================
+// Real-world configuration tests
+// Domain rules extracted from popular open-source Clash/mihomo configs on GitHub.
+// ===========================================================================
+
+/// Parse a Clash rule line and extract the domain if it's a domain-type rule.
+/// Returns (pattern, is_suffix) where is_suffix means DOMAIN-SUFFIX.
+fn parse_clash_domain_rule(line: &str) -> Option<(&str, bool)> {
+    let line = line.trim().trim_start_matches("- ");
+    if let Some(rest) = line.strip_prefix("DOMAIN-SUFFIX,") {
+        let domain = rest.split(',').next()?;
+        Some((domain, true))
+    } else if let Some(rest) = line.strip_prefix("DOMAIN,") {
+        let domain = rest.split(',').next()?;
+        Some((domain, false))
+    } else {
+        None
+    }
+}
+
+fn build_trie_from_clash_rules(rules: &[&str]) -> DomainTrie<()> {
+    let mut trie: DomainTrie<()> = DomainTrie::new();
+    for rule in rules {
+        if let Some((domain, is_suffix)) = parse_clash_domain_rule(rule) {
+            if is_suffix {
+                trie.insert(&format!("+.{domain}"), ());
+                trie.insert(domain, ());
+            } else {
+                trie.insert(domain, ());
+            }
+        }
+    }
+    trie
+}
+
+/// Real-world config: lotusnetwork/lotusboard default.clash.yaml
+/// https://github.com/lotusnetwork/lotusboard
+/// 300+ domain rules covering Apple, CN domestic, international, Telegram, ads.
+fn lotusboard_rules() -> Vec<&'static str> {
+    vec![
+        // Apple
+        "DOMAIN,safebrowsing.urlsec.qq.com,DIRECT",
+        "DOMAIN,safebrowsing.googleapis.com,DIRECT",
+        "DOMAIN,developer.apple.com,Switcher",
+        "DOMAIN-SUFFIX,digicert.com,Switcher",
+        "DOMAIN,ocsp.apple.com,Switcher",
+        "DOMAIN,ocsp.comodoca.com,Switcher",
+        "DOMAIN,ocsp.usertrust.com,Switcher",
+        "DOMAIN,ocsp.sectigo.com,Switcher",
+        "DOMAIN,ocsp.verisign.net,Switcher",
+        "DOMAIN-SUFFIX,apple-dns.net,Switcher",
+        "DOMAIN,testflight.apple.com,Switcher",
+        "DOMAIN,sandbox.itunes.apple.com,Switcher",
+        "DOMAIN,itunes.apple.com,Switcher",
+        "DOMAIN-SUFFIX,apps.apple.com,Switcher",
+        "DOMAIN-SUFFIX,blobstore.apple.com,Switcher",
+        "DOMAIN,cvws.icloud-content.com,Switcher",
+        "DOMAIN-SUFFIX,mzstatic.com,DIRECT",
+        "DOMAIN-SUFFIX,itunes.apple.com,DIRECT",
+        "DOMAIN-SUFFIX,icloud.com,DIRECT",
+        "DOMAIN-SUFFIX,icloud-content.com,DIRECT",
+        "DOMAIN-SUFFIX,me.com,DIRECT",
+        "DOMAIN-SUFFIX,aaplimg.com,DIRECT",
+        "DOMAIN-SUFFIX,cdn20.com,DIRECT",
+        "DOMAIN-SUFFIX,cdn-apple.com,DIRECT",
+        "DOMAIN-SUFFIX,akadns.net,DIRECT",
+        "DOMAIN-SUFFIX,akamaiedge.net,DIRECT",
+        "DOMAIN-SUFFIX,edgekey.net,DIRECT",
+        "DOMAIN-SUFFIX,mwcloudcdn.com,DIRECT",
+        "DOMAIN-SUFFIX,mwcname.com,DIRECT",
+        "DOMAIN-SUFFIX,apple.com,DIRECT",
+        "DOMAIN-SUFFIX,apple-cloudkit.com,DIRECT",
+        "DOMAIN-SUFFIX,apple-mapkit.com,DIRECT",
+        // CN domestic
+        "DOMAIN-SUFFIX,126.com,DIRECT",
+        "DOMAIN-SUFFIX,126.net,DIRECT",
+        "DOMAIN-SUFFIX,127.net,DIRECT",
+        "DOMAIN-SUFFIX,163.com,DIRECT",
+        "DOMAIN-SUFFIX,360buyimg.com,DIRECT",
+        "DOMAIN-SUFFIX,36kr.com,DIRECT",
+        "DOMAIN-SUFFIX,acfun.tv,DIRECT",
+        "DOMAIN-SUFFIX,air-matters.com,DIRECT",
+        "DOMAIN-SUFFIX,aixifan.com,DIRECT",
+        "DOMAIN-SUFFIX,amap.com,DIRECT",
+        "DOMAIN-SUFFIX,autonavi.com,DIRECT",
+        "DOMAIN-SUFFIX,bdimg.com,DIRECT",
+        "DOMAIN-SUFFIX,bdstatic.com,DIRECT",
+        "DOMAIN-SUFFIX,bilibili.com,DIRECT",
+        "DOMAIN-SUFFIX,bilivideo.com,DIRECT",
+        "DOMAIN-SUFFIX,caiyunapp.com,DIRECT",
+        "DOMAIN-SUFFIX,clouddn.com,DIRECT",
+        "DOMAIN-SUFFIX,cnbeta.com,DIRECT",
+        "DOMAIN-SUFFIX,cnbetacdn.com,DIRECT",
+        "DOMAIN-SUFFIX,cootekservice.com,DIRECT",
+        "DOMAIN-SUFFIX,csdn.net,DIRECT",
+        "DOMAIN-SUFFIX,ctrip.com,DIRECT",
+        "DOMAIN-SUFFIX,dgtle.com,DIRECT",
+        "DOMAIN-SUFFIX,dianping.com,DIRECT",
+        "DOMAIN-SUFFIX,douban.com,DIRECT",
+        "DOMAIN-SUFFIX,doubanio.com,DIRECT",
+        "DOMAIN-SUFFIX,duokan.com,DIRECT",
+        "DOMAIN-SUFFIX,easou.com,DIRECT",
+        "DOMAIN-SUFFIX,ele.me,DIRECT",
+        "DOMAIN-SUFFIX,feng.com,DIRECT",
+        "DOMAIN-SUFFIX,fir.im,DIRECT",
+        "DOMAIN-SUFFIX,frdic.com,DIRECT",
+        "DOMAIN-SUFFIX,g-cores.com,DIRECT",
+        "DOMAIN-SUFFIX,godic.net,DIRECT",
+        "DOMAIN-SUFFIX,gtimg.com,DIRECT",
+        "DOMAIN,cdn.hockeyapp.net,DIRECT",
+        "DOMAIN-SUFFIX,hongxiu.com,DIRECT",
+        "DOMAIN-SUFFIX,hxcdn.net,DIRECT",
+        "DOMAIN-SUFFIX,iciba.com,DIRECT",
+        "DOMAIN-SUFFIX,ifeng.com,DIRECT",
+        "DOMAIN-SUFFIX,ifengimg.com,DIRECT",
+        "DOMAIN-SUFFIX,ipip.net,DIRECT",
+        "DOMAIN-SUFFIX,iqiyi.com,DIRECT",
+        "DOMAIN-SUFFIX,jd.com,DIRECT",
+        "DOMAIN-SUFFIX,jianshu.com,DIRECT",
+        "DOMAIN-SUFFIX,knewone.com,DIRECT",
+        "DOMAIN-SUFFIX,le.com,DIRECT",
+        "DOMAIN-SUFFIX,lecloud.com,DIRECT",
+        "DOMAIN-SUFFIX,lemicp.com,DIRECT",
+        "DOMAIN-SUFFIX,licdn.com,DIRECT",
+        "DOMAIN-SUFFIX,luoo.net,DIRECT",
+        "DOMAIN-SUFFIX,meituan.com,DIRECT",
+        "DOMAIN-SUFFIX,meituan.net,DIRECT",
+        "DOMAIN-SUFFIX,mi.com,DIRECT",
+        "DOMAIN-SUFFIX,miaopai.com,DIRECT",
+        "DOMAIN-SUFFIX,microsoft.com,DIRECT",
+        "DOMAIN-SUFFIX,microsoftonline.com,DIRECT",
+        "DOMAIN-SUFFIX,miui.com,DIRECT",
+        "DOMAIN-SUFFIX,miwifi.com,DIRECT",
+        "DOMAIN-SUFFIX,mob.com,DIRECT",
+        "DOMAIN-SUFFIX,netease.com,DIRECT",
+        "DOMAIN-SUFFIX,office.com,DIRECT",
+        "DOMAIN-SUFFIX,office365.com,DIRECT",
+        "DOMAIN-SUFFIX,oschina.net,DIRECT",
+        "DOMAIN-SUFFIX,ppsimg.com,DIRECT",
+        "DOMAIN-SUFFIX,pstatp.com,DIRECT",
+        "DOMAIN-SUFFIX,qcloud.com,DIRECT",
+        "DOMAIN-SUFFIX,qdaily.com,DIRECT",
+        "DOMAIN-SUFFIX,qdmm.com,DIRECT",
+        "DOMAIN-SUFFIX,qhimg.com,DIRECT",
+        "DOMAIN-SUFFIX,qhres.com,DIRECT",
+        "DOMAIN-SUFFIX,qidian.com,DIRECT",
+        "DOMAIN-SUFFIX,qihucdn.com,DIRECT",
+        "DOMAIN-SUFFIX,qiniu.com,DIRECT",
+        "DOMAIN-SUFFIX,qiniucdn.com,DIRECT",
+        "DOMAIN-SUFFIX,qiyipic.com,DIRECT",
+        "DOMAIN-SUFFIX,qq.com,DIRECT",
+        "DOMAIN-SUFFIX,qqurl.com,DIRECT",
+        "DOMAIN-SUFFIX,rarbg.to,DIRECT",
+        "DOMAIN-SUFFIX,ruguoapp.com,DIRECT",
+        "DOMAIN-SUFFIX,segmentfault.com,DIRECT",
+        "DOMAIN-SUFFIX,sinaapp.com,DIRECT",
+        "DOMAIN-SUFFIX,smzdm.com,DIRECT",
+        "DOMAIN-SUFFIX,snapdrop.net,DIRECT",
+        "DOMAIN-SUFFIX,sogou.com,DIRECT",
+        "DOMAIN-SUFFIX,sogoucdn.com,DIRECT",
+        "DOMAIN-SUFFIX,sohu.com,DIRECT",
+        "DOMAIN-SUFFIX,soku.com,DIRECT",
+        "DOMAIN-SUFFIX,speedtest.net,DIRECT",
+        "DOMAIN-SUFFIX,sspai.com,DIRECT",
+        "DOMAIN-SUFFIX,suning.com,DIRECT",
+        "DOMAIN-SUFFIX,taobao.com,DIRECT",
+        "DOMAIN-SUFFIX,tencent.com,DIRECT",
+        "DOMAIN-SUFFIX,tenpay.com,DIRECT",
+        "DOMAIN-SUFFIX,tianyancha.com,DIRECT",
+        "DOMAIN-SUFFIX,tmall.com,DIRECT",
+        "DOMAIN-SUFFIX,tudou.com,DIRECT",
+        "DOMAIN-SUFFIX,umetrip.com,DIRECT",
+        "DOMAIN-SUFFIX,upaiyun.com,DIRECT",
+        "DOMAIN-SUFFIX,upyun.com,DIRECT",
+        "DOMAIN-SUFFIX,veryzhun.com,DIRECT",
+        "DOMAIN-SUFFIX,weather.com,DIRECT",
+        "DOMAIN-SUFFIX,weibo.com,DIRECT",
+        "DOMAIN-SUFFIX,xiami.com,DIRECT",
+        "DOMAIN-SUFFIX,xiami.net,DIRECT",
+        "DOMAIN-SUFFIX,xiaomicp.com,DIRECT",
+        "DOMAIN-SUFFIX,ximalaya.com,DIRECT",
+        "DOMAIN-SUFFIX,xmcdn.com,DIRECT",
+        "DOMAIN-SUFFIX,xunlei.com,DIRECT",
+        "DOMAIN-SUFFIX,yhd.com,DIRECT",
+        "DOMAIN-SUFFIX,yihaodianimg.com,DIRECT",
+        "DOMAIN-SUFFIX,yinxiang.com,DIRECT",
+        "DOMAIN-SUFFIX,ykimg.com,DIRECT",
+        "DOMAIN-SUFFIX,youdao.com,DIRECT",
+        "DOMAIN-SUFFIX,youku.com,DIRECT",
+        "DOMAIN-SUFFIX,zealer.com,DIRECT",
+        "DOMAIN-SUFFIX,zhihu.com,DIRECT",
+        "DOMAIN-SUFFIX,zhimg.com,DIRECT",
+        "DOMAIN-SUFFIX,zimuzu.tv,DIRECT",
+        "DOMAIN-SUFFIX,zoho.com,DIRECT",
+        // International
+        "DOMAIN-SUFFIX,9to5mac.com,Switcher",
+        "DOMAIN-SUFFIX,abpchina.org,Switcher",
+        "DOMAIN-SUFFIX,adblockplus.org,Switcher",
+        "DOMAIN-SUFFIX,adobe.com,Switcher",
+        "DOMAIN-SUFFIX,akamaized.net,Switcher",
+        "DOMAIN-SUFFIX,alfredapp.com,Switcher",
+        "DOMAIN-SUFFIX,amplitude.com,Switcher",
+        "DOMAIN-SUFFIX,ampproject.org,Switcher",
+        "DOMAIN-SUFFIX,android.com,Switcher",
+        "DOMAIN-SUFFIX,angularjs.org,Switcher",
+        "DOMAIN-SUFFIX,aolcdn.com,Switcher",
+        "DOMAIN-SUFFIX,apkpure.com,Switcher",
+        "DOMAIN-SUFFIX,appledaily.com,Switcher",
+        "DOMAIN-SUFFIX,appshopper.com,Switcher",
+        "DOMAIN-SUFFIX,appspot.com,Switcher",
+        "DOMAIN-SUFFIX,arcgis.com,Switcher",
+        "DOMAIN-SUFFIX,archive.org,Switcher",
+        "DOMAIN-SUFFIX,armorgames.com,Switcher",
+        "DOMAIN-SUFFIX,aspnetcdn.com,Switcher",
+        "DOMAIN-SUFFIX,att.com,Switcher",
+        "DOMAIN-SUFFIX,awsstatic.com,Switcher",
+        "DOMAIN-SUFFIX,azureedge.net,Switcher",
+        "DOMAIN-SUFFIX,azurewebsites.net,Switcher",
+        "DOMAIN-SUFFIX,bing.com,Switcher",
+        "DOMAIN-SUFFIX,bintray.com,Switcher",
+        "DOMAIN-SUFFIX,bit.com,Switcher",
+        "DOMAIN-SUFFIX,bit.ly,Switcher",
+        "DOMAIN-SUFFIX,bitbucket.org,Switcher",
+        "DOMAIN-SUFFIX,bjango.com,Switcher",
+        "DOMAIN-SUFFIX,bkrtx.com,Switcher",
+        "DOMAIN-SUFFIX,blog.com,Switcher",
+        "DOMAIN-SUFFIX,blogcdn.com,Switcher",
+        "DOMAIN-SUFFIX,blogger.com,Switcher",
+        "DOMAIN-SUFFIX,blogsmithmedia.com,Switcher",
+        "DOMAIN-SUFFIX,blogspot.com,Switcher",
+        "DOMAIN-SUFFIX,blogspot.hk,Switcher",
+        "DOMAIN-SUFFIX,bloomberg.com,Switcher",
+        "DOMAIN-SUFFIX,box.com,Switcher",
+        "DOMAIN-SUFFIX,box.net,Switcher",
+        "DOMAIN-SUFFIX,cachefly.net,Switcher",
+        "DOMAIN-SUFFIX,chromium.org,Switcher",
+        "DOMAIN-SUFFIX,cl.ly,Switcher",
+        "DOMAIN-SUFFIX,cloudflare.com,Switcher",
+        "DOMAIN-SUFFIX,cloudfront.net,Switcher",
+        "DOMAIN-SUFFIX,cloudmagic.com,Switcher",
+        "DOMAIN-SUFFIX,cmail19.com,Switcher",
+        "DOMAIN-SUFFIX,cnet.com,Switcher",
+        "DOMAIN-SUFFIX,cocoapods.org,Switcher",
+        "DOMAIN-SUFFIX,comodoca.com,Switcher",
+        "DOMAIN-SUFFIX,crashlytics.com,Switcher",
+        "DOMAIN-SUFFIX,culturedcode.com,Switcher",
+        "DOMAIN-SUFFIX,d.pr,Switcher",
+        "DOMAIN-SUFFIX,danilo.to,Switcher",
+        "DOMAIN-SUFFIX,dayone.me,Switcher",
+        "DOMAIN-SUFFIX,db.tt,Switcher",
+        "DOMAIN-SUFFIX,deskconnect.com,Switcher",
+        "DOMAIN-SUFFIX,disq.us,Switcher",
+        "DOMAIN-SUFFIX,disqus.com,Switcher",
+        "DOMAIN-SUFFIX,disquscdn.com,Switcher",
+        "DOMAIN-SUFFIX,dnsimple.com,Switcher",
+        "DOMAIN-SUFFIX,docker.com,Switcher",
+        "DOMAIN-SUFFIX,dribbble.com,Switcher",
+        "DOMAIN-SUFFIX,droplr.com,Switcher",
+        "DOMAIN-SUFFIX,duckduckgo.com,Switcher",
+        "DOMAIN-SUFFIX,dueapp.com,Switcher",
+        "DOMAIN-SUFFIX,dytt8.net,Switcher",
+        "DOMAIN-SUFFIX,edgecastcdn.net,Switcher",
+        "DOMAIN-SUFFIX,edgekey.net,Switcher",
+        "DOMAIN-SUFFIX,edgesuite.net,Switcher",
+        "DOMAIN-SUFFIX,engadget.com,Switcher",
+        "DOMAIN-SUFFIX,entrust.net,Switcher",
+        "DOMAIN-SUFFIX,eurekavpt.com,Switcher",
+        "DOMAIN-SUFFIX,evernote.com,Switcher",
+        "DOMAIN-SUFFIX,fabric.io,Switcher",
+        "DOMAIN-SUFFIX,fast.com,Switcher",
+        "DOMAIN-SUFFIX,fastly.net,Switcher",
+        "DOMAIN-SUFFIX,fc2.com,Switcher",
+        "DOMAIN-SUFFIX,feedburner.com,Switcher",
+        "DOMAIN-SUFFIX,feedly.com,Switcher",
+        "DOMAIN-SUFFIX,feedsportal.com,Switcher",
+        "DOMAIN-SUFFIX,fiftythree.com,Switcher",
+        "DOMAIN-SUFFIX,firebaseio.com,Switcher",
+        "DOMAIN-SUFFIX,flexibits.com,Switcher",
+        "DOMAIN-SUFFIX,flickr.com,Switcher",
+        "DOMAIN-SUFFIX,flipboard.com,Switcher",
+        "DOMAIN-SUFFIX,g.co,Switcher",
+        "DOMAIN-SUFFIX,gabia.net,Switcher",
+        "DOMAIN-SUFFIX,geni.us,Switcher",
+        "DOMAIN-SUFFIX,gfx.ms,Switcher",
+        "DOMAIN-SUFFIX,ggpht.com,Switcher",
+        "DOMAIN-SUFFIX,ghostnoteapp.com,Switcher",
+        "DOMAIN-SUFFIX,git.io,Switcher",
+        "DOMAIN-SUFFIX,globalsign.com,Switcher",
+        "DOMAIN-SUFFIX,gmodules.com,Switcher",
+        "DOMAIN-SUFFIX,godaddy.com,Switcher",
+        "DOMAIN-SUFFIX,golang.org,Switcher",
+        "DOMAIN-SUFFIX,gongm.in,Switcher",
+        "DOMAIN-SUFFIX,goo.gl,Switcher",
+        "DOMAIN-SUFFIX,goodreaders.com,Switcher",
+        "DOMAIN-SUFFIX,goodreads.com,Switcher",
+        "DOMAIN-SUFFIX,gravatar.com,Switcher",
+        "DOMAIN-SUFFIX,gstatic.com,Switcher",
+        "DOMAIN-SUFFIX,gvt0.com,Switcher",
+        "DOMAIN-SUFFIX,hockeyapp.net,Switcher",
+        "DOMAIN-SUFFIX,hotmail.com,Switcher",
+        "DOMAIN-SUFFIX,icons8.com,Switcher",
+        "DOMAIN-SUFFIX,ifixit.com,Switcher",
+        "DOMAIN-SUFFIX,ift.tt,Switcher",
+        "DOMAIN-SUFFIX,ifttt.com,Switcher",
+        "DOMAIN-SUFFIX,iherb.com,Switcher",
+        "DOMAIN-SUFFIX,imageshack.us,Switcher",
+        "DOMAIN-SUFFIX,img.ly,Switcher",
+        "DOMAIN-SUFFIX,imgur.com,Switcher",
+        "DOMAIN-SUFFIX,imore.com,Switcher",
+        "DOMAIN-SUFFIX,instapaper.com,Switcher",
+        "DOMAIN-SUFFIX,ipn.li,Switcher",
+        "DOMAIN-SUFFIX,is.gd,Switcher",
+        "DOMAIN-SUFFIX,issuu.com,Switcher",
+        "DOMAIN-SUFFIX,itgonglun.com,Switcher",
+        "DOMAIN-SUFFIX,itun.es,Switcher",
+        "DOMAIN-SUFFIX,ixquick.com,Switcher",
+        "DOMAIN-SUFFIX,j.mp,Switcher",
+        "DOMAIN-SUFFIX,jshint.com,Switcher",
+        "DOMAIN-SUFFIX,jtvnw.net,Switcher",
+        "DOMAIN-SUFFIX,justgetflux.com,Switcher",
+        "DOMAIN-SUFFIX,kat.cr,Switcher",
+        "DOMAIN-SUFFIX,klip.me,Switcher",
+        "DOMAIN-SUFFIX,libsyn.com,Switcher",
+        "DOMAIN-SUFFIX,linkedin.com,Switcher",
+        "DOMAIN-SUFFIX,line-apps.com,Switcher",
+        "DOMAIN-SUFFIX,linode.com,Switcher",
+        "DOMAIN-SUFFIX,lithium.com,Switcher",
+        "DOMAIN-SUFFIX,littlehj.com,Switcher",
+        "DOMAIN-SUFFIX,live.com,Switcher",
+        "DOMAIN-SUFFIX,live.net,Switcher",
+        "DOMAIN-SUFFIX,livefilestore.com,Switcher",
+        "DOMAIN-SUFFIX,llnwd.net,Switcher",
+        "DOMAIN-SUFFIX,macid.co,Switcher",
+        "DOMAIN-SUFFIX,macromedia.com,Switcher",
+        "DOMAIN-SUFFIX,macrumors.com,Switcher",
+        "DOMAIN-SUFFIX,mashable.com,Switcher",
+        "DOMAIN-SUFFIX,mathjax.org,Switcher",
+        "DOMAIN-SUFFIX,medium.com,Switcher",
+        "DOMAIN-SUFFIX,mega.co.nz,Switcher",
+        "DOMAIN-SUFFIX,mega.nz,Switcher",
+        "DOMAIN-SUFFIX,megaupload.com,Switcher",
+        "DOMAIN-SUFFIX,microsofttranslator.com,Switcher",
+        "DOMAIN-SUFFIX,mindnode.com,Switcher",
+        "DOMAIN-SUFFIX,mobile01.com,Switcher",
+        "DOMAIN-SUFFIX,modmyi.com,Switcher",
+        "DOMAIN-SUFFIX,msedge.net,Switcher",
+        "DOMAIN-SUFFIX,myfontastic.com,Switcher",
+        "DOMAIN-SUFFIX,name.com,Switcher",
+        "DOMAIN-SUFFIX,nextmedia.com,Switcher",
+        "DOMAIN-SUFFIX,nsstatic.net,Switcher",
+        "DOMAIN-SUFFIX,nssurge.com,Switcher",
+        "DOMAIN-SUFFIX,nyt.com,Switcher",
+        "DOMAIN-SUFFIX,nytimes.com,Switcher",
+        "DOMAIN-SUFFIX,omnigroup.com,Switcher",
+        "DOMAIN-SUFFIX,onedrive.com,Switcher",
+        "DOMAIN-SUFFIX,onenote.com,Switcher",
+        "DOMAIN-SUFFIX,ooyala.com,Switcher",
+        "DOMAIN-SUFFIX,openvpn.net,Switcher",
+        "DOMAIN-SUFFIX,openwrt.org,Switcher",
+        "DOMAIN-SUFFIX,orkut.com,Switcher",
+        "DOMAIN-SUFFIX,osxdaily.com,Switcher",
+        "DOMAIN-SUFFIX,outlook.com,Switcher",
+        "DOMAIN-SUFFIX,ow.ly,Switcher",
+        "DOMAIN-SUFFIX,paddleapi.com,Switcher",
+        "DOMAIN-SUFFIX,parallels.com,Switcher",
+        "DOMAIN-SUFFIX,parse.com,Switcher",
+        "DOMAIN-SUFFIX,pdfexpert.com,Switcher",
+        "DOMAIN-SUFFIX,periscope.tv,Switcher",
+        "DOMAIN-SUFFIX,pinboard.in,Switcher",
+        "DOMAIN-SUFFIX,pinterest.com,Switcher",
+        "DOMAIN-SUFFIX,pixelmator.com,Switcher",
+        "DOMAIN-SUFFIX,pixiv.net,Switcher",
+        "DOMAIN-SUFFIX,playpcesor.com,Switcher",
+        "DOMAIN-SUFFIX,playstation.com,Switcher",
+        "DOMAIN-SUFFIX,playstation.com.hk,Switcher",
+        "DOMAIN-SUFFIX,playstation.net,Switcher",
+        "DOMAIN-SUFFIX,playstationnetwork.com,Switcher",
+        "DOMAIN-SUFFIX,pushwoosh.com,Switcher",
+        "DOMAIN-SUFFIX,rime.im,Switcher",
+        "DOMAIN-SUFFIX,servebom.com,Switcher",
+        "DOMAIN-SUFFIX,sfx.ms,Switcher",
+        "DOMAIN-SUFFIX,shadowsocks.org,Switcher",
+        "DOMAIN-SUFFIX,sharethis.com,Switcher",
+        "DOMAIN-SUFFIX,shazam.com,Switcher",
+        "DOMAIN-SUFFIX,skype.com,Switcher",
+        "DOMAIN-SUFFIX,smartmailcloud.com,Switcher",
+        "DOMAIN-SUFFIX,sndcdn.com,Switcher",
+        "DOMAIN-SUFFIX,sony.com,Switcher",
+        "DOMAIN-SUFFIX,soundcloud.com,Switcher",
+        "DOMAIN-SUFFIX,sourceforge.net,Switcher",
+        "DOMAIN-SUFFIX,spotify.com,Switcher",
+        "DOMAIN-SUFFIX,squarespace.com,Switcher",
+        "DOMAIN-SUFFIX,sstatic.net,Switcher",
+        "DOMAIN-SUFFIX,stackoverflow.com,Switcher",
+        "DOMAIN-SUFFIX,startpage.com,Switcher",
+        "DOMAIN-SUFFIX,staticflickr.com,Switcher",
+        "DOMAIN-SUFFIX,steamcommunity.com,Switcher",
+        "DOMAIN-SUFFIX,symauth.com,Switcher",
+        "DOMAIN-SUFFIX,symcb.com,Switcher",
+        "DOMAIN-SUFFIX,symcd.com,Switcher",
+        "DOMAIN-SUFFIX,tapbots.com,Switcher",
+        "DOMAIN-SUFFIX,tapbots.net,Switcher",
+        "DOMAIN-SUFFIX,tdesktop.com,Switcher",
+        "DOMAIN-SUFFIX,techcrunch.com,Switcher",
+        "DOMAIN-SUFFIX,techsmith.com,Switcher",
+        "DOMAIN-SUFFIX,thepiratebay.org,Switcher",
+        "DOMAIN-SUFFIX,theverge.com,Switcher",
+        "DOMAIN-SUFFIX,time.com,Switcher",
+        "DOMAIN-SUFFIX,timeinc.net,Switcher",
+        "DOMAIN-SUFFIX,tiny.cc,Switcher",
+        "DOMAIN-SUFFIX,tinypic.com,Switcher",
+        "DOMAIN-SUFFIX,tmblr.co,Switcher",
+        "DOMAIN-SUFFIX,todoist.com,Switcher",
+        "DOMAIN-SUFFIX,trello.com,Switcher",
+        "DOMAIN-SUFFIX,trustasiassl.com,Switcher",
+        "DOMAIN-SUFFIX,tumblr.co,Switcher",
+        "DOMAIN-SUFFIX,tumblr.com,Switcher",
+        "DOMAIN-SUFFIX,tweetdeck.com,Switcher",
+        "DOMAIN-SUFFIX,tweetmarker.net,Switcher",
+        "DOMAIN-SUFFIX,twitch.tv,Switcher",
+        "DOMAIN-SUFFIX,txmblr.com,Switcher",
+        "DOMAIN-SUFFIX,typekit.net,Switcher",
+        "DOMAIN-SUFFIX,ubertags.com,Switcher",
+        "DOMAIN-SUFFIX,ublock.org,Switcher",
+        "DOMAIN-SUFFIX,ubnt.com,Switcher",
+        "DOMAIN-SUFFIX,ulyssesapp.com,Switcher",
+        "DOMAIN-SUFFIX,urchin.com,Switcher",
+        "DOMAIN-SUFFIX,usertrust.com,Switcher",
+        "DOMAIN-SUFFIX,v.gd,Switcher",
+        "DOMAIN-SUFFIX,v2ex.com,Switcher",
+        "DOMAIN-SUFFIX,vimeo.com,Switcher",
+        "DOMAIN-SUFFIX,vimeocdn.com,Switcher",
+        "DOMAIN-SUFFIX,vine.co,Switcher",
+        "DOMAIN-SUFFIX,vivaldi.com,Switcher",
+        "DOMAIN-SUFFIX,vox-cdn.com,Switcher",
+        "DOMAIN-SUFFIX,vsco.co,Switcher",
+        "DOMAIN-SUFFIX,vultr.com,Switcher",
+        "DOMAIN-SUFFIX,w.org,Switcher",
+        "DOMAIN-SUFFIX,w3schools.com,Switcher",
+        "DOMAIN-SUFFIX,webtype.com,Switcher",
+        "DOMAIN-SUFFIX,wikiwand.com,Switcher",
+        "DOMAIN-SUFFIX,wikileaks.org,Switcher",
+        "DOMAIN-SUFFIX,wikimedia.org,Switcher",
+        "DOMAIN-SUFFIX,wikipedia.com,Switcher",
+        "DOMAIN-SUFFIX,wikipedia.org,Switcher",
+        "DOMAIN-SUFFIX,windows.com,Switcher",
+        "DOMAIN-SUFFIX,windows.net,Switcher",
+        "DOMAIN-SUFFIX,wire.com,Switcher",
+        "DOMAIN-SUFFIX,wordpress.com,Switcher",
+        "DOMAIN-SUFFIX,workflowy.com,Switcher",
+        "DOMAIN-SUFFIX,wp.com,Switcher",
+        "DOMAIN-SUFFIX,wsj.com,Switcher",
+        "DOMAIN-SUFFIX,wsj.net,Switcher",
+        "DOMAIN-SUFFIX,xda-developers.com,Switcher",
+        "DOMAIN-SUFFIX,xeeno.com,Switcher",
+        "DOMAIN-SUFFIX,xiti.com,Switcher",
+        "DOMAIN-SUFFIX,yahoo.com,Switcher",
+        "DOMAIN-SUFFIX,yimg.com,Switcher",
+        "DOMAIN-SUFFIX,ying.com,Switcher",
+        "DOMAIN-SUFFIX,yoyo.org,Switcher",
+        "DOMAIN-SUFFIX,ytimg.com,Switcher",
+        // Telegram
+        "DOMAIN-SUFFIX,telegra.ph,Switcher",
+        "DOMAIN-SUFFIX,telegram.org,Switcher",
+        // Google CN
+        "DOMAIN-SUFFIX,services.googleapis.cn,Switcher",
+        "DOMAIN-SUFFIX,xn--ngstr-lra8j.com,Switcher",
+        // Ad blocking
+        "DOMAIN-SUFFIX,appsflyer.com,REJECT",
+        "DOMAIN-SUFFIX,doubleclick.net,REJECT",
+        "DOMAIN-SUFFIX,mmstat.com,REJECT",
+        "DOMAIN-SUFFIX,vungle.com,REJECT",
+        // LAN
+        "DOMAIN,injections.adguard.org,DIRECT",
+        "DOMAIN,local.adguard.org,DIRECT",
+        "DOMAIN-SUFFIX,local,DIRECT",
+        "DOMAIN-SUFFIX,cn,DIRECT",
+    ]
+}
+
+/// Real-world config: trojan-gfw/igniter clash_config.yaml
+/// https://github.com/trojan-gfw/igniter
+fn igniter_rules() -> Vec<&'static str> {
+    vec![
+        "DOMAIN,safebrowsing.urlsec.qq.com,DIRECT",
+        "DOMAIN,safebrowsing.googleapis.com,DIRECT",
+        "DOMAIN,ocsp.apple.com,Proxy",
+        "DOMAIN-SUFFIX,digicert.com,Proxy",
+        "DOMAIN-SUFFIX,entrust.net,Proxy",
+        "DOMAIN,ocsp.verisign.net,Proxy",
+        "DOMAIN-SUFFIX,apps.apple.com,Proxy",
+        "DOMAIN,itunes.apple.com,Proxy",
+        "DOMAIN-SUFFIX,blobstore.apple.com,Proxy",
+        "DOMAIN-SUFFIX,music.apple.com,DIRECT",
+        "DOMAIN-SUFFIX,mzstatic.com,DIRECT",
+        "DOMAIN-SUFFIX,itunes.apple.com,DIRECT",
+        "DOMAIN-SUFFIX,icloud.com,DIRECT",
+        "DOMAIN-SUFFIX,icloud-content.com,DIRECT",
+        "DOMAIN-SUFFIX,me.com,DIRECT",
+        "DOMAIN-SUFFIX,mzstatic.com,DIRECT",
+        "DOMAIN-SUFFIX,akadns.net,DIRECT",
+        "DOMAIN-SUFFIX,aaplimg.com,DIRECT",
+        "DOMAIN-SUFFIX,cdn-apple.com,DIRECT",
+        "DOMAIN-SUFFIX,apple.com,DIRECT",
+        "DOMAIN-SUFFIX,apple-cloudkit.com,DIRECT",
+        "DOMAIN,services.googleapis.cn,Proxy",
+        "DOMAIN,services.googleapis.com,Proxy",
+        "DOMAIN,www.googleapis.com,Proxy",
+        "DOMAIN,www.googleapis.cn,Proxy",
+        "DOMAIN-SUFFIX,cn,DIRECT",
+        "DOMAIN-SUFFIX,local,DIRECT",
+    ]
+}
+
+/// Real-world rule-set: Loyalsoldier/clash-rules proxy.txt (partial)
+/// https://github.com/Loyalsoldier/clash-rules
+/// Exact-match domain list used with RULE-SET,Domain behavior.
+fn loyalsoldier_proxy_domains() -> Vec<&'static str> {
+    vec![
+        "3dns-1.adobe.com",
+        "3dns-2.adobe.com",
+        "3dns-3.adobe.com",
+        "3dns-4.adobe.com",
+        "3dns-5.adobe.com",
+        "3dns.adobe.com",
+        "a.ppy.sh",
+        "activate-sea.adobe.com",
+        "activate-sjc0.adobe.com",
+        "activate.adobe.com",
+        "activate.wip1.adobe.com",
+        "activate.wip2.adobe.com",
+        "activate.wip3.adobe.com",
+        "activate.wip4.adobe.com",
+        "adobe-dns-1.adobe.com",
+        "adobe-dns-2.adobe.com",
+        "adobe-dns-3.adobe.com",
+        "adobe-dns-4.adobe.com",
+        "adobe-dns.adobe.com",
+        "adobeereg.com",
+        "ai.google.dev",
+        "alkalicore-pa.clients6.google.com",
+        "alkalimakersuite-pa.clients6.google.com",
+        "alt1-mtalk.google.com",
+        "alt2-mtalk.google.com",
+        "alt3-mtalk.google.com",
+        "alt4-mtalk.google.com",
+        "alt5-mtalk.google.com",
+        "alt6-mtalk.google.com",
+        "alt7-mtalk.google.com",
+        "alt8-mtalk.google.com",
+        "android.googlesource.com",
+        "antigravity-pa.googleapis.com",
+        "antigravity.googleapis.com",
+        "apple-tv-plus-press.apple.com",
+        "apple.com.akadns.net",
+        "audio-ak-spotify-com.akamaized.net",
+        "audio4-ak-spotify-com.akamaized.net",
+        "az764295.vo.msecnd.net",
+        "azure.microsoft.com",
+        "azuremarketplace.microsoft.com",
+        "cdn-spotify-experiments.conductrics.com",
+        "clients1.google.com",
+        "cloudaicompanion.googleapis.com",
+        "cloudcode-pa.googleapis.com",
+        "copilot-proxy.githubusercontent.com",
+        "copilot-workspace.githubnext.com",
+        "copilotprodattachments.blob.core.windows.net",
+        "daily-cloudcode-pa.googleapis.com",
+        "default.exp-tas.com",
+        "developer.microsoft.com",
+        "developers.facebook.com",
+        "discord-attachments-uploads-prd.storage.googleapis.com",
+        "download.visualstudio.microsoft.com",
+        "github-api.arkoselabs.com",
+        "github-cloud.s3.amazonaws.com",
+        "github-production-release-asset-2e65be.s3.amazonaws.com",
+        "github-production-repository-file-5c1aeb.s3.amazonaws.com",
+        "github-production-repository-image-32fea6.s3.amazonaws.com",
+        "github-production-upload-manifest-file-7fdce7.s3.amazonaws.com",
+        "github-production-user-asset-6210df.s3.amazonaws.com",
+        "heads-ak-spotify-com.akamaized.net",
+        "heads4-ak-spotify-com.akamaized.net",
+        "netflix.com.edgesuite.net",
+        "notebooklm-pa.googleapis.com",
+        "notebooklm.googleapis.com",
+        "pki.google.com",
+        "publicca.googleapis.com",
+        "spotify.com.edgesuite.net",
+        "spotify.map.fastly.net",
+        "spotify.map.fastlylb.net",
+        "upos-hz-mirrorakam.akamaized.net",
+        "yt3.googleusercontent.com",
+    ]
+}
+
+/// Real-world rule-set: Loyalsoldier/clash-rules direct.txt (partial)
+/// https://github.com/Loyalsoldier/clash-rules
+/// Exact-match CN direct domain list.
+fn loyalsoldier_direct_domains() -> Vec<&'static str> {
+    vec![
+        "265.com",
+        "2mdn-cn.net",
+        "2mdn.net",
+        "a1.mzstatic.com",
+        "a2.mzstatic.com",
+        "a3.mzstatic.com",
+        "a4.mzstatic.com",
+        "a5.mzstatic.com",
+        "activate.activation-v2.kaspersky.com",
+        "activation-v2.geo.kaspersky.com",
+        "activation-v2.kaspersky.com",
+        "adcdownload.apple.com",
+        "adcdownload.apple.com.akadns.net",
+        "admob-cn.com",
+        "adservice.google.com",
+        "afcs.dell.com",
+        "amp-api-edge.apps.apple.com",
+        "amp-api-edge.music.apple.com",
+        "amp-api-search-edge.apps.apple.com",
+        "amp-api-updates.apps.apple.com",
+        "amp-api.apps.apple.com",
+        "amp-api.media.apple.com",
+        "amp-api.music.apple.com",
+        "aod-ssl.itunes.apple.com",
+        "aod.itunes.apple.com",
+        "api-edge.apps.apple.com",
+        "app-analytics-services.com",
+        "app-measurement-cn.com",
+        "app-measurement.com",
+        "app-site-association.cdn-apple.com",
+        "appldnld.apple.com",
+        "appldnld.g.aaplimg.com",
+        "appleid.cdn-apple.com",
+        "apps.mzstatic.com",
+        "apptrailers.itunes.apple.com",
+        "auth.music.apple.com",
+        "bag.itunes.apple.com",
+        "beacons.gvt2.com",
+        "beacons2.gvt2.com",
+        "beacons3.gvt2.com",
+        "bookkeeper.itunes.apple.com",
+        "build.microsoft.com",
+        "c.android.clients.google.com",
+        "c.pki.goog",
+        "cdn-cn.apple-mapkit.com",
+        "cdn.apple-mapkit.com",
+        "cdn.ampproject.org",
+        "cds.apple.com",
+        "cdsassets.apple.com",
+        "certs.apple.com",
+        "checkin.gstatic.com",
+        "cl1.apple.com",
+        "cl2.apple.com",
+        "cl3.apple.com",
+        "cl4.apple.com",
+        "cl5.apple.com",
+        "client-api.itunes.apple.com",
+        "clientflow.apple.com",
+        "clientservices.googleapis.com",
+        "cn.download.nvidia.com",
+        "cn.widevine.com",
+        "cn.windowssearch.com",
+        "communities.apple.com",
+        "configuration.apple.com",
+        "connectivitycheck.gstatic.com",
+        "crl.apple.com",
+        "crl.globalsign.net",
+        "crl.pki.goog",
+        "crls.pki.goog",
+        "csi.gstatic.com",
+        "cstat.apple.com",
+        "ctldl.windowsupdate.com",
+        "devblogs.microsoft.com",
+        "developer.microsoft.com",
+        "devimages-cdn.apple.com",
+        "devstreaming-cdn.apple.com",
+        "dl.google.com",
+        "dl.l.google.com",
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Real-world config tests
+// ---------------------------------------------------------------------------
+
+/// lotusnetwork/lotusboard: 300+ domain rules, FPR < 1%.
+#[test]
+fn realworld_lotusboard_mismatch_below_1_percent() {
+    let rules = lotusboard_rules();
+    let trie = build_trie_from_clash_rules(&rules);
+    let probes = unrelated_probes(10_000);
+
+    // Verify no false negatives on exact matches
+    let exact_checks = [
+        "safebrowsing.urlsec.qq.com",
+        "developer.apple.com",
+        "ocsp.apple.com",
+        "ocsp.verisign.net",
+        "cdn.hockeyapp.net",
+        "injections.adguard.org",
+    ];
+    for domain in &exact_checks {
+        assert!(
+            trie.search(domain).is_some(),
+            "false negative for exact domain: {domain}"
+        );
+    }
+
+    // Verify suffix matches work
+    let suffix_checks = [
+        "www.bilibili.com",
+        "api.qq.com",
+        "cdn.jd.com",
+        "m.taobao.com",
+        "static.zhihu.com",
+        "app.spotify.com",
+        "api.tumblr.com",
+        "cdn.vimeo.com",
+    ];
+    for domain in &suffix_checks {
+        assert!(
+            trie.search(domain).is_some(),
+            "false negative for suffix domain: {domain}"
+        );
+    }
+
+    // FPR check
+    let mut false_positives = 0u64;
+    let mut fp_examples: Vec<String> = Vec::new();
+    for probe in &probes {
+        if trie.search(probe).is_some() {
+            false_positives += 1;
+            if fp_examples.len() < 5 {
+                fp_examples.push(probe.clone());
+            }
+        }
+    }
+    let fpr = false_positives as f64 / probes.len() as f64;
+    assert!(
+        fpr < 0.01,
+        "lotusboard config: bloom FPR {:.2}% exceeds 1% \
+         ({false_positives}/{} FPs)\nexamples: {fp_examples:?}",
+        fpr * 100.0,
+        probes.len()
+    );
+}
+
+/// trojan-gfw/igniter: compact 27-rule config, FPR < 1%.
+#[test]
+fn realworld_igniter_mismatch_below_1_percent() {
+    let rules = igniter_rules();
+    let trie = build_trie_from_clash_rules(&rules);
+    let probes = unrelated_probes(10_000);
+
+    // Verify matches
+    assert!(trie.search("safebrowsing.urlsec.qq.com").is_some());
+    assert!(trie.search("www.icloud.com").is_some());
+    assert!(trie.search("cdn.apple.com").is_some());
+    assert!(trie.search("services.googleapis.com").is_some());
+
+    let mut false_positives = 0u64;
+    for probe in &probes {
+        if trie.search(probe).is_some() {
+            false_positives += 1;
+        }
+    }
+    let fpr = false_positives as f64 / probes.len() as f64;
+    assert!(
+        fpr < 0.01,
+        "igniter config: bloom FPR {:.2}% exceeds 1% ({false_positives}/{})",
+        fpr * 100.0,
+        probes.len()
+    );
+}
+
+/// Loyalsoldier/clash-rules: combined proxy + direct domain lists (150+ exact
+/// domains), FPR < 1%.
+#[test]
+fn realworld_loyalsoldier_mismatch_below_1_percent() {
+    let mut trie: DomainTrie<()> = DomainTrie::new();
+    for domain in loyalsoldier_proxy_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in loyalsoldier_direct_domains() {
+        trie.insert(domain, ());
+    }
+    let probes = unrelated_probes(10_000);
+
+    // Verify no false negatives
+    let checks = [
+        "ai.google.dev",
+        "clients1.google.com",
+        "copilot-proxy.githubusercontent.com",
+        "netflix.com.edgesuite.net",
+        "certs.apple.com",
+        "dl.google.com",
+        "connectivitycheck.gstatic.com",
+    ];
+    for domain in &checks {
+        assert!(
+            trie.search(domain).is_some(),
+            "false negative for: {domain}"
+        );
+    }
+
+    let mut false_positives = 0u64;
+    for probe in &probes {
+        if trie.search(probe).is_some() {
+            false_positives += 1;
+        }
+    }
+    let fpr = false_positives as f64 / probes.len() as f64;
+    assert!(
+        fpr < 0.01,
+        "loyalsoldier config: bloom FPR {:.2}% exceeds 1% ({false_positives}/{})",
+        fpr * 100.0,
+        probes.len()
+    );
+}
+
+/// Combined stress test: merge ALL real-world configs into one trie (~500+
+/// domain entries). This simulates a power-user config that imports multiple
+/// rule sources. FPR must stay < 1%.
+#[test]
+fn realworld_combined_all_configs_mismatch_below_1_percent() {
+    let mut trie: DomainTrie<()> = DomainTrie::new();
+
+    // lotusboard + igniter via Clash rule format
+    for rule in lotusboard_rules() {
+        if let Some((domain, is_suffix)) = parse_clash_domain_rule(rule) {
+            if is_suffix {
+                trie.insert(&format!("+.{domain}"), ());
+                trie.insert(domain, ());
+            } else {
+                trie.insert(domain, ());
+            }
+        }
+    }
+    for rule in igniter_rules() {
+        if let Some((domain, is_suffix)) = parse_clash_domain_rule(rule) {
+            if is_suffix {
+                trie.insert(&format!("+.{domain}"), ());
+                trie.insert(domain, ());
+            } else {
+                trie.insert(domain, ());
+            }
+        }
+    }
+
+    // Loyalsoldier exact domains
+    for domain in loyalsoldier_proxy_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in loyalsoldier_direct_domains() {
+        trie.insert(domain, ());
+    }
+
+    // Also add MetaCubeX geosite domains from the earlier test
+    for domain in google_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in twitter_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in youtube_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in telegram_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in netflix_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in github_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in bilibili_domains() {
+        trie.insert(domain, ());
+    }
+    for domain in spotify_domains() {
+        trie.insert(domain, ());
+    }
+
+    // 50k probes for high statistical confidence
+    let mut false_positives = 0u64;
+    let total = 50_000u64;
+    let mut fp_examples: Vec<String> = Vec::new();
+
+    for i in 0..total {
+        let probe = format!(
+            "svc{}.zone{}.rack{}.unmatched{}.test.invalid",
+            i % 200,
+            i % 50,
+            i % 10,
+            i / 1000
+        );
+        if trie.search(&probe).is_some() {
+            false_positives += 1;
+            if fp_examples.len() < 5 {
+                fp_examples.push(probe);
+            }
+        }
+    }
+
+    let fpr = false_positives as f64 / total as f64;
+    assert!(
+        fpr < 0.01,
+        "combined real-world config: bloom FPR {:.2}% exceeds 1% \
+         ({false_positives}/{total} FPs)\nexamples: {fp_examples:?}",
+        fpr * 100.0,
+    );
+}
+
+/// Adversarial test against real-world configs: probe with domains that look
+/// like they could belong to the rule-set but are subtly different.
+#[test]
+fn realworld_combined_adversarial_below_1_percent() {
+    let rules = lotusboard_rules();
+    let trie = build_trie_from_clash_rules(&rules);
+
+    // Near-miss domains: typos/variants of domains in the config
+    let adversarial = [
+        "bilibil.com",
+        "bilbili.com",
+        "taoboa.com",
+        "tabao.com",
+        "jdd.com",
+        "j-d.com",
+        "weib.com",
+        "webo.com",
+        "zhihi.com",
+        "zhhu.com",
+        "appl.com",
+        "aple.com",
+        "gogle.com",
+        "googl.com",
+        "spotfy.com",
+        "sptify.com",
+        "twtter.com",
+        "twitr.com",
+        "flikr.com",
+        "flickrr.com",
+    ];
+    let subs = [
+        "www", "api", "cdn", "m", "app", "static", "img", "video", "live", "auth",
+    ];
+
+    let mut false_positives = 0u64;
+    let mut total = 0u64;
+    for near in &adversarial {
+        for sub in &subs {
+            let probe = format!("{sub}.{near}");
+            total += 1;
+            if trie.search(&probe).is_some() {
+                false_positives += 1;
+            }
+        }
+        // Also test bare domain
+        total += 1;
+        if trie.search(near).is_some() {
+            false_positives += 1;
+        }
+    }
+
+    let fpr = false_positives as f64 / total as f64;
+    assert!(
+        fpr < 0.01,
+        "adversarial real-world config: bloom FPR {:.2}% exceeds 1% \
+         ({false_positives}/{total})",
+        fpr * 100.0,
+    );
+}

--- a/docs/specs/bloom-filter-domain-trie.md
+++ b/docs/specs/bloom-filter-domain-trie.md
@@ -1,0 +1,193 @@
+# Spec: Bloom Filter in the Domain Trie
+
+Status: Implemented (2026-05)
+Upstream commit: `8cf1cf5` (fix(trie): replace RegexSet with Bloom filters)
+Crate: `meow-trie`
+File: `crates/meow-trie/src/trie.rs`
+
+## Motivation
+
+The `DomainTrie` originally used Rust's `regex::RegexSet` to match domain
+patterns. That broke when configs grew past ~7,745 rules -- the regex DFA
+exceeded its 10 MB compilation limit. Bloom filters replaced it, dropping
+memory from unbounded to ~18 KB per 10,000 domains while preserving
+matching semantics. With full geosite data loaded, config memory dropped
+from 99 MB to 2.3 MB.
+
+## Two compilation paths
+
+When `DomainTrie::search()` is first called, the trie lazily compiles its
+entries into one of two forms depending on the value type `T`:
+
+### BloomCheck (ZST path)
+
+Used when `size_of::<T>() == 0` (i.e. `T = ()`). This is the path taken by
+`DomainRuleSet` and `GeositeDB`, where the only question is "does this
+domain match any rule?"
+
+Three independent bloom filters are built: `exact`, `star`, `dot`.
+
+**False positives are real** -- there is no HashMap fallback, so a bloom
+false positive translates directly to a rule mismatch (domain routed
+through the wrong proxy group).
+
+### BloomMap (value-bearing path)
+
+Used when `T` carries data (e.g. `DomainTrie<i32>`). Each bloom filter is
+paired with a `HashMap<String, T>` for exact value retrieval on hits.
+
+**Effective FPR = 0%** -- false positives from the bloom filter are caught
+by the HashMap miss. The bloom filter serves purely as a fast-rejection
+pre-filter.
+
+## Filter parameters
+
+| Parameter | Value | Derivation |
+|-----------|-------|------------|
+| Target FPR | 0.1% (1 in 1,000) | Design choice |
+| Bits per item | 14.4 | `-ln(0.001) / ln(2)^2` |
+| Hash functions | 10 | `-ln(0.001) / ln(2)` |
+| Storage alignment | 64-bit words | Implementation detail |
+
+For 10,000 items this works out to ~18 KB of memory. Size scales linearly
+with item count.
+
+## Hash strategy
+
+Double-hashing generates all 10 hash positions from two base hashes:
+
+```
+h1 = DefaultHasher(item)
+h2 = DefaultHasher(h1) | 1      // force odd for coprime distribution
+h_i(x) = h1 + i * h2  (mod num_bits)    for i in 0..10
+```
+
+The `| 1` trick ensures `h2` is odd, so when taken mod a power-of-2 bit
+array it cycles through all positions before repeating -- better spread
+than even values would give.
+
+## Three filters, three match semantics
+
+Each `DomainTrie` compiles entries into three separate bloom filters based
+on the pattern type:
+
+| Filter | Inserted key | Matches query | Rule syntax |
+|--------|-------------|---------------|-------------|
+| `exact` | `"example.com"` | `query == "example.com"` | `DOMAIN,example.com` |
+| `star` | `".example.com"` | `"sub.example.com"` (single-label prefix only) | `*.example.com` |
+| `dot` | `".example.com"` | `"any.depth.example.com"` (any prefix depth) | `.example.com` |
+
+The `+.example.com` syntax (mihomo convention) inserts into **both** `star`
+and `dot`, plus a bare exact entry for the apex domain.
+
+## Search algorithm (BloomCheck path)
+
+```
+search(query):
+  if exact.maybe_contains(query) -> match
+
+  for each '.' at position i in query:
+    suffix = query[i..]          // e.g. ".example.com"
+    prefix = query[..i]          // e.g. "www"
+
+    if star.maybe_contains(suffix) AND prefix has no dots -> match
+    if dot.maybe_contains(suffix) -> match
+
+  -> no match
+```
+
+The "prefix has no dots" check enforces single-label star semantics:
+`*.example.com` matches `www.example.com` but not `a.b.example.com`.
+
+## Integration with the rule engine
+
+### DomainRuleSet
+
+`DomainRuleSet` (`crates/meow-rules/src/rule_set.rs`) wraps a
+`DomainTrie<()>`. When a domain rule-set is loaded from a rule-provider
+(file or HTTP):
+
+```
+DomainRuleSet::from_entries(["example.com", "+.google.com", ...])
+  -> DomainTrie<()>::insert(...)       // stores entries
+  -> first search() call triggers compile() -> BloomCheck
+```
+
+For `+.domain` entries, `DomainRuleSet` also inserts the bare domain to
+match mihomo semantics (apex + all subdomains).
+
+### GeositeDB
+
+`GeositeDB` (`crates/meow-rules/src/geosite.rs`) holds one
+`DomainTrie<()>` per geosite category (cn, google, telegram, etc.). Each
+category gets its own independently-sized bloom filter. Supports both MRS
+(MetaCubeX binary format) and DAT (V2Ray protobuf) inputs.
+
+## Mismatch risk analysis
+
+Since `BloomCheck` has no HashMap fallback, bloom false positives translate
+directly to incorrect rule matches. The 0.1% theoretical FPR means roughly
+1 in 1,000 unrelated domain lookups could false-match against a given
+filter.
+
+In practice the risk is mitigated by:
+
+1. **Three independent filters** -- a query must false-positive against the
+   right filter (exact vs star vs dot) for the right suffix. The effective
+   per-query FPR is lower than the raw per-filter rate.
+
+2. **Star filter structural guard** -- even if `star.maybe_contains()`
+   returns a false positive, the match is rejected unless the prefix is a
+   single label (no dots). This eliminates false matches for multi-level
+   subdomain queries.
+
+3. **Small filter populations** -- each geosite category or rule-set
+   provider builds its own trie. A category with 50 entries gets a ~90-byte
+   filter, not a shared 18 KB filter. Smaller populations have lower
+   absolute FP counts.
+
+## Test coverage
+
+Integration tests in `crates/meow-trie/tests/bloom_mismatch_test.rs`
+verify the <1% mismatch threshold:
+
+### MetaCubeX geosite tests
+
+Domain lists sourced from
+[MetaCubeX/meta-rules-dat](https://github.com/MetaCubeX/meta-rules-dat),
+matching the wiki example configuration at
+<https://wiki.metacubex.one/example/conf/#__tabbed_3_1>.
+
+| Test | Description |
+|------|-------------|
+| `bloom_rules_no_false_negatives` | Every inserted domain matches (zero false negatives) |
+| `bloom_rules_mismatch_rate_unrelated_below_1_percent` | 10k unrelated probes |
+| `bloom_rules_mismatch_rate_adversarial_below_1_percent` | 10k near-miss probes (googl.com, twiter.com, etc.) |
+| `bloom_rules_per_category_mismatch_below_1_percent` | Each of 8 geosite categories individually |
+| `bloom_rules_large_scale_50k_probes_below_1_percent` | 50k diverse probes for statistical confidence |
+| `bloom_rules_star_wildcard_no_cross_category_leakage` | Star wildcards don't match unrelated TLDs (zero tolerance) |
+| `bloom_rules_deep_subdomains_no_star_leakage` | Multi-level subdomains don't leak through star filters |
+
+### Real-world configuration tests
+
+Domain rules extracted from popular open-source Clash/mihomo configs on
+GitHub:
+
+| Test | Source | Rules |
+|------|--------|-------|
+| `realworld_lotusboard_mismatch_below_1_percent` | [lotusnetwork/lotusboard](https://github.com/lotusnetwork/lotusboard) | 300+ rules (Apple, CN domestic, intl, ads) |
+| `realworld_igniter_mismatch_below_1_percent` | [trojan-gfw/igniter](https://github.com/trojan-gfw/igniter) | 27 rules (compact config) |
+| `realworld_loyalsoldier_mismatch_below_1_percent` | [Loyalsoldier/clash-rules](https://github.com/Loyalsoldier/clash-rules) | 150+ exact domains (proxy.txt + direct.txt) |
+| `realworld_combined_all_configs_mismatch_below_1_percent` | All above + MetaCubeX geosite | 1000+ entries, 50k probes |
+| `realworld_combined_adversarial_below_1_percent` | lotusboard rules | 220 near-miss typo domains |
+
+All tests observe 0% false positives, well within the 1% threshold.
+
+## Unit tests (in crate)
+
+The `crates/meow-trie/src/trie.rs` module also contains:
+
+- `test_bloom_filter_size` -- 10k items, verifies 10-25 KB range
+- `test_bloom_false_positive_rate` -- 10k items, 100k probes, asserts FPR < 0.5%
+- Property-based test (`matches_naive_reference`) -- randomized patterns
+  validated against a naive string matcher via proptest

--- a/docs/specs/bloom-filter-domain-trie.md
+++ b/docs/specs/bloom-filter-domain-trie.md
@@ -1,46 +1,55 @@
-# Spec: Bloom Filter in the Domain Trie
+# Spec: Domain Trie Matching Engine
 
 Status: Implemented (2026-05)
-Upstream commit: `8cf1cf5` (fix(trie): replace RegexSet with Bloom filters)
 Crate: `meow-trie`
 File: `crates/meow-trie/src/trie.rs`
 
-## Motivation
+## History
 
-The `DomainTrie` originally used Rust's `regex::RegexSet` to match domain
-patterns. That broke when configs grew past ~7,745 rules -- the regex DFA
-exceeded its 10 MB compilation limit. Bloom filters replaced it, dropping
-memory from unbounded to ~18 KB per 10,000 domains while preserving
-matching semantics. With full geosite data loaded, config memory dropped
-from 99 MB to 2.3 MB.
+1. **RegexSet** (original) -- broke at ~7,745 rules when the DFA exceeded
+   its 10 MB compilation limit.
+2. **Bloom filters** (`8cf1cf5`) -- replaced RegexSet; dropped config memory
+   from 99 MB to 2.3 MB but introduced a 0.1% theoretical false-positive
+   rate on the ZST path.
+3. **Prefix trie** (current) -- replaced bloom filters on the ZST path;
+   achieves 0% false-positive rate with acceptable memory overhead.
 
 ## Two compilation paths
 
 When `DomainTrie::search()` is first called, the trie lazily compiles its
 entries into one of two forms depending on the value type `T`:
 
-### BloomCheck (ZST path)
+### TrieCheck (ZST path) -- 0% FPR
 
 Used when `size_of::<T>() == 0` (i.e. `T = ()`). This is the path taken by
-`DomainRuleSet` and `GeositeDB`, where the only question is "does this
-domain match any rule?"
+`DomainRuleSet`, `GeositeDB`, fake-IP skipper, and SNI sniffer skip/force
+lists -- anywhere the only question is "does this domain match any rule?"
 
-Three independent bloom filters are built: `exact`, `star`, `dot`.
+A real prefix trie is built from domain labels in reverse order (TLD
+first). Each `TrieNode` carries three boolean flags:
 
-**False positives are real** -- there is no HashMap fallback, so a bloom
-false positive translates directly to a rule mismatch (domain routed
-through the wrong proxy group).
+```rust
+struct TrieNode {
+    children: HashMap<Box<str>, TrieNode>,
+    exact: bool,   // DOMAIN,example.com
+    star: bool,    // *.example.com (single-label prefix only)
+    dot: bool,     // .example.com (any-depth prefix)
+}
+```
 
-### BloomMap (value-bearing path)
+**0% false-positive rate** -- exact matching, no probabilistic structures.
 
-Used when `T` carries data (e.g. `DomainTrie<i32>`). Each bloom filter is
-paired with a `HashMap<String, T>` for exact value retrieval on hits.
+### BloomMap (value-bearing path) -- 0% FPR
+
+Used when `T` carries data (e.g. `DomainTrie<(usize, Arc<str>)>` in the
+match engine). Three bloom filters provide fast rejection; three
+`HashMap<String, T>` provide exact value retrieval on hits.
 
 **Effective FPR = 0%** -- false positives from the bloom filter are caught
 by the HashMap miss. The bloom filter serves purely as a fast-rejection
 pre-filter.
 
-## Filter parameters
+#### Bloom filter parameters (BloomMap only)
 
 | Parameter | Value | Derivation |
 |-----------|-------|------------|
@@ -48,11 +57,6 @@ pre-filter.
 | Bits per item | 14.4 | `-ln(0.001) / ln(2)^2` |
 | Hash functions | 10 | `-ln(0.001) / ln(2)` |
 | Storage alignment | 64-bit words | Implementation detail |
-
-For 10,000 items this works out to ~18 KB of memory. Size scales linearly
-with item count.
-
-## Hash strategy
 
 Double-hashing generates all 10 hash positions from two base hashes:
 
@@ -62,41 +66,54 @@ h2 = DefaultHasher(h1) | 1      // force odd for coprime distribution
 h_i(x) = h1 + i * h2  (mod num_bits)    for i in 0..10
 ```
 
-The `| 1` trick ensures `h2` is odd, so when taken mod a power-of-2 bit
-array it cycles through all positions before repeating -- better spread
-than even values would give.
+## Three match semantics
 
-## Three filters, three match semantics
+| Pattern type | Inserted key | Matches query | Rule syntax |
+|-------------|-------------|---------------|-------------|
+| Exact | `"example.com"` | `query == "example.com"` | `DOMAIN,example.com` |
+| Star | `"example.com"` | `"sub.example.com"` (single-label prefix only) | `*.example.com` |
+| Dot | `"example.com"` | `"any.depth.example.com"` (any prefix depth) | `.example.com` |
 
-Each `DomainTrie` compiles entries into three separate bloom filters based
-on the pattern type:
+The `+.example.com` syntax (mihomo convention) inserts **both** star and
+dot entries, plus a bare exact entry for the apex domain.
 
-| Filter | Inserted key | Matches query | Rule syntax |
-|--------|-------------|---------------|-------------|
-| `exact` | `"example.com"` | `query == "example.com"` | `DOMAIN,example.com` |
-| `star` | `".example.com"` | `"sub.example.com"` (single-label prefix only) | `*.example.com` |
-| `dot` | `".example.com"` | `"any.depth.example.com"` (any prefix depth) | `.example.com` |
+## Trie structure (TrieCheck path)
 
-The `+.example.com` syntax (mihomo convention) inserts into **both** `star`
-and `dot`, plus a bare exact entry for the apex domain.
+Labels are stored in reverse order: `google.com` becomes `com -> google`.
 
-## Search algorithm (BloomCheck path)
+```
+root
+├── com
+│   ├── google  [exact ✓, star ✓, dot ✓]   ← +.google.com
+│   │   └── www [exact ✓]                   ← DOMAIN,www.google.com
+│   ├── bilibili [exact ✓, dot ✓]           ← +.bilibili.com
+│   └── example [star ✓]                    ← *.example.com
+└── org
+    └── telegram [dot ✓]                    ← .telegram.org
+```
+
+### Search algorithm
 
 ```
 search(query):
-  if exact.maybe_contains(query) -> match
+  labels = query.rsplit('.')           // ["com", "google", "www"]
+  n = labels.len()
+  node = root
 
-  for each '.' at position i in query:
-    suffix = query[i..]          // e.g. ".example.com"
-    prefix = query[..i]          // e.g. "www"
+  for d in 0..n:
+    child = node.children[labels[d]]
+    if child is None -> no match
+    node = child
+    remaining = n - d - 1
 
-    if star.maybe_contains(suffix) AND prefix has no dots -> match
-    if dot.maybe_contains(suffix) -> match
+    if remaining == 0 AND node.exact -> match
+    if remaining == 1 AND node.star  -> match    // single-label prefix
+    if remaining > 0  AND node.dot   -> match    // any-depth prefix
 
   -> no match
 ```
 
-The "prefix has no dots" check enforces single-label star semantics:
+The `remaining == 1` check enforces single-label star semantics:
 `*.example.com` matches `www.example.com` but not `a.b.example.com`.
 
 ## Integration with the rule engine
@@ -104,13 +121,12 @@ The "prefix has no dots" check enforces single-label star semantics:
 ### DomainRuleSet
 
 `DomainRuleSet` (`crates/meow-rules/src/rule_set.rs`) wraps a
-`DomainTrie<()>`. When a domain rule-set is loaded from a rule-provider
-(file or HTTP):
+`DomainTrie<()>`. When a domain rule-set is loaded from a rule-provider:
 
 ```
 DomainRuleSet::from_entries(["example.com", "+.google.com", ...])
   -> DomainTrie<()>::insert(...)       // stores entries
-  -> first search() call triggers compile() -> BloomCheck
+  -> first search() call triggers compile() -> TrieCheck
 ```
 
 For `+.domain` entries, `DomainRuleSet` also inserts the bare domain to
@@ -120,74 +136,51 @@ match mihomo semantics (apex + all subdomains).
 
 `GeositeDB` (`crates/meow-rules/src/geosite.rs`) holds one
 `DomainTrie<()>` per geosite category (cn, google, telegram, etc.). Each
-category gets its own independently-sized bloom filter. Supports both MRS
+category gets its own independently-sized trie. Supports both MRS
 (MetaCubeX binary format) and DAT (V2Ray protobuf) inputs.
 
-## Mismatch risk analysis
+### Other consumers
 
-Since `BloomCheck` has no HashMap fallback, bloom false positives translate
-directly to incorrect rule matches. The 0.1% theoretical FPR means roughly
-1 in 1,000 unrelated domain lookups could false-match against a given
-filter.
-
-In practice the risk is mitigated by:
-
-1. **Three independent filters** -- a query must false-positive against the
-   right filter (exact vs star vs dot) for the right suffix. The effective
-   per-query FPR is lower than the raw per-filter rate.
-
-2. **Star filter structural guard** -- even if `star.maybe_contains()`
-   returns a false positive, the match is rejected unless the prefix is a
-   single label (no dots). This eliminates false matches for multi-level
-   subdomain queries.
-
-3. **Small filter populations** -- each geosite category or rule-set
-   provider builds its own trie. A category with 50 entries gets a ~90-byte
-   filter, not a shared 18 KB filter. Smaller populations have lower
-   absolute FP counts.
+- **DomainIndex** (`meow-tunnel/src/match_engine.rs`) -- `DomainTrie<(usize, Arc<str>)>`, uses BloomMap path
+- **NameserverPolicy** (`meow-dns/src/resolver.rs`) -- `DomainTrie<PolicyEntry>`, uses BloomMap path
+- **FallbackFilter** (`meow-dns/src/resolver.rs`) -- `DomainTrie<()>`, uses TrieCheck path
+- **Fake-IP Skipper** (`meow-dns/src/fakeip.rs`) -- `DomainTrie<()>`, uses TrieCheck path
+- **SNI Sniffer** (`meow-listener/src/sniffer.rs`) -- `DomainTrie<()>`, uses TrieCheck path
 
 ## Test coverage
 
+### Mismatch rate tests
+
 Integration tests in `crates/meow-trie/tests/bloom_mismatch_test.rs`
-verify the <1% mismatch threshold:
+verify correctness with realistic domain rule-sets. With the prefix trie,
+FPR is exactly 0% (all tests pass trivially).
 
-### MetaCubeX geosite tests
-
-Domain lists sourced from
-[MetaCubeX/meta-rules-dat](https://github.com/MetaCubeX/meta-rules-dat),
-matching the wiki example configuration at
-<https://wiki.metacubex.one/example/conf/#__tabbed_3_1>.
+**MetaCubeX geosite tests** (8 categories from
+[MetaCubeX/meta-rules-dat](https://github.com/MetaCubeX/meta-rules-dat)):
 
 | Test | Description |
 |------|-------------|
 | `bloom_rules_no_false_negatives` | Every inserted domain matches (zero false negatives) |
 | `bloom_rules_mismatch_rate_unrelated_below_1_percent` | 10k unrelated probes |
-| `bloom_rules_mismatch_rate_adversarial_below_1_percent` | 10k near-miss probes (googl.com, twiter.com, etc.) |
+| `bloom_rules_mismatch_rate_adversarial_below_1_percent` | 10k near-miss probes |
 | `bloom_rules_per_category_mismatch_below_1_percent` | Each of 8 geosite categories individually |
-| `bloom_rules_large_scale_50k_probes_below_1_percent` | 50k diverse probes for statistical confidence |
-| `bloom_rules_star_wildcard_no_cross_category_leakage` | Star wildcards don't match unrelated TLDs (zero tolerance) |
+| `bloom_rules_large_scale_50k_probes_below_1_percent` | 50k diverse probes |
+| `bloom_rules_star_wildcard_no_cross_category_leakage` | Star wildcards don't match unrelated TLDs |
 | `bloom_rules_deep_subdomains_no_star_leakage` | Multi-level subdomains don't leak through star filters |
 
-### Real-world configuration tests
-
-Domain rules extracted from popular open-source Clash/mihomo configs on
-GitHub:
+**Real-world configuration tests** (from GitHub):
 
 | Test | Source | Rules |
 |------|--------|-------|
-| `realworld_lotusboard_mismatch_below_1_percent` | [lotusnetwork/lotusboard](https://github.com/lotusnetwork/lotusboard) | 300+ rules (Apple, CN domestic, intl, ads) |
-| `realworld_igniter_mismatch_below_1_percent` | [trojan-gfw/igniter](https://github.com/trojan-gfw/igniter) | 27 rules (compact config) |
-| `realworld_loyalsoldier_mismatch_below_1_percent` | [Loyalsoldier/clash-rules](https://github.com/Loyalsoldier/clash-rules) | 150+ exact domains (proxy.txt + direct.txt) |
-| `realworld_combined_all_configs_mismatch_below_1_percent` | All above + MetaCubeX geosite | 1000+ entries, 50k probes |
+| `realworld_lotusboard_mismatch_below_1_percent` | lotusnetwork/lotusboard | 300+ rules |
+| `realworld_igniter_mismatch_below_1_percent` | trojan-gfw/igniter | 27 rules |
+| `realworld_loyalsoldier_mismatch_below_1_percent` | Loyalsoldier/clash-rules | 150+ domains |
+| `realworld_combined_all_configs_mismatch_below_1_percent` | All above + MetaCubeX | 1000+ entries, 50k probes |
 | `realworld_combined_adversarial_below_1_percent` | lotusboard rules | 220 near-miss typo domains |
 
-All tests observe 0% false positives, well within the 1% threshold.
+### Unit tests and property tests
 
-## Unit tests (in crate)
-
-The `crates/meow-trie/src/trie.rs` module also contains:
-
-- `test_bloom_filter_size` -- 10k items, verifies 10-25 KB range
-- `test_bloom_false_positive_rate` -- 10k items, 100k probes, asserts FPR < 0.5%
-- Property-based test (`matches_naive_reference`) -- randomized patterns
-  validated against a naive string matcher via proptest
+- `test_bloom_filter_size` -- bloom filter sizing (BloomMap path only)
+- `test_bloom_false_positive_rate` -- bloom filter FPR (BloomMap path only)
+- `matches_naive_reference` -- proptest for BloomMap path (`DomainTrie<bool>`)
+- `matches_naive_reference_zst` -- proptest for TrieCheck path (`DomainTrie<()>`)


### PR DESCRIPTION
## Summary

- Replace the `BloomCheck` compilation path (`DomainTrie<()>`) with a real domain-label prefix trie, eliminating the 0.1% false-positive rate inherent to bloom filters — now **0% FPR**
- Add 12 mismatch-rate integration tests using realistic domain rules from MetaCubeX geosite lists and real-world Clash configs found on GitHub (lotusnetwork/lotusboard, trojan-gfw/igniter, Loyalsoldier/clash-rules)
- Add a geosite RSS scaling test that measures memory usage at 1k–50k domains — prefix trie uses ~350 kB for 50k domains
- Add spec doc covering the domain trie matching engine design

## Changes

**`crates/meow-trie/src/trie.rs`** (+96/-61)
- Add `TrieNode` struct with `HashMap<Box<str>, TrieNode>` children and `exact`/`star`/`dot` match flags
- Replace `Compiled::BloomCheck` with `Compiled::TrieCheck` (prefix trie walk via `rsplit('.')`)
- Box `BloomMap` data to satisfy `large_enum_variant` lint
- Add `matches_naive_reference_zst` proptest for the trie path
- `BloomFilter` and `BloomMap` path unchanged (still used for value-bearing `DomainTrie<T>`)

**`crates/meow-trie/tests/bloom_mismatch_test.rs`** (new, 1950 lines)
- 7 tests with MetaCubeX geosite domains (google, twitter, youtube, telegram, netflix, github, bilibili, spotify)
- 5 tests with real-world Clash configs from GitHub

**`crates/meow-rules/tests/geosite_rss_test.rs`** (new, 334 lines)
- RSS scaling test: builds synthetic geosite MRS at 1k–50k CN domains, measures `/proc/self/status` VmRSS
- Result: 50k domains → ~350 kB RSS delta

**`docs/specs/bloom-filter-domain-trie.md`** (new)

## Test plan

- [x] `cargo test -p meow-trie --lib` — 14 unit tests + 2 proptests pass
- [x] `cargo test -p meow-trie --test bloom_mismatch_test` — 12 mismatch tests pass (0% FPR)
- [x] `cargo test --test rules_test` — 100 rule matching tests pass
- [x] `cargo test -p meow-rules --lib` — 134 tests pass
- [x] `cargo test -p meow-tunnel --lib` — 14 tests pass
- [x] `cargo test -p meow-listener --lib` — 23 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p meow-rules --test geosite_rss_test --release -- --ignored --nocapture` — 50k domains < 50 MB budget

https://claude.ai/code/session_01X6mzvSXb3iMC55n1KeoPBd

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6mzvSXb3iMC55n1KeoPBd)_