### PR TITLE
ci: add daily benchmark workflow on hosted Linux runner

### DIFF
--- a/.github/workflows/bench-daily.yml
+++ b/.github/workflows/bench-daily.yml
@@ -1,0 +1,85 @@
+name: Daily Benchmark
+
+on:
+  schedule:
+    # 03:17 UTC daily (off the top of the hour to avoid scheduler congestion)
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: "Steady-state duration per workload (seconds)"
+        required: false
+        default: "30"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-daily
+  cancel-in-progress: false
+
+jobs:
+  bench:
+    name: Run benchmark harness (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: bench-daily-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: bench-daily-${{ runner.os }}-
+
+      - name: Build release binaries
+        run: cargo build --release -p meow-app -p meow-bench
+
+      - name: Run benchmark harness
+        env:
+          DURATION: ${{ github.event.inputs.duration || '30' }}
+          # bench.sh uses `gh release download` to fetch the Go mihomo binary
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p target/bench
+          bash bench.sh | tee target/bench/results.md
+
+      - name: Publish results to run summary
+        if: always()
+        run: |
+          {
+            echo "## Daily benchmark — $(date -u +%F)"
+            echo ""
+            echo '```'
+            cat target/bench/results.md
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check regression vs baseline
+        # Non-blocking: the checked-in baseline was measured on the dedicated
+        # bench box (docs/benchmarks/hardware.md); GitHub-hosted runners are
+        # slower and noisier, so absolute deltas are informational only.
+        # Day-over-day tracking comes from the uploaded artifacts.
+        if: hashFiles('docs/benchmarks/baseline-*.json') != ''
+        continue-on-error: true
+        run: |
+          BASELINE=$(ls docs/benchmarks/baseline-*.json | sort | tail -1)
+          python3 bench/compare.py "$BASELINE" target/bench/results.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bench-daily-${{ github.run_id }}
+          path: |
+            target/bench/results.json
+            target/bench/results.md
+          retention-days: 90


### PR DESCRIPTION
## Summary

Adds `.github/workflows/bench-daily.yml`: a scheduled daily run (03:17 UTC) of the existing `bench.sh` harness (meow-rs vs Go mihomo, W1–W3) on `ubuntu-latest`, publishing the comparison table to the run summary and uploading `results.json`/`results.md` as 90-day artifacts for day-over-day tracking.

Complements the existing `bench.yml` rather than duplicating it: that workflow is manual-dispatch on the dedicated self-hosted bench box with a blocking regression check; this one tracks trends on hosted runners, so the baseline comparison is `continue-on-error` (the checked-in baseline was measured on the bench box per `docs/benchmarks/hardware.md` — absolute deltas on hosted runners are informational only).

Validated against current main: `bench.sh` runs headless (`GH_TOKEN` provided for the mihomo release download, linux/amd64 asset pattern matches), `config-bench.yaml` exists, `meow-bench` supports all flags used (`--config/--duration/--output/--markdown`), and `bench/compare.py` + `baseline-2026-04-18.json` are present so the comparison step is live.

Known cosmetic nit (acceptable): `bash bench.sh | tee results.md` captures build/download banners alongside the markdown table, so the run summary includes some noise.

## Test plan

- Workflow YAML is new (no conflicts with existing workflows); branch is 3 commits behind main with no overlapping paths.
- `workflow_dispatch` is wired with a `duration` input, so the job can be smoke-tested manually after merge without waiting for the cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)