### PR TITLE
fix: disable BoringSSL unbounded session cache (memory leak)

### DIFF
--- a/crates/meow-transport/src/tls.rs
+++ b/crates/meow-transport/src/tls.rs
@@ -846,6 +846,15 @@ impl BoringInner {
                 .map_err(|e| TransportError::Tls(format!("boring: set_private_key: {e}")))?;
         }
 
+        // Disable the internal session cache. BoringSSL defaults to
+        // SSL_SESS_CACHE_BOTH with unbounded size — every completed
+        // handshake stores an SSL_SESSION in the SSL_CTX that is never
+        // evicted, leaking memory proportional to connection count.
+        // A proxy client dials many distinct servers and gains nothing
+        // from caching sessions to a single upstream; turning the cache
+        // off eliminates the leak with no performance cost.
+        b.set_session_cache_mode(boring::ssl::SslSessionCacheMode::OFF);
+
         let connector = b.build();
         Ok(Self {
             connector,


### PR DESCRIPTION
## Summary

- **Root cause**: BoringSSL defaults to `SSL_SESS_CACHE_BOTH` with unbounded size (0 = unlimited). Every completed TLS handshake through the fingerprint/ECH path stores an `SSL_SESSION` in the shared `SSL_CTX` that is never evicted — memory grows proportional to total connection count.
- **Fix**: `set_session_cache_mode(SslSessionCacheMode::OFF)` on the `SslConnector` builder. A proxy client dials many distinct servers; caching sessions to a single upstream provides no benefit.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default / no-default-features / all-features)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` (610 tests pass)
- [x] `meow-bench --only memleak`: 20 rounds × 500 connections (10,000 total), RSS flat at 20.4 MB (6 KB/round = noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)