### PR TITLE
test(rules): cover IPv6 and mixed-family IpCidrRuleSet matching

### DIFF
--- a/crates/meow-rules/src/rule_set.rs
+++ b/crates/meow-rules/src/rule_set.rs
@@ -424,6 +424,38 @@ mod tests {
     }
 
     #[test]
+    fn ipcidr_rule_set_matches_ipv6() {
+        let set = IpCidrRuleSet::from_entries(&["fd00::/8".to_string()]);
+        assert_eq!(set.len(), 1);
+        assert!(set.matches(&meta_ip("fd12::1"), &helper()));
+        assert!(!set.matches(&meta_ip("2001:db8::1"), &helper()));
+        // An IPv4 destination must not match a v6-only rule set.
+        assert!(!set.matches(&meta_ip("10.1.2.3"), &helper()));
+    }
+
+    #[test]
+    fn ipcidr_rule_set_matches_mixed_families() {
+        let set = IpCidrRuleSet::from_entries(&["10.0.0.0/8".to_string(), "fd00::/8".to_string()]);
+        assert_eq!(set.len(), 2);
+        assert!(set.matches(&meta_ip("10.1.2.3"), &helper()));
+        assert!(set.matches(&meta_ip("fd12::1"), &helper()));
+        assert!(!set.matches(&meta_ip("11.0.0.1"), &helper()));
+        assert!(!set.matches(&meta_ip("2001:db8::1"), &helper()));
+    }
+
+    #[test]
+    fn ipcidr_rule_set_coalesces_adjacent_cidrs_without_semantic_change() {
+        // Adjacent /24s coalesce into one /23 inside the trie; matching
+        // behavior must be identical to checking each CIDR independently.
+        let set =
+            IpCidrRuleSet::from_entries(&["10.0.0.0/24".to_string(), "10.0.1.0/24".to_string()]);
+        assert_eq!(set.len(), 2);
+        assert!(set.matches(&meta_ip("10.0.0.128"), &helper()));
+        assert!(set.matches(&meta_ip("10.0.1.128"), &helper()));
+        assert!(!set.matches(&meta_ip("10.0.2.1"), &helper()));
+    }
+
+    #[test]
     fn classical_rule_set_delegates_to_parser() {
         let ctx = ParserContext::empty();
         let set = ClassicalRuleSet::from_entries(


### PR DESCRIPTION
## Summary

Follow-up to #190, which replaced the `IpCidrRuleSet` O(N) scan with `IpRange` Patricia tries but landed without any unit test exercising the `v6` trie dispatch arm (the only existing test used a single IPv4 CIDR).

Adds three tests to `crates/meow-rules/src/rule_set.rs`:
- `ipcidr_rule_set_matches_ipv6` — v6-only set: match, non-match, and cross-family (IPv4 dst) non-match
- `ipcidr_rule_set_matches_mixed_families` — v4 + v6 entries in one set, both directions
- `ipcidr_rule_set_coalesces_adjacent_cidrs_without_semantic_change` — pins that `IpRange::simplify()` merging adjacent /24s into a /23 does not alter match semantics

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` (default / no-default-features / all-features)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` — 643 passed (meow-rules: 136, up from 133)

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)