### PR TITLE
feat: periodic health checks for fallback/url-test proxy groups

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -1030,13 +1030,7 @@ async fn probe_and_record(
     expected: Option<&str>,
     timeout: Duration,
 ) -> Result<u16, meow_proxy::health::UrlTestError> {
-    let adapter: &dyn meow_common::ProxyAdapter = proxy.as_ref();
-    let result = meow_proxy::health::url_test(adapter, url, expected, timeout).await;
-    match &result {
-        Ok(d) => proxy.health().record_delay(*d),
-        Err(_) => proxy.health().record_delay(0),
-    }
-    result
+    meow_proxy::health::probe_and_record(proxy, url, expected, timeout).await
 }
 
 async fn get_proxy_delay(

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -1,0 +1,97 @@
+use meow_tunnel::Tunnel;
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+const DEFAULT_URL: &str = "http://www.gstatic.com/generate_204";
+const DEFAULT_INTERVAL_SECS: u64 = 300;
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct HealthCheckSpec {
+    pub group_name: String,
+    pub url: String,
+    pub interval_secs: u64,
+    pub lazy: bool,
+}
+
+pub fn extract_specs(raw_groups: &[meow_config::raw::RawProxyGroup]) -> Vec<HealthCheckSpec> {
+    raw_groups
+        .iter()
+        .filter(|g| matches!(g.group_type.as_str(), "fallback" | "url-test"))
+        .map(|g| HealthCheckSpec {
+            group_name: g.name.clone(),
+            url: g.url.as_deref().unwrap_or(DEFAULT_URL).to_string(),
+            interval_secs: g.interval.unwrap_or(DEFAULT_INTERVAL_SECS),
+            lazy: g.lazy.unwrap_or(false),
+        })
+        .collect()
+}
+
+pub fn spawn_health_checks(tunnel: &Tunnel, specs: Vec<HealthCheckSpec>) {
+    for spec in specs {
+        let tunnel = tunnel.clone();
+        tokio::spawn(async move {
+            run_health_check_loop(tunnel, spec).await;
+        });
+    }
+}
+
+async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
+    let mut ticker = tokio::time::interval(Duration::from_secs(spec.interval_secs));
+
+    if spec.lazy {
+        ticker.tick().await;
+    }
+
+    loop {
+        ticker.tick().await;
+
+        let proxies = tunnel.proxies();
+        let Some(group) = proxies.get(spec.group_name.as_str()).cloned() else {
+            debug!(
+                "health-check: group '{}' not found, skipping tick",
+                spec.group_name
+            );
+            continue;
+        };
+        let Some(member_names) = group.members() else {
+            continue;
+        };
+
+        let members: Vec<_> = member_names
+            .into_iter()
+            .filter_map(|n| proxies.get(n.as_str()).cloned().map(|p| (n, p)))
+            .collect();
+        drop(proxies);
+
+        let url = spec.url.clone();
+        let mut set: tokio::task::JoinSet<(String, u16)> = tokio::task::JoinSet::new();
+        for (name, proxy) in members {
+            let url = url.clone();
+            set.spawn(async move {
+                let delay = meow_proxy::health::probe_and_record(&proxy, &url, None, PROBE_TIMEOUT)
+                    .await
+                    .unwrap_or(0);
+                (name, delay)
+            });
+        }
+
+        let mut alive_count = 0u32;
+        let mut total_count = 0u32;
+        while let Some(Ok((name, delay))) = set.join_next().await {
+            total_count += 1;
+            if delay > 0 {
+                alive_count += 1;
+            } else {
+                warn!(
+                    "health-check: {} / {} is dead (probe failed)",
+                    spec.group_name, name
+                );
+            }
+        }
+
+        info!(
+            "health-check: {} — {}/{} alive",
+            spec.group_name, alive_count, total_count
+        );
+    }
+}

--- a/crates/meow-app/src/lib.rs
+++ b/crates/meow-app/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod geodata_fetch;
+pub mod health_check;
 pub mod subscription_refresh;
 
 /// Generate a systemd unit file for the meow service.

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -457,6 +457,16 @@ async fn run(
     tunnel.update_proxies(config.proxies);
     tunnel.spawn_background_tasks();
 
+    // Spawn periodic health checks for fallback / url-test proxy groups.
+    {
+        let raw_groups = config.raw.proxy_groups.as_deref().unwrap_or(&[]);
+        let specs = meow_app::health_check::extract_specs(raw_groups);
+        if !specs.is_empty() {
+            info!("Starting health checks for {} group(s)", specs.len());
+            meow_app::health_check::spawn_health_checks(&tunnel, specs);
+        }
+    }
+
     // Start DNS server if configured
     if let Some(listen_addr) = config.dns.listen_addr {
         let dns_server = DnsServer::new(Arc::clone(&config.dns.resolver), listen_addr);

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -203,7 +203,11 @@ async fn handle_http_inner(
                     Err(e) => debug!("HTTP CONNECT relay error: {}", e),
                 }
             }
-            Err(e) => warn!("HTTP CONNECT dial error: {}", e),
+            Err(e) => warn!(
+                "{} HTTP CONNECT dial error: {}",
+                metadata.remote_address(),
+                e
+            ),
         }
         // _guard drops here, removing the entry from Statistics.
     } else {
@@ -307,7 +311,7 @@ async fn handle_http_inner(
                 }
             }
             Err(e) => {
-                warn!("HTTP dial error: {}", e);
+                warn!("{}:{} HTTP dial error: {}", host, port, e);
                 stream
                     .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
                     .await?;

--- a/crates/meow-listener/src/socks5.rs
+++ b/crates/meow-listener/src/socks5.rs
@@ -207,7 +207,7 @@ async fn handle_socks5_inner(
                 Err(e) => debug!("SOCKS5 relay error: {}", e),
             }
         }
-        Err(e) => warn!("SOCKS5 dial error: {}", e),
+        Err(e) => warn!("{} SOCKS5 dial error: {}", metadata.remote_address(), e),
     }
 
     Ok(())

--- a/crates/meow-proxy/src/health.rs
+++ b/crates/meow-proxy/src/health.rs
@@ -1,4 +1,4 @@
-use meow_common::ProxyAdapter;
+use meow_common::{Proxy, ProxyAdapter};
 use smol_str::SmolStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -69,6 +69,25 @@ pub async fn url_test(
             Err(UrlTestError::Timeout)
         }
     }
+}
+
+/// Probe a proxy and record the result in its [`ProxyHealth`].
+///
+/// On success the measured delay (ms) is recorded; on any failure `0` is
+/// recorded so `last_delay == 0` and `alive() == false`.
+pub async fn probe_and_record(
+    proxy: &Arc<dyn Proxy>,
+    url: &str,
+    expected: Option<&str>,
+    timeout: Duration,
+) -> Result<u16, UrlTestError> {
+    let adapter: &dyn ProxyAdapter = proxy.as_ref();
+    let result = url_test(adapter, url, expected, timeout).await;
+    match &result {
+        Ok(d) => proxy.health().record_delay(*d),
+        Err(_) => proxy.health().record_delay(0),
+    }
+    result
 }
 
 async fn probe_once(


### PR DESCRIPTION
## Summary
- Proxy groups configured as `fallback` or `url-test` now run background health checks using the group's `url` and `interval` config fields (defaults: `http://www.gstatic.com/generate_204`, 300s). Dead proxies are marked not-alive so fallback groups automatically skip them.
- Extracted `probe_and_record` from `meow-api` into `meow-proxy::health` so both the REST API delay endpoint and the health check task share the same logic.
- Dial-error WARN logs in `http_proxy.rs` and `socks5.rs` now include the destination address for easier debugging.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` (default, no-default-features, all-features) passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` passes
- [x] `cargo test --lib` — 636 tests pass
- [x] Deployed to production Pi (`mlv-rasp`), first health check detected 14 dead Premium nodes out of 141 total
- [x] Connectivity verified through proxy after deployment (google.com 200 OK in 0.5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)