### PR TITLE
ci: skip RSS stress test and live download in coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,9 @@ jobs:
                --skip doh_resolves_example_com \
                --skip dot_bogus_sni_fails_cert_validation \
                --skip doh_bogus_sni_fails_cert_validation \
-               --skip dot_hostname_with_bootstrap_resolves
+               --skip dot_hostname_with_bootstrap_resolves \
+               --skip geosite_rss_10k_rules_100k_queries \
+               --skip live_download_from_default_urls
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary
- Skip `geosite_rss_10k_rules_100k_queries` — RSS inflated under llvm-cov, causing spurious leak detection (7744 KB vs 512 KB threshold)
- Skip `live_download_from_default_urls` — flaky on CI (hits real GitHub CDN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)