### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "libc",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
Release 0.13.0.

## Changes since v0.12.0
- feat: periodic health checks for fallback/url-test proxy groups (#163-ish)
- fix(udp): try every resolved address for the SS UDP relay instead of the first
- fix: bound gRPC frame buffer, abort fakeip flush task, skip redundant geosite lowercase (#164)
- fix: skip hot-path alloc-count assertions under coverage instrumentation (#163)
- docs: replace ASCII architecture diagram with SVG, update crates table

## Verification (local)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` (default / no-default-features / all-features) ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✅
- `cargo test --lib` — 639 passed ✅

Tag `v0.13.0` will be pushed after merge to trigger the Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)