### PR TITLE
perf(transport): upgrade tokio-tungstenite 0.24 → 0.29; Bytes WS payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -997,7 +997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1468,7 +1468,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1687,7 +1687,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2003,7 +2003,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tracing",
@@ -2225,7 +2225,7 @@ dependencies = [
  "tokio",
  "tokio-boring",
  "tokio-rustls",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
  "webpki-root-certs",
@@ -2356,7 +2356,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2729,7 +2729,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3036,7 +3036,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3400,7 +3400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3495,7 +3495,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3687,18 +3687,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -3706,7 +3694,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3906,24 +3894,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.8.6",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -4010,12 +3980,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4263,7 +4227,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ futures = "0.3"
 futures-util = "0.3"
 
 # WebSocket
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "handshake"] }
 
 # HTTP types
 http = "1"

--- a/crates/meow-api/tests/api_logs_ws_test.rs
+++ b/crates/meow-api/tests/api_logs_ws_test.rs
@@ -83,6 +83,7 @@ async fn recv_text(ws: &mut WsStream) -> String {
         .expect("ws recv error")
         .into_text()
         .unwrap()
+        .to_string()
 }
 
 // ── E. LogMessage serialization (unit tests, no server) ──────────

--- a/crates/meow-transport/src/grpc.rs
+++ b/crates/meow-transport/src/grpc.rs
@@ -327,6 +327,13 @@ impl AsyncRead for GunStream {
                         }
                     }
                 }
+
+                // Incomplete frame, but the gun header already told us the
+                // full length: reserve it once instead of letting the
+                // extend_from_slice below regrow the Vec repeatedly for
+                // large frames (bounded by MAX_GUN_FRAME_LEN).
+                this.pending_frame
+                    .reserve(frame_len - this.pending_frame.len());
             }
 
             // ── Need more bytes from the h2 DATA stream ───────────────────────

--- a/crates/meow-transport/src/ws.rs
+++ b/crates/meow-transport/src/ws.rs
@@ -27,6 +27,7 @@ use base64::Engine as _;
 use futures_util::{Sink, Stream as FuturesStream};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
+use tokio_tungstenite::tungstenite::Bytes;
 use tokio_tungstenite::WebSocketStream;
 use tracing::warn;
 
@@ -37,15 +38,12 @@ use crate::{Result, Stream, Transport, TransportError};
 /// high concurrency). 4 KiB matches `RELAY_BUF_SIZE` and is plenty for the
 /// streaming-relay use case where each write is a single relay-buf chunk.
 fn ws_config() -> WebSocketConfig {
-    #[allow(deprecated)]
-    WebSocketConfig {
-        max_send_queue: None,
-        write_buffer_size: 4 * 1024,
-        max_write_buffer_size: 64 * 1024,
-        max_message_size: Some(4 * 1024 * 1024),
-        max_frame_size: Some(1024 * 1024),
-        accept_unmasked_frames: false,
-    }
+    WebSocketConfig::default()
+        .write_buffer_size(4 * 1024)
+        .max_write_buffer_size(64 * 1024)
+        .max_message_size(Some(4 * 1024 * 1024))
+        .max_frame_size(Some(1024 * 1024))
+        .accept_unmasked_frames(false)
 }
 
 // ─── Public types ────────────────────────────────────────────────────────────
@@ -256,7 +254,9 @@ struct PendingState {
 
 struct ConnectedState {
     ws: WebSocketStream<BoxStream>,
-    read_buf: Vec<u8>,
+    /// Payload of the last Binary frame, held as received (`Bytes`) and
+    /// drained by `poll_read` — no copy into an intermediate Vec.
+    read_buf: Bytes,
     read_pos: usize,
 }
 
@@ -276,7 +276,7 @@ impl WsStream {
         Self {
             inner: WsInner::Connected(Box::new(ConnectedState {
                 ws,
-                read_buf: Vec::new(),
+                read_buf: Bytes::new(),
                 read_pos: 0,
             })),
         }
@@ -347,7 +347,7 @@ fn poll_upgrade(inner: &mut WsInner, cx: &mut Context<'_>) -> Poll<io::Result<()
         Poll::Ready(Ok(Ok(ws))) => {
             *inner = WsInner::Connected(Box::new(ConnectedState {
                 ws,
-                read_buf: Vec::new(),
+                read_buf: Bytes::new(),
                 read_pos: 0,
             }));
             Poll::Ready(Ok(()))
@@ -479,16 +479,14 @@ impl AsyncWrite for WsStream {
                         }
                         Poll::Pending => return Poll::Pending,
                     }
-                    // ADR-0008 HP-3: this `buf.to_vec()` allocates one
-                    // Vec<u8> per WS-relayed chunk and is the largest per-byte
-                    // allocation in the transport stack. tokio-tungstenite 0.24
-                    // requires `Message::Binary(Vec<u8>)`; 0.26+ accepts
-                    // `Bytes` and would let this be a refcount bump on a
-                    // shared `Bytes` buf. Tracked separately — upgrading the
-                    // tungstenite version is out of scope here because the
-                    // call/handshake API changed.
-                    if let Err(e) =
-                        Pin::new(&mut state.ws).start_send(Message::Binary(buf.to_vec()))
+                    // ADR-0008 HP-3: one `Bytes::copy_from_slice` per
+                    // WS-relayed chunk. With tokio-tungstenite >=0.26 the
+                    // `Bytes` payload is uniquely owned, so tungstenite masks
+                    // it in place (`try_into_mut`) instead of re-copying the
+                    // frame — one allocation per chunk, down from the 0.24
+                    // `Vec<u8>` copy + internal re-copy.
+                    if let Err(e) = Pin::new(&mut state.ws)
+                        .start_send(Message::Binary(Bytes::copy_from_slice(buf)))
                     {
                         return Poll::Ready(Err(io::Error::other(e)));
                     }


### PR DESCRIPTION
## Summary

Fixes #178 (June 2026 performance audit, M6; relevant to ADR-0008 HP-3).

`tokio-tungstenite` 0.24's `Message::Binary` took `Vec<u8>`, forcing a `buf.to_vec()` copy + allocation per outbound frame on the WS relay path — one per ~8 KB chunk through any v2ray-plugin/WS proxy. The site in `ws.rs` was already annotated as tracked for this upgrade.

- **Dep bump 0.24 → 0.29** (issue asked ≥0.26; 0.29 additionally **deduplicates** with the tokio-tungstenite 0.29 that axum 0.8 already pulls — previously two whole tungstenite stacks were compiled in).
- **Write path**: `Message::Binary(Bytes::copy_from_slice(buf))`. The uniquely-owned `Bytes` lets tungstenite mask the frame in place (`try_into_mut`) instead of re-copying — one allocation per chunk, down from copy + internal re-copy.
- **Read path**: received Binary payloads are now stored as `Bytes` directly (`read_buf: Vec<u8>` → `Bytes`), dropping the copy out of each inbound message.
- `WebSocketConfig` moved to the 0.26+ builder API (struct went `#[non_exhaustive]`; deprecated `max_send_queue` is gone). Same bounded values as before (4 KiB write buffer, 64 KiB max, 4 MiB message, 1 MiB frame).
- meow-api's log-websocket test helper adapts to `into_text()` now returning `Utf8Bytes`.

**Related (same audit item, flagged lower priority):** gRPC gun-frame reassembly now `reserve`s the full frame length once the gun header is parsed, instead of letting `extend_from_slice` regrow `pending_frame` per read (bounded by the 16 MB `MAX_GUN_FRAME_LEN` cap).

## Test plan

- [x] `cargo test -p meow-transport --all-features` — ws (11), grpc (4+1 unbounded), h2, tls, boring_tls, httpupgrade, crate-invariants all green.
- [x] `cargo test -p meow-proxy` — 220 lib tests + suites green (covers the SS v2ray-plugin WS path).
- [x] `cargo test -p meow-api --test api_logs_ws_test` — 16 green.
- [x] `cargo fmt --all -- --check`, three-way `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` — all 10 crates green (modulo the known env-dependent meow-dns timeout test).

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_