### PR TITLE
fix: gate ECH inline test for --all-features CI

### DIFF
--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -14,6 +14,7 @@ vmess = ["meow-proxy/vmess"]
 anytls = ["meow-proxy/anytls"]
 hysteria2 = ["meow-proxy/hysteria2"]
 boring-tls = ["meow-transport/boring-tls"]
+ech = ["meow-transport/ech"]
 ech-tls-tunnel = ["ss", "meow-proxy/ech-tls-tunnel"]
 
 [dependencies]

--- a/crates/meow-config/tests/ech_dns_test.rs
+++ b/crates/meow-config/tests/ech_dns_test.rs
@@ -24,7 +24,9 @@
 
 use std::collections::HashMap;
 
+// Used by E9 (boring-tls + !ech) and E9b (!boring-tls).
 #[cfg(feature = "vless")]
+#[allow(unused_imports)]
 use base64::Engine;
 use meow_config::ech_dns::preresolve_ech;
 #[cfg(feature = "vless")]
@@ -240,12 +242,12 @@ proxies:
 
 // ─── E9: well-formed inline base64 loads cleanly through parse_vless ──────
 //
-// Requires `boring-tls`: without the feature, `TlsLayer::new` rejects any
-// `TlsConfig.ech = Some(_)` at construction time (the rustls path can't
-// honour ECH), and parse_vless propagates the error so the proxy is
-// dropped. With `boring-tls` on, the layer accepts the config (the actual
-// wire-format validation happens on connect, covered in boring_tls_test).
-#[cfg(all(feature = "vless", feature = "boring-tls"))]
+// Requires `boring-tls` *without* `ech`: the boring backend defers ECH
+// wire-format validation to connect-time, so junk bytes are accepted at
+// parse time. When the `ech` feature is also on, rustls eagerly validates
+// the ECH config list and rejects the dummy bytes, causing the proxy to be
+// dropped — that path is correct but makes this test fail.
+#[cfg(all(feature = "vless", feature = "boring-tls", not(feature = "ech")))]
 #[tokio::test]
 async fn parse_vless_ech_inline_valid_base64_loads() {
     let blob = base64::engine::general_purpose::STANDARD.encode(b"\x00\x01\x02\x03");


### PR DESCRIPTION
## Summary
- With `--all-features`, both `boring-tls` and `ech` are active. ECH routes through rustls which eagerly rejects the dummy config bytes in test E9. Gate E9 on `not(feature = "ech")` and add `ech` feature forwarding to meow-config.

## Test plan
- [x] Full regression bar (fmt, clippy x3, doc, tests)
- [ ] Coverage CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)