### PR TITLE
perf: cache TlsLayer per adapter, fix per-connection SSL_CTX rebuilds

### DIFF
--- a/config-memleak-ech.yaml.example
+++ b/config-memleak-ech.yaml.example
@@ -1,0 +1,36 @@
+# Memory-leak test config for meow-bench --only memleak
+#
+# Copy this file to config-memleak-ech.yaml (gitignored) and fill in your
+# ECH-TLS-tunnel server details. Then run:
+#
+#   cargo run --bin meow-bench -- --only memleak \
+#       --memleak-config config-memleak-ech.yaml \
+#       --memleak-rounds 20 --memleak-conns 200 --concurrency 16
+
+mixed-port: 17890
+allow-lan: false
+bind-address: "127.0.0.1"
+mode: rule
+log-level: warning
+ipv6: false
+
+dns:
+  enable: false
+
+proxies:
+  - name: ech-tunnel
+    type: ss
+    server: tunnel.example.com       # <-- your server hostname
+    port: 443
+    cipher: aes-128-gcm              # <-- your cipher
+    password: "your-password"        # <-- your password
+    udp: false
+    plugin: ech-tls-tunnel
+    plugin-opts:
+      mode: client
+      sni: tunnel.example.com       # <-- inner SNI (usually same as server)
+      path: /ws-secret              # <-- your WebSocket path
+      ech_config: "REPLACE_ME"      # <-- base64 ECHConfigList from server
+
+rules:
+  - MATCH,ech-tunnel

--- a/crates/meow-bench/src/bench_memleak.rs
+++ b/crates/meow-bench/src/bench_memleak.rs
@@ -1,0 +1,200 @@
+/// Memory-leak detection test for long-running proxy workloads.
+///
+/// Simulates real-world browsing-like traffic through the proxy's SOCKS5 port:
+/// domain-based CONNECT to external HTTP(S) hosts, short-lived connections with
+/// small payloads, concurrent bursts, repeated over many rounds.  Samples RSS
+/// after each round and fits a linear regression to detect unbounded growth.
+///
+/// Intended for use with a real proxy config (e.g. ECH-TLS-tunnel) against a
+/// live server — requires network access.
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::bench_memory::measure_rss;
+use crate::socks5_client::socks5_connect_domain;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MemleakResult {
+    pub rounds: usize,
+    pub connections_per_round: usize,
+    pub concurrency: usize,
+    pub rss_samples_mb: Vec<f64>,
+    pub slope_kb_per_round: f64,
+    pub r_squared: f64,
+    pub verdict: String,
+}
+
+struct Target {
+    host: &'static str,
+    port: u16,
+    request: &'static str,
+}
+
+const TARGETS: &[Target] = &[
+    Target {
+        host: "www.gstatic.com",
+        port: 80,
+        request: "GET /generate_204 HTTP/1.1\r\nHost: www.gstatic.com\r\nConnection: close\r\n\r\n",
+    },
+    Target {
+        host: "cp.cloudflare.com",
+        port: 80,
+        request: "GET / HTTP/1.1\r\nHost: cp.cloudflare.com\r\nConnection: close\r\n\r\n",
+    },
+    Target {
+        host: "detectportal.firefox.com",
+        port: 80,
+        request: "GET /success.txt HTTP/1.1\r\nHost: detectportal.firefox.com\r\nConnection: close\r\n\r\n",
+    },
+];
+
+async fn do_one_request(proxy: SocketAddr, target: &Target) -> bool {
+    let Ok(mut stream) = socks5_connect_domain(proxy, target.host, target.port).await else {
+        return false;
+    };
+    if stream.write_all(target.request.as_bytes()).await.is_err() {
+        return false;
+    }
+    let mut buf = vec![0u8; 4096];
+    // Read at least the status line; don't care about full body.
+    match tokio::time::timeout(Duration::from_secs(10), stream.read(&mut buf)).await {
+        Ok(Ok(n)) if n > 0 => {}
+        _ => return false,
+    }
+    let _ = stream.shutdown().await;
+    true
+}
+
+/// Run one round: `conns_per_round` connections spread across `concurrency` workers.
+async fn run_round(proxy: SocketAddr, conns_per_round: usize, concurrency: usize) -> usize {
+    let per_worker = conns_per_round / concurrency.max(1);
+    let remainder = conns_per_round % concurrency.max(1);
+
+    let mut handles = Vec::with_capacity(concurrency);
+    for w in 0..concurrency {
+        let count = per_worker + if w < remainder { 1 } else { 0 };
+        let offset = w;
+        handles.push(tokio::spawn(async move {
+            let mut ok = 0usize;
+            for i in 0..count {
+                let idx = offset + i * concurrency;
+                let target = &TARGETS[idx % TARGETS.len()];
+                if do_one_request(proxy, target).await {
+                    ok += 1;
+                }
+            }
+            ok
+        }));
+    }
+
+    let mut total_ok = 0;
+    for h in handles {
+        if let Ok(n) = h.await {
+            total_ok += n;
+        }
+    }
+    total_ok
+}
+
+fn linear_regression(ys: &[f64]) -> (f64, f64, f64) {
+    let n = ys.len() as f64;
+    let xs: Vec<f64> = (0..ys.len()).map(|i| i as f64).collect();
+    let sum_x: f64 = xs.iter().sum();
+    let sum_y: f64 = ys.iter().sum();
+    let sum_xy: f64 = xs.iter().zip(ys.iter()).map(|(x, y)| x * y).sum();
+    let sum_xx: f64 = xs.iter().map(|x| x * x).sum();
+
+    let denom = n * sum_xx - sum_x * sum_x;
+    if denom.abs() < f64::EPSILON {
+        return (0.0, sum_y / n, 0.0);
+    }
+    let slope = (n * sum_xy - sum_x * sum_y) / denom;
+    let intercept = (sum_y - slope * sum_x) / n;
+
+    let mean_y = sum_y / n;
+    let ss_tot: f64 = ys.iter().map(|y| (y - mean_y).powi(2)).sum();
+    let ss_res: f64 = xs
+        .iter()
+        .zip(ys.iter())
+        .map(|(x, y)| {
+            let predicted = slope * x + intercept;
+            (y - predicted).powi(2)
+        })
+        .sum();
+    let r_squared = if ss_tot > 0.0 {
+        1.0 - ss_res / ss_tot
+    } else {
+        0.0
+    };
+
+    (slope, intercept, r_squared)
+}
+
+/// Maximum tolerable RSS growth rate (KB per round). Accounts for normal
+/// allocator fragmentation and OS page-rounding.  A true leak in the
+/// relay / transport / TLS path will far exceed this.
+const MAX_SLOPE_KB_PER_ROUND: f64 = 50.0;
+
+pub async fn bench_memleak(
+    proxy: SocketAddr,
+    proxy_pid: u32,
+    rounds: usize,
+    conns_per_round: usize,
+    concurrency: usize,
+) -> anyhow::Result<MemleakResult> {
+    eprintln!(
+        "  memleak: {rounds} rounds × {conns_per_round} connections, concurrency={concurrency}"
+    );
+
+    // Warmup — prime TLS session caches, DNS caches, etc.
+    eprintln!("  memleak: warming up (50 connections)...");
+    run_round(proxy, 50.min(conns_per_round), concurrency).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let mut rss_samples = Vec::with_capacity(rounds);
+
+    for round in 0..rounds {
+        let start = Instant::now();
+        let ok = run_round(proxy, conns_per_round, concurrency).await;
+        let elapsed = start.elapsed();
+
+        // Let the proxy settle (GC-like allocator coalescing, tokio task cleanup).
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let rss = measure_rss(proxy_pid)?;
+        let rss_mb = rss as f64 / 1_048_576.0;
+        rss_samples.push(rss_mb);
+
+        eprintln!(
+            "  memleak: round {}/{rounds}  ok={ok}/{conns_per_round}  {:.1}s  RSS={:.1} MB",
+            round + 1,
+            elapsed.as_secs_f64(),
+            rss_mb,
+        );
+    }
+
+    let (slope_mb, _intercept, r_squared) = linear_regression(&rss_samples);
+    let slope_kb = slope_mb * 1024.0;
+
+    let verdict = if slope_kb > MAX_SLOPE_KB_PER_ROUND && r_squared > 0.7 {
+        format!(
+            "LEAK SUSPECTED: RSS growing {slope_kb:.1} KB/round (R²={r_squared:.2}), threshold={MAX_SLOPE_KB_PER_ROUND} KB/round"
+        )
+    } else {
+        format!("OK: RSS slope {slope_kb:.1} KB/round (R²={r_squared:.2})")
+    };
+
+    eprintln!("  memleak: {verdict}");
+
+    Ok(MemleakResult {
+        rounds,
+        connections_per_round: conns_per_round,
+        concurrency,
+        rss_samples_mb: rss_samples,
+        slope_kb_per_round: slope_kb,
+        r_squared,
+        verdict,
+    })
+}

--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -3,6 +3,7 @@ mod bench_connrate;
 mod bench_dns;
 mod bench_idle_conns;
 mod bench_latency;
+mod bench_memleak;
 mod bench_memory;
 mod bench_throughput;
 mod echo_server;
@@ -61,9 +62,26 @@ struct Args {
     #[arg(long, default_value = "64")]
     concurrency: usize,
 
-    /// Run only a specific benchmark
+    /// Run only a specific benchmark (throughput, latency, connrate, dns, memleak)
     #[arg(long)]
     only: Option<String>,
+
+    /// Config for the memleak test (separate from the perf-bench config,
+    /// because it needs a live proxy with internet access, e.g. ECH-TLS-tunnel)
+    #[arg(long, default_value = "config.yaml")]
+    memleak_config: PathBuf,
+
+    /// Number of rounds for the memleak test
+    #[arg(long, default_value = "10")]
+    memleak_rounds: usize,
+
+    /// Connections per round in the memleak test
+    #[arg(long, default_value = "200")]
+    memleak_conns: usize,
+
+    /// SOCKS5 port the memleak config listens on (must match the config's mixed-port)
+    #[arg(long, default_value = "17890")]
+    memleak_port: u16,
 }
 
 const PROXY_PORT: u16 = 17890;
@@ -299,6 +317,12 @@ async fn main() -> anyhow::Result<()> {
 
     eprintln!("=== meow-rs benchmark suite ===\n");
 
+    // Memleak test is a standalone flow — it dials real external hosts through
+    // the proxy instead of using a local echo server.
+    if args.only.as_deref() == Some("memleak") {
+        return run_memleak_test(&args).await;
+    }
+
     // Benchmark Rust
     let rust_results = benchmark_target(&args.rust_binary, &args.config, "rust", &args).await?;
 
@@ -336,5 +360,78 @@ async fn main() -> anyhow::Result<()> {
         println!("{md}");
     }
 
+    Ok(())
+}
+
+async fn run_memleak_test(args: &Args) -> anyhow::Result<()> {
+    let proxy_addr: SocketAddr = format!("127.0.0.1:{}", args.memleak_port).parse()?;
+
+    eprintln!(
+        "[memleak] config: {}  binary: {}",
+        args.memleak_config.display(),
+        args.rust_binary.display()
+    );
+
+    if !args.memleak_config.exists() {
+        anyhow::bail!(
+            "memleak config not found: {}  (create one with an ECH-TLS-tunnel proxy or pass --memleak-config)",
+            args.memleak_config.display()
+        );
+    }
+
+    eprintln!("[memleak] starting proxy...");
+    let mut child = Command::new(&args.rust_binary)
+        .args(["-f", &args.memleak_config.to_string_lossy()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to start {}: {e}", args.rust_binary.display()))?;
+
+    let pid = child.id();
+
+    if let Err(e) = wait_for_port(proxy_addr, Duration::from_secs(15)).await {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(e);
+    }
+    eprintln!(
+        "[memleak] proxy ready (pid {pid}) on port {}",
+        args.memleak_port
+    );
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let rss_idle = bench_memory::measure_rss(pid)?;
+    eprintln!(
+        "[memleak] idle RSS: {:.1} MB",
+        rss_idle as f64 / 1_048_576.0
+    );
+
+    let result = bench_memleak::bench_memleak(
+        proxy_addr,
+        pid,
+        args.memleak_rounds,
+        args.memleak_conns,
+        args.concurrency,
+    )
+    .await?;
+
+    // Stop proxy
+    let _ = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status();
+    let _ = child.wait();
+
+    let json = serde_json::to_string_pretty(&result)?;
+    if let Some(output_path) = &args.output {
+        std::fs::write(output_path, &json)?;
+        eprintln!("[memleak] results written to {}", output_path.display());
+    } else {
+        println!("{json}");
+    }
+
+    if result.slope_kb_per_round > 50.0 && result.r_squared > 0.7 {
+        std::process::exit(1);
+    }
     Ok(())
 }

--- a/crates/meow-bench/src/socks5_client.rs
+++ b/crates/meow-bench/src/socks5_client.rs
@@ -54,3 +54,47 @@ pub async fn socks5_connect(proxy: SocketAddr, target: SocketAddr) -> std::io::R
 
     Ok(stream)
 }
+
+/// SOCKS5 CONNECT via domain name (ATYP 0x03). Returns a stream tunneled to
+/// `host:port` through `proxy`.
+pub async fn socks5_connect_domain(
+    proxy: SocketAddr,
+    host: &str,
+    port: u16,
+) -> std::io::Result<TcpStream> {
+    let mut stream = TcpStream::connect(proxy).await?;
+
+    stream.write_all(&[0x05, 0x01, 0x00]).await?;
+
+    let mut buf = [0u8; 2];
+    stream.read_exact(&mut buf).await?;
+    if buf[0] != 0x05 || buf[1] != 0x00 {
+        return Err(std::io::Error::other(format!(
+            "SOCKS5 auth failed: {:02x} {:02x}",
+            buf[0], buf[1]
+        )));
+    }
+
+    let host_bytes = host.as_bytes();
+    let len = host_bytes.len();
+    if len > 255 {
+        return Err(std::io::Error::other("domain name too long"));
+    }
+    // VER=5, CMD=CONNECT, RSV=0, ATYP=0x03 (domain), LEN, DOMAIN, PORT
+    let mut req = Vec::with_capacity(4 + 1 + len + 2);
+    req.extend_from_slice(&[0x05, 0x01, 0x00, 0x03, len as u8]);
+    req.extend_from_slice(host_bytes);
+    req.extend_from_slice(&port.to_be_bytes());
+    stream.write_all(&req).await?;
+
+    let mut reply = [0u8; 10];
+    stream.read_exact(&mut reply).await?;
+    if reply[0] != 0x05 || reply[1] != 0x00 {
+        return Err(std::io::Error::other(format!(
+            "SOCKS5 connect failed: reply status {:02x}",
+            reply[1]
+        )));
+    }
+
+    Ok(stream)
+}

--- a/crates/meow-proxy/src/ech_tls_tunnel.rs
+++ b/crates/meow-proxy/src/ech_tls_tunnel.rs
@@ -135,10 +135,27 @@ pub fn parse_opts(s: &str) -> Result<EchTlsTunnelConfig> {
     })
 }
 
+/// Build a reusable `TlsLayer` from the parsed ECH config.
+///
+/// Call once at adapter construction time; the returned layer's
+/// `Transport::connect()` is safe to call from many tasks concurrently.
+pub fn build_tls_layer(cfg: &EchTlsTunnelConfig) -> Result<TlsLayer> {
+    let mut tls_config = TlsConfig::new(cfg.sni.clone());
+    tls_config.alpn = vec!["http/1.1".to_string()];
+    tls_config.ech = Some(EchOpts::Config(cfg.ech_config.clone()));
+    tls_config.fingerprint = cfg.fingerprint.clone();
+    TlsLayer::new(&tls_config).map_err(transport_to_proxy_err)
+}
+
 /// Dial a TLS-with-ECH + WebSocket connection to `server_host:server_port`
 /// and return the framed stream ready for the SS encryption layer.
+///
+/// `tls_layer` must be the layer returned by [`build_tls_layer`] — it is
+/// reused across connections so the BoringSSL `SSL_CTX` and root cert store
+/// are allocated only once.
 pub async fn dial(
     cfg: &EchTlsTunnelConfig,
+    tls_layer: &TlsLayer,
     server_host: &str,
     server_port: u16,
 ) -> Result<Box<dyn meow_transport::Stream>> {
@@ -157,14 +174,8 @@ pub async fn dial(
         .map_err(MeowError::Io)?;
     let _ = tcp.set_nodelay(true);
 
-    // 2) TLS (with ECH). The outer SNI is taken from the ECHConfigList's
-    //    `public_name` field by rustls; the `sni` we supply here becomes the
-    //    encrypted inner ServerName and the cert-validation target.
-    let mut tls_config = TlsConfig::new(cfg.sni.clone());
-    tls_config.alpn = vec!["http/1.1".to_string()];
-    tls_config.ech = Some(EchOpts::Config(cfg.ech_config.clone()));
-    tls_config.fingerprint = cfg.fingerprint.clone();
-    let tls_layer = TlsLayer::new(&tls_config).map_err(transport_to_proxy_err)?;
+    // 2) TLS (with ECH). Reuse the pre-built TlsLayer — avoids rebuilding
+    //    the BoringSSL SSL_CTX and re-parsing ~150 root certs per connection.
     let tls_stream = tls_layer
         .connect(Box::new(tcp))
         .await

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use meow_common::{
     AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
 };
+use meow_transport::tls::TlsLayer;
 use shadowsocks::config::{Mode, ServerAddr, ServerConfig, ServerType};
 use shadowsocks::context::Context;
 use shadowsocks::crypto::CipherKind;
@@ -44,9 +45,9 @@ enum PluginKind {
     /// subprocess alive for the adapter's lifetime.
     External(#[allow(dead_code)] Plugin),
     Obfs(BuiltinObfs),
-    V2ray(V2rayPluginConfig),
+    V2ray(V2rayPluginConfig, Option<TlsLayer>),
     #[cfg(feature = "ech-tls-tunnel")]
-    EchTlsTunnel(EchTlsTunnelConfig),
+    EchTlsTunnel(EchTlsTunnelConfig, TlsLayer),
 }
 
 pub struct ShadowsocksAdapter {
@@ -96,7 +97,8 @@ impl ShadowsocksAdapter {
                     "SS '{}' using built-in v2ray-plugin: tls={} host={} path={} mux={}",
                     name, cfg.tls, cfg.host, cfg.path, cfg.mux
                 );
-                PluginKind::V2ray(cfg)
+                let tls = v2ray_plugin::build_tls_layer(&cfg)?;
+                PluginKind::V2ray(cfg, tls)
             }
             #[cfg(feature = "ech-tls-tunnel")]
             Some("ech-tls-tunnel") => {
@@ -108,7 +110,8 @@ impl ShadowsocksAdapter {
                     cfg.path,
                     cfg.ech_config.len()
                 );
-                PluginKind::EchTlsTunnel(cfg)
+                let tls = ech_tls_tunnel::build_tls_layer(&cfg)?;
+                PluginKind::EchTlsTunnel(cfg, tls)
             }
             Some(pname) => {
                 let plugin_config = PluginConfig {
@@ -352,8 +355,9 @@ impl ProxyAdapter for ShadowsocksAdapter {
                     }
                 }
             }
-            PluginKind::V2ray(cfg) => {
-                let transport = v2ray_plugin::dial(cfg, &self.server, self.port).await?;
+            PluginKind::V2ray(cfg, tls) => {
+                let transport =
+                    v2ray_plugin::dial(cfg, tls.as_ref(), &self.server, self.port).await?;
                 let stream = ProxyClientStream::from_stream(
                     Arc::clone(&self.context),
                     transport,
@@ -363,8 +367,8 @@ impl ProxyAdapter for ShadowsocksAdapter {
                 Ok(Box::new(SsConn(stream)))
             }
             #[cfg(feature = "ech-tls-tunnel")]
-            PluginKind::EchTlsTunnel(cfg) => {
-                let transport = ech_tls_tunnel::dial(cfg, &self.server, self.port).await?;
+            PluginKind::EchTlsTunnel(cfg, tls) => {
+                let transport = ech_tls_tunnel::dial(cfg, tls, &self.server, self.port).await?;
                 let stream = ProxyClientStream::from_stream(
                     Arc::clone(&self.context),
                     transport,
@@ -407,13 +411,13 @@ impl ProxyAdapter for ShadowsocksAdapter {
     }
 
     async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        if matches!(self.plugin, PluginKind::V2ray(_)) {
+        if matches!(self.plugin, PluginKind::V2ray(..)) {
             return Err(MeowError::NotSupported(
                 "v2ray-plugin does not support UDP relay".into(),
             ));
         }
         #[cfg(feature = "ech-tls-tunnel")]
-        if matches!(self.plugin, PluginKind::EchTlsTunnel(_)) {
+        if matches!(self.plugin, PluginKind::EchTlsTunnel(..)) {
             return Err(MeowError::NotSupported(
                 "ech-tls-tunnel does not support UDP relay".into(),
             ));

--- a/crates/meow-proxy/src/v2ray_plugin.rs
+++ b/crates/meow-proxy/src/v2ray_plugin.rs
@@ -117,10 +117,30 @@ pub fn parse_opts(s: &str) -> Result<V2rayPluginConfig> {
     Ok(cfg)
 }
 
+/// Build a reusable `TlsLayer` for a v2ray-plugin config with `tls=true`.
+///
+/// Call once at adapter construction time. Returns `None` when TLS is disabled.
+pub fn build_tls_layer(cfg: &V2rayPluginConfig) -> Result<Option<TlsLayer>> {
+    if !cfg.tls {
+        return Ok(None);
+    }
+    let tls_config = TlsConfig {
+        skip_cert_verify: cfg.skip_cert_verify,
+        ..TlsConfig::new(cfg.host.clone())
+    };
+    TlsLayer::new(&tls_config)
+        .map(Some)
+        .map_err(transport_to_proxy_err)
+}
+
 /// Dial a TCP (+ optional TLS) + WebSocket connection to `server_host:server_port`
 /// and return the framed stream ready to be wrapped by the SS encryption layer.
+///
+/// When `tls_layer` is `Some`, it is reused across connections so the
+/// BoringSSL `SSL_CTX` and root cert store are allocated only once.
 pub async fn dial(
     cfg: &V2rayPluginConfig,
+    tls_layer: Option<&TlsLayer>,
     server_host: &str,
     server_port: u16,
 ) -> Result<Box<dyn meow_transport::Stream>> {
@@ -140,15 +160,9 @@ pub async fn dial(
         .await
         .map_err(MeowError::Io)?;
 
-    // 2) Optional TLS handshake via TlsLayer.
-    let stream: Box<dyn meow_transport::Stream> = if cfg.tls {
-        let tls_config = TlsConfig {
-            skip_cert_verify: cfg.skip_cert_verify,
-            ..TlsConfig::new(host_header.clone())
-        };
-        let tls_layer = TlsLayer::new(&tls_config).map_err(transport_to_proxy_err)?;
-        tls_layer
-            .connect(Box::new(tcp))
+    // 2) Optional TLS handshake via the pre-built TlsLayer.
+    let stream: Box<dyn meow_transport::Stream> = if let Some(tls) = tls_layer {
+        tls.connect(Box::new(tcp))
             .await
             .map_err(transport_to_proxy_err)?
     } else {


### PR DESCRIPTION
## Summary

- **Fixed per-connection BoringSSL SSL_CTX rebuilds** in `ech_tls_tunnel::dial()` and `v2ray_plugin::dial()` — the `TlsLayer` (wrapping an `SSL_CTX` + ~150 webpki root certs) was rebuilt on every connection instead of being reused. Now built once at `ShadowsocksAdapter` construction time.
- **Added `meow-bench --only memleak`** — drives real HTTP traffic through the SOCKS5 proxy, samples RSS per round, fits linear regression to detect unbounded growth.

**Before fix:** 95 MB peak RSS, 1655 KB/round growth (R²=0.75, LEAK SUSPECTED)
**After fix:** 20 MB peak RSS, -1.6 KB/round growth (R²=0.01, flat)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default / no-default-features / all-features)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` (610 tests pass)
- [x] Memleak bench run with ECH-TLS-tunnel config: 20 rounds × 500 connections × 32 concurrency — RSS flat at 20.2 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)