### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64",
  "libc",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
Bumps the workspace version from `0.13.0` to `0.14.0` in preparation for the v0.14.0 release.

- Updated `[workspace.package].version` in `Cargo.toml`
- Regenerated `Cargo.lock` (12 meow-rs crates → 0.14.0)

Verified locally:
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓ (no issues)
- `cargo test --lib` ✓ (691 passed)

Once merged, tag `v0.14.0` on main triggers the release workflow (musl builds + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)