### PR TITLE
test(config): fix temp-file collision flake in encoding tests

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -1301,14 +1301,18 @@ mod load_config_encoding_tests {
     // step succeeds (i.e. the BOM was stripped and YAML parsing started).
     const MINIMAL_YAML: &str = "port: 7890\n";
 
-    fn write_tmp(bytes: &[u8]) -> std::path::PathBuf {
+    // `tag` must be unique per test: these tests run concurrently in one
+    // process, and SystemTime's clock granularity is coarse enough that two
+    // tests starting in the same tick collide on a pid+nanos-only name (one
+    // test then reads the other's bytes — observed as a flaky failure).
+    fn write_tmp(tag: &str, bytes: &[u8]) -> std::path::PathBuf {
         let mut path = std::env::temp_dir();
         let pid = std::process::id();
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        path.push(format!("meow-cfg-{pid}-{nanos}.yaml"));
+        path.push(format!("meow-cfg-{tag}-{pid}-{nanos}.yaml"));
         let mut f = std::fs::File::create(&path).unwrap();
         f.write_all(bytes).unwrap();
         path
@@ -1317,7 +1321,7 @@ mod load_config_encoding_tests {
     #[tokio::test]
     async fn invalid_utf8_yields_actionable_error() {
         // 0xFF is never valid in UTF-8.
-        let path = write_tmp(b"port: 7890\nrubbish: \xFF\xFE\n");
+        let path = write_tmp("invalid-utf8", b"port: 7890\nrubbish: \xFF\xFE\n");
         let Err(err) = load_config(path.to_str().unwrap()).await else {
             panic!("non-UTF-8 config must fail");
         };
@@ -1337,7 +1341,7 @@ mod load_config_encoding_tests {
     async fn utf8_bom_is_stripped() {
         let mut bytes = b"\xEF\xBB\xBF".to_vec();
         bytes.extend_from_slice(MINIMAL_YAML.as_bytes());
-        let path = write_tmp(&bytes);
+        let path = write_tmp("bom", &bytes);
         // We don't assert success of full load_config (it requires more fields),
         // but the error — if any — must NOT be the UTF-8/BOM error path.
         let result = load_config(path.to_str().unwrap()).await;


### PR DESCRIPTION
## Summary

`load_config_encoding_tests::utf8_bom_is_stripped` failed once during local verification of an unrelated docs branch, then passed on rerun. Root cause: both encoding tests build their temp path as `meow-cfg-{pid}-{nanos}.yaml`. They run concurrently in one process, and `SystemTime` granularity is coarse enough for both to land in the same clock tick — same pid + same nanos = same file. The failure message proves the collision: the BOM test hit `invalid utf-8 sequence ... at byte 20`, and byte 20 is exactly where `invalid_utf8_yields_actionable_error`'s `\xFF` payload sits in *its* file content.

Fix: add a per-test `tag` parameter to `write_tmp` (`meow-cfg-{tag}-{pid}-{nanos}.yaml`) so the two tests can never share a path, with a comment explaining why the tag is load-bearing.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` (default / no-default-features / all-features)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` — 640 passed
- 10 consecutive runs of `cargo test -p meow-config --lib load_config_encoding` (both tests concurrent, the exact race window): 10/10 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)