### PR TITLE
fix: bound gRPC frame buffer + abort fakeip flush task + skip redundant geosite lowercase

### DIFF
--- a/crates/meow-dns/src/fakeip.rs
+++ b/crates/meow-dns/src/fakeip.rs
@@ -148,6 +148,10 @@ pub struct FileStore {
     reverse: Mutex<HashMap<IpAddr, SmolStr>>,
     dirty: Arc<AtomicBool>,
     notify: Arc<tokio::sync::Notify>,
+    /// Handle to the background debounce-flush task, aborted on drop so the
+    /// task (which parks forever on `notify.notified()` and holds `Arc` clones
+    /// of `state`/`dirty`/`notify`) does not outlive the store.
+    flush_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl FileStore {
@@ -189,24 +193,29 @@ impl FileStore {
         let dirty = Arc::new(AtomicBool::new(false));
         let notify = Arc::new(tokio::sync::Notify::new());
 
-        let store = Self {
+        let flush_task = Self::spawn_flush_task(
+            path.clone(),
+            Arc::clone(&state),
+            Arc::clone(&dirty),
+            Arc::clone(&notify),
+        );
+
+        Ok(Self {
             path,
             state,
             reverse: Mutex::new(reverse),
             dirty,
             notify,
-        };
-
-        store.spawn_flush_task();
-        Ok(store)
+            flush_task: Some(flush_task),
+        })
     }
 
-    fn spawn_flush_task(&self) {
-        let path = self.path.clone();
-        let state = Arc::clone(&self.state);
-        let dirty = Arc::clone(&self.dirty);
-        let notify = Arc::clone(&self.notify);
-
+    fn spawn_flush_task(
+        path: PathBuf,
+        state: Arc<Mutex<PersistedSnapshot>>,
+        dirty: Arc<AtomicBool>,
+        notify: Arc<tokio::sync::Notify>,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             loop {
                 notify.notified().await;
@@ -221,7 +230,7 @@ impl FileStore {
                     persist_to_file(&path, &snap);
                 }
             }
-        });
+        })
     }
 
     fn mark_dirty(&self) {
@@ -240,6 +249,17 @@ impl Drop for FileStore {
         if self.dirty.swap(false, Ordering::SeqCst) {
             let snap = serialise(&self.state.lock());
             persist_to_file(&self.path, &snap);
+        }
+        // Abort the background flush task. It parks forever on
+        // `notify.notified()` (nothing signals it after the store drops) and
+        // holds `Arc` clones of `state`/`dirty`/`notify`, so without this it
+        // would leak a task plus the snapshot on every `FileStore` drop —
+        // e.g. once per fake-ip config reload. The final flush above already
+        // persisted any pending state. `abort()` cancels at the task's next
+        // await point, so an in-progress synchronous `persist_to_file` is not
+        // torn.
+        if let Some(handle) = self.flush_task.take() {
+            handle.abort();
         }
     }
 }

--- a/crates/meow-dns/tests/filestore_task_leak_test.rs
+++ b/crates/meow-dns/tests/filestore_task_leak_test.rs
@@ -1,0 +1,56 @@
+//! Regression test: `fakeip::FileStore` must abort its background flush task
+//! on drop, not leak it.
+//!
+//! `FileStore::open` spawns a debounce-flush task that parks on
+//! `notify.notified().await` and holds `Arc` clones of the store's
+//! `state`/`dirty`/`notify`. Before the fix the `JoinHandle` was discarded and
+//! `Drop for FileStore` did not abort it, so every dropped store (e.g. once per
+//! fake-ip config reload) leaked one detached task plus its snapshot —
+//! unbounded task + heap growth over a long-running daemon. The fix stores the
+//! handle and `abort()`s it in `Drop` (mirroring the UDP NAT sweeper's
+//! self-exit at crates/meow-tunnel/src/udp.rs:71).
+//!
+//! This test opens and drops many `FileStore`s and asserts the runtime's
+//! alive-task count returns to baseline. It FAILS if the abort-on-drop
+//! regresses.
+
+use std::time::Duration;
+
+use meow_dns::fakeip::FileStore;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn filestore_does_not_leak_flush_task_on_drop() {
+    let handle = tokio::runtime::Handle::current();
+    let tmp = std::env::temp_dir();
+
+    // Settle, then snapshot the alive-task count.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let baseline = handle.metrics().num_alive_tasks();
+
+    const N: usize = 50;
+    for i in 0..N {
+        let path = tmp.join(format!("meow-fakeip-leak-{}-{i}.json", std::process::id()));
+        let store = FileStore::open(&path).expect("open FileStore");
+        // Each open() spawned a flush task; dropping the store should reclaim it.
+        drop(store);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // Give any (correct) drop-time cleanup time to run.
+    // Allow abort-on-drop cancellations to be reaped by the runtime.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let after = handle.metrics().num_alive_tasks();
+    let leaked = after.saturating_sub(baseline);
+
+    println!(
+        "FileStore flush tasks: baseline_alive_tasks={baseline} after_{N}_open+drop={after} \
+         leaked={leaked}  (must be ~0 — the flush task is aborted on drop)"
+    );
+
+    assert!(
+        leaked <= 2,
+        "FileStore leaked {leaked} background flush tasks after opening and dropping {N} stores \
+         — Drop for FileStore must abort the task spawned in spawn_flush_task. Each leaked task \
+         also pins an Arc<Mutex<PersistedSnapshot>>."
+    );
+}

--- a/crates/meow-dns/tests/leak_net_test.rs
+++ b/crates/meow-dns/tests/leak_net_test.rs
@@ -1,0 +1,148 @@
+//! Net-allocation leak detection for the DNS-side bounded caches.
+//!
+//! Unlike `cache_soak.rs` (which samples process RSS — coarse, allocator-
+//! retention-dependent) this test installs a counting global allocator and
+//! measures *live* allocations (alloc − dealloc) at two different churn depths.
+//! A structure that frees on eviction keeps a roughly constant live-allocation
+//! count regardless of how many distinct keys flow through it, so the retained
+//! allocations *per operation* tends to zero. A genuine leak retains ~1 (or
+//! more) live allocation per operation, which this test catches as a
+//! near-linear slope.
+//!
+//! Run: `cargo test -p meow-dns --test leak_net_test -- --nocapture`
+//!
+//! Single `#[test]` running scenarios sequentially: the global allocator's
+//! counters are process-wide, so concurrent test functions would race them.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use meow_dns::fakeip::{MemoryStore, Pool, Store};
+use meow_dns::DnsCache;
+
+struct CountingAlloc;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static DEALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static A: CountingAlloc = CountingAlloc;
+
+/// `cargo llvm-cov` injects allocations that invalidate these thresholds.
+fn under_coverage() -> bool {
+    std::env::var_os("LLVM_PROFILE_FILE").is_some()
+}
+
+/// Currently-live heap allocations (alloc count − dealloc count).
+fn live() -> i64 {
+    ALLOCS.load(Ordering::SeqCst) as i64 - DEALLOCS.load(Ordering::SeqCst) as i64
+}
+
+fn ipv4(n: u32) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::from(n))
+}
+
+/// Two-point slope leak probe.
+///
+/// `op(i)` performs one churn operation (e.g. a unique cache insert). We run
+/// `warm` ops to bring the structure to steady state, snapshot live allocs,
+/// run `n` more ops, snapshot again, and return retained-per-op. A bounded
+/// structure returns ~0.0; an unbounded one returns ~1.0+ (one live alloc
+/// retained per op).
+fn retained_per_op(label: &str, warm: u32, n: u32, mut op: impl FnMut(u32)) -> f64 {
+    for i in 0..warm {
+        op(i);
+    }
+    let before = live();
+    for i in warm..(warm + n) {
+        op(i);
+    }
+    let after = live();
+    let slope = (after - before) as f64 / n as f64;
+    println!("  {label}: live {before} -> {after} over {n} ops  =>  {slope:+.5} retained-alloc/op");
+    slope
+}
+
+#[test]
+fn dns_side_caches_do_not_leak_under_churn() {
+    // Thresholds: a bounded structure must retain well under 0.05 live
+    // allocations per churn op once at steady state. A leak retains ~1.0/op.
+    const MAX_SLOPE: f64 = 0.05;
+
+    println!("\n── DnsCache forward+reverse LRU (cap=1024) ──");
+    let cache = DnsCache::new(1024);
+    // Each put: unique domain + single unique IP -> exercises forward LRU
+    // (Arc<str> key + Box<[IpAddr]>) and reverse LRU (Arc<str> clone).
+    let dns_slope = retained_per_op("DnsCache.put", 4_096, 50_000, |i| {
+        cache.put(
+            &format!("host-{i}.example.test"),
+            &[ipv4(i.wrapping_add(1))],
+            Duration::from_secs(60),
+        );
+    });
+    println!(
+        "  steady state: forward_len={} reverse_len={}",
+        cache.forward_len(),
+        cache.reverse_len()
+    );
+    assert!(
+        cache.forward_len() <= 1024,
+        "forward cache exceeded cap: {}",
+        cache.forward_len()
+    );
+
+    println!("\n── fakeip Pool / MemoryStore (store cap=256, /24 range) ──");
+    // /24 has ~250 allocatable addresses; store cap 256. Churning 50k unique
+    // hosts forces both the pool cursor to cycle AND the LRU to evict — the
+    // stress case for the host<->ip desync / leak hypothesis.
+    let store: Arc<dyn Store> = Arc::new(MemoryStore::new(256));
+    let pool = Pool::new("198.18.0.0/24".parse().unwrap(), Arc::clone(&store)).unwrap();
+    let fakeip_slope = retained_per_op("Pool.lookup", 2_048, 50_000, |i| {
+        let ip = pool.lookup(&format!("svc-{i}.fake.test"));
+        std::hint::black_box(ip);
+    });
+
+    println!("\n── fakeip Pool sized to full range (no LRU pressure, cursor-only) ──");
+    // Store cap larger than range: eviction is driven purely by the pool
+    // cursor (del_by_ip on wrap), not the LRU. This isolates the cursor
+    // eviction path — the FileStore's only bound uses the same logic.
+    let store2: Arc<dyn Store> = Arc::new(MemoryStore::new(1 << 20));
+    let pool2 = Pool::new("198.18.0.0/24".parse().unwrap(), Arc::clone(&store2)).unwrap();
+    let cursor_slope = retained_per_op("Pool.lookup(cursor)", 2_048, 50_000, |i| {
+        let ip = pool2.lookup(&format!("c-{i}.fake.test"));
+        std::hint::black_box(ip);
+    });
+
+    if under_coverage() {
+        println!("\n(coverage instrumentation active — skipping slope assertions)");
+        return;
+    }
+
+    assert!(
+        dns_slope < MAX_SLOPE,
+        "DnsCache leaks {dns_slope:.4} live allocs/put (threshold {MAX_SLOPE}) — \
+         reverse or forward map is not evicting"
+    );
+    assert!(
+        fakeip_slope < MAX_SLOPE,
+        "fakeip Pool (LRU store) leaks {fakeip_slope:.4} live allocs/lookup (threshold {MAX_SLOPE})"
+    );
+    assert!(
+        cursor_slope < MAX_SLOPE,
+        "fakeip Pool (cursor-only eviction) leaks {cursor_slope:.4} live allocs/lookup \
+         (threshold {MAX_SLOPE}) — cursor del_by_ip is not removing stale forward entries"
+    );
+}

--- a/crates/meow-rules/src/geosite.rs
+++ b/crates/meow-rules/src/geosite.rs
@@ -81,16 +81,26 @@ impl GeositeDB {
             category
         };
 
-        let domain_lower = domain.to_ascii_lowercase();
+        // `domain` is already ASCII-lowercased at every ingestion point
+        // (rule_host(), commit 0068548), so only pay for a lowercase copy on
+        // the rare mixed-case input — mirroring the `cat` guard above instead
+        // of allocating a String on every lookup.
+        let domain_lower;
+        let domain = if domain.bytes().any(|b| b.is_ascii_uppercase()) {
+            domain_lower = domain.to_ascii_lowercase();
+            domain_lower.as_str()
+        } else {
+            domain
+        };
 
         if let Some(trie) = self.categories.get(cat) {
-            if trie.search_normalized(&domain_lower).is_some() {
+            if trie.search_normalized(domain).is_some() {
                 return true;
             }
         }
 
         if let Some(kws) = self.keywords.get(cat) {
-            if kws.iter().any(|kw| domain_lower.contains(kw.as_str())) {
+            if kws.iter().any(|kw| domain.contains(kw.as_str())) {
                 return true;
             }
         }
@@ -106,7 +116,7 @@ impl GeositeDB {
                     })
                     .unwrap_or_default()
             });
-            if compiled.iter().any(|re| re.is_match(&domain_lower)) {
+            if compiled.iter().any(|re| re.is_match(domain)) {
                 return true;
             }
         }

--- a/crates/meow-rules/tests/geosite_lookup_alloc_test.rs
+++ b/crates/meow-rules/tests/geosite_lookup_alloc_test.rs
@@ -1,0 +1,81 @@
+//! Regression test: `GeositeDB::lookup` must not allocate for already-lowercase
+//! input.
+//!
+//! The category argument is guarded — only lowercased when it actually contains
+//! an uppercase byte (geosite.rs:77-82). Before the fix the domain was
+//! lowercased UNCONDITIONALLY via `domain.to_ascii_lowercase()`, even though the
+//! sole production caller, `GeoSiteRule::match_metadata`, passes
+//! `metadata.rule_host()` — guaranteed ASCII-lowercase at every ingestion point
+//! since commit 0068548. `str::to_ascii_lowercase` always allocates a fresh
+//! `String`, so that was ≈1 wasted heap allocation per match on the rule hot
+//! path. The fix guards the domain lowercase the same way the category is
+//! guarded.
+//!
+//! This installs a counting global allocator and asserts the per-lookup
+//! allocation count for already-lowercase input is ~0. It FAILS if the guard
+//! regresses.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use meow_rules::geosite::GeositeDB;
+
+struct CountingAlloc;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static A: CountingAlloc = CountingAlloc;
+
+fn under_coverage() -> bool {
+    std::env::var_os("LLVM_PROFILE_FILE").is_some()
+}
+
+#[test]
+fn geosite_lookup_is_zero_alloc_for_normalized_input() {
+    let mut db = GeositeDB::empty();
+    // A category with a few domains so the trie path is exercised on lookup.
+    db.insert("ads", "doubleclick.net");
+    db.insert("ads", "ad.example.com");
+    db.insert("cn", "example.cn");
+
+    // All inputs already lowercase (the production contract) and category is
+    // lowercase too (so the category guard takes its zero-alloc branch).
+    let domain = "lookup.misses.every.category.test";
+
+    // Warm any lazy init (regex OnceLock etc. — none here, but be safe).
+    let _ = db.lookup("ads", domain);
+
+    let before = ALLOCS.load(Ordering::SeqCst);
+    let n = 10_000;
+    for _ in 0..n {
+        let hit = db.lookup("ads", domain);
+        std::hint::black_box(hit);
+    }
+    let allocs = ALLOCS.load(Ordering::SeqCst) - before;
+    let per_lookup = allocs as f64 / n as f64;
+    println!(
+        "GeositeDB::lookup (already-lowercase input): {allocs} allocs / {n} lookups = \
+         {per_lookup:.3} allocs/lookup  (must be ~0 — the domain lowercase is guarded like cat)"
+    );
+
+    if under_coverage() {
+        println!("(coverage instrumentation active — skipping assertion)");
+        return;
+    }
+    assert!(
+        per_lookup < 0.1,
+        "GeositeDB::lookup allocates {per_lookup:.3} heap allocations per lookup for \
+         already-lowercase input — the domain lowercase must be guarded like the category arg \
+         (geosite.rs:77-82) given the rule_host() lowercase-at-ingestion contract (commit 0068548)."
+    );
+}

--- a/crates/meow-transport/Cargo.toml
+++ b/crates/meow-transport/Cargo.toml
@@ -120,6 +120,10 @@ name = "grpc_test"
 required-features = ["grpc"]
 
 [[test]]
+name = "grpc_unbounded_test"
+required-features = ["grpc"]
+
+[[test]]
 name = "h2_test"
 required-features = ["h2"]
 

--- a/crates/meow-transport/src/grpc.rs
+++ b/crates/meow-transport/src/grpc.rs
@@ -233,6 +233,18 @@ fn decode_varint(src: &[u8]) -> std::result::Result<(u64, usize), String> {
 
 // ─── GunStream ────────────────────────────────────────────────────────────────
 
+/// Maximum accepted gun-frame inner length (16 MiB).
+///
+/// `inner_len` arrives on the wire as an attacker-controlled BE32 (up to
+/// ~4 GiB) and [`GunStream::poll_read`] buffers a frame in `pending_frame`
+/// until it is complete. Without this cap a malicious/compromised upstream can
+/// declare a giant frame and trickle bytes to drive unbounded heap growth — a
+/// memory-exhaustion DoS (h2 flow-control does not bound it because every chunk
+/// eagerly releases receive-window capacity). 16 MiB sits far above any
+/// realistic relay frame while bounding worst-case in-flight buffering per
+/// connection. Mirrors the WebSocket `max_frame_size` cap in `ws.rs`.
+const MAX_GUN_FRAME_LEN: usize = 16 * 1024 * 1024;
+
 /// A bidirectional gRPC-framed stream over a single h2 request/response pair.
 struct GunStream {
     send: h2::SendStream<Bytes>,
@@ -286,6 +298,17 @@ impl AsyncRead for GunStream {
                     this.pending_frame[3],
                     this.pending_frame[4],
                 ]) as usize;
+                // Reject oversize frames up front (DoS guard). Checked on
+                // `inner_len` itself — not `5 + inner_len` — to avoid usize
+                // overflow on 32-bit targets where `5 + u32::MAX` would wrap.
+                if inner_len > MAX_GUN_FRAME_LEN {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "grpc: frame inner_len {inner_len} exceeds cap {MAX_GUN_FRAME_LEN}"
+                        ),
+                    )));
+                }
                 let frame_len = 5 + inner_len;
 
                 if this.pending_frame.len() >= frame_len {

--- a/crates/meow-transport/tests/grpc_unbounded_test.rs
+++ b/crates/meow-transport/tests/grpc_unbounded_test.rs
@@ -1,0 +1,178 @@
+//! Regression test: `GunStream::poll_read` must reject an oversize gun frame
+//! instead of buffering attacker-trickled bytes unbounded.
+//!
+//! `inner_len` arrives as an attacker-controlled BE32 (up to ~4 GiB) and the
+//! read path accumulates into `pending_frame` until the frame is complete. h2
+//! flow-control does not bound this because every received chunk eagerly
+//! releases receive-window capacity (grpc.rs:318). Before the fix a malicious /
+//! compromised upstream could send a 5-byte header declaring a 1 GiB frame and
+//! trickle bytes to drive the client toward OOM — a memory-exhaustion DoS.
+//!
+//! The fix caps the accepted frame at `MAX_GUN_FRAME_LEN` (16 MiB), rejecting
+//! oversize frames with `InvalidData` as soon as the header is seen (mirroring
+//! the WebSocket `max_frame_size` cap in ws.rs).
+//!
+//! This test drives a real in-process adversarial h2 server over loopback. With
+//! the cap, the client's read completes quickly with `InvalidData` and a
+//! byte-counting global allocator confirms heap growth stays well under the
+//! cap. WITHOUT the cap the read would stay `Pending` forever (buffering the
+//! trickle) and the outer timeout would fire — so the timeout is itself the
+//! regression guard.
+//!
+//! Requires `--features grpc`. Run:
+//!   cargo test -p meow-transport --features grpc --test grpc_unbounded_test -- --nocapture
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
+
+use bytes::Bytes;
+use meow_transport::grpc::{GrpcConfig, GrpcLayer};
+use meow_transport::Transport;
+use tokio::io::AsyncReadExt;
+use tokio::net::{TcpListener, TcpStream};
+
+struct ByteCountingAlloc;
+static LIVE_BYTES: AtomicI64 = AtomicI64::new(0);
+
+unsafe impl GlobalAlloc for ByteCountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            LIVE_BYTES.fetch_add(layout.size() as i64, Ordering::Relaxed);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE_BYTES.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static A: ByteCountingAlloc = ByteCountingAlloc;
+
+fn live_bytes() -> i64 {
+    LIVE_BYTES.load(Ordering::Relaxed)
+}
+
+/// Bytes the adversarial server attempts to trickle after the malicious header.
+/// A capped client resets the stream long before this lands; an uncapped client
+/// would buffer all of it.
+const TRICKLE_TOTAL: usize = 24 * 1024 * 1024; // 24 MiB
+const CHUNK: usize = 32 * 1024; // 32 KiB per h2 DATA frame
+/// The client's live-heap growth handling the attack must stay under this. The
+/// cap (`MAX_GUN_FRAME_LEN`) is 16 MiB; the oversize frame here declares 1 GiB
+/// and is rejected on sight, so growth should be near zero — well under 4 MiB.
+const MAX_OK_GROWTH: i64 = 4 * 1024 * 1024; // 4 MiB
+
+/// Spawn an adversarial gRPC (h2) server: accept one connection, send a
+/// gun-frame header declaring a 1 GiB inner length, then trickle data without
+/// ever completing the frame or ending the stream.
+async fn spawn_adversarial_server() -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+
+    tokio::spawn(async move {
+        let Ok((tcp, _)) = listener.accept().await else {
+            return;
+        };
+        let Ok(mut conn) = h2::server::handshake(tcp).await else {
+            return;
+        };
+        let Some(Ok((_req, mut respond))) = conn.accept().await else {
+            return;
+        };
+        // Drive connection-level frames in the background.
+        tokio::spawn(async move { while conn.accept().await.is_some() {} });
+
+        let response = http::Response::builder()
+            .status(200)
+            .body(())
+            .expect("resp");
+        let Ok(mut send) = respond.send_response(response, false) else {
+            return;
+        };
+
+        // Malicious gun-frame header: [compression=0x00][BE32 inner_len=0x40000000].
+        // inner_len = 1 GiB — far above MAX_GUN_FRAME_LEN, so a fixed client
+        // rejects it immediately.
+        let header = Bytes::from_static(&[0x00, 0x40, 0x00, 0x00, 0x00]);
+        if !send_data(&mut send, header).await {
+            return;
+        }
+
+        // Trickle (reusing one ref-counted chunk so the server itself does not
+        // allocate per chunk). `send_data` starts failing once the capped
+        // client resets the stream — that's expected.
+        let chunk = Bytes::from(vec![0u8; CHUNK]);
+        let mut sent = 0usize;
+        while sent < TRICKLE_TOTAL {
+            if !send_data(&mut send, chunk.clone()).await {
+                break;
+            }
+            sent += CHUNK;
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    addr
+}
+
+/// Send one DATA frame, waiting for h2 send capacity. Returns false on error.
+async fn send_data(send: &mut h2::SendStream<Bytes>, data: Bytes) -> bool {
+    let len = data.len();
+    send.reserve_capacity(len);
+    loop {
+        match std::future::poll_fn(|cx| send.poll_capacity(cx)).await {
+            Some(Ok(n)) if n >= len => break,
+            Some(Ok(_)) => continue,
+            _ => return false,
+        }
+    }
+    send.send_data(data, false).is_ok()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grpc_oversize_frame_is_rejected_not_buffered() {
+    let addr = spawn_adversarial_server().await;
+
+    let tcp = TcpStream::connect(addr).await.expect("tcp connect");
+    let layer = GrpcLayer::new(GrpcConfig::default());
+    let mut stream = layer.connect(Box::new(tcp)).await.expect("grpc connect");
+
+    let baseline = live_bytes();
+
+    // With the cap, poll_read rejects the 1 GiB frame as soon as the 5-byte
+    // header is seen, so this read returns InvalidData quickly. Without the cap
+    // it would stay Pending (buffering the trickle) and the timeout would fire.
+    let mut buf = [0u8; 4096];
+    let read_result = tokio::time::timeout(Duration::from_secs(10), stream.read(&mut buf)).await;
+
+    let growth = live_bytes() - baseline;
+    println!(
+        "gRPC oversize-frame guard: completed={}  heap_growth={} MiB  (max_ok {} MiB)",
+        read_result.is_ok(),
+        growth >> 20,
+        MAX_OK_GROWTH >> 20,
+    );
+
+    let io_result = read_result.expect(
+        "read did not complete within 10s — the oversize frame was not rejected; GunStream is \
+         buffering attacker-trickled data unbounded (MAX_GUN_FRAME_LEN cap missing or too high)",
+    );
+    let err = io_result.expect_err("expected an error for the oversize gun frame, got bytes");
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::InvalidData,
+        "oversize gun frame must be rejected with InvalidData, got: {err:?}"
+    );
+
+    assert!(
+        growth < MAX_OK_GROWTH,
+        "client heap grew {} MiB handling the oversize-frame attack — the MAX_GUN_FRAME_LEN cap \
+         must bound buffering well under {} MiB",
+        growth >> 20,
+        MAX_OK_GROWTH >> 20,
+    );
+}

--- a/crates/meow-tunnel/tests/leak_net_test.rs
+++ b/crates/meow-tunnel/tests/leak_net_test.rs
@@ -1,0 +1,228 @@
+//! Net-allocation leak detection for tunnel-side per-connection bookkeeping.
+//!
+//! Installs a counting global allocator and measures *live* allocations
+//! (alloc − dealloc) across churn. A correctly-cleaning structure keeps a
+//! constant live count regardless of how many connections/sessions flow
+//! through it (each insert's allocations are freed on close/remove), so the
+//! retained-per-op slope tends to zero. A leak retains ~1+/op.
+//!
+//! Run: `cargo test -p meow-tunnel --test leak_net_test -- --nocapture`
+//!
+//! One sequential `#[test]`: the allocator counters are process-wide, so
+//! concurrent test functions would race them. The async sweeper-drain check
+//! runs on a current-thread runtime built inside the single test.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use meow_common::error::Result as MeowResult;
+use meow_common::{ConnType, DnsMode, Metadata, Network, ProxyPacketConn};
+use meow_tunnel::udp::{new_nat_table, UdpSession};
+use meow_tunnel::Statistics;
+use smallvec::smallvec;
+use smol_str::SmolStr;
+
+struct CountingAlloc;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static DEALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static A: CountingAlloc = CountingAlloc;
+
+fn under_coverage() -> bool {
+    std::env::var_os("LLVM_PROFILE_FILE").is_some()
+}
+
+fn live() -> i64 {
+    ALLOCS.load(Ordering::SeqCst) as i64 - DEALLOCS.load(Ordering::SeqCst) as i64
+}
+
+fn retained_per_op(label: &str, warm: u32, n: u32, mut op: impl FnMut(u32)) -> f64 {
+    for i in 0..warm {
+        op(i);
+    }
+    let before = live();
+    for i in warm..(warm + n) {
+        op(i);
+    }
+    let after = live();
+    let slope = (after - before) as f64 / n as f64;
+    println!("  {label}: live {before} -> {after} over {n} ops  =>  {slope:+.5} retained-alloc/op");
+    slope
+}
+
+fn test_metadata() -> Metadata {
+    Metadata {
+        network: Network::Tcp,
+        conn_type: ConnType::Http,
+        host: SmolStr::new_static("example.com"),
+        dst_port: 443,
+        dns_mode: DnsMode::Normal,
+        ..Default::default()
+    }
+}
+
+/// Minimal UDP conn that owns a small heap buffer, so a failure to free the
+/// session (Box<dyn ProxyPacketConn> + its buffer) is visible to the counter.
+struct HeapConn {
+    _buf: Vec<u8>,
+}
+impl HeapConn {
+    fn new() -> Self {
+        Self {
+            _buf: vec![0u8; 64],
+        }
+    }
+}
+#[async_trait]
+impl ProxyPacketConn for HeapConn {
+    async fn read_packet(&self, _buf: &mut [u8]) -> MeowResult<(usize, SocketAddr)> {
+        Ok((0, "0.0.0.0:0".parse().unwrap()))
+    }
+    async fn write_packet(&self, buf: &[u8], _addr: &SocketAddr) -> MeowResult<usize> {
+        Ok(buf.len())
+    }
+    fn local_addr(&self) -> MeowResult<SocketAddr> {
+        Ok("0.0.0.0:0".parse().unwrap())
+    }
+    fn close(&self) -> MeowResult<()> {
+        Ok(())
+    }
+}
+
+fn nat_key(port: u16) -> (SocketAddr, SocketAddr) {
+    (
+        SocketAddr::from(([127, 0, 0, 1], port)),
+        SocketAddr::from(([8, 8, 8, 8], 53)),
+    )
+}
+
+#[test]
+fn tunnel_side_bookkeeping_does_not_leak() {
+    const MAX_SLOPE: f64 = 0.05;
+
+    println!("\n── Statistics: track_connection + close_connection churn ──");
+    let stats = Statistics::new();
+    let meta = test_metadata();
+    let stats_slope = retained_per_op("track+close", 1_000, 50_000, |_| {
+        let id = stats.track_connection(
+            meta.pure(),
+            SmolStr::new_static("DOMAIN"),
+            SmolStr::new_static("example.com"),
+            smallvec![Arc::from("Proxy")],
+        );
+        stats.close_connection(id);
+    });
+    assert_eq!(
+        stats.active_connection_count(),
+        0,
+        "all connections were closed; table must be empty"
+    );
+
+    println!("\n── Statistics: bulk track, then close_all (cleanup discipline) ──");
+    let base = live();
+    let ids: Vec<_> = (0..20_000)
+        .map(|_| {
+            stats.track_connection(
+                meta.pure(),
+                SmolStr::new_static("DOMAIN"),
+                SmolStr::new_static("example.com"),
+                smallvec![Arc::from("Proxy")],
+            )
+        })
+        .collect();
+    let with_conns = live();
+    assert_eq!(stats.active_connection_count(), 20_000);
+    for id in &ids {
+        stats.close_connection(*id);
+    }
+    drop(ids);
+    let after_close = live();
+    println!(
+        "  live: base={base} with_20k_conns={with_conns} after_close={after_close} \
+         (held ~{} allocs for 20k conns)",
+        with_conns - base
+    );
+    assert_eq!(stats.active_connection_count(), 0);
+    // After closing everything, live allocs must return close to the pre-bulk
+    // baseline. DashMap retains some bucket capacity, so allow generous slack
+    // but reject anything proportional to the 20k connections.
+    let residual = after_close - base;
+    println!("  residual live allocs after close_all: {residual}");
+
+    println!("\n── UDP NAT table: insert + remove churn ──");
+    let table = new_nat_table();
+    let udp_slope = retained_per_op("nat insert+remove", 1_000, 50_000, |i| {
+        let key = nat_key((i % 60000) as u16 + 1);
+        let session = Arc::new(UdpSession::new(
+            Box::new(HeapConn::new()),
+            Arc::from("proxy"),
+        ));
+        table.insert(key, session);
+        table.remove(&key);
+    });
+    assert_eq!(table.len(), 0, "every inserted session was removed");
+
+    println!("\n── UDP NAT table: bulk insert, then retain(false) drain ──");
+    let base_nat = live();
+    for i in 0..20_000u32 {
+        let key = nat_key((i % 60000) as u16 + 1);
+        table.insert(
+            key,
+            Arc::new(UdpSession::new(
+                Box::new(HeapConn::new()),
+                Arc::from("proxy"),
+            )),
+        );
+    }
+    let nat_full = live();
+    let nat_count = table.len();
+    table.retain(|_, _| false);
+    let nat_drained = live();
+    println!(
+        "  live: base={base_nat} full={nat_full} drained={nat_drained}  (table held {nat_count})"
+    );
+    assert_eq!(table.len(), 0, "retain(false) must drop all sessions");
+    let nat_residual = nat_drained - base_nat;
+    println!("  residual live allocs after drain: {nat_residual}");
+
+    if under_coverage() {
+        println!("\n(coverage instrumentation active — skipping slope assertions)");
+        return;
+    }
+
+    assert!(
+        stats_slope < MAX_SLOPE,
+        "Statistics leaks {stats_slope:.4} live allocs per track+close (threshold {MAX_SLOPE})"
+    );
+    assert!(
+        udp_slope < MAX_SLOPE,
+        "UDP NAT table leaks {udp_slope:.4} live allocs per insert+remove (threshold {MAX_SLOPE})"
+    );
+    // Residual after closing 20k connections must be far below 20k (would be
+    // ~20k+ if entries or their Arc<Metadata> leaked). Allow 2048 for retained
+    // DashMap/Vec bucket capacity.
+    assert!(
+        residual < 2_048,
+        "Statistics retained {residual} live allocs after closing 20k connections — \
+         entries or per-conn data are not being freed"
+    );
+    assert!(
+        nat_residual < 2_048,
+        "UDP NAT table retained {nat_residual} live allocs after draining 20k sessions"
+    );
+}

--- a/crates/meow-tunnel/tests/relay_churn_leak_test.rs
+++ b/crates/meow-tunnel/tests/relay_churn_leak_test.rs
@@ -1,0 +1,185 @@
+//! End-to-end relay-path churn leak test.
+//!
+//! `raii_guard_test.rs` proves a *single* aborted `handle_tcp` cleans up its
+//! `Statistics` entry. This test proves the *steady-state* path: thousands of
+//! short-lived connections, each fully relayed through a Direct-mode `Tunnel`
+//! against a loopback echo server, must leave no residual `Statistics` entries
+//! and no growing heap retention.
+//!
+//! A counting global allocator measures live allocations (alloc − dealloc)
+//! before and after a deep churn; the per-connection retention slope must be
+//! ~0. Leaking the per-connection `ConnectionInfo` (Arc<Metadata> + entry)
+//! would show ≥2 retained allocs/conn.
+//!
+//! No external network — loopback only.
+//! Run: `cargo test -p meow-tunnel --test relay_churn_leak_test -- --nocapture`
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use meow_common::{ConnType, Metadata, Network};
+use meow_dns::Resolver;
+use meow_trie::DomainTrie;
+use meow_tunnel::{tcp::handle_tcp, Tunnel};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+struct CountingAlloc;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static DEALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static A: CountingAlloc = CountingAlloc;
+
+fn under_coverage() -> bool {
+    std::env::var_os("LLVM_PROFILE_FILE").is_some()
+}
+
+fn live() -> i64 {
+    ALLOCS.load(Ordering::SeqCst) as i64 - DEALLOCS.load(Ordering::SeqCst) as i64
+}
+
+fn direct_tunnel() -> Tunnel {
+    let resolver = Arc::new(Resolver::new(
+        vec![],
+        vec![],
+        meow_common::DnsMode::Normal,
+        DomainTrie::new(),
+        false,
+    ));
+    let tunnel = Tunnel::new(resolver);
+    tunnel.set_mode(meow_common::TunnelMode::Direct);
+    tunnel
+}
+
+/// Loopback echo server: echoes every byte until the peer closes.
+async fn spawn_echo_server() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut s, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 1024];
+                loop {
+                    match s.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            if s.write_all(&buf[..n]).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+async fn loopback_pair() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (accept_res, connect_res) = tokio::join!(listener.accept(), TcpStream::connect(addr));
+    let (server, _) = accept_res.unwrap();
+    let client = connect_res.unwrap();
+    (server, client)
+}
+
+/// Drive one full connection through the tunnel: open an inbound loopback pair,
+/// hand the server half to `handle_tcp` (which dials the echo server in Direct
+/// mode), round-trip a payload, then close and await full teardown.
+async fn one_connection(tunnel: &Tunnel, echo: SocketAddr) {
+    let (server_stream, mut client_stream) = loopback_pair().await;
+    let metadata = Metadata {
+        network: Network::Tcp,
+        conn_type: ConnType::Inner,
+        dst_ip: Some(echo.ip()),
+        dst_port: echo.port(),
+        ..Default::default()
+    };
+    let inner = Arc::clone(tunnel.inner());
+    let h = tokio::spawn(async move {
+        handle_tcp(&inner, Box::new(server_stream), metadata).await;
+    });
+
+    client_stream.write_all(b"hello").await.unwrap();
+    let mut rbuf = [0u8; 5];
+    client_stream.read_exact(&mut rbuf).await.unwrap();
+    assert_eq!(&rbuf, b"hello", "echo round-trip failed");
+
+    // Close the inbound client → relay sees EOF → echo server sees EOF →
+    // handle_tcp returns → ConnectionGuard drops → Statistics entry removed.
+    client_stream.shutdown().await.ok();
+    drop(client_stream);
+    let _ = h.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relay_churn_does_not_leak_connections_or_heap() {
+    let echo = spawn_echo_server().await;
+    let tunnel = direct_tunnel();
+    let stats = Arc::clone(tunnel.statistics());
+
+    // Warm up: prime DashMap buckets, tokio task slabs, echo-server accept loop.
+    const WARM: u32 = 100;
+    const MEASURE: u32 = 1_000;
+    for _ in 0..WARM {
+        one_connection(&tunnel, echo).await;
+    }
+    // The guard removes the entry on the handle_tcp task's completion, which we
+    // already awaited; counts should be quiescent.
+    assert_eq!(
+        stats.active_connection_count(),
+        0,
+        "warmup left {} live connections — entries leaking",
+        stats.active_connection_count()
+    );
+
+    let before = live();
+    for _ in 0..MEASURE {
+        one_connection(&tunnel, echo).await;
+    }
+    let after = live();
+
+    let final_count = stats.active_connection_count();
+    let slope = (after - before) as f64 / MEASURE as f64;
+    println!(
+        "relay churn: {MEASURE} connections, live {before} -> {after}  =>  {slope:+.4} \
+         retained-alloc/conn, active_connections={final_count}"
+    );
+
+    assert_eq!(
+        final_count, 0,
+        "after {MEASURE} fully-closed connections, {final_count} entries remain in Statistics — \
+         the ConnectionGuard / close_connection path leaks under churn"
+    );
+
+    if under_coverage() {
+        println!("(coverage instrumentation active — skipping slope assertion)");
+        return;
+    }
+    // A clean relay path retains ~0 allocs/conn at steady state. Leaking the
+    // per-connection ConnectionInfo would retain >=2/conn. Allow slack for
+    // allocator/tokio steady-state jitter but reject a real linear leak.
+    assert!(
+        slope < 1.0,
+        "relay path retained {slope:.4} live allocs per connection over {MEASURE} \
+         connections — a per-connection heap leak"
+    );
+}

--- a/crates/meow-tunnel/tests/reload_churn_leak_test.rs
+++ b/crates/meow-tunnel/tests/reload_churn_leak_test.rs
@@ -1,0 +1,150 @@
+//! Config-reload churn leak test.
+//!
+//! Long-running proxies reload their rule/proxy tables repeatedly (subscription
+//! auto-refresh, REST `PUT /configs`, provider refresh). Each reload builds a
+//! fresh `RouteTable` and atomically swaps it in via `ArcSwap`; the previous
+//! table must be released once no in-flight connection references it. A reload
+//! path that pins old `RouteTable`s (rules Vec + domain index) would grow the
+//! heap monotonically across reload cycles — a slow leak that only shows up
+//! after days of uptime.
+//!
+//! This installs a counting global allocator and asserts the retained-alloc
+//! slope across many reloads is ~0.
+//!
+//! Run: `cargo test -p meow-tunnel --test reload_churn_leak_test -- --nocapture`
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
+use meow_dns::Resolver;
+use meow_trie::DomainTrie;
+use meow_tunnel::Tunnel;
+
+struct CountingAlloc;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static DEALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOCS.fetch_add(1, Ordering::SeqCst);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static A: CountingAlloc = CountingAlloc;
+
+fn under_coverage() -> bool {
+    std::env::var_os("LLVM_PROFILE_FILE").is_some()
+}
+
+fn live() -> i64 {
+    ALLOCS.load(Ordering::SeqCst) as i64 - DEALLOCS.load(Ordering::SeqCst) as i64
+}
+
+struct DomainRule {
+    domain: String,
+    adapter: String,
+}
+impl Rule for DomainRule {
+    fn rule_type(&self) -> RuleType {
+        RuleType::Domain
+    }
+    fn match_metadata(&self, m: &Metadata, _: &RuleMatchHelper) -> bool {
+        m.host.eq_ignore_ascii_case(&self.domain)
+    }
+    fn adapter(&self) -> &str {
+        &self.adapter
+    }
+    fn payload(&self) -> &str {
+        &self.domain
+    }
+}
+
+struct FinalRule;
+impl Rule for FinalRule {
+    fn rule_type(&self) -> RuleType {
+        RuleType::Match
+    }
+    fn match_metadata(&self, _: &Metadata, _: &RuleMatchHelper) -> bool {
+        true
+    }
+    fn adapter(&self) -> &str {
+        "DIRECT"
+    }
+    fn payload(&self) -> &str {
+        ""
+    }
+}
+
+fn direct_tunnel() -> Tunnel {
+    let resolver = Arc::new(Resolver::new(
+        vec![],
+        vec![],
+        meow_common::DnsMode::Normal,
+        DomainTrie::new(),
+        false,
+    ));
+    let tunnel = Tunnel::new(resolver);
+    tunnel.set_mode(meow_common::TunnelMode::Direct);
+    tunnel
+}
+
+/// Build a fresh ruleset of `n` domain rules + a final rule. Each call
+/// allocates new heap (Strings, Boxes, the Vec) that the prior reload's
+/// `RouteTable` must have released.
+fn build_rules(n: usize, salt: u32) -> Vec<Box<dyn Rule>> {
+    let mut rules: Vec<Box<dyn Rule>> = Vec::with_capacity(n + 1);
+    for i in 0..n {
+        rules.push(Box::new(DomainRule {
+            domain: format!("host-{i}-{salt}.example.test"),
+            adapter: "DIRECT".to_string(),
+        }));
+    }
+    rules.push(Box::new(FinalRule));
+    rules
+}
+
+#[test]
+fn config_reload_does_not_leak_old_route_tables() {
+    const RULES_PER_RELOAD: usize = 200;
+    const WARM: u32 = 20;
+    const RELOADS: u32 = 2_000;
+    // Each reload builds ~200 rules with heap-backed Strings; a clean swap
+    // retains ~0/reload. A leaked RouteTable retains hundreds of allocs/reload.
+    const MAX_SLOPE: f64 = 5.0;
+
+    let tunnel = direct_tunnel();
+
+    for s in 0..WARM {
+        tunnel.update_rules(build_rules(RULES_PER_RELOAD, s));
+    }
+
+    let before = live();
+    for s in 0..RELOADS {
+        tunnel.update_rules(build_rules(RULES_PER_RELOAD, WARM + s));
+    }
+    let after = live();
+
+    let slope = (after - before) as f64 / RELOADS as f64;
+    println!(
+        "config reload: {RELOADS} reloads × {RULES_PER_RELOAD} rules, live {before} -> {after}  \
+         =>  {slope:+.4} retained-alloc/reload"
+    );
+
+    if under_coverage() {
+        println!("(coverage instrumentation active — skipping slope assertion)");
+        return;
+    }
+    assert!(
+        slope < MAX_SLOPE,
+        "config reload retained {slope:.4} live allocs per reload over {RELOADS} reloads — \
+         old RouteTable (rules + domain index) is not being released by the ArcSwap swap"
+    );
+}


### PR DESCRIPTION
## Summary

A memory audit of meow-rs found **three confirmed memory issues** at the transport/DNS/rules edges. The data-plane hot paths (Statistics, DnsCache, fakeip Pool, UDP NAT, the relay path, ArcSwap config reload) were proven **leak-free** via new net-allocation tests, so the fixes here are localized to the edges.

## Fixes

**1. gRPC `pending_frame` unbounded growth — memory-exhaustion DoS (high)**
`GunStream::poll_read` buffered attacker-controlled gun frames (`inner_len` is a wire BE32, up to ~4 GiB) into `pending_frame` with no cap, and eagerly released the h2 receive window every chunk — defeating backpressure. A malicious/compromised upstream could send a 5-byte header declaring a 1 GiB frame and trickle bytes to drive the client toward OOM. Now `inner_len > MAX_GUN_FRAME_LEN` (16 MiB) is rejected with `InvalidData` on sight, mirroring the WebSocket `max_frame_size` cap. The 16 MiB cap is well above any realistic relay frame (and the existing 4 MiB round-trip test).

**2. fakeip `FileStore` detached flush-task leak (high)**
`FileStore::open` spawned an infinite debounce-flush task, discarded the `JoinHandle`, and `Drop` deliberately didn't abort it — so each dropped store (e.g. once per fake-ip config reload) leaked a task parked forever on `notify.notified()` plus its snapshot `Arc`. Now the handle is stored and `abort()`ed on `Drop` (the final synchronous flush still runs first). Mirrors the UDP NAT sweeper's self-exit pattern.

**3. GeositeDB per-lookup redundant allocation (efficiency)**
`lookup` unconditionally did `domain.to_ascii_lowercase()` though `rule_host()` is already lowercased at every ingestion point (commit 0068548) — ~1 wasted heap allocation per match on the rule hot path. Now guarded the same way the category arg already is.

## Tests

Regression tests for each fix (fail if the fix regresses):
- `grpc_unbounded_test` — adversarial in-process h2 server trickles a "1 GiB frame"; asserts the read fails fast with `InvalidData` and heap stays bounded (without the cap it hangs → timeout fails the test).
- `filestore_task_leak_test` — opens/drops 50 stores; asserts tokio alive-task count returns to baseline.
- `geosite_lookup_alloc_test` — asserts 0 allocs/lookup for already-lowercase input.

Net-allocation leak probes (new methodology: counting global allocator, live = alloc−dealloc, two-point slope) proving the data plane stays bounded under 20k–50k churn:
- `meow-tunnel`: Statistics, UDP NAT, real relay path, ArcSwap config reload
- `meow-dns`: DnsCache LRU, fakeip Pool

## Verification
- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets` (default / no-default-features / all-features) `-D warnings` ✓
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` ✓
- `cargo test --lib` ✓ ; gRPC round-trip, rules, trojan, dns integration ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)