### PR TITLE
fix(anytls): stop fd/stream leak under repeated dials (#201 item 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "anytls-rs"
 version = "0.5.4"
-source = "git+https://github.com/madeye/anytls-rs.git?rev=47668026ccd793204500eb68853a3aeb4665054d#47668026ccd793204500eb68853a3aeb4665054d"
+source = "git+https://github.com/madeye/anytls-rs.git?rev=e6134889d3abbfaa2cb7439969dbda2ef6930611#e6134889d3abbfaa2cb7439969dbda2ef6930611"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "anytls-rs"
 version = "0.5.4"
-source = "git+https://github.com/madeye/anytls-rs.git?rev=1d13befb2fdd40685f7e4f75b785e9e77ad5eefa#1d13befb2fdd40685f7e4f75b785e9e77ad5eefa"
+source = "git+https://github.com/madeye/anytls-rs.git?rev=47668026ccd793204500eb68853a3aeb4665054d#47668026ccd793204500eb68853a3aeb4665054d"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ serde_yaml = "0.9"
 # `connect_tcp` / `bind_udp` helpers (Android protect hook), plus the
 # fd/stream-leak fix for issue #201 item 4 (madeye/anytls-rs#1: orphaned
 # client sessions, unclosed client streams, and the server outbound-socket
-# leak). Repin to the main-branch SHA once madeye/anytls-rs#1 merges.
-anytls-rs = { git = "https://github.com/madeye/anytls-rs.git", rev = "47668026ccd793204500eb68853a3aeb4665054d" }
+# leak), now merged to the fork's main.
+anytls-rs = { git = "https://github.com/madeye/anytls-rs.git", rev = "e6134889d3abbfaa2cb7439969dbda2ef6930611" }
 shadowsocks = { version = "1.21", default-features = false, features = ["aead-cipher", "aead-cipher-2022", "stream-cipher"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,12 +77,12 @@ serde_json = "1"
 serde_yaml = "0.9"
 
 # Networking
-# Pinned to the madeye fork's `feat/android-protect-hook` branch — adds a
-# `SocketProtector` registry + `connect_tcp` / `bind_udp` helpers and
-# routes the client-side outbound dials through them, mirroring the
-# `meow_common::SocketProtector` API. Drop the pin once upstream merges
-# https://github.com/jxo-me/anytls-rs/pull/2.
-anytls-rs = { git = "https://github.com/madeye/anytls-rs.git", rev = "1d13befb2fdd40685f7e4f75b785e9e77ad5eefa" }
+# Pinned to the madeye fork. Carries the `SocketProtector` registry +
+# `connect_tcp` / `bind_udp` helpers (Android protect hook), plus the
+# fd/stream-leak fix for issue #201 item 4 (madeye/anytls-rs#1: orphaned
+# client sessions, unclosed client streams, and the server outbound-socket
+# leak). Repin to the main-branch SHA once madeye/anytls-rs#1 merges.
+anytls-rs = { git = "https://github.com/madeye/anytls-rs.git", rev = "47668026ccd793204500eb68853a3aeb4665054d" }
 shadowsocks = { version = "1.21", default-features = false, features = ["aead-cipher", "aead-cipher-2022", "stream-cipher"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }

--- a/crates/meow-proxy/src/anytls_adapter.rs
+++ b/crates/meow-proxy/src/anytls_adapter.rs
@@ -250,10 +250,24 @@ impl AsyncWrite for AnytlsConn {
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // Dropping the Arc<Stream> + Arc<Session> here would close the
-        // session prematurely if it's pooled for reuse. Rely on the
-        // session pool's idle reaper instead.
+        // Tear down just this stream (not the whole session, which is pooled
+        // and multiplexes other streams): `Stream::close` emits a FIN frame so
+        // the server releases the proxied target connection and evicts the
+        // stream from the session maps. Without this the server-side proxied
+        // socket and the session's per-stream map entry leaked on every dial
+        // (issue #201 item 4). Idempotent and lock-free.
+        self.stream.close();
         Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for AnytlsConn {
+    fn drop(&mut self) {
+        // Belt-and-suspenders: the relay path that drops the boxed `ProxyConn`
+        // without first calling `poll_shutdown` (e.g. on a copy error) must
+        // still FIN the stream so the proxied connection and map entry are
+        // released. `close()` is idempotent with `poll_shutdown`.
+        self.stream.close();
     }
 }
 

--- a/crates/meow-proxy/tests/anytls_leak.rs
+++ b/crates/meow-proxy/tests/anytls_leak.rs
@@ -1,0 +1,174 @@
+#![cfg(feature = "anytls")]
+//! Regression test for issue #201 item 4: the AnyTLS adapter must not leak
+//! file descriptors (one TLS socket per orphaned session) under repeated
+//! sequential dials. The upstream `anytls-rs` session pool removed a reused
+//! session from the pool but never returned it, so every reused session was
+//! orphaned — kept alive forever by its heartbeat task — leaking its fd. Under
+//! churn this exhausted fds ("No file descriptors available (os error 24)")
+//! and then aborted on allocation failure.
+//!
+//! This test dials many times through an in-process anytls server and asserts
+//! the process's open-fd count stays bounded.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anytls_rs::padding::PaddingFactory;
+use anytls_rs::server::Server as AnytlsServer;
+use meow_common::{Metadata, Network, ProxyAdapter};
+use meow_proxy::AnytlsAdapter;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::{timeout, Duration};
+
+const PASSWORD: &str = "test-anytls-password";
+const T: Duration = Duration::from_secs(15);
+
+fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// Count this process's currently-open file descriptors. Works on Linux
+/// (`/proc/self/fd`) and macOS (`/dev/fd`). Returns `None` on platforms where
+/// neither is available, in which case the test skips its assertion.
+fn open_fd_count() -> Option<usize> {
+    for dir in ["/proc/self/fd", "/dev/fd"] {
+        if let Ok(rd) = std::fs::read_dir(dir) {
+            return Some(rd.count());
+        }
+    }
+    None
+}
+
+fn self_signed_cert() -> (
+    rustls::pki_types::CertificateDer<'static>,
+    rustls::pki_types::PrivateKeyDer<'static>,
+) {
+    let ck = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+    let cert_der = rustls::pki_types::CertificateDer::from(ck.cert.der().to_vec());
+    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(
+        rustls::pki_types::PrivatePkcs8KeyDer::from(ck.key_pair.serialize_der()),
+    );
+    (cert_der, key_der)
+}
+
+async fn start_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let h = tokio::spawn(async move {
+        while let Ok((mut sock, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    let n = match sock.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => n,
+                    };
+                    if sock.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    (addr, h)
+}
+
+async fn start_anytls_server(
+    cert_der: rustls::pki_types::CertificateDer<'static>,
+    key_der: rustls::pki_types::PrivateKeyDer<'static>,
+) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .unwrap();
+    let acceptor = Arc::new(tokio_rustls::TlsAcceptor::from(Arc::new(tls_config)));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let padding = PaddingFactory::default();
+    let server = AnytlsServer::new(PASSWORD, acceptor, padding, None);
+    let listen_addr = format!("127.0.0.1:{}", addr.port());
+    let h = tokio::spawn(async move {
+        let _ = server.listen(&listen_addr).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, h)
+}
+
+async fn one_round_trip(adapter: &AnytlsAdapter, echo_addr: SocketAddr) {
+    let metadata = Metadata {
+        network: Network::Tcp,
+        host: smol_str::SmolStr::from(echo_addr.ip().to_string()),
+        dst_port: echo_addr.port(),
+        ..Default::default()
+    };
+    let mut conn = timeout(T, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial must not stall")
+        .expect("dial must succeed");
+    let payload = b"leakprobe";
+    conn.write_all(payload).await.expect("write");
+    conn.flush().await.expect("flush");
+    let mut buf = [0u8; 9];
+    timeout(T, conn.read_exact(&mut buf))
+        .await
+        .expect("echo must not stall")
+        .expect("echo");
+    assert_eq!(&buf[..], payload);
+    // conn dropped here -> exercises AnytlsConn teardown
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anytls_repeated_dials_do_not_leak_fds() {
+    install_crypto_provider();
+    let (echo_addr, _echo_h) = start_echo_server().await;
+    let (cert, key) = self_signed_cert();
+    let (server_addr, _server_h) = start_anytls_server(cert, key).await;
+
+    let adapter = AnytlsAdapter::new(
+        "test-anytls-leak",
+        &server_addr.ip().to_string(),
+        server_addr.port(),
+        PASSWORD,
+        Some("localhost"),
+        true,
+    )
+    .expect("adapter must build");
+
+    // Warm up: reach steady state (pooled warm session established).
+    for _ in 0..3 {
+        one_round_trip(&adapter, echo_addr).await;
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let baseline = open_fd_count();
+    eprintln!("baseline fds: {baseline:?}");
+
+    const N: usize = 40;
+    for i in 0..N {
+        one_round_trip(&adapter, echo_addr).await;
+        if i % 10 == 9 {
+            eprintln!("after {} dials: fds = {:?}", i + 1, open_fd_count());
+        }
+    }
+    // Give teardown a moment to settle.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let after = open_fd_count();
+    eprintln!("after {N} dials: fds = {after:?} (baseline {baseline:?})");
+
+    if let (Some(b), Some(a)) = (baseline, after) {
+        let growth = a.saturating_sub(b);
+        // A correct, non-leaking adapter reuses/closes sessions, so fd growth
+        // across N dials must stay small and bounded — NOT proportional to N.
+        assert!(
+            growth <= 8,
+            "fd leak: {N} sequential dials grew open fds by {growth} \
+             (baseline {b} -> {a}); expected a small bounded delta. \
+             This is issue #201 item 4 (orphaned anytls sessions leak their socket)."
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes issue #201 item 4: the AnyTLS outbound exhausted file descriptors (`No file descriptors available (os error 24)`) and then OOM-aborted under sustained load.

### Reproduction

New regression test `crates/meow-proxy/tests/anytls_leak.rs` dials 40 times through an in-process anytls server and counts the process's open fds:

| | open-fd growth over 40 dials |
|---|---|
| before fix | **+120** (linear, never reclaimed → EMFILE → OOM) |
| after fix | **0** (flat) |

### Root cause (three compounding leaks)

Two are upstream in `anytls-rs`, fixed in **madeye/anytls-rs#1** and pulled in here via the `rev` bump in the workspace `Cargo.toml`:

1. **Orphaned client sessions** — `SessionPool::get_idle_session` removed a reused session from the pool but never returned it, so every reused session was kept alive forever by its own heartbeat task and never freed its socket. Now peeks-and-touches the live session (left pooled for multiplexing); cleanup retires it once idle and stream-free.
2. **Unclosed client streams** — streams were never FIN'd nor evicted from `Session::streams`/`stream_receive_tx`, so the maps grew one entry per dial for the session's life. `Stream::close` now emits a FIN and evicts the maps; `recv_loop` closes its session on exit.
3. **Server outbound socket** — the proxy `join!`'d both copy tasks, so a client FIN left the target→stream half blocked forever and leaked the outbound socket per stream. Now tears down when either direction ends.

### meow-rs side (this PR)

`AnytlsConn::poll_shutdown` was a no-op that deferred to the (ineffective) idle reaper. It now calls `Stream::close` (emit FIN → session evicts the stream → server releases the proxied connection), and a new `Drop for AnytlsConn` does the same for teardown paths that bypass `poll_shutdown` (e.g. the relay dropping the boxed conn on a copy error).

## Verification

- New `anytls_leak` regression test: fd delta 0 over 40 dials (against the pinned remote anytls-rs rev, not a local patch).
- `anytls_integration` (4 tests incl. concurrent multiplexing) — green.
- Full regression bar: `cargo fmt --check`, `clippy --all-targets` (default / no-default-features / all-features) `-D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo test --lib` (**691 passed**) — all green.

> Note: the `anytls-rs` dep is pinned to the fix branch HEAD (`47668026`); repin to the main SHA once madeye/anytls-rs#1 merges.

Closes #201 (item 4; items 1–3 landed in #204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
