### PR TITLE
test(snell): add outbound coverage; fix dead zero-chunk detection in pool drain

### DIFF
--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1799,4 +1799,175 @@ tls: true
         parse_proxy_group(&config, &existing, &Default::default())
             .expect("relay with url+interval must not hard-error");
     }
+
+    // ─── snell proxy parser ───────────────────────────────────────────────────
+
+    #[cfg(feature = "snell")]
+    fn snell_config(yaml: &str) -> HashMap<String, serde_yaml::Value> {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_minimal_ok() {
+        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: secret\n");
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_full_ok() {
+        let cfg = snell_config(
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: secret\nversion: 5\nudp: true\nreuse: true\nobfs-opts:\n  mode: http\n  host: bing.com\n",
+        );
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_missing_psk() {
+        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("missing psk must hard-error (Class A)");
+        };
+        assert!(err.contains("missing psk"), "msg: {err}");
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_missing_server() {
+        let cfg = snell_config("name: sn\ntype: snell\nport: 8388\npsk: secret\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("missing server must hard-error (Class A)");
+        };
+        assert!(err.contains("missing server"), "msg: {err}");
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_missing_port() {
+        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\npsk: secret\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("missing port must hard-error (Class A)");
+        };
+        assert!(err.contains("missing port"), "msg: {err}");
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_rejects_port_zero() {
+        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\nport: 0\npsk: secret\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("port 0 must hard-error (Class A)");
+        };
+        assert!(err.contains("port must be non-zero"), "msg: {err}");
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_rejects_empty_psk() {
+        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: ''\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("empty psk must hard-error (Class A)");
+        };
+        assert!(err.contains("psk must not be empty"), "msg: {err}");
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_version_aliases() {
+        for yaml in &[
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 4\n",
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: v4\n",
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: V5\n",
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 5\n",
+        ] {
+            let cfg = snell_config(yaml);
+            assert!(parse_proxy(&cfg).is_ok(), "expected Ok for yaml: {yaml}");
+        }
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_rejects_legacy_versions() {
+        for (yaml, ver) in &[
+            (
+                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 1\n",
+                "1",
+            ),
+            (
+                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 2\n",
+                "2",
+            ),
+            (
+                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 3\n",
+                "3",
+            ),
+            (
+                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: v2\n",
+                "v2",
+            ),
+        ] {
+            let cfg = snell_config(yaml);
+            let Err(err) = parse_proxy(&cfg) else {
+                panic!("legacy version {ver} must hard-error (Class A)");
+            };
+            assert!(
+                err.contains("not supported"),
+                "version {ver}: expected 'not supported' in msg: {err}"
+            );
+        }
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_rejects_unknown_version() {
+        let cfg_six = snell_config(
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: '6'\n",
+        );
+        let Err(err) = parse_proxy(&cfg_six) else {
+            panic!("unknown version '6' must hard-error (Class A)");
+        };
+        assert!(err.contains("unknown version"), "msg: {err}");
+
+        let cfg_bool = snell_config(
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: true\n",
+        );
+        let Err(err) = parse_proxy(&cfg_bool) else {
+            panic!("boolean version must hard-error (Class A)");
+        };
+        assert!(err.contains("must be an integer or string"), "msg: {err}");
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_obfs_modes() {
+        let cfg_tls = snell_config(
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nobfs-opts:\n  mode: tls\n",
+        );
+        assert!(parse_proxy(&cfg_tls).is_ok(), "tls obfs mode must be Ok");
+
+        let cfg_none = snell_config(
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nobfs-opts:\n  mode: none\n",
+        );
+        assert!(parse_proxy(&cfg_none).is_ok(), "none obfs mode must be Ok");
+
+        let cfg_socks = snell_config(
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nobfs-opts:\n  mode: socks\n",
+        );
+        let Err(err) = parse_proxy(&cfg_socks) else {
+            panic!("invalid obfs mode 'socks' must hard-error (Class A)");
+        };
+        assert!(err.contains("obfs-opts.mode"), "msg: {err}");
+    }
+
+    #[cfg(feature = "snell")]
+    #[test]
+    fn parse_snell_obfs_host_falls_back_to_server() {
+        // obfs-opts with mode: http but no host key → falls back to server value.
+        let cfg = snell_config(
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nobfs-opts:\n  mode: http\n",
+        );
+        assert!(parse_proxy(&cfg).is_ok());
+    }
 }

--- a/crates/meow-proxy/src/snell/adapter.rs
+++ b/crates/meow-proxy/src/snell/adapter.rs
@@ -149,6 +149,14 @@ impl SnellAdapter {
         Ok(Snell::new(inner, Arc::clone(&self.psk)))
     }
 
+    /// Number of idle connections currently parked in the reuse pool.
+    /// Returns 0 when reuse is disabled. Exposed so integration tests can
+    /// synchronize with the background drain-and-return task that runs after
+    /// a pooled connection is dropped, instead of sleeping.
+    pub fn idle_pool_size(&self) -> usize {
+        self.pool.as_ref().map_or(0, |pool| pool.idle_count())
+    }
+
     fn extract_dest(metadata: &Metadata) -> Result<(String, u16)> {
         let port = metadata.dst_port;
         if !metadata.host.is_empty() {

--- a/crates/meow-proxy/src/snell/pool.rs
+++ b/crates/meow-proxy/src/snell/pool.rs
@@ -79,6 +79,17 @@ impl Pool {
         None
     }
 
+    /// Number of idle entries currently parked (expired entries included —
+    /// they are lazily discarded by [`Pool::take_idle`]). Exposed so callers
+    /// (and integration tests) can observe when the background
+    /// drain-and-return task has replenished the pool.
+    pub fn idle_count(&self) -> usize {
+        self.items
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
     /// Re-insert a conn that has just finished a session. Drops the conn if
     /// the pool is full or the conn has reached its session cap.
     pub fn put(&self, conn: PoolStream, uses: u32) {
@@ -109,6 +120,10 @@ impl Default for Pool {
 /// Drain trailing data + the server's zero-chunk so the conn is clean for
 /// reuse. Returns `true` when the zero-chunk was observed within
 /// `DRAIN_DEADLINE`, `false` otherwise (caller should discard the conn).
+///
+/// Reads via the raw `V4Conn` (not the `Snell` wrapper): the wrapper maps
+/// the zero-chunk into a clean EOF, which is indistinguishable from the
+/// peer closing the TCP stream.
 pub async fn drain_for_reuse(conn: &mut PoolStream) -> bool {
     let mut scratch = [0u8; 4096];
     let deadline = tokio::time::sleep(DRAIN_DEADLINE);
@@ -117,7 +132,7 @@ pub async fn drain_for_reuse(conn: &mut PoolStream) -> bool {
         tokio::select! {
             biased;
             () = &mut deadline => return false,
-            res = conn.read(&mut scratch) => {
+            res = conn.v4_conn_mut().read(&mut scratch) => {
                 match res {
                     Ok(0) => return false, // peer closed underlying TCP
                     Ok(_) => continue,
@@ -126,5 +141,136 @@ pub async fn drain_for_reuse(conn: &mut PoolStream) -> bool {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use tokio::io::{AsyncWrite, AsyncWriteExt};
+    use tokio::time::timeout;
+
+    use crate::snell::v4::V4Conn;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Build a pool-typed snell stream over an in-memory duplex. The peer
+    /// half is returned so tests can keep the underlying stream open (or
+    /// wrap it in a `V4Conn` to speak the AEAD protocol from the far side).
+    fn make_stream() -> (PoolStream, tokio::io::DuplexStream) {
+        let (a, b) = tokio::io::duplex(1 << 16);
+        (
+            Snell::new(
+                Box::new(a) as Box<dyn TransportStream>,
+                Arc::from(b"k".as_slice()),
+            ),
+            b,
+        )
+    }
+
+    #[test]
+    fn take_idle_on_empty_pool_is_none() {
+        let pool = Pool::new();
+        assert!(pool.take_idle().is_none());
+    }
+
+    #[test]
+    fn pool_is_lifo() {
+        let pool = Pool::new();
+        let (conn_a, _peer_a) = make_stream();
+        let (conn_b, _peer_b) = make_stream();
+        pool.put(conn_a, 0);
+        pool.put(conn_b, 1);
+
+        let (_conn, uses) = pool.take_idle().expect("first take should pop an entry");
+        assert_eq!(uses, 1, "most recently returned conn comes back first");
+        let (_conn, uses) = pool.take_idle().expect("second take should pop an entry");
+        assert_eq!(uses, 0);
+        assert!(pool.take_idle().is_none());
+    }
+
+    #[test]
+    fn put_discards_at_uses_cap() {
+        let pool = Pool::new();
+        // Surge snell-server v5.0.1 closes after the second session, so a
+        // conn that has already served 2 sessions must not be pooled.
+        let (capped, _peer_capped) = make_stream();
+        pool.put(capped, 2);
+        assert!(pool.take_idle().is_none());
+
+        let (reusable, _peer_reusable) = make_stream();
+        pool.put(reusable, 1);
+        let (_conn, uses) = pool.take_idle().expect("uses=1 should be pooled");
+        assert_eq!(uses, 1);
+    }
+
+    #[test]
+    fn put_respects_max_size() {
+        let pool = Pool::new();
+        let mut peers = Vec::new();
+        for _ in 0..11 {
+            let (conn, peer) = make_stream();
+            peers.push(peer);
+            pool.put(conn, 0);
+        }
+        for i in 0..10 {
+            assert!(
+                pool.take_idle().is_some(),
+                "take {i} should pop a pooled conn"
+            );
+        }
+        assert!(pool.take_idle().is_none(), "pool is capped at 10 entries");
+    }
+
+    #[tokio::test]
+    async fn drain_for_reuse_true_on_zero_chunk() {
+        let (mut conn, peer) = make_stream();
+        // Skip the status-byte handshake — the pool drains mid-session
+        // streams whose reply has already been consumed.
+        conn.mark_reply_consumed();
+
+        // The v4 codec is symmetric (each direction sends its own salt), so
+        // a V4Conn over the peer half acts as the mock server.
+        let mut server = V4Conn::new(peer, Arc::from(b"k".as_slice()));
+        server.write_all(b"tail").await.unwrap();
+        // `write_all(&[])` short-circuits in tokio without polling, so drive
+        // `poll_write(&[])` by hand to emit the zero-chunk frame.
+        std::future::poll_fn(|cx| Pin::new(&mut server).poll_write(cx, &[]))
+            .await
+            .unwrap();
+        server.flush().await.unwrap();
+
+        let drained = timeout(TEST_TIMEOUT, drain_for_reuse(&mut conn))
+            .await
+            .expect("drain must finish within the deadline");
+        assert!(drained, "trailing data + zero chunk should mark conn clean");
+        drop(server);
+    }
+
+    #[tokio::test]
+    async fn drain_for_reuse_false_on_peer_close() {
+        let (mut conn, peer) = make_stream();
+        conn.mark_reply_consumed();
+        drop(peer); // peer closes without sending anything
+
+        let drained = timeout(TEST_TIMEOUT, drain_for_reuse(&mut conn))
+            .await
+            .expect("drain must finish within the deadline");
+        assert!(!drained, "closed peer must not be marked reusable");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_for_reuse_false_on_timeout() {
+        let (mut conn, _peer) = make_stream();
+        conn.mark_reply_consumed();
+
+        // Peer stays alive but silent; paused time auto-advances past the
+        // 500ms drain deadline as soon as the runtime is otherwise idle.
+        let drained = timeout(TEST_TIMEOUT, drain_for_reuse(&mut conn))
+            .await
+            .expect("drain must finish within the deadline");
+        assert!(!drained, "a silent peer must hit the drain deadline");
     }
 }

--- a/crates/meow-proxy/src/snell/protocol.rs
+++ b/crates/meow-proxy/src/snell/protocol.rs
@@ -137,6 +137,15 @@ impl<S> Snell<S> {
         self.reply_consumed = true;
     }
 
+    /// Mutable access to the underlying v4 codec. The `AsyncRead` impl on
+    /// `Snell` maps the zero-chunk half-close into a clean EOF; the reuse
+    /// pool's drain must observe the *raw* tagged error instead, so it can
+    /// distinguish the peer's half-close (conn reusable) from a genuine TCP
+    /// close (conn dead).
+    pub fn v4_conn_mut(&mut self) -> &mut V4Conn<S> {
+        &mut self.inner
+    }
+
     /// Stage a single frame carrying `buf` verbatim as a UDP datagram
     /// payload. The frame is written via the underlying `V4Conn` so the
     /// codec keeps producing valid AEAD frames.
@@ -285,5 +294,200 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for Snell<S> {
     }
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::Future;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, DuplexStream};
+
+    /// Wrap an await that could hang so a failure is an assertion instead of
+    /// a test-runner timeout.
+    async fn within<T>(fut: impl Future<Output = T>) -> T {
+        tokio::time::timeout(Duration::from_secs(10), fut)
+            .await
+            .expect("test future timed out")
+    }
+
+    /// Client `Snell` wrapper on one duplex half, mock-server `V4Conn` on the
+    /// other. The v4 codec is symmetric (each direction sends its own salt),
+    /// so a bare `V4Conn` works as the server side.
+    fn rig() -> (Snell<DuplexStream>, V4Conn<DuplexStream>) {
+        let (a, b) = tokio::io::duplex(1 << 16);
+        let psk: Arc<[u8]> = Arc::from(b"test-psk".as_slice());
+        (Snell::new(a, Arc::clone(&psk)), V4Conn::new(b, psk))
+    }
+
+    /// Emit a zero chunk by hand: tokio's `write_all(&[])` short-circuits
+    /// without calling `poll_write`, so drive the poll directly.
+    async fn emit_zero_chunk(conn: &mut V4Conn<DuplexStream>) -> io::Result<usize> {
+        std::future::poll_fn(|cx| Pin::new(&mut *conn).poll_write(cx, &[])).await
+    }
+
+    #[tokio::test]
+    async fn write_header_connect_layout() {
+        let (mut client, mut peer) = rig();
+        within(write_header(&mut client, "example.com", 443, false))
+            .await
+            .unwrap();
+        within(client.flush()).await.unwrap();
+
+        let mut got = [0u8; 17];
+        within(peer.read_exact(&mut got)).await.unwrap();
+        let mut expected = vec![HEADER_VERSION, COMMAND_CONNECT, 0, 11];
+        expected.extend_from_slice(b"example.com");
+        expected.extend_from_slice(&[0x01, 0xBB]); // 443 BE
+        assert_eq!(&got[..], &expected[..]);
+    }
+
+    #[tokio::test]
+    async fn write_header_reuse_uses_connect_v2() {
+        let (mut client, mut peer) = rig();
+        within(write_header(&mut client, "example.com", 443, true))
+            .await
+            .unwrap();
+        within(client.flush()).await.unwrap();
+
+        let mut got = [0u8; 17];
+        within(peer.read_exact(&mut got)).await.unwrap();
+        assert_eq!(got[0], HEADER_VERSION);
+        assert_eq!(got[1], COMMAND_CONNECT_V2);
+    }
+
+    #[tokio::test]
+    async fn write_header_rejects_long_host() {
+        let host = "h".repeat(256);
+        let mut sink = tokio::io::sink();
+        let err = write_header(&mut sink, &host, 80, false).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn write_udp_header_layout() {
+        let (mut client, mut peer) = rig();
+        within(write_udp_header(&mut client)).await.unwrap();
+        within(client.flush()).await.unwrap();
+
+        let mut got = [0u8; 3];
+        within(peer.read_exact(&mut got)).await.unwrap();
+        assert_eq!(got, [HEADER_VERSION, COMMAND_UDP, 0x00]);
+    }
+
+    #[tokio::test]
+    async fn read_reply_accepts_tunnel_and_pong() {
+        let (mut client, mut peer) = rig();
+        within(peer.write_all(&[RESPONSE_TUNNEL])).await.unwrap();
+        within(peer.flush()).await.unwrap();
+        within(client.read_reply()).await.unwrap();
+
+        let (mut client, mut peer) = rig();
+        within(peer.write_all(&[RESPONSE_PONG])).await.unwrap();
+        within(peer.flush()).await.unwrap();
+        within(client.read_reply()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_reply_parses_error_code_and_message() {
+        let (mut client, mut peer) = rig();
+        within(peer.write_all(&[RESPONSE_ERROR, 42, 5, b'o', b'o', b'p', b's', b'!']))
+            .await
+            .unwrap();
+        within(peer.flush()).await.unwrap();
+
+        let err = within(client.read_reply()).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("42"), "missing error code in: {msg}");
+        assert!(msg.contains("oops!"), "missing error message in: {msg}");
+    }
+
+    #[tokio::test]
+    async fn read_reply_rejects_unknown_code() {
+        let (mut client, mut peer) = rig();
+        within(peer.write_all(&[0x7F])).await.unwrap();
+        within(peer.flush()).await.unwrap();
+
+        let err = within(client.read_reply()).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("unknown response code"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_read_consumes_reply_then_yields_data() {
+        let (mut client, mut peer) = rig();
+        within(peer.write_all(&[RESPONSE_TUNNEL])).await.unwrap();
+        within(peer.write_all(b"hello")).await.unwrap();
+        within(peer.flush()).await.unwrap();
+
+        let mut buf = [0u8; 16];
+        let n = within(client.read(&mut buf)).await.unwrap();
+        assert_eq!(&buf[..n], b"hello");
+
+        // Reply already consumed by the first read — explicit call is a no-op.
+        within(client.read_reply()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn zero_chunk_maps_to_clean_eof() {
+        let (mut client, mut peer) = rig();
+        within(peer.write_all(&[RESPONSE_TUNNEL])).await.unwrap();
+        within(peer.flush()).await.unwrap();
+        within(emit_zero_chunk(&mut peer)).await.unwrap();
+        within(peer.flush()).await.unwrap();
+
+        let mut buf = [0u8; 8];
+        let n = within(client.read(&mut buf)).await.unwrap();
+        assert_eq!(n, 0, "zero chunk should surface as clean EOF");
+    }
+
+    #[tokio::test]
+    async fn reset_reply_state_consumes_next_status_byte() {
+        let (mut client, mut peer) = rig();
+        within(peer.write_all(&[RESPONSE_TUNNEL])).await.unwrap();
+        within(peer.write_all(b"hello")).await.unwrap();
+        within(peer.flush()).await.unwrap();
+
+        let mut buf = [0u8; 16];
+        let n = within(client.read(&mut buf)).await.unwrap();
+        assert_eq!(&buf[..n], b"hello");
+
+        // Pool-reuse semantics: the next request's status byte is pending
+        // again after a reset.
+        client.reset_reply_state();
+        within(peer.write_all(&[RESPONSE_TUNNEL])).await.unwrap();
+        within(peer.write_all(b"again")).await.unwrap();
+        within(peer.flush()).await.unwrap();
+
+        let n = within(client.read(&mut buf)).await.unwrap();
+        assert_eq!(&buf[..n], b"again");
+    }
+
+    #[tokio::test]
+    async fn write_packet_frame_rejects_oversize() {
+        let (mut client, _peer) = rig();
+        let oversize = vec![0u8; MAX_PAYLOAD_LENGTH + 1];
+        let err = within(client.write_packet_frame(&oversize))
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn write_packet_frame_roundtrips() {
+        let (mut client, mut peer) = rig();
+        let n = within(client.write_packet_frame(b"datagram"))
+            .await
+            .unwrap();
+        assert_eq!(n, b"datagram".len());
+
+        // Each datagram is exactly one AEAD frame, so a single read drains it.
+        let mut buf = [0u8; 64];
+        let m = within(peer.read(&mut buf)).await.unwrap();
+        assert_eq!(&buf[..m], b"datagram");
     }
 }

--- a/crates/meow-proxy/tests/snell_integration.rs
+++ b/crates/meow-proxy/tests/snell_integration.rs
@@ -1,0 +1,769 @@
+#![cfg(feature = "snell")]
+//! Integration tests for the Snell adapter.
+//!
+//! Uses an embedded mock Snell server: the v4 AEAD codec is symmetric (each
+//! direction sends its own salt and derives its own key), so `V4Conn::new`
+//! over an accepted `TcpStream` speaks the server side. No external binaries
+//! required.
+
+use meow_common::{MeowError, Metadata, Network, ProxyAdapter};
+use meow_proxy::snell::protocol::{
+    write_header, AppError, Snell, COMMAND_CONNECT, COMMAND_CONNECT_V2, COMMAND_UDP,
+    COMMAND_UDP_FORWARD, HEADER_VERSION, RESPONSE_ERROR, RESPONSE_TUNNEL,
+};
+use meow_proxy::snell::v4::{is_zero_chunk, V4Conn};
+use meow_proxy::snell::{SnellAdapter, SnellObfs, SnellVersion};
+use std::io::ErrorKind;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{timeout, Duration};
+
+const PSK: &str = "snell-integration-psk";
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// What the mock server does after reading (and recording) a request header.
+#[derive(Clone, Copy)]
+enum Behavior {
+    /// Reply `RESPONSE_TUNNEL`, then echo every chunk back. Honours the
+    /// zero-chunk half-close handshake so reuse-mode sessions work.
+    Echo,
+    /// Reply `RESPONSE_ERROR` with the given code/message, then close.
+    ErrorReply { code: u8, msg: &'static str },
+    /// Reply a single raw status byte, then close.
+    RawReplyByte(u8),
+}
+
+/// One request header as seen by the mock server.
+#[derive(Debug, Clone)]
+struct RecordedRequest {
+    cmd: u8,
+    host: String,
+    port: u16,
+}
+
+struct MockServer {
+    addr: SocketAddr,
+    /// Number of accepted TCP connections (not sessions).
+    accepted: Arc<AtomicUsize>,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    /// Protocol violations observed by spawned per-connection tasks. A panic
+    /// inside a tokio-spawned task would be swallowed by the runtime, so the
+    /// serve functions report violations through this list instead and every
+    /// test asserts it is empty via [`MockServer::assert_no_violations`].
+    violations: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockServer {
+    fn assert_no_violations(&self) {
+        let violations = self.violations.lock().unwrap();
+        assert!(
+            violations.is_empty(),
+            "mock server observed protocol violations: {violations:?}"
+        );
+    }
+}
+
+/// Emit a v4 zero-chunk (half-close) frame. `write_all(&[])` short-circuits
+/// inside tokio without calling `poll_write`, so drive the poll by hand.
+async fn send_zero_chunk<S: AsyncRead + AsyncWrite + Unpin>(
+    conn: &mut V4Conn<S>,
+) -> std::io::Result<()> {
+    std::future::poll_fn(|cx| Pin::new(&mut *conn).poll_write(cx, &[])).await?;
+    conn.flush().await
+}
+
+/// Echo loop for a `COMMAND_UDP` session: parse each client datagram frame
+/// `[0x01, 0x00, family, ip, port_be, payload]` and echo back a response
+/// frame `[family, ip, port_be, payload]` as a single write.
+///
+/// Runs inside a tokio-spawned task where panics would be swallowed, so
+/// protocol violations are reported as `Err(message)` and surfaced by
+/// [`MockServer::assert_no_violations`].
+async fn serve_udp_echo(conn: &mut V4Conn<TcpStream>) -> Result<(), String> {
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = match conn.read(&mut buf).await {
+            Ok(0) => return Ok(()),
+            Ok(n) => n,
+            Err(e) if is_zero_chunk(&e) => {
+                let _ = send_zero_chunk(conn).await;
+                return Ok(());
+            }
+            Err(_) => return Ok(()),
+        };
+        let frame = &buf[..n];
+        if frame.len() < 3 {
+            return Err(format!("udp request frame too short: {n} bytes"));
+        }
+        if frame[0] != COMMAND_UDP_FORWARD {
+            let cmd = frame[0];
+            return Err(format!("bad udp frame command 0x{cmd:x}"));
+        }
+        if frame[1] != 0 {
+            let host_len = frame[1];
+            return Err(format!(
+                "expected raw-IP address encoding (host_len 0), got host_len {host_len}"
+            ));
+        }
+        let family = frame[2];
+        let ip_len = match family {
+            0x04 => 4,
+            0x06 => 16,
+            other => return Err(format!("unknown udp address family 0x{other:x}")),
+        };
+        if frame.len() < 3 + ip_len + 2 {
+            return Err(format!(
+                "udp frame truncated: {n} bytes for family 0x{family:x}"
+            ));
+        }
+        let mut reply = Vec::with_capacity(1 + ip_len + 2 + frame.len());
+        reply.push(family);
+        reply.extend_from_slice(&frame[3..3 + ip_len + 2]); // ip + port
+        reply.extend_from_slice(&frame[3 + ip_len + 2..]); // payload
+        if conn.write_all(&reply).await.is_err() || conn.flush().await.is_err() {
+            return Ok(());
+        }
+    }
+}
+
+/// Serve one accepted connection. Loops over sessions so reuse-mode clients
+/// can issue several CONNECTs on the same TCP stream.
+///
+/// Runs inside a tokio-spawned task where panics would be swallowed, so
+/// protocol violations are reported as `Err(message)` and surfaced by
+/// [`MockServer::assert_no_violations`].
+async fn serve_conn(
+    mut conn: V4Conn<TcpStream>,
+    behavior: Behavior,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+) -> Result<(), String> {
+    loop {
+        // Request header: [ver, cmd, client_id_len] then, for CONNECT
+        // commands, [host_len, host..., port_be].
+        let mut prefix = [0u8; 3];
+        if conn.read_exact(&mut prefix).await.is_err() {
+            return Ok(());
+        }
+        if prefix[0] != HEADER_VERSION {
+            let ver = prefix[0];
+            return Err(format!("unexpected snell header version {ver}"));
+        }
+        if prefix[2] != 0 {
+            let id_len = prefix[2];
+            return Err(format!("expected empty client id, got length {id_len}"));
+        }
+        let cmd = prefix[1];
+        let (host, port) = if cmd == COMMAND_UDP {
+            (String::new(), 0u16)
+        } else {
+            let mut len = [0u8; 1];
+            if conn.read_exact(&mut len).await.is_err() {
+                return Ok(());
+            }
+            let mut host_buf = vec![0u8; len[0] as usize];
+            if conn.read_exact(&mut host_buf).await.is_err() {
+                return Ok(());
+            }
+            let mut port_buf = [0u8; 2];
+            if conn.read_exact(&mut port_buf).await.is_err() {
+                return Ok(());
+            }
+            (
+                String::from_utf8(host_buf).map_err(|e| format!("host must be utf-8: {e}"))?,
+                u16::from_be_bytes(port_buf),
+            )
+        };
+        requests
+            .lock()
+            .unwrap()
+            .push(RecordedRequest { cmd, host, port });
+
+        match behavior {
+            Behavior::ErrorReply { code, msg } => {
+                let mut reply = vec![RESPONSE_ERROR, code, msg.len() as u8];
+                reply.extend_from_slice(msg.as_bytes());
+                let _ = conn.write_all(&reply).await;
+                let _ = conn.flush().await;
+                return Ok(());
+            }
+            Behavior::RawReplyByte(byte) => {
+                let _ = conn.write_all(&[byte]).await;
+                let _ = conn.flush().await;
+                return Ok(());
+            }
+            Behavior::Echo => {
+                if conn.write_all(&[RESPONSE_TUNNEL]).await.is_err() || conn.flush().await.is_err()
+                {
+                    return Ok(());
+                }
+                if cmd == COMMAND_UDP {
+                    return serve_udp_echo(&mut conn).await;
+                }
+                let mut buf = vec![0u8; 64 * 1024];
+                loop {
+                    match conn.read(&mut buf).await {
+                        Ok(0) => return Ok(()),
+                        Ok(n) => {
+                            if conn.write_all(&buf[..n]).await.is_err()
+                                || conn.flush().await.is_err()
+                            {
+                                return Ok(());
+                            }
+                        }
+                        Err(e) if is_zero_chunk(&e) => {
+                            // Acknowledge the client's half-close with our
+                            // own zero chunk, then wait for the next session
+                            // header on the same TCP stream (reuse mode).
+                            if send_zero_chunk(&mut conn).await.is_err() {
+                                return Ok(());
+                            }
+                            break;
+                        }
+                        Err(_) => return Ok(()),
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn start_mock_server(psk: &'static str, behavior: Behavior) -> MockServer {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accepted = Arc::new(AtomicUsize::new(0));
+    let requests: Arc<Mutex<Vec<RecordedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let violations: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let accepted_task = Arc::clone(&accepted);
+    let requests_task = Arc::clone(&requests);
+    let violations_task = Arc::clone(&violations);
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            accepted_task.fetch_add(1, Ordering::SeqCst);
+            let conn = V4Conn::new(stream, Arc::from(psk.as_bytes()));
+            let requests_conn = Arc::clone(&requests_task);
+            let violations_conn = Arc::clone(&violations_task);
+            tokio::spawn(async move {
+                if let Err(violation) = serve_conn(conn, behavior, requests_conn).await {
+                    violations_conn.lock().unwrap().push(violation);
+                }
+            });
+        }
+    });
+    MockServer {
+        addr,
+        accepted,
+        requests,
+        violations,
+    }
+}
+
+fn make_adapter(server_port: u16, psk: &str, udp: bool, reuse: bool) -> SnellAdapter {
+    SnellAdapter::new(
+        "snell-test",
+        "127.0.0.1",
+        server_port,
+        psk,
+        SnellObfs::None,
+        SnellVersion::V4,
+        udp,
+        reuse,
+    )
+    .expect("adapter config must be valid")
+}
+
+fn tcp_metadata(host: &str, port: u16) -> Metadata {
+    Metadata {
+        network: Network::Tcp,
+        host: host.into(),
+        dst_port: port,
+        ..Default::default()
+    }
+}
+
+/// Write `payload`, flush, and read the echo back, all under timeouts.
+async fn roundtrip<C>(conn: &mut C, payload: &[u8])
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+{
+    timeout(TIMEOUT, conn.write_all(payload))
+        .await
+        .expect("write timed out")
+        .expect("write failed");
+    timeout(TIMEOUT, conn.flush())
+        .await
+        .expect("flush timed out")
+        .expect("flush failed");
+    let mut buf = vec![0u8; payload.len()];
+    timeout(TIMEOUT, conn.read_exact(&mut buf))
+        .await
+        .expect("echo read timed out")
+        .expect("echo read failed");
+    assert_eq!(buf, payload, "echoed payload must match");
+}
+
+/// Wait until the adapter's reuse pool holds at least `want` idle conns.
+/// `PooledConn::Drop` returns the conn from a spawned task (drain + put), so
+/// a fixed sleep would race it; poll the pool size under the global timeout
+/// instead.
+async fn wait_for_pool_size(adapter: &SnellAdapter, want: usize) {
+    timeout(TIMEOUT, async {
+        while adapter.idle_pool_size() < want {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("reuse pool was not replenished in time");
+}
+
+#[tokio::test]
+async fn tcp_connect_roundtrip_no_reuse() {
+    let server = start_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, false);
+
+    let metadata = tcp_metadata("echo.example.com", 8080);
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial timed out")
+        .expect("dial failed");
+    roundtrip(&mut conn, b"hello snell").await;
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].cmd, COMMAND_CONNECT);
+        assert_eq!(requests[0].host, "echo.example.com");
+        assert_eq!(requests[0].port, 8080);
+    }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn tcp_large_payload_roundtrip() {
+    let server = start_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, false);
+
+    let conn = timeout(
+        TIMEOUT,
+        adapter.dial_tcp(&tcp_metadata("bulk.example.com", 80)),
+    )
+    .await
+    .expect("dial timed out")
+    .expect("dial failed");
+
+    // ~100 KiB patterned payload — spans many frames and exercises the v4
+    // payload-limit ramp-up in both directions.
+    let payload: Vec<u8> = (0u32..100 * 1024).map(|i| (i % 251) as u8).collect();
+    let (mut read_half, mut write_half) = tokio::io::split(conn);
+    let to_send = payload.clone();
+    let writer = tokio::spawn(async move {
+        write_half
+            .write_all(&to_send)
+            .await
+            .expect("large write failed");
+        write_half.flush().await.expect("large flush failed");
+    });
+
+    let mut got = vec![0u8; payload.len()];
+    timeout(TIMEOUT, read_half.read_exact(&mut got))
+        .await
+        .expect("large echo read timed out")
+        .expect("large echo read failed");
+    timeout(TIMEOUT, writer)
+        .await
+        .expect("writer join timed out")
+        .expect("writer task panicked");
+    assert_eq!(got, payload, "100 KiB payload must round-trip intact");
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].cmd, COMMAND_CONNECT);
+    }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn metadata_ip_literal_when_no_host() {
+    let server = start_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, false);
+
+    // No host — the adapter must fall back to the destination IP literal.
+    let metadata = Metadata {
+        network: Network::Tcp,
+        dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        dst_port: 4242,
+        ..Default::default()
+    };
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial timed out")
+        .expect("dial failed");
+    roundtrip(&mut conn, b"ip literal").await;
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].cmd, COMMAND_CONNECT);
+        assert_eq!(requests[0].host, "127.0.0.1");
+        assert_eq!(requests[0].port, 4242);
+    }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn reuse_pool_reuses_tcp_connection() {
+    let server = start_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, true);
+    let metadata = tcp_metadata("reuse.example.com", 443);
+
+    // Session 1 — fresh dial.
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial 1 timed out")
+        .expect("dial 1 failed");
+    roundtrip(&mut conn, b"session-1").await;
+    timeout(TIMEOUT, conn.shutdown())
+        .await
+        .expect("shutdown 1 timed out")
+        .expect("shutdown 1 failed");
+    drop(conn); // Drop drains the server zero-chunk and pools the conn.
+    wait_for_pool_size(&adapter, 1).await;
+
+    // Session 2 — must reuse the pooled TCP connection.
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial 2 timed out")
+        .expect("dial 2 failed");
+    roundtrip(&mut conn, b"session-2").await;
+    assert_eq!(
+        server.accepted.load(Ordering::SeqCst),
+        1,
+        "session 2 must reuse the pooled TCP connection"
+    );
+    timeout(TIMEOUT, conn.shutdown())
+        .await
+        .expect("shutdown 2 timed out")
+        .expect("shutdown 2 failed");
+    drop(conn);
+    // No synchronization needed here: `Pool::put` discards a conn at the
+    // 2-uses cap without ever inserting it, so the pool is empty whether or
+    // not the background drain task has finished.
+
+    // Session 3 — the 2-uses-per-conn cap forces a fresh dial.
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial 3 timed out")
+        .expect("dial 3 failed");
+    roundtrip(&mut conn, b"session-3").await;
+    assert_eq!(
+        server.accepted.load(Ordering::SeqCst),
+        2,
+        "the uses-per-conn cap must force a fresh dial for session 3"
+    );
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        assert!(
+            requests.iter().all(|r| r.cmd == COMMAND_CONNECT_V2),
+            "reuse mode must always send COMMAND_CONNECT_V2, got {requests:?}"
+        );
+    }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn server_error_reply_fails_first_read() {
+    let server = start_mock_server(
+        PSK,
+        Behavior::ErrorReply {
+            code: 42,
+            msg: "denied",
+        },
+    )
+    .await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, false);
+
+    // The CONNECT header is written blind, so the dial itself succeeds.
+    let mut conn = timeout(
+        TIMEOUT,
+        adapter.dial_tcp(&tcp_metadata("denied.example.com", 80)),
+    )
+    .await
+    .expect("dial timed out")
+    .expect("dial must succeed — the header is written blind");
+
+    let mut buf = [0u8; 16];
+    let err = timeout(TIMEOUT, conn.read(&mut buf))
+        .await
+        .expect("read timed out")
+        .expect_err("first read must surface the server error reply");
+    assert_eq!(err.kind(), ErrorKind::Other);
+    assert!(
+        err.to_string().contains("error response"),
+        "unexpected error: {err}"
+    );
+
+    // The poll_read path deliberately reports a generic error; the structured
+    // code + message must be observable via the explicit `read_reply` path.
+    // Speak the protocol by hand on a fresh connection to verify it.
+    let tcp = timeout(TIMEOUT, TcpStream::connect(server.addr))
+        .await
+        .expect("connect timed out")
+        .expect("connect failed");
+    let mut snell = Snell::new(tcp, Arc::from(PSK.as_bytes()));
+    timeout(
+        TIMEOUT,
+        write_header(&mut snell, "denied.example.com", 80, false),
+    )
+    .await
+    .expect("header write timed out")
+    .expect("header write failed");
+    timeout(TIMEOUT, snell.flush())
+        .await
+        .expect("flush timed out")
+        .expect("flush failed");
+    let err = timeout(TIMEOUT, snell.read_reply())
+        .await
+        .expect("read_reply timed out")
+        .expect_err("read_reply must surface the structured server error");
+    let app = err
+        .get_ref()
+        .and_then(|e| e.downcast_ref::<AppError>())
+        .unwrap_or_else(|| panic!("error must carry an AppError payload, got: {err}"));
+    assert_eq!(app.code, 42, "server error code must be surfaced");
+    assert_eq!(
+        app.message, "denied",
+        "server error message must be surfaced"
+    );
+
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn unknown_reply_byte_rejected() {
+    let server = start_mock_server(PSK, Behavior::RawReplyByte(0x7E)).await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, false);
+
+    let mut conn = timeout(
+        TIMEOUT,
+        adapter.dial_tcp(&tcp_metadata("weird.example.com", 80)),
+    )
+    .await
+    .expect("dial timed out")
+    .expect("dial failed");
+
+    let mut buf = [0u8; 16];
+    let err = timeout(TIMEOUT, conn.read(&mut buf))
+        .await
+        .expect("read timed out")
+        .expect_err("first read must reject the unknown reply byte");
+    assert_eq!(err.kind(), ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("unknown response code"),
+        "unexpected error: {err}"
+    );
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn wrong_psk_fails_with_decrypt_error() {
+    // Custom mock: replies `RESPONSE_TUNNEL` immediately, AEAD-sealed under a
+    // *different* PSK, without reading the request first. The client must
+    // fail to open the frame — deterministically an InvalidData decrypt
+    // error, not an opaque EOF/reset from the server tearing down.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let Ok((stream, _)) = listener.accept().await else {
+            return;
+        };
+        let mut conn = V4Conn::new(stream, Arc::from(b"a-completely-different-psk".as_slice()));
+        if conn.write_all(&[RESPONSE_TUNNEL]).await.is_err() || conn.flush().await.is_err() {
+            return;
+        }
+        // Hold the conn open until the client has read the bogus reply (this
+        // read fails to decrypt the client's header — irrelevant here).
+        let mut buf = [0u8; 1024];
+        let _ = conn.read(&mut buf).await;
+    });
+
+    let adapter = make_adapter(addr.port(), PSK, false, false);
+    let mut conn = timeout(
+        TIMEOUT,
+        adapter.dial_tcp(&tcp_metadata("psk.example.com", 80)),
+    )
+    .await
+    .expect("dial timed out")
+    .expect("dial must succeed — the header is written blind");
+
+    let mut buf = [0u8; 16];
+    let err = timeout(TIMEOUT, conn.read(&mut buf))
+        .await
+        .expect("read timed out")
+        .expect_err("read with a mismatched psk must fail");
+    assert_eq!(
+        err.kind(),
+        ErrorKind::InvalidData,
+        "wrong psk must surface as an AEAD decrypt failure, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("decrypt"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn udp_roundtrip_ipv4() {
+    let server = start_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter(server.addr.port(), PSK, true, false);
+
+    let metadata = Metadata {
+        network: Network::Udp,
+        dst_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+        dst_port: 5353,
+        ..Default::default()
+    };
+    let pc = timeout(TIMEOUT, adapter.dial_udp(&metadata))
+        .await
+        .expect("dial_udp timed out")
+        .expect("dial_udp failed");
+
+    let dst: SocketAddr = "1.2.3.4:5353".parse().unwrap();
+    let payload = b"dns-query-ipv4";
+    let n = timeout(TIMEOUT, pc.write_packet(payload, &dst))
+        .await
+        .expect("write_packet timed out")
+        .expect("write_packet failed");
+    assert_eq!(n, payload.len());
+
+    let mut buf = [0u8; 1500];
+    let (n, from) = timeout(TIMEOUT, pc.read_packet(&mut buf))
+        .await
+        .expect("read_packet timed out")
+        .expect("read_packet failed");
+    assert_eq!(&buf[..n], payload);
+    assert_eq!(from, dst, "echoed source address must round-trip");
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].cmd, COMMAND_UDP);
+    }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn udp_roundtrip_ipv6() {
+    let server = start_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter(server.addr.port(), PSK, true, false);
+
+    let metadata = Metadata {
+        network: Network::Udp,
+        dst_ip: Some("2001:db8::1".parse().unwrap()),
+        dst_port: 53,
+        ..Default::default()
+    };
+    let pc = timeout(TIMEOUT, adapter.dial_udp(&metadata))
+        .await
+        .expect("dial_udp timed out")
+        .expect("dial_udp failed");
+
+    let dst: SocketAddr = "[2001:db8::1]:53".parse().unwrap();
+    let payload = b"dns-query-ipv6";
+    let n = timeout(TIMEOUT, pc.write_packet(payload, &dst))
+        .await
+        .expect("write_packet timed out")
+        .expect("write_packet failed");
+    assert_eq!(n, payload.len());
+
+    let mut buf = [0u8; 1500];
+    let (n, from) = timeout(TIMEOUT, pc.read_packet(&mut buf))
+        .await
+        .expect("read_packet timed out")
+        .expect("read_packet failed");
+    assert_eq!(&buf[..n], payload);
+    assert_eq!(from, dst, "echoed source address must round-trip");
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].cmd, COMMAND_UDP);
+    }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn udp_disabled_is_rejected() {
+    // Port 1 is never dialed — the rejection happens before any I/O.
+    let adapter = make_adapter(1, PSK, false, false);
+    let metadata = Metadata {
+        network: Network::Udp,
+        dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        dst_port: 53,
+        ..Default::default()
+    };
+    match adapter.dial_udp(&metadata).await {
+        Ok(_) => panic!("dial_udp must fail when udp is disabled"),
+        Err(MeowError::NotSupported(msg)) => {
+            assert!(
+                msg.to_lowercase().contains("udp"),
+                "error should mention udp: {msg}"
+            );
+        }
+        Err(other) => panic!("expected NotSupported, got {other:?}"),
+    }
+}
+
+#[test]
+fn constructor_rejects_bad_config() {
+    assert!(
+        SnellAdapter::new(
+            "s",
+            "127.0.0.1",
+            80,
+            "",
+            SnellObfs::None,
+            SnellVersion::V4,
+            false,
+            false
+        )
+        .is_err(),
+        "empty psk must be rejected"
+    );
+    assert!(
+        SnellAdapter::new(
+            "s",
+            "127.0.0.1",
+            0,
+            PSK,
+            SnellObfs::None,
+            SnellVersion::V4,
+            false,
+            false
+        )
+        .is_err(),
+        "port 0 must be rejected"
+    );
+    assert!(
+        SnellAdapter::new(
+            "s",
+            "",
+            80,
+            PSK,
+            SnellObfs::None,
+            SnellVersion::V4,
+            false,
+            false
+        )
+        .is_err(),
+        "empty server must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary

Adds 42 tests for the Snell v4/v5 outbound adapter introduced in #138, and fixes a real bug the new tests exposed: **`reuse: true` never actually reused connections.**

### The bug

`drain_for_reuse` (`pool.rs`) read through the `Snell` wrapper, whose `poll_read` maps the tagged v4 zero-chunk error into a clean EOF. The `Err(e) if is_zero_chunk(&e) => return true` arm was therefore unreachable: a server zero-chunk was indistinguishable from a TCP close, every drained conn returned `false`, and pooled reuse silently degraded to a fresh dial per session. Fixed by draining via the raw `V4Conn` (new `Snell::v4_conn_mut()`), where the tagged error is visible. The integration test now proves session 2 rides the same TCP conn (server accept-count stays 1) and the 2-uses cap forces a fresh dial on session 3.

### Test coverage

- **`tests/snell_integration.rs`** (new) — embedded mock Snell server (the v4 codec is symmetric, so `V4Conn` doubles as the server side; no external binaries). TCP roundtrips incl. 100 KiB across the payload-limit ramp-up, domain vs IP-literal addressing, pool reuse + uses cap, structured `AppError` replies, unknown reply bytes, wrong-PSK AEAD failure (`InvalidData`), UDP-over-TCP IPv4/IPv6, UDP-disabled rejection, constructor validation. Mock-server protocol violations are collected and asserted at test end (not swallowed by the tokio runtime).
- **`protocol.rs`** — 12 unit tests: CONNECT / CONNECT_V2 / UDP header layouts, oversize host rejection, reply parsing (tunnel/pong/error/unknown), first-read status consumption, zero-chunk → EOF, reuse reset, packet frames.
- **`pool.rs`** — 7 unit tests: LIFO order, 2-uses cap, max-size 10, all three `drain_for_reuse` outcomes (timeout case under a paused clock).
- **`proxy_parser.rs`** — 12 parser tests: version aliases (4/"v4"/"V5"/5), legacy v1–v3 rejection, obfs modes, missing/invalid fields.

`Pool::idle_count()` / `SnellAdapter::idle_pool_size()` accessors were added so the reuse test waits on pool state deterministically instead of sleeping.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` (default / `--no-default-features` / `--all-features`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` — 686 passed
- `cargo test -p meow-proxy --test snell_integration` — 11 passed, run repeatedly with no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)