### PR TITLE
perf(proxy): hoist TlsLayer construction out of HTTP/SOCKS5 dial path

### DIFF
--- a/crates/meow-proxy/src/http_adapter.rs
+++ b/crates/meow-proxy/src/http_adapter.rs
@@ -45,8 +45,9 @@ pub struct HttpAdapter {
     addr_str: SmolStr,
     /// `Some((username, password))` — both present or neither (ADR-0002 Class A).
     auth: Option<(String, String)>,
-    tls: bool,
-    skip_cert_verify: bool,
+    /// Built once at construction (rustls ClientConfig + root store are
+    /// expensive); `TlsLayer::connect` is safe to call concurrently.
+    tls_layer: Option<meow_transport::tls::TlsLayer>,
     /// Extra headers injected into the CONNECT request only.
     extra_headers: Vec<(String, String)>,
     health: ProxyHealth,
@@ -66,14 +67,26 @@ impl HttpAdapter {
         skip_cert_verify: bool,
         extra_headers: Vec<(String, String)>,
     ) -> Self {
+        // Hoisted out of the dial path: TlsLayer::new clones the webpki root
+        // store and builds verifier + crypto provider — per-adapter, not
+        // per-connection (same pattern as TrojanAdapter::new).
+        let tls_layer = tls.then(|| {
+            use meow_transport::tls::{TlsConfig, TlsLayer};
+            let tls_cfg = TlsConfig {
+                skip_cert_verify,
+                ..TlsConfig::new(server)
+            };
+            TlsLayer::new(&tls_cfg)
+                .expect("HttpAdapter: failed to build TlsLayer — check TLS config")
+        });
+
         Self {
             name: SmolStr::from(name),
             addr_str: SmolStr::from(format!("{server}:{port}")),
             server: SmolStr::from(server),
             port,
             auth,
-            tls,
-            skip_cert_verify,
+            tls_layer,
             extra_headers,
             health: ProxyHealth::new(),
         }
@@ -85,15 +98,8 @@ impl HttpAdapter {
             .await
             .map_err(MeowError::Io)?;
 
-        if self.tls {
-            use meow_transport::tls::{TlsConfig, TlsLayer};
+        if let Some(tls_layer) = &self.tls_layer {
             use meow_transport::Transport;
-
-            let tls_cfg = TlsConfig {
-                skip_cert_verify: self.skip_cert_verify,
-                ..TlsConfig::new(self.server.as_str())
-            };
-            let tls_layer = TlsLayer::new(&tls_cfg).map_err(|e| MeowError::Proxy(e.to_string()))?;
             tls_layer
                 .connect(Box::new(tcp))
                 .await

--- a/crates/meow-proxy/src/socks5_adapter.rs
+++ b/crates/meow-proxy/src/socks5_adapter.rs
@@ -57,8 +57,9 @@ pub struct Socks5Adapter {
     addr_str: SmolStr,
     /// `Some((username, password))` — both present or neither (ADR-0002 Class A).
     auth: Option<(String, String)>,
-    tls: bool,
-    skip_cert_verify: bool,
+    /// Built once at construction (rustls ClientConfig + root store are
+    /// expensive); `TlsLayer::connect` is safe to call concurrently.
+    tls_layer: Option<meow_transport::tls::TlsLayer>,
     health: ProxyHealth,
 }
 
@@ -75,14 +76,26 @@ impl Socks5Adapter {
         tls: bool,
         skip_cert_verify: bool,
     ) -> Self {
+        // Hoisted out of the dial path: TlsLayer::new clones the webpki root
+        // store and builds verifier + crypto provider — per-adapter, not
+        // per-connection (same pattern as TrojanAdapter::new).
+        let tls_layer = tls.then(|| {
+            use meow_transport::tls::{TlsConfig, TlsLayer};
+            let tls_cfg = TlsConfig {
+                skip_cert_verify,
+                ..TlsConfig::new(server)
+            };
+            TlsLayer::new(&tls_cfg)
+                .expect("Socks5Adapter: failed to build TlsLayer — check TLS config")
+        });
+
         Self {
             name: SmolStr::from(name),
             addr_str: SmolStr::from(format!("{server}:{port}")),
             server: SmolStr::from(server),
             port,
             auth,
-            tls,
-            skip_cert_verify,
+            tls_layer,
             health: ProxyHealth::new(),
         }
     }
@@ -93,15 +106,8 @@ impl Socks5Adapter {
             .await
             .map_err(MeowError::Io)?;
 
-        if self.tls {
-            use meow_transport::tls::{TlsConfig, TlsLayer};
+        if let Some(tls_layer) = &self.tls_layer {
             use meow_transport::Transport;
-
-            let tls_cfg = TlsConfig {
-                skip_cert_verify: self.skip_cert_verify,
-                ..TlsConfig::new(self.server.as_str())
-            };
-            let tls_layer = TlsLayer::new(&tls_cfg).map_err(|e| MeowError::Proxy(e.to_string()))?;
             tls_layer
                 .connect(Box::new(tcp))
                 .await


### PR DESCRIPTION
## Summary

Fixes #171 (June 2026 performance audit, H1 — largest per-connection CPU/allocation cost found).

`dial_stream()` in `HttpAdapter` and `Socks5Adapter` constructed `TlsConfig` + `TlsLayer::new()` **per connection**; each call clones the ~50 KB webpki root store and builds a fresh verifier + crypto provider.

The `TlsLayer` is now built once in the adapter constructor (stored as `Option<TlsLayer>`, `None` when TLS is off), mirroring the existing pattern in `TrojanAdapter::new` and the shadowsocks plugin adapters — including the `expect` on construction failure, which Trojan already uses. `TlsLayer::connect()` is documented as safe to call concurrently from many tasks. Constructor signatures are unchanged; the `tls`/`skip_cert_verify` fields fold into the stored layer.

## Test plan

- [x] `cargo test -p meow-proxy --lib` — all 220 tests pass, including the http/socks5 adapter handshake suites against loopback mock proxies.
- [x] `cargo fmt --all -- --check`, three-way `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` — all 10 crates green (sole exception: pre-existing env-dependent `meow-dns udp_client_times_out_on_unroutable`, also failing on clean `main` in this sandbox).
- meow-bench connection-rate against a live TLS upstream wasn't run here (no external endpoints in this environment); the change removes a per-dial root-store clone + config build, identical handshake bytes.

Related: #174 (sharing the `ClientConfig` *across* adapters) builds on top of this.

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_