### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.11.0 to 0.12.0 for release

## Test plan
- [x] `cargo check` builds successfully
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test --lib` — 636 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)