### PR TITLE
fix: install rustls crypto provider before geodata download

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -465,6 +465,12 @@ fn parse_sniffer_config(raw: &raw::RawConfig) -> Result<SnifferConfig, anyhow::E
 /// subsequent parser-context build will hard-error if the file is still
 /// absent, giving a clear diagnostic.
 async fn ensure_geodata(raw: &raw::RawConfig, geo: &GeoDataConfig) {
+    // The direct download path (no proxy) uses reqwest which needs a rustls
+    // CryptoProvider. Install ring as the default — idempotent if main.rs
+    // already did this, and harmless in --all-features builds where both
+    // ring and aws-lc-rs are compiled in.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let lines: &[String] = raw.rules.as_deref().unwrap_or(&[]);
 
     let needs_geoip = lines.iter().any(|l| line_is_geoip_rule(l));


### PR DESCRIPTION
## Summary
- Coverage CI runs `--all-features` which enables both `ring` and `aws-lc-rs`. The `ensure_geodata` direct-download path uses `reqwest` which needs a process-level `CryptoProvider` — panics when it can't auto-detect one. Fix: call `install_default()` with ring before the download, matching what `main.rs` does.

## Test plan
- [x] Full regression bar passes locally
- [ ] Coverage CI re-run should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)