### PR TITLE
docs(config): drop stale "fake-ip is not implemented" messaging

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -364,8 +364,9 @@ fn parse_sniffer_config(raw: &raw::RawConfig) -> Result<SnifferConfig, anyhow::E
             // Warn-and-ignore force-dns-mapping.
             if rs.force_dns_mapping.unwrap_or(false) {
                 warn!(
-                    "sniffer.force-dns-mapping is accepted and ignored: \
-                    fake-ip is not implemented in meow-rs"
+                    "sniffer.force-dns-mapping is accepted and ignored: meow-rs \
+                    always maps fake-ip / snooped destinations back to their \
+                    domain via the DNS reverse table, so the flag has no effect"
                 );
             }
             let enable = rs.enable.unwrap_or(false);

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -291,7 +291,6 @@ pub struct RawSniffer {
     pub timeout: Option<u64>,
     pub parse_pure_ip: Option<bool>,
     pub override_destination: Option<bool>,
-    /// Accepted and ignored — we do not implement fake-ip.
     /// Accepted; respected when fake-ip mode is enabled. When true and the
     /// destination IP is a fake-IP allocation, the sniffer skips peek and
     /// trusts the fake-IP reverse mapping. Currently unused (the tunnel's


### PR DESCRIPTION
## Summary

Addresses #152 ("why FakeIP DNS mode is removed?").

Fake-IP mode is **not** removed — it's fully implemented (`enhanced-mode: fake-ip`, `fake-ip-range`, `fake-ip-filter`, `fake-ip-filter-mode`, `store-fake-ip` JSON persistence; `crates/meow-dns/src/fakeip.rs`, rows in `docs/gap-analysis.md`). What remained were two stale strings from before it landed, which plausibly caused the confusion:

1. The `sniffer.force-dns-mapping` warning claimed the option is ignored because *"fake-ip is not implemented in meow-rs"*. The option is still parsed-and-ignored, but for the opposite reason: the tunnel **unconditionally** maps fake-IP / snooped destination IPs back to their domain via the DNS reverse table, so the flag has no effect. Reworded accordingly.
2. `raw.rs` carried a leftover doc line ("Accepted and ignored — we do not implement fake-ip.") stacked directly above the already-corrected description of the same field. Removed.

Closes #152

## Test plan

- [x] `cargo test -p meow-config --lib` (86) green; `cargo test --lib` green across the workspace.
- [x] `cargo fmt --all -- --check`, three-way `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgByBotb615NmNAPH7NZM6)_