### PR TITLE
perf(dns): decode QNAME into one pre-sized String in parse_question

### DIFF
--- a/crates/meow-dns/src/server.rs
+++ b/crates/meow-dns/src/server.rs
@@ -199,9 +199,9 @@ impl DnsServer {
     fn parse_question(
         data: &[u8],
     ) -> Result<(String, u16, usize), Box<dyn std::error::Error + Send + Sync>> {
-        let mut labels = Vec::new();
+        // First pass: validate label framing and find the QNAME wire length,
+        // so the domain buffer below is allocated exactly once.
         let mut pos = 0;
-
         loop {
             if pos >= data.len() {
                 return Err("DNS question truncated".into());
@@ -214,8 +214,24 @@ impl DnsServer {
             if pos + 1 + len > data.len() {
                 return Err("DNS label truncated".into());
             }
-            labels.push(String::from_utf8_lossy(&data[pos + 1..pos + 1 + len]).to_string());
             pos += 1 + len;
+        }
+
+        // Second pass: append labels separated by '.' into one pre-sized
+        // String. `from_utf8_lossy` only allocates on invalid UTF-8, so the
+        // lossy semantics are preserved without per-label Strings.
+        let mut domain = String::with_capacity(pos.saturating_sub(2));
+        let mut lpos = 0;
+        loop {
+            let len = data[lpos] as usize;
+            if len == 0 {
+                break;
+            }
+            if !domain.is_empty() {
+                domain.push('.');
+            }
+            domain.push_str(&String::from_utf8_lossy(&data[lpos + 1..lpos + 1 + len]));
+            lpos += 1 + len;
         }
 
         if pos + 4 > data.len() {
@@ -224,7 +240,7 @@ impl DnsServer {
         let qtype = u16::from_be_bytes([data[pos], data[pos + 1]]);
         pos += 4; // skip type and class
 
-        Ok((labels.join("."), qtype, pos))
+        Ok((domain, qtype, pos))
     }
 
     fn build_response(


### PR DESCRIPTION
## Summary

Fixes #173 (June 2026 performance audit, H3).

`parse_question` built a `Vec<String>` with two allocations per label (`from_utf8_lossy(...).to_string()`) plus a final `join(".")` — roughly 2·labels + 2 heap allocations per UDP datagram before resolution even started.

This change walks the labels twice:
1. First pass validates label framing and finds the QNAME wire length (error behavior unchanged — same truncation checks).
2. Second pass appends each label, dot-separated, into a single `String` pre-sized to the textual name length (`wire_len − 2`).

`from_utf8_lossy` only allocates on invalid UTF-8, so pushing the `Cow` straight into the output buffer keeps the lossy semantics. Net: one allocation per query on the DNS UDP fast path.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Three-way `cargo clippy --all-targets -- -D warnings` (default / no-default-features / all-features)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` — all green except the pre-existing, environment-dependent `meow-dns client::tests::udp_client_times_out_on_unroutable`, which also fails on clean `main` in this sandbox (TEST-NET-1 egress returns an immediate error instead of timing out). Untouched by this change.
- Existing `parse_question` unit tests (qname/qtype decode, truncated label, missing type/class) cover the rewritten code and pass.

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_