### PR TITLE
perf(listener,sniffer): drop per-header lowercase copy; sniffers return SmolStr

### DIFF
--- a/crates/meow-common/src/sniffer/http.rs
+++ b/crates/meow-common/src/sniffer/http.rs
@@ -1,9 +1,14 @@
+use smol_str::SmolStr;
+
 /// Parse the HTTP `Host:` header from the first request bytes.
 ///
 /// Returns `None` if the buffer does not look like HTTP/1.x or has no Host header.
 /// `httparse::Status::Partial` is treated as success — as long as we've seen
 /// the Host line we don't need the full request.
-pub fn sniff_http(buf: &[u8]) -> Option<String> {
+///
+/// Returns `SmolStr` so typical hostnames (≤ 23 bytes) are inlined without
+/// a heap allocation per sniffed request.
+pub fn sniff_http(buf: &[u8]) -> Option<SmolStr> {
     let mut headers = [httparse::EMPTY_HEADER; 32];
     let mut req = httparse::Request::new(&mut headers);
     // Both Complete and Partial are fine; an Err means the buffer isn't HTTP.
@@ -23,7 +28,13 @@ pub fn sniff_http(buf: &[u8]) -> Option<String> {
             if host.is_empty() {
                 return None;
             }
-            return Some(host.to_ascii_lowercase());
+            // Hostnames are usually already lowercase — only pay for a
+            // char-mapped rebuild when one actually contains uppercase.
+            return Some(if host.bytes().any(|b| b.is_ascii_uppercase()) {
+                host.chars().map(|c| c.to_ascii_lowercase()).collect()
+            } else {
+                SmolStr::new(host)
+            });
         }
     }
     None
@@ -36,26 +47,26 @@ mod tests {
     #[test]
     fn sniff_http_basic_host_header() {
         let buf = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        assert_eq!(sniff_http(buf), Some("example.com".to_string()));
+        assert_eq!(sniff_http(buf).as_deref(), Some("example.com"));
     }
 
     #[test]
     fn sniff_http_host_with_port_stripped() {
         let buf = b"GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
-        assert_eq!(sniff_http(buf), Some("example.com".to_string()));
+        assert_eq!(sniff_http(buf).as_deref(), Some("example.com"));
     }
 
     #[test]
     fn sniff_http_case_insensitive_header_name() {
         let buf = b"GET / HTTP/1.1\r\nHOST: example.com\r\n\r\n";
-        assert_eq!(sniff_http(buf), Some("example.com".to_string()));
+        assert_eq!(sniff_http(buf).as_deref(), Some("example.com"));
     }
 
     #[test]
     fn sniff_http_partial_request_ok() {
         // No trailing \r\n\r\n — httparse returns Partial, which we treat as success.
         let buf = b"GET / HTTP/1.1\r\nHost: example.com\r\n";
-        assert_eq!(sniff_http(buf), Some("example.com".to_string()));
+        assert_eq!(sniff_http(buf).as_deref(), Some("example.com"));
     }
 
     #[test]
@@ -73,14 +84,14 @@ mod tests {
     #[test]
     fn sniff_http_ipv6_host_brackets_stripped() {
         let buf = b"GET / HTTP/1.1\r\nHost: [::1]:8080\r\n\r\n";
-        assert_eq!(sniff_http(buf), Some("::1".to_string()));
+        assert_eq!(sniff_http(buf).as_deref(), Some("::1"));
     }
 
     #[test]
     fn sniff_http_ipv6_host_no_port() {
         // Bracketed IPv6 host without a `:port` suffix is still recognised.
         let buf = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]\r\n\r\n";
-        assert_eq!(sniff_http(buf), Some("2001:db8::1".to_string()));
+        assert_eq!(sniff_http(buf).as_deref(), Some("2001:db8::1"));
     }
 
     #[test]
@@ -95,6 +106,6 @@ mod tests {
     fn sniff_http_host_with_surrounding_whitespace() {
         // Field-value LWS must be trimmed.
         let buf = b"GET / HTTP/1.1\r\nHost:    example.com   \r\n\r\n";
-        assert_eq!(sniff_http(buf), Some("example.com".to_string()));
+        assert_eq!(sniff_http(buf).as_deref(), Some("example.com"));
     }
 }

--- a/crates/meow-common/src/sniffer/tls.rs
+++ b/crates/meow-common/src/sniffer/tls.rs
@@ -1,5 +1,10 @@
+use smol_str::SmolStr;
+
 /// Parse SNI hostname from raw TLS ClientHello bytes.
-pub fn sniff_tls(buf: &[u8]) -> Option<String> {
+///
+/// Returns `SmolStr` so typical hostnames (≤ 23 bytes) are inlined without
+/// a heap allocation per sniffed handshake.
+pub fn sniff_tls(buf: &[u8]) -> Option<SmolStr> {
     // TLS record header: content_type(1) + version(2) + length(2)
     if buf.len() < 5 {
         return None;
@@ -61,7 +66,7 @@ pub fn sniff_tls(buf: &[u8]) -> Option<String> {
     None
 }
 
-fn parse_sni_extension(data: &[u8]) -> Option<String> {
+fn parse_sni_extension(data: &[u8]) -> Option<SmolStr> {
     if data.len() < 2 {
         return None;
     }
@@ -76,9 +81,14 @@ fn parse_sni_extension(data: &[u8]) -> Option<String> {
 
         if name_type == 0x00 {
             let name_bytes = list.get(pos..pos + name_len)?;
-            let mut s = String::from_utf8(name_bytes.to_vec()).ok()?;
-            s.make_ascii_lowercase();
-            return Some(s);
+            let s = std::str::from_utf8(name_bytes).ok()?;
+            // Hostnames are usually already lowercase — only pay for a
+            // char-mapped rebuild when one actually contains uppercase.
+            return Some(if s.bytes().any(|b| b.is_ascii_uppercase()) {
+                s.chars().map(|c| c.to_ascii_lowercase()).collect()
+            } else {
+                SmolStr::new(s)
+            });
         }
         pos += name_len;
     }
@@ -139,21 +149,21 @@ mod tests {
     #[test]
     fn test_extract_sni_basic() {
         let data = build_client_hello("example.com");
-        assert_eq!(sniff_tls(&data), Some("example.com".to_string()));
+        assert_eq!(sniff_tls(&data).as_deref(), Some("example.com"));
     }
 
     #[test]
     fn test_extract_sni_subdomain() {
         let data = build_client_hello("www.google.com");
-        assert_eq!(sniff_tls(&data), Some("www.google.com".to_string()));
+        assert_eq!(sniff_tls(&data).as_deref(), Some("www.google.com"));
     }
 
     #[test]
     fn test_extract_sni_long_hostname() {
         let data = build_client_hello("very.long.subdomain.example.co.uk");
         assert_eq!(
-            sniff_tls(&data),
-            Some("very.long.subdomain.example.co.uk".to_string())
+            sniff_tls(&data).as_deref(),
+            Some("very.long.subdomain.example.co.uk")
         );
     }
 
@@ -282,6 +292,6 @@ mod tests {
         record.extend_from_slice(&(record_len as u16).to_be_bytes());
         record.extend_from_slice(&handshake);
 
-        assert_eq!(sniff_tls(&record), Some("target.example.com".to_string()));
+        assert_eq!(sniff_tls(&record).as_deref(), Some("target.example.com"));
     }
 }

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -268,15 +268,22 @@ async fn handle_http_inner(
                 // Rewrite the request line: remove the absolute URI scheme+host,
                 // keep the path. Rebuild headers without Proxy-* headers.
                 let path = extract_path_from_url(url);
-                let mut rewritten = format!("{} {} {}\r\n", method, path, parts[2]);
+                // Capacity hint: the rewrite never grows beyond the original
+                // request (the absolute URI shrinks to a path; headers only
+                // ever drop).
+                let mut rewritten = String::with_capacity(request_str.len());
+                {
+                    use std::fmt::Write as _;
+                    let _ = write!(rewritten, "{} {} {}\r\n", method, path, parts[2]);
+                }
                 for line in request_str.lines().skip(1) {
                     if line.is_empty() {
                         break;
                     }
-                    // Skip proxy-specific headers
-                    let lower = line.to_ascii_lowercase();
-                    if lower.starts_with("proxy-connection")
-                        || lower.starts_with("proxy-authorization")
+                    // Skip proxy-specific headers — case-insensitive compare
+                    // on the slice, no per-line lowercased copy.
+                    if starts_with_ignore_ascii_case(line, "proxy-connection")
+                        || starts_with_ignore_ascii_case(line, "proxy-authorization")
                     {
                         continue;
                     }
@@ -362,6 +369,13 @@ fn extract_path_from_url(url: &str) -> &str {
     without_scheme
         .find('/')
         .map_or("/", |i| &without_scheme[i..])
+}
+
+/// Case-insensitive ASCII prefix test without allocating a lowercased copy.
+/// Byte-wise so a multi-byte UTF-8 char at the boundary can't panic a slice.
+fn starts_with_ignore_ascii_case(line: &str, prefix: &str) -> bool {
+    line.len() >= prefix.len()
+        && line.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
 }
 
 /// Parse `Proxy-Authorization: Basic <base64>` from raw request headers.


### PR DESCRIPTION
## Summary

Fixes #175 (June 2026 performance audit, M2 + M3).

**1. HTTP proxy header rewrite (`crates/meow-listener/src/http_proxy.rs`)**
The plain-HTTP request rewrite called `line.to_ascii_lowercase()` on every header line — one discarded `String` per line per request — just to test two prefixes. Replaced with a byte-wise `starts_with_ignore_ascii_case` helper (same approach `parse_proxy_authorization` in the same file already uses; byte-slice based so a multi-byte UTF-8 char at the boundary can't panic). Also gives the `rewritten` buffer a capacity hint from the original request length, which is a safe upper bound since the rewrite only shrinks.

**2. Sniffers return `SmolStr` (`crates/meow-common/src/sniffer/{tls,http}.rs`)**
`sniff_tls`/`sniff_http` returned `Option<String>` and the consumer (`meow-listener/src/sniffer.rs`) immediately converted to `SmolStr`. They now return `Option<SmolStr>` directly — typical hostnames (≤ 23 B) are inlined, allocation-free per sniffed handshake. The TLS path additionally drops the avoidable `name_bytes.to_vec()` intermediate. Lowercasing semantics preserved: both sniffers only rebuild the string when it actually contains uppercase (the common all-lowercase case is a straight inline copy).

Call sites needed no changes (deref coercion); test assertions switched to `as_deref()` comparisons.

## Test plan

- [x] `cargo test -p meow-common --lib` (40 — includes both sniffer suites: case-insensitivity, IPv6 literals, whitespace trim, truncation safety) and `cargo test -p meow-listener --lib` (23) pass.
- [x] `cargo fmt --all -- --check`, three-way `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` — all 10 crates green (modulo the known env-dependent `meow-dns udp_client_times_out_on_unroutable`, which fails on clean `main` in this sandbox).

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_