### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
## Release v0.11.0

### New Features
- **Geosite Plain/Regex support** — all four V2Ray geosite domain types now matched: Domain (suffix), Full (exact), Plain (keyword via substring), Regex (via per-category lazy RegexSet)
- **Config compatibility** — accept upstream mihomo configs verbatim: port ranges (`8080-8880`), scalar `exclude-type`, `tls://` IP-literal default-nameserver

### Performance
- **Active memory footprint 53→38 MB** (−28%) — DomainTrie builds nodes directly during insert, eliminating the double-allocation watermark from buffered entries + lazy compilation
- **3→1 heap allocations per geosite query** — `search_normalized()` skips redundant `to_ascii_lowercase()` when caller pre-normalizes; domain lowercased once and reused across trie, keyword, and regex paths
- **Lazy RegexSet compilation** — patterns stored as raw strings, compiled on first lookup per category; +0 MB idle cost
- **DomainTrie seal() API** — optional HashMap→sorted-slice compaction for compact read-only representation

### Testing
- RSS stress tests (10K domains × 200K queries) confirming zero RSS growth between query batches
- 610 unit tests, 3-way clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)