### PR TITLE
perf(rules): ipcidr rule-sets match via IpRange Patricia tries, not O(N) scan

### DIFF
--- a/crates/meow-rules/Cargo.toml
+++ b/crates/meow-rules/Cargo.toml
@@ -28,6 +28,10 @@ harness = false
 name = "regex_rules_bench"
 harness = false
 
+[[bench]]
+name = "ipcidr_ruleset_bench"
+harness = false
+
 [dev-dependencies]
 tempfile = { workspace = true }
 criterion = { workspace = true }

--- a/crates/meow-rules/benches/ipcidr_ruleset_bench.rs
+++ b/crates/meow-rules/benches/ipcidr_ruleset_bench.rs
@@ -1,0 +1,79 @@
+//! Benchmark for `IpCidrRuleSet` lookups (issue #172 / audit H2).
+//!
+//! Rule-providers with `behavior: ipcidr` commonly carry thousands of CIDRs
+//! (country/ASN lists). This bench builds a 10k-entry synthetic set and times
+//! hit and miss lookups two ways:
+//!
+//! 1. **`ipcidr_ruleset/*`** — the real `IpCidrRuleSet` (split `IpRange`
+//!    Patricia tries, O(prefix-depth) lookup).
+//! 2. **`linear_scan_baseline/*`** — the pre-#172 representation
+//!    (`Vec<IpNet>` + `iter().any()`), kept here so the before/after delta
+//!    stays recorded per ADR-0006 without digging through git history.
+//!
+//! Build cost is benched separately (`build_10k`) since it runs only at
+//! config (re)load.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ipnet::IpNet;
+use meow_common::{Metadata, RuleMatchHelper};
+use meow_rules::parser::ParserContext;
+use meow_rules::rule_set::{build_rule_set, RuleSetBehavior};
+use std::net::{IpAddr, Ipv4Addr};
+
+/// 10k /24 networks spread over 10.0.0.0/8 — disjoint, realistic prefix mix.
+fn synthetic_entries() -> Vec<String> {
+    let mut out = Vec::with_capacity(10_000);
+    for i in 0..10_000u32 {
+        let b = (i >> 8) & 0xff;
+        let c = i & 0xff;
+        out.push(format!("10.{b}.{c}.0/24"));
+    }
+    out
+}
+
+fn meta_for(ip: IpAddr) -> Metadata {
+    Metadata {
+        dst_ip: Some(ip),
+        ..Default::default()
+    }
+}
+
+fn bench_ipcidr(c: &mut Criterion) {
+    let entries = synthetic_entries();
+    let ctx = ParserContext::default();
+    let helper = RuleMatchHelper;
+
+    let set = build_rule_set(RuleSetBehavior::IpCidr, &entries, &ctx);
+    // Worst-case-ish hit: an entry late in insertion order.
+    let hit = meta_for(IpAddr::V4(Ipv4Addr::new(10, 38, 200, 7)));
+    let miss = meta_for(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)));
+
+    let mut g = c.benchmark_group("ipcidr_ruleset");
+    g.bench_function("hit_10k", |b| {
+        b.iter(|| black_box(set.matches(black_box(&hit), &helper)));
+    });
+    g.bench_function("miss_10k", |b| {
+        b.iter(|| black_box(set.matches(black_box(&miss), &helper)));
+    });
+    g.bench_function("build_10k", |b| {
+        b.iter(|| black_box(build_rule_set(RuleSetBehavior::IpCidr, &entries, &ctx)));
+    });
+    g.finish();
+
+    // Pre-#172 baseline: Vec<IpNet> linear scan.
+    let cidrs: Vec<IpNet> = entries.iter().map(|e| e.parse().unwrap()).collect();
+    let hit_ip = IpAddr::V4(Ipv4Addr::new(10, 38, 200, 7));
+    let miss_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+
+    let mut g = c.benchmark_group("linear_scan_baseline");
+    g.bench_function("hit_10k", |b| {
+        b.iter(|| black_box(cidrs.iter().any(|net| net.contains(black_box(&hit_ip)))));
+    });
+    g.bench_function("miss_10k", |b| {
+        b.iter(|| black_box(cidrs.iter().any(|net| net.contains(black_box(&miss_ip)))));
+    });
+    g.finish();
+}
+
+criterion_group!(benches, bench_ipcidr);
+criterion_main!(benches);

--- a/crates/meow-rules/src/rule_set.rs
+++ b/crates/meow-rules/src/rule_set.rs
@@ -13,7 +13,8 @@
 use std::fmt;
 use std::str::FromStr;
 
-use ipnet::IpNet;
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use iprange::IpRange;
 use meow_common::{Metadata, Rule, RuleMatchHelper};
 use meow_trie::DomainTrie;
 use tracing::warn;
@@ -245,27 +246,47 @@ impl RuleSet for DomainRuleSet {
 // IpCidr
 // ---------------------------------------------------------------------------
 
+/// ipcidr rule-set backed by split `IpRange` Patricia tries — lookup is
+/// O(prefix-depth) instead of a linear scan over every CIDR. Country/ASN
+/// providers commonly carry thousands of entries, and every connection that
+/// reaches the rule paid O(N) comparisons with the previous `Vec<IpNet>`.
+/// Same structure `country_index.rs` already uses for GEOIP rules.
 pub struct IpCidrRuleSet {
-    cidrs: Vec<IpNet>,
+    v4: IpRange<Ipv4Net>,
+    v6: IpRange<Ipv6Net>,
+    /// Parsed-entry count, as reported by `len()`. Kept separately because
+    /// `simplify()` merges adjacent/nested networks inside the tries.
+    count: usize,
 }
 
 impl IpCidrRuleSet {
     pub fn from_entries(entries: &[String]) -> Self {
-        let mut cidrs = Vec::new();
+        let mut v4: IpRange<Ipv4Net> = IpRange::new();
+        let mut v6: IpRange<Ipv6Net> = IpRange::new();
+        let mut count = 0usize;
         for entry in entries {
             let entry = entry.trim();
             if entry.is_empty() {
                 continue;
             }
             match entry.parse::<IpNet>() {
-                Ok(net) => cidrs.push(net),
+                Ok(IpNet::V4(net)) => {
+                    v4.add(net);
+                    count += 1;
+                }
+                Ok(IpNet::V6(net)) => {
+                    v6.add(net);
+                    count += 1;
+                }
                 Err(e) => warn!(
                     "rule-set (ipcidr): skipping invalid entry '{}': {}",
                     entry, e
                 ),
             }
         }
-        Self { cidrs }
+        v4.simplify();
+        v6.simplify();
+        Self { v4, v6, count }
     }
 }
 
@@ -278,11 +299,18 @@ impl RuleSet for IpCidrRuleSet {
         let Some(ip) = metadata.dst_ip else {
             return false;
         };
-        self.cidrs.iter().any(|net| net.contains(&ip))
+        match ip {
+            std::net::IpAddr::V4(v4) => self
+                .v4
+                .contains(&Ipv4Net::new(v4, 32).expect("/32 is always valid")),
+            std::net::IpAddr::V6(v6) => self
+                .v6
+                .contains(&Ipv6Net::new(v6, 128).expect("/128 is always valid")),
+        }
     }
 
     fn len(&self) -> usize {
-        self.cidrs.len()
+        self.count
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #172 (June 2026 performance audit, H2 — biggest algorithmic win available in the rule engine).

`IpCidrRuleSet::matches` did `self.cidrs.iter().any(|net| net.contains(&ip))` — O(N) per connection for `behavior: ipcidr` providers that commonly carry thousands of country/ASN CIDRs.

- `Vec<IpNet>` → split `IpRange<Ipv4Net>` / `IpRange<Ipv6Net>` Patricia tries with `simplify()` after build; lookup wraps the address as `/32`–`/128` and is O(prefix-depth). Identical structure (and already-present workspace crate) to what `country_index.rs` uses for GEOIP rules.
- `len()` still reports the parsed-entry count (tracked separately, since `simplify()` merges adjacent/nested networks).
- Both YAML and MRS loading paths go through `from_entries`, so both benefit.
- The inline `IP-CIDR` rule (one net per rule) is untouched, per the issue's scope note.

## Benchmark (new, per ADR-0006)

`crates/meow-rules/benches/ipcidr_ruleset_bench.rs` — 10k disjoint `/24`s, with the pre-change linear scan kept as an in-bench baseline so the delta stays reproducible. On this 4-core dev container:

| lookup | linear scan (before) | IpRange trie (after) |
|---|---|---|
| hit | 255.7 µs | **26.9 ns** |
| miss | 257.6 µs | **7.3 ns** |
| build (config-load only) | — | 2.20 ms |

## Test plan

- [x] `cargo test -p meow-rules` — 134 lib tests + suites green; `cargo test --test rules_test` — all 100 rule-matching tests pass.
- [x] `cargo fmt --all -- --check`, three-way `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` — all 10 crates green (modulo the known env-dependent meow-dns timeout test).

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_