### PR TITLE
perf(dns): allocation-free cache hits; skip useless pop on clean miss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "smallvec",
  "smol_str",
  "sysinfo",
  "thiserror 2.0.18",

--- a/crates/meow-dns/Cargo.toml
+++ b/crates/meow-dns/Cargo.toml
@@ -25,6 +25,7 @@ dashmap = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
+smallvec = { workspace = true }
 ipnet = { workspace = true }
 maxminddb = { workspace = true }
 futures = { workspace = true }

--- a/crates/meow-dns/src/cache.rs
+++ b/crates/meow-dns/src/cache.rs
@@ -20,11 +20,17 @@
 // reverse-entry domain allocation drops from N+1 to 1 per cache write.
 use lru::LruCache;
 use parking_lot::Mutex;
+use smallvec::SmallVec;
 use smol_str::SmolStr;
 use std::net::IpAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// IP list returned by cache hits. Domains overwhelmingly resolve to 1–2
+/// addresses, which fit inline — making cache hits allocation-free in the
+/// common case.
+pub type IpList = SmallVec<[IpAddr; 2]>;
 
 struct CacheEntry {
     ips: Box<[IpAddr]>,
@@ -96,16 +102,20 @@ impl DnsCache {
         }
     }
 
-    pub fn get(&self, domain: &str) -> Option<Vec<IpAddr>> {
+    pub fn get(&self, domain: &str) -> Option<IpList> {
         let shard = &self.cache[shard_str(domain)];
         let mut cache = shard.lock();
+        let mut expired = false;
         if let Some(entry) = cache.get(domain) {
             if entry.expire_at > Instant::now() {
-                return Some(entry.ips.to_vec());
+                return Some(SmallVec::from_slice(&entry.ips));
             }
-            // Expired, but don't remove here to avoid borrow issues
+            // Expired — flag for eviction; can't pop while `entry` borrows.
+            expired = true;
         }
-        cache.pop(domain);
+        if expired {
+            cache.pop(domain);
+        }
         None
     }
 
@@ -207,7 +217,7 @@ mod tests {
         let c = DnsCache::new(64);
         let ips = vec![ipv4(1, 2, 3, 4), ipv4(5, 6, 7, 8)];
         c.put("a.example", &ips, Duration::from_secs(30));
-        assert_eq!(c.get("a.example"), Some(ips));
+        assert_eq!(c.get("a.example").as_deref(), Some(&ips[..]));
         assert!(c.get("nope.example").is_none());
     }
 
@@ -257,7 +267,10 @@ mod tests {
         let c = DnsCache::new(64);
         c.put("dup.example", &[ipv4(1, 1, 1, 1)], Duration::from_secs(30));
         c.put("dup.example", &[ipv4(2, 2, 2, 2)], Duration::from_secs(30));
-        assert_eq!(c.get("dup.example"), Some(vec![ipv4(2, 2, 2, 2)]));
+        assert_eq!(
+            c.get("dup.example").as_deref(),
+            Some(&[ipv4(2, 2, 2, 2)][..])
+        );
     }
 
     #[test]
@@ -279,7 +292,7 @@ mod tests {
         // lookup returns an empty Vec without touching the reverse table.
         let c = DnsCache::new(64);
         c.put("nx.example", &[], Duration::from_secs(30));
-        assert_eq!(c.get("nx.example"), Some(vec![]));
+        assert_eq!(c.get("nx.example").as_deref(), Some(&[][..]));
         assert_eq!(c.reverse_len(), 0);
     }
 
@@ -288,7 +301,7 @@ mod tests {
         let c = DnsCache::new(64);
         let v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
         c.put("v6.example", &[v6], Duration::from_secs(30));
-        assert_eq!(c.get("v6.example"), Some(vec![v6]));
+        assert_eq!(c.get("v6.example").as_deref(), Some(&[v6][..]));
         assert_eq!(c.reverse_lookup(v6).as_deref(), Some("v6.example"));
     }
 

--- a/crates/meow-dns/tests/dns_cache_test.rs
+++ b/crates/meow-dns/tests/dns_cache_test.rs
@@ -11,7 +11,7 @@ fn test_cache_put_and_get() {
 
     let result = cache.get("example.com");
     assert!(result.is_some());
-    assert_eq!(result.unwrap(), ips);
+    assert_eq!(result.unwrap().as_slice(), ips.as_slice());
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn test_cache_multiple_ips() {
 
     let result = cache.get("cloudflare.com").unwrap();
     assert_eq!(result.len(), 3);
-    assert_eq!(result, ips);
+    assert_eq!(result.as_slice(), ips.as_slice());
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn test_cache_overwrite() {
     cache.put("example.com", &ips2, Duration::from_secs(300));
 
     let result = cache.get("example.com").unwrap();
-    assert_eq!(result, ips2);
+    assert_eq!(result.as_slice(), ips2.as_slice());
 }
 
 #[test]
@@ -236,6 +236,6 @@ fn test_cache_different_domains_independent() {
     cache.put("a.com", &ips_a, Duration::from_secs(300));
     cache.put("b.com", &ips_b, Duration::from_secs(300));
 
-    assert_eq!(cache.get("a.com").unwrap(), ips_a);
-    assert_eq!(cache.get("b.com").unwrap(), ips_b);
+    assert_eq!(cache.get("a.com").unwrap().as_slice(), ips_a.as_slice());
+    assert_eq!(cache.get("b.com").unwrap().as_slice(), ips_b.as_slice());
 }


### PR DESCRIPTION
## Summary

Fixes #176 (June 2026 performance audit, M4).

Two changes to `DnsCache::get` (`crates/meow-dns/src/cache.rs`):

1. **Hits no longer clone the IP list to the heap.** `get` now returns `SmallVec<[IpAddr; 2]>` (exported as `pub type IpList`); the common 1–2 address case is copied inline, so cache hits are allocation-free. All resolver call sites only iterate/`first()` the result, so they work unchanged via deref.
2. **Clean misses no longer pay a second hash lookup.** The fall-through `cache.pop(domain)` ran on every miss but can only ever remove something in the expired-entry case; it's now gated on an `expired` flag. Expired-entry eviction behavior is unchanged (covered by `get_on_expired_entry_returns_none_and_evicts`).

**ADR-0011:** `CacheEntry` layout is untouched (`Box<[IpAddr]>` 16 B + `Instant` 16 B = 32 B before and after — no field changed), so the 72 B per-LruEntry-slot M2 target is unaffected; only `get`'s return type changed. `smallvec` was already a workspace dependency; this adds it to `meow-dns`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Three-way `cargo clippy --all-targets -- -D warnings` (default / no-default / all-features)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test -p meow-dns --no-fail-fast` — lib (91) + `dns_cache_test` (17) + remaining suites green; sole failure is the pre-existing, environment-dependent `udp_client_times_out_on_unroutable` (also fails on clean `main` in this sandbox).
- [x] `cargo test --lib` for the rest of the workspace — green.

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_