### PR TITLE
perf(api): serialize connections straight from the table; share memory-ws frames

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -360,31 +360,25 @@ async fn get_rules(State(state): State<Arc<AppState>>) -> Json<RulesResponse> {
 }
 
 #[derive(Serialize)]
-struct ConnectionsResponse {
+struct ConnectionsResponse<'a> {
     upload_total: i64,
     download_total: i64,
-    connections: Vec<serde_json::Value>,
+    /// Serialised straight from the live table — no per-connection
+    /// `serde_json::Value` tree, no cloned snapshot Vec (audit M8). The
+    /// JSON shape (id/upload/download/start/chains/rule/rulePayload) comes
+    /// from `ConnectionInfo`'s `Serialize` derive.
+    connections: meow_tunnel::statistics::ActiveConnectionsView<'a>,
 }
 
-async fn get_connections(State(state): State<Arc<AppState>>) -> Json<ConnectionsResponse> {
+async fn get_connections(State(state): State<Arc<AppState>>) -> Response {
     let stats = state.tunnel.statistics();
     let (up, down) = stats.snapshot();
-    let conns = stats.active_connections();
-    let connections: Vec<serde_json::Value> = conns
-        .into_iter()
-        .map(|c| {
-            serde_json::json!({
-                "id": c.id, "upload": c.upload, "download": c.download,
-                "start": c.start, "chains": c.chains, "rule": c.rule,
-                "rulePayload": c.rule_payload,
-            })
-        })
-        .collect();
     Json(ConnectionsResponse {
         upload_total: up,
         download_total: down,
-        connections,
+        connections: stats.active_connections_view(),
     })
+    .into_response()
 }
 
 async fn close_connection(
@@ -1409,16 +1403,59 @@ async fn get_logs(
 // ── WebSocket: memory stream ─────────────────────────────────────────
 
 // upstream: hub/route/memory.go
-async fn get_memory(State(_state): State<Arc<AppState>>, ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(|mut socket| async move {
+//
+// One process-wide sampler task reads RSS + limit and serialises the JSON
+// frame once per tick; every connected socket forwards the shared string
+// (audit M8 — previously each socket sampled and serialised independently,
+// per-socket per-tick). The sampler starts with the first subscriber and
+// exits once the last socket disconnects, so an idle API server pays nothing.
+// Model: the log websocket's single-serialisation broadcast fan-out.
+static MEMORY_FEED: std::sync::Mutex<Option<broadcast::Sender<Arc<str>>>> =
+    std::sync::Mutex::new(None);
+
+fn subscribe_memory_feed() -> broadcast::Receiver<Arc<str>> {
+    let mut guard = MEMORY_FEED.lock().expect("memory feed lock poisoned");
+    if let Some(tx) = guard.as_ref() {
+        // Sampler still alive (it clears the slot under this lock on exit).
+        return tx.subscribe();
+    }
+    let (tx, rx) = broadcast::channel(2);
+    *guard = Some(tx.clone());
+    tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(1));
         loop {
             interval.tick().await;
+            if tx.receiver_count() == 0 {
+                // Re-check under the lock so a subscriber arriving right now
+                // either sees the live sender or a cleared slot — never a
+                // sender whose sampler has already exited.
+                let mut guard = MEMORY_FEED.lock().expect("memory feed lock poisoned");
+                if tx.receiver_count() == 0 {
+                    *guard = None;
+                    break;
+                }
+            }
             let inuse = read_rss_bytes();
             let oslimit = read_os_memory_limit();
-            let msg = serde_json::json!({ "inuse": inuse, "oslimit": oslimit });
+            let msg: Arc<str> = Arc::from(format!("{{\"inuse\":{inuse},\"oslimit\":{oslimit}}}"));
+            let _ = tx.send(msg);
+        }
+    });
+    rx
+}
+
+async fn get_memory(State(_state): State<Arc<AppState>>, ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(|mut socket| async move {
+        let mut feed = subscribe_memory_feed();
+        loop {
+            let msg = match feed.recv().await {
+                Ok(msg) => msg,
+                // Slow consumer skipped a tick — just continue with the next.
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => break,
+            };
             if socket
-                .send(Message::Text(msg.to_string().into()))
+                .send(Message::Text(msg.as_ref().into()))
                 .await
                 .is_err()
             {

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -2497,3 +2497,56 @@ async fn get_metrics_returns_prometheus_text() {
         "missing meow_connections_active in metrics output"
     );
 }
+
+/// GET /connections serialises entries with the documented camelCase shape
+/// (id/upload/download/start/chains/rule/rulePayload). Guards the
+/// borrow-based `ActiveConnectionsView` serialize path (audit M8), which
+/// replaced the per-entry `serde_json::json!` tree.
+#[tokio::test]
+async fn get_connections_entry_has_camel_case_shape() {
+    use meow_common::{ConnType, Metadata, Network};
+    let state = test_state_default();
+
+    let meta = Metadata {
+        network: Network::Tcp,
+        conn_type: ConnType::Http,
+        host: "example.com".into(),
+        dst_port: 80,
+        ..Default::default()
+    };
+    let conn_id = state.tunnel.statistics().track_connection(
+        meta,
+        smol_str::SmolStr::new_static("DOMAIN"),
+        smol_str::SmolStr::new_static("example.com"),
+        smallvec![Arc::from("DIRECT")],
+    );
+
+    let app = create_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::get("/connections")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let conn = &json["connections"].as_array().unwrap()[0];
+
+    assert_eq!(conn["id"], conn_id.to_string());
+    assert_eq!(conn["rule"], "DOMAIN");
+    assert_eq!(conn["rulePayload"], "example.com", "must stay camelCase");
+    assert_eq!(conn["chains"], serde_json::json!(["DIRECT"]));
+    assert_eq!(conn["upload"], 0);
+    assert_eq!(conn["download"], 0);
+    assert!(conn["start"].is_string());
+    assert!(
+        conn.get("metadata").is_none(),
+        "metadata stays serde-skipped"
+    );
+    assert!(
+        conn.get("rule_payload").is_none(),
+        "snake_case key must not appear"
+    );
+}

--- a/crates/meow-tunnel/src/statistics.rs
+++ b/crates/meow-tunnel/src/statistics.rs
@@ -70,6 +70,8 @@ pub struct ConnectionInfo {
     /// hot path).
     pub rule: SmolStr,
     /// Rule payload (e.g. the domain pattern). Config-derived, low-cardinality.
+    /// Renamed so the derived JSON matches the REST API's camelCase field.
+    #[serde(rename = "rulePayload")]
     pub rule_payload: SmolStr,
 }
 
@@ -142,6 +144,16 @@ impl Statistics {
         self.connections.iter().map(|e| e.value().clone()).collect()
     }
 
+    /// Borrow-serializing view over the active-connections table.
+    ///
+    /// Serialises each entry in place while iterating the DashMap — no
+    /// per-call `Vec` clone, no intermediate `serde_json::Value` tree.
+    /// Shard read locks are held per entry during serialization, the same
+    /// window the clone in [`Self::active_connections`] holds them.
+    pub fn active_connections_view(&self) -> ActiveConnectionsView<'_> {
+        ActiveConnectionsView(self)
+    }
+
     pub fn close_all_connections(&self) {
         self.connections.clear();
     }
@@ -150,6 +162,25 @@ impl Statistics {
 impl Default for Statistics {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// See [`Statistics::active_connections_view`].
+pub struct ActiveConnectionsView<'a>(&'a Statistics);
+
+impl Serialize for ActiveConnectionsView<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_seq(self.0.connections.iter().map(EntryRef))
+    }
+}
+
+/// Wraps a DashMap entry guard so `collect_seq` can serialize the borrowed
+/// `ConnectionInfo` without cloning it out of the map.
+struct EntryRef<'a>(dashmap::mapref::multiple::RefMulti<'a, Uuid, ConnectionInfo>);
+
+impl Serialize for EntryRef<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.value().serialize(serializer)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #180 (June 2026 performance audit, M8). All three items:

**1. `GET /connections` — no more `Value` trees or snapshot clones.** The handler mapped every `ConnectionInfo` through `serde_json::json!` (one `Value` tree per connection per request), fed by `active_connections()` cloning every DashMap entry into a fresh `Vec`. New `Statistics::active_connections_view()` returns a borrow-based `ActiveConnectionsView` that `collect_seq`s straight over the DashMap iterator, serializing each entry in place via `ConnectionInfo`'s existing `Serialize` derive. Shard read locks are held per entry — the same window the old clone held them.

**2. Wire shape pinned.** `rule_payload` gains `#[serde(rename = "rulePayload")]` so the derive output matches the camelCase JSON the route previously hand-built (`metadata` was already `#[serde(skip)]`). A new integration test (`get_connections_entry_has_camel_case_shape`) asserts the full entry shape, that `rule_payload` (snake) never appears, and that `metadata` stays hidden.

**3. `/memory` websocket — sample + serialize once per tick.** Each socket previously ran its own 1 s interval doing a sysinfo RSS refresh + `json!` + `to_string`. A single process-wide sampler now builds the frame once per tick and fans it out via a `broadcast` channel (modeled on the log websocket's single-serialization broadcast). The sampler spawns with the first subscriber and exits with the last (re-checked under the registry lock to avoid the subscribe/exit race), so an idle server pays nothing.

**ADR-0011:** `ConnectionInfo` 136 B → 136 B (`-Zprint-type-sizes`, nightly, this container — measured on clean `main` and on this branch; the change is a serde attribute only, no layout change).

## Test plan

- [x] New `get_connections_entry_has_camel_case_shape` integration test.
- [x] `cargo test -p meow-api -p meow-tunnel --no-fail-fast` — all suites green (90 api_test cases incl. the connections CRUD tests, relay churn leak test, etc.).
- [x] `cargo fmt --all -- --check`, three-way `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` — all 10 crates green.

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_