### PR TITLE
perf: batch of low-severity cleanups from the June 2026 audit (#182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,6 @@ version = "0.13.0"
 dependencies = [
  "criterion",
  "proptest",
- "smallvec",
 ]
 
 [[package]]

--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -289,9 +289,9 @@ struct ProxiesResponse {
 }
 
 async fn get_proxies(State(state): State<Arc<AppState>>) -> Json<ProxiesResponse> {
-    let proxies = state.tunnel.proxies();
+    let route = state.tunnel.route_snapshot();
     let mut result = std::collections::HashMap::new();
-    for (name, proxy) in &proxies {
+    for (name, proxy) in &route.proxies {
         result.insert(name.to_string(), ProxyInfo::from_proxy(proxy));
     }
     Json(ProxiesResponse { proxies: result })
@@ -301,8 +301,11 @@ async fn get_proxy(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<ProxyInfo>, StatusCode> {
-    let proxies = state.tunnel.proxies();
-    let proxy = proxies.get(name.as_str()).ok_or(StatusCode::NOT_FOUND)?;
+    let route = state.tunnel.route_snapshot();
+    let proxy = route
+        .proxies
+        .get(name.as_str())
+        .ok_or(StatusCode::NOT_FOUND)?;
     Ok(Json(ProxyInfo::from_proxy(proxy)))
 }
 
@@ -317,8 +320,8 @@ async fn update_proxy(
     Json(body): Json<UpdateProxyRequest>,
 ) -> StatusCode {
     use meow_proxy::SelectorGroup;
-    let proxies = state.tunnel.proxies();
-    if let Some(proxy) = proxies.get(group_name.as_str()) {
+    let route = state.tunnel.route_snapshot();
+    if let Some(proxy) = route.proxies.get(group_name.as_str()) {
         if let Some(selector) = proxy
             .as_any()
             .and_then(|a| a.downcast_ref::<SelectorGroup>())
@@ -334,29 +337,32 @@ async fn update_proxy(
 }
 
 #[derive(Serialize)]
-struct RuleInfo {
+struct RuleInfo<'a> {
     #[serde(rename = "type")]
-    rule_type: String,
-    payload: String,
-    proxy: String,
+    rule_type: &'static str,
+    payload: &'a str,
+    proxy: &'a str,
 }
 
 #[derive(Serialize)]
-struct RulesResponse {
-    rules: Vec<RuleInfo>,
+struct RulesResponse<'a> {
+    rules: Vec<RuleInfo<'a>>,
 }
 
-async fn get_rules(State(state): State<Arc<AppState>>) -> Json<RulesResponse> {
-    let rules = state.tunnel.rules_info();
-    let result: Vec<RuleInfo> = rules
-        .into_iter()
-        .map(|(rt, payload, adapter)| RuleInfo {
-            rule_type: rt,
-            payload,
-            proxy: adapter,
+async fn get_rules(State(state): State<Arc<AppState>>) -> Response {
+    // Serialise straight off the route snapshot — the old rules_info()
+    // accessor built 3 Strings per rule per call (audit #182).
+    let route = state.tunnel.route_snapshot();
+    let result: Vec<RuleInfo> = route
+        .rules
+        .iter()
+        .map(|r| RuleInfo {
+            rule_type: r.rule_type().as_str(),
+            payload: r.payload(),
+            proxy: r.adapter(),
         })
         .collect();
-    Json(RulesResponse { rules: result })
+    Json(RulesResponse { rules: result }).into_response()
 }
 
 #[derive(Serialize)]
@@ -742,7 +748,8 @@ struct ProxyGroupInfo {
 async fn get_proxy_groups(State(state): State<Arc<AppState>>) -> Json<Vec<ProxyGroupInfo>> {
     let raw = state.raw_config.read();
     let groups = raw.proxy_groups.as_deref().unwrap_or(&[]);
-    let tunnel_proxies = state.tunnel.proxies();
+    let route = state.tunnel.route_snapshot();
+    let tunnel_proxies = &route.proxies;
 
     let result: Vec<ProxyGroupInfo> = groups
         .iter()
@@ -870,8 +877,8 @@ async fn select_proxy_in_group(
     Json(body): Json<SelectProxyRequest>,
 ) -> StatusCode {
     use meow_proxy::SelectorGroup;
-    let proxies = state.tunnel.proxies();
-    if let Some(proxy) = proxies.get(group_name.as_str()) {
+    let route = state.tunnel.route_snapshot();
+    if let Some(proxy) = route.proxies.get(group_name.as_str()) {
         if let Some(selector) = proxy
             .as_any()
             .and_then(|a| a.downcast_ref::<SelectorGroup>())
@@ -1045,12 +1052,12 @@ async fn get_proxy_delay(
     let url = params.url.as_deref().unwrap_or("").to_string();
     let expected = params.expected.clone();
 
-    let proxies = state.tunnel.proxies();
+    let route = state.tunnel.route_snapshot();
     // upstream: hub/route/proxies.go::getProxyDelay — findProxyByName middleware
-    let Some(proxy) = proxies.get(name.as_str()).cloned() else {
+    let Some(proxy) = route.proxies.get(name.as_str()).cloned() else {
         return msg_err(StatusCode::NOT_FOUND, "resource not found");
     };
-    drop(proxies);
+    drop(route);
 
     match probe_and_record(&proxy, &url, expected.as_deref(), timeout).await {
         Ok(delay) => Json(DelayResp { delay }).into_response(),
@@ -1078,8 +1085,8 @@ async fn get_group_delay(
     let url = params.url.as_deref().unwrap_or("").to_string();
     let expected = params.expected.clone();
 
-    let proxies = state.tunnel.proxies();
-    let Some(group) = proxies.get(name.as_str()).cloned() else {
+    let route = state.tunnel.route_snapshot();
+    let Some(group) = route.proxies.get(name.as_str()).cloned() else {
         return msg_err(StatusCode::NOT_FOUND, "resource not found");
     };
     // upstream: findProxyByName rejects non-groups with 404 for this route.
@@ -1091,9 +1098,9 @@ async fn get_group_delay(
     // proxies map so the spawned tasks hold their own Arc clones.
     let members: Vec<(String, Arc<dyn meow_common::Proxy>)> = member_names
         .into_iter()
-        .filter_map(|n| proxies.get(n.as_str()).cloned().map(|p| (n, p)))
+        .filter_map(|n| route.proxies.get(n.as_str()).cloned().map(|p| (n, p)))
         .collect();
-    drop(proxies);
+    drop(route);
 
     let url_shared = Arc::new(url);
     let expected_shared = Arc::new(expected);
@@ -1295,7 +1302,8 @@ async fn get_metrics(State(state): State<Arc<AppState>>) -> Response {
     // meow_proxy_alive and meow_proxy_delay_ms — gauge{proxy_name,adapter_type}
     let proxy_alive = Family::<Vec<(String, String)>, Gauge<i64, AtomicI64>>::default();
     let proxy_delay = Family::<Vec<(String, String)>, Gauge<i64, AtomicI64>>::default();
-    for (name, proxy) in state.tunnel.proxies() {
+    let route = state.tunnel.route_snapshot();
+    for (name, proxy) in &route.proxies {
         let labels = vec![
             ("proxy_name".to_string(), name.to_string()),
             ("adapter_type".to_string(), proxy.adapter_type().to_string()),

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -1618,7 +1618,8 @@ async fn a1_get_proxy_delay_ok_records_delay() {
     assert!(delay > 0, "delay must be positive, got {delay}");
     assert_eq!(body.as_object().unwrap().len(), 1, "only the delay key");
     // Verify recorded into history
-    let proxies = state.tunnel.proxies();
+    let route = state.tunnel.route_snapshot();
+    let proxies = &route.proxies;
     let proxy = proxies.get("T").unwrap();
     assert_eq!(proxy.delay_history().len(), 1);
 }

--- a/crates/meow-app/src/geodata_fetch.rs
+++ b/crates/meow-app/src/geodata_fetch.rs
@@ -101,10 +101,11 @@ pub async fn run_on_startup(
 ) {
     let targets = compute_targets(&geo);
 
-    let proxies = tunnel.proxies();
+    let route = tunnel.route_snapshot();
+    let proxies = &route.proxies;
     let download_proxy = meow_config::internal_http::first_named_proxy(
         raw_config.read().proxies.as_deref(),
-        &proxies,
+        proxies,
     );
 
     let downloaded = fetch_missing(&targets, download_proxy.as_ref()).await;
@@ -158,10 +159,11 @@ pub async fn auto_update_loop(
 
         let mut any_updated = false;
 
-        let proxies = tunnel.proxies();
+        let route = tunnel.route_snapshot();
+        let proxies = &route.proxies;
         let download_proxy = meow_config::internal_http::first_named_proxy(
             raw_config.read().proxies.as_deref(),
-            &proxies,
+            proxies,
         );
 
         if let Err(e) =

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -45,7 +45,8 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
     loop {
         ticker.tick().await;
 
-        let proxies = tunnel.proxies();
+        let route = tunnel.route_snapshot();
+        let proxies = &route.proxies;
         let Some(group) = proxies.get(spec.group_name.as_str()).cloned() else {
             debug!(
                 "health-check: group '{}' not found, skipping tick",
@@ -61,7 +62,7 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
             .into_iter()
             .filter_map(|n| proxies.get(n.as_str()).cloned().map(|p| (n, p)))
             .collect();
-        drop(proxies);
+        drop(route);
 
         let url = spec.url.clone();
         let mut set: tokio::task::JoinSet<(String, u16)> = tokio::task::JoinSet::new();

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -223,6 +223,11 @@ fn url_to_plain_socketaddr(url: &NameServerUrl) -> SocketAddr {
 
 /// Query a pool of clients in parallel; return the first successful A+AAAA
 /// result. `select_ok` semantics — first `Ok` wins, remaining are cancelled.
+/// Unit error for racing upstream attempts: the failure detail is discarded
+/// by `select_ok` callers, so attempts must not allocate an error String.
+#[derive(Debug, Clone, Copy)]
+struct LookupFailed;
+
 async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<(Vec<IpAddr>, Duration)> {
     match clients.len() {
         0 => None,
@@ -259,13 +264,16 @@ async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<(Vec<IpAdd
             // ≥ 3 nameservers: fall back to select_ok with Vec<Pin<Box<…>>>.
             // host can still be borrowed because `select_ok` keeps the
             // futures alive only until it resolves.
+            // Unit error: the per-attempt failure reason is never read
+            // (select_ok only reports the last error), so don't format!
+            // an error String per failed attempt.
             let futs: Vec<_> = clients
                 .iter()
                 .map(|c| {
                     Box::pin(async move {
-                        let (ips, ttl) = c.lookup_ip(host).await.map_err(|e| format!("{e}"))?;
+                        let (ips, ttl) = c.lookup_ip(host).await.map_err(|_| LookupFailed)?;
                         if ips.is_empty() {
-                            return Err("empty".to_string());
+                            return Err(LookupFailed);
                         }
                         Ok((ips, clamp_ttl(ttl)))
                     })
@@ -305,7 +313,7 @@ async fn query_pool_generic(
                 .iter()
                 .map(|c| {
                     Box::pin(
-                        async move { c.query(host, record_type).await.map_err(|e| format!("{e}")) },
+                        async move { c.query(host, record_type).await.map_err(|_| LookupFailed) },
                     )
                 })
                 .collect();

--- a/crates/meow-listener/src/socks5.rs
+++ b/crates/meow-listener/src/socks5.rs
@@ -83,26 +83,26 @@ async fn handle_socks5_inner(
         if sub_ver[0] != 0x01 {
             return Err("invalid auth sub-negotiation version".into());
         }
+        // Borrow username/password from stack buffers; the username is only
+        // copied to the heap after a successful verify (audit #182 — the
+        // failure/empty path previously allocated two Strings regardless).
         let mut ulen = [0u8; 1];
         stream.read_exact(&mut ulen).await?;
-        let mut auth_buf = [0u8; 255];
-        stream.read_exact(&mut auth_buf[..ulen[0] as usize]).await?;
-        let username = std::str::from_utf8(&auth_buf[..ulen[0] as usize])
-            .unwrap_or_default()
-            .to_string();
+        let mut user_buf = [0u8; 255];
+        stream.read_exact(&mut user_buf[..ulen[0] as usize]).await?;
+        let username = std::str::from_utf8(&user_buf[..ulen[0] as usize]).unwrap_or_default();
         let mut plen = [0u8; 1];
         stream.read_exact(&mut plen).await?;
-        stream.read_exact(&mut auth_buf[..plen[0] as usize]).await?;
-        let password = std::str::from_utf8(&auth_buf[..plen[0] as usize])
-            .unwrap_or_default()
-            .to_string();
+        let mut pass_buf = [0u8; 255];
+        stream.read_exact(&mut pass_buf[..plen[0] as usize]).await?;
+        let password = std::str::from_utf8(&pass_buf[..plen[0] as usize]).unwrap_or_default();
 
-        if !auth.credentials.verify(&username, &password) {
+        if !auth.credentials.verify(username, password) {
             stream.write_all(&[0x01, 0x01]).await?;
             return Err(format!("SOCKS5 auth failed for user {username:?}").into());
         }
         stream.write_all(&[0x01, 0x00]).await?;
-        Some(username)
+        Some(username.to_string())
     } else {
         // No auth required
         stream.write_all(&[SOCKS5_VERSION, NO_AUTH]).await?;

--- a/crates/meow-listener/src/tproxy/mod.rs
+++ b/crates/meow-listener/src/tproxy/mod.rs
@@ -96,7 +96,8 @@ impl TProxyListener {
 /// Collect all upstream proxy server IPs from the tunnel's proxy map.
 /// These IPs must be excluded from firewall redirection to prevent loops.
 fn collect_proxy_server_ips(tunnel: &Tunnel) -> Vec<IpAddr> {
-    let proxies = tunnel.proxies();
+    let route = tunnel.route_snapshot();
+    let proxies = &route.proxies;
     let mut ips = HashSet::new();
 
     for proxy in proxies.values() {

--- a/crates/meow-listener/src/tproxy/orig_dest.rs
+++ b/crates/meow-listener/src/tproxy/orig_dest.rs
@@ -91,10 +91,22 @@ mod macos {
 
         let listen_port = listen_addr.port();
 
-        let pf_fd = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open("/dev/pf")?;
+        // /dev/pf is opened once and cached for the process lifetime —
+        // opening it per connection cost an open/close syscall pair on
+        // every accepted tproxy connection (audit #182). Only success is
+        // cached, so a transient failure (pf not loaded yet) can recover.
+        static PF_FD: std::sync::OnceLock<std::fs::File> = std::sync::OnceLock::new();
+        let pf_fd = match PF_FD.get() {
+            Some(f) => f,
+            None => {
+                let f = std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open("/dev/pf")?;
+                // A racing open just drops the extra fd.
+                PF_FD.get_or_init(|| f)
+            }
+        };
 
         let mut nl = PfiocNatlook {
             af: PF_ADDR_IPV4,

--- a/crates/meow-trie/Cargo.toml
+++ b/crates/meow-trie/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-smallvec = { workspace = true }
 
 [[bench]]
 name = "trie_bench"

--- a/crates/meow-trie/src/trie.rs
+++ b/crates/meow-trie/src/trie.rs
@@ -180,13 +180,14 @@ impl<T: Clone + 'static> DomainTrie<T> {
     }
 
     fn search_build<'a>(root: &'a BuildNode<T>, query: &str) -> Option<&'a T> {
-        let labels: smallvec::SmallVec<[&str; 8]> = query.rsplit('.').collect();
-        let n = labels.len();
+        // Count labels up front (dots + 1) so `remaining` is known while
+        // iterating `rsplit` directly — no per-search SmallVec collection.
+        let n = query.bytes().filter(|&b| b == b'.').count() + 1;
         let mut node = root;
         let mut best: Option<&T> = None;
 
-        for (d, label) in labels.iter().enumerate() {
-            match node.children.get(*label) {
+        for (d, label) in query.rsplit('.').enumerate() {
+            match node.children.get(label) {
                 None => break,
                 Some(child) => {
                     node = child;
@@ -211,12 +212,12 @@ impl<T: Clone + 'static> DomainTrie<T> {
     }
 
     fn search_sealed<'a>(root: &'a SealedNode<T>, query: &str) -> Option<&'a T> {
-        let labels: smallvec::SmallVec<[&str; 8]> = query.rsplit('.').collect();
-        let n = labels.len();
+        // Same direct-rsplit iteration as `search_build` — see comment there.
+        let n = query.bytes().filter(|&b| b == b'.').count() + 1;
         let mut node = root;
         let mut best: Option<&T> = None;
 
-        for (d, label) in labels.iter().enumerate() {
+        for (d, label) in query.rsplit('.').enumerate() {
             let found = node
                 .children
                 .binary_search_by(|(k, _)| k.as_bytes().cmp(label.as_bytes()));

--- a/crates/meow-tunnel/src/match_engine.rs
+++ b/crates/meow-tunnel/src/match_engine.rs
@@ -38,22 +38,34 @@ impl DomainIndex {
     /// Build an index from the rule list, recording the first (minimum-index)
     /// occurrence of each domain pattern.
     pub fn build(rules: &[Box<dyn Rule>]) -> Self {
+        use std::borrow::Cow;
         let mut trie: DomainTrie<(usize, Arc<str>)> = DomainTrie::new();
         let mut seen: HashSet<String> = HashSet::new();
         for (idx, rule) in rules.iter().enumerate() {
             match rule.rule_type() {
                 RuleType::Domain | RuleType::DomainSuffix => {
-                    let pattern = rule.payload().to_lowercase();
-                    if seen.insert(pattern.clone()) {
-                        // For Domain: exact match pattern; trie handles it directly.
-                        // For DomainSuffix: use "+." prefix so trie matches subdomains.
-                        let trie_key = if rule.rule_type() == RuleType::DomainSuffix {
-                            format!("+.{pattern}")
-                        } else {
-                            pattern
-                        };
-                        trie.insert(&trie_key, (idx, Arc::from(rule.adapter())));
+                    // Patterns are normally already lowercase; only allocate
+                    // for the rare mixed-case entry, and check `seen` before
+                    // taking an owned copy — duplicates cost no allocation.
+                    let payload = rule.payload();
+                    let lowered: Cow<'_, str> = if payload.chars().any(char::is_uppercase) {
+                        Cow::Owned(payload.to_lowercase())
+                    } else {
+                        Cow::Borrowed(payload)
+                    };
+                    if seen.contains(lowered.as_ref()) {
+                        continue;
                     }
+                    let pattern = lowered.into_owned();
+                    // For Domain: exact match pattern; trie handles it directly.
+                    // For DomainSuffix: use "+." prefix so trie matches subdomains.
+                    if rule.rule_type() == RuleType::DomainSuffix {
+                        let trie_key = format!("+.{pattern}");
+                        trie.insert(&trie_key, (idx, Arc::from(rule.adapter())));
+                    } else {
+                        trie.insert(&pattern, (idx, Arc::from(rule.adapter())));
+                    }
+                    seen.insert(pattern);
                 }
                 _ => {}
             }

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -287,8 +287,13 @@ impl Tunnel {
         &self.inner.resolver
     }
 
-    pub fn proxies(&self) -> HashMap<SmolStr, Arc<dyn Proxy>> {
-        self.inner.route.load().proxies.clone()
+    /// Snapshot of the current route table (rules + domain index + proxies).
+    ///
+    /// One atomic load + refcount bump; callers iterate `snapshot.proxies`
+    /// / `snapshot.rules` in place. Replaces the old `proxies()` accessor,
+    /// which cloned the whole proxy map on every call (audit #182).
+    pub fn route_snapshot(&self) -> Arc<RouteTable> {
+        self.inner.route.load_full()
     }
 
     pub fn proxy(&self, name: &str) -> Option<Arc<dyn Proxy>> {
@@ -303,22 +308,6 @@ impl Tunnel {
             udp::DEFAULT_UDP_IDLE,
             udp::DEFAULT_SWEEP_INTERVAL,
         );
-    }
-
-    pub fn rules_info(&self) -> Vec<(String, String, String)> {
-        self.inner
-            .route
-            .load()
-            .rules
-            .iter()
-            .map(|r| {
-                (
-                    format!("{}", r.rule_type()),
-                    r.payload().to_string(),
-                    r.adapter().to_string(),
-                )
-            })
-            .collect()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #182 — all six low-severity items from the June 2026 performance audit umbrella, batched as one PR since each is small and none is on a hard hot path.

1. **`Tunnel::proxies()` map clone** → new `Tunnel::route_snapshot()` (`ArcSwap::load_full`, one atomic load + refcount bump). All consumers (REST handlers, health check, geodata fetch, tproxy listener, tests) now iterate the snapshot in place; `proxies()` is removed. `rules_info()` (3 `String`s per rule per call) is gone too — `GET /rules` serialises borrowed `&str`/`&'static str` straight off the snapshot via a lifetime-parametrised `RuleInfo<'a>`.
2. **Trie search label collection** — both `search_build` and `search_sealed` now compute the label count up front (dots + 1) and iterate `rsplit('.')` directly instead of collecting into a `SmallVec<[&str; 8]>` per lookup. `smallvec` dropped from `meow-trie`'s deps (now unused). The match engine already called `search_normalized()`, so the mixed-case fallback only remains for raw-input callers.
3. **`DomainIndex::build` allocations** — the dedupe check now runs against a `Cow` before any owned copy: duplicate rules allocate nothing, unique already-lowercase patterns allocate once (was 2–3 `String`s per domain rule). Config-reload only.
4. **DNS upstream error `format!`** — the ≥3-nameserver race used `format!`-allocated error `String`s per failed attempt that `select_ok` discards; replaced with a unit `LookupFailed` struct.
5. **macOS tproxy `/dev/pf`** — opened per accepted connection; now cached in a `OnceLock` for the process lifetime. Only success is cached, so a transient open failure (pf not loaded yet) can recover.
6. **SOCKS5 inbound auth** — username/password are borrowed from stack buffers and verified; the username is copied to the heap only after a successful verify (failure/empty paths previously allocated two `String`s regardless).

The release-profile note in the issue (per-crate opt-level experiment) is a deliberate ADR-0007 trade, not a defect — untouched.

## Test plan

- [x] `cargo test --lib` — all 10 crates green; full suites for meow-api / meow-tunnel / meow-listener / meow-trie (209 tests) green, including the api_test proxy/rules/group endpoints that exercise the snapshot migration.
- [x] `cargo fmt --all -- --check`, three-way `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- Known env-dependent exception: `meow-dns udp_client_times_out_on_unroutable` (fails on clean `main` in this sandbox).

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_


Closes #182
