### PR TITLE
fix(udp): try every resolved address for the SS UDP relay instead of the first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "libc",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/crates/meow-common/src/lib.rs
+++ b/crates/meow-common/src/lib.rs
@@ -23,7 +23,7 @@ pub use network::Network;
 pub use process_lookup::{find_process, ProcessInfo};
 pub use rule::{Rule, RuleMatchHelper, RuleType};
 pub use sniffer::SnifferConfig;
-pub use socket_protect::{bind_udp, connect_tcp, connect_tcp_host, resolve_host};
+pub use socket_protect::{bind_udp, connect_tcp, connect_tcp_host, resolve_host, resolve_host_all};
 #[cfg(target_os = "android")]
 pub use socket_protect::{
     clear_host_resolver, clear_socket_protector, host_resolver, set_host_resolver,

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -256,12 +256,28 @@ pub async fn connect_tcp_host(host: &str, port: u16) -> io::Result<TcpStream> {
 /// Resolve `host` to a single [`SocketAddr`] using the same hook chain
 /// as [`connect_tcp_host`]: IP literals short-circuit, the installed
 /// `HostResolver` is preferred when a `SocketProtector` is present,
-/// and the system resolver is the (warning-logged) fallback. Use this
-/// from call sites that need a `SocketAddr` for a subsequent operation
-/// other than `connect()` — e.g. `UdpSocket::connect(addr)`.
+/// and the system resolver is the (warning-logged) fallback.
+///
+/// Prefer [`resolve_host_all`] for call sites that can try candidates in
+/// order (e.g. a UDP `connect()` loop): taking only the first address
+/// silently drops the family fallback that `TcpStream::connect` gets for
+/// free, which strands the caller on an unreachable family when the
+/// resolver orders AAAA first on an IPv4-only network (or vice versa).
 pub async fn resolve_host(host: &str, port: u16) -> io::Result<SocketAddr> {
+    resolve_host_all(host, port).await.map(|addrs| addrs[0])
+}
+
+/// Resolve `host` to every candidate [`SocketAddr`], in resolver order,
+/// using the same hook chain as [`connect_tcp_host`]: IP literals
+/// short-circuit, the installed `HostResolver` is preferred when a
+/// `SocketProtector` is present (it returns a single address), and the
+/// system resolver is the (warning-logged) fallback.
+///
+/// Never returns an empty `Vec` — no-address resolution is an `Err`, so
+/// callers may index `[0]` safely.
+pub async fn resolve_host_all(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
     if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        return Ok(SocketAddr::new(ip, port));
+        return Ok(vec![SocketAddr::new(ip, port)]);
     }
 
     #[cfg(any(target_os = "android", all(test, unix)))]
@@ -269,7 +285,7 @@ pub async fn resolve_host(host: &str, port: u16) -> io::Result<SocketAddr> {
         if android::socket_protector().is_some() {
             if let Some(r) = android::host_resolver() {
                 let ip = r.resolve(host).await?;
-                return Ok(SocketAddr::new(ip, port));
+                return Ok(vec![SocketAddr::new(ip, port)]);
             }
             tracing::warn!(
                 host,
@@ -279,15 +295,14 @@ pub async fn resolve_host(host: &str, port: u16) -> io::Result<SocketAddr> {
         }
     }
 
-    tokio::net::lookup_host((host, port))
-        .await?
-        .next()
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("resolve_host: no address for {host}:{port}"),
-            )
-        })
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port)).await?.collect();
+    if addrs.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("resolve_host: no address for {host}:{port}"),
+        ));
+    }
+    Ok(addrs)
 }
 
 /// Bind an outbound UDP socket. On Android, applies the installed
@@ -601,6 +616,60 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let sock = bind_udp(addr).await.expect("bind");
         assert!(sock.local_addr().unwrap().port() != 0);
+    }
+
+    // ─── resolve_host / resolve_host_all ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_host_all_ip_literal_is_single_candidate() {
+        let _g = LOCK.lock().await;
+        clear_socket_protector();
+        clear_host_resolver();
+        // Installing a failing resolver + protector proves the literal
+        // short-circuit never consults the hook chain.
+        set_socket_protector(Counting::new() as Arc<dyn SocketProtector>);
+        set_host_resolver(Arc::new(FailingResolver) as Arc<dyn HostResolver>);
+
+        let addrs = resolve_host_all("192.0.2.7", 443).await.expect("literal");
+        assert_eq!(addrs, vec!["192.0.2.7:443".parse().unwrap()]);
+
+        clear_host_resolver();
+        clear_socket_protector();
+    }
+
+    #[tokio::test]
+    async fn resolve_host_all_uses_installed_resolver_when_protected() {
+        let _g = LOCK.lock().await;
+        set_socket_protector(Counting::new() as Arc<dyn SocketProtector>);
+        let resolver = FixedResolver::new(IpAddr::from([127, 0, 0, 1]));
+        set_host_resolver(Arc::clone(&resolver) as Arc<dyn HostResolver>);
+
+        let addrs = resolve_host_all("example.invalid", 8388)
+            .await
+            .expect("resolve");
+        assert_eq!(addrs, vec!["127.0.0.1:8388".parse().unwrap()]);
+        assert_eq!(resolver.count(), 1, "resolver must be consulted once");
+
+        clear_host_resolver();
+        clear_socket_protector();
+    }
+
+    #[tokio::test]
+    async fn resolve_host_first_matches_resolve_host_all_head() {
+        let _g = LOCK.lock().await;
+        clear_socket_protector();
+        clear_host_resolver();
+
+        // `localhost` resolves through the system resolver (/etc/hosts) and
+        // may legitimately return both families — exactly the multi-candidate
+        // shape resolve_host_all exists for.
+        let all = resolve_host_all("localhost", 1080).await.expect("resolve");
+        assert!(!all.is_empty(), "resolve_host_all never returns empty Ok");
+        let single = resolve_host("localhost", 1080).await.expect("resolve");
+        assert_eq!(
+            single, all[0],
+            "resolve_host must stay an alias for the first candidate"
+        );
     }
 
     // ─── registry semantics ─────────────────────────────────────────────────

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -433,23 +433,47 @@ impl ProxyAdapter for ShadowsocksAdapter {
         // `udp_external_addr` returns a literal `SocketAddr` for the standard
         // path and the SIP003 plugin's local listener for external plugins
         // (where the connect is loopback — protect is harmless).
-        let remote = match self.server_config.udp_external_addr() {
-            ServerAddr::SocketAddr(sa) => *sa,
-            ServerAddr::DomainName(host, port) => meow_common::resolve_host(host, *port)
+        let candidates = match self.server_config.udp_external_addr() {
+            ServerAddr::SocketAddr(sa) => vec![*sa],
+            ServerAddr::DomainName(host, port) => meow_common::resolve_host_all(host, *port)
                 .await
                 .map_err(|e| MeowError::Proxy(format!("ss udp lookup {host}:{port}: {e}")))?,
         };
-        let bind_addr: SocketAddr = if remote.is_ipv4() {
-            "0.0.0.0:0".parse().expect("static")
-        } else {
-            "[::]:0".parse().expect("static")
+        // Try candidates in resolver order rather than committing to the
+        // first one: on a single-stack network the resolver can still order
+        // the unreachable family first (AAAA on an IPv4-only path), and a
+        // UDP connect() to an unreachable family fails immediately with
+        // ENETUNREACH — so falling through to the next candidate is cheap
+        // and keeps UDP relay alive where TcpStream::connect's built-in
+        // multi-address loop already keeps TCP alive.
+        let mut connected = None;
+        let mut last_err = None;
+        for remote in candidates {
+            let bind_addr: SocketAddr = if remote.is_ipv4() {
+                "0.0.0.0:0".parse().expect("static")
+            } else {
+                "[::]:0".parse().expect("static")
+            };
+            let udp = match meow_common::bind_udp(bind_addr).await {
+                Ok(udp) => udp,
+                Err(e) => {
+                    last_err = Some(format!("ss udp bind for {remote}: {e}"));
+                    continue;
+                }
+            };
+            match udp.connect(remote).await {
+                Ok(()) => {
+                    connected = Some((udp, remote));
+                    break;
+                }
+                Err(e) => last_err = Some(format!("ss udp connect {remote}: {e}")),
+            }
+        }
+        let Some((udp, remote)) = connected else {
+            return Err(MeowError::Proxy(
+                last_err.unwrap_or_else(|| "ss udp connect: no candidates".into()),
+            ));
         };
-        let udp = meow_common::bind_udp(bind_addr)
-            .await
-            .map_err(|e| MeowError::Proxy(format!("ss udp bind: {e}")))?;
-        udp.connect(remote)
-            .await
-            .map_err(|e| MeowError::Proxy(format!("ss udp connect: {e}")))?;
         let socket = ProxySocket::<TokioUdpDatagram>::from_socket(
             UdpSocketType::Client,
             Arc::clone(&self.context),


### PR DESCRIPTION
Closes #167.

## Problem

`meow_common::resolve_host` takes only the first `lookup_host` candidate, and the Shadowsocks UDP relay (`shadowsocks_adapter.rs`) connects to it with no fallback. On a single-stack network where the resolver orders the unreachable family first (AAAA-first on an IPv4-only path), SS UDP (QUIC, DNS-over-proxy) fails for the life of the session — while TCP survives, because `TcpStream::connect((host, port))` already iterates every resolved address.

Latent on iOS/macOS thanks to Darwin's RFC 6724 sorting, but resolver-order-dependent; Android's `HostResolver` hook has the same single-IP shape.

## Fix

- **meow-common**: new `resolve_host_all(host, port) -> io::Result<Vec<SocketAddr>>` — same hook chain as `connect_tcp_host` (IP-literal short-circuit → installed `HostResolver` → warning-logged system fallback), returns candidates in resolver order, never empty on `Ok`. `resolve_host` is now an alias for its first element — existing call sites are behavior-identical.
- **meow-proxy**: the SS UDP relay iterates candidates: family-matched bind (`0.0.0.0:0` / `[::]:0`) + `connect()` per candidate, first success wins, last error reported. UDP `connect()` to an unreachable family fails immediately with `ENETUNREACH`, so fallback is free in the common case.
- **Cargo.lock**: refreshed workspace crate versions to 0.12.0 — the lock on main is stale after the version bump (any local build regenerates this hunk).

## Tests

- `resolve_host_all_ip_literal_is_single_candidate` — literal short-circuits the hook chain (failing resolver installed to prove it).
- `resolve_host_all_uses_installed_resolver_when_protected` — hook path returns the single resolver address.
- `resolve_host_first_matches_resolve_host_all_head` — `resolve_host` stays an alias for candidate 0 via the system resolver.

Local verification: `cargo fmt --all -- --check` ✚ `cargo clippy --all-targets -- -D warnings` ✚ `cargo test --lib` → **639 passed across 11 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)