### PR TITLE
feat: support Snell v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A high-performance Rust implementation of the [mihomo](https://github.com/MetaCu
 - **VLESS** -- Plain VLESS and XTLS-Vision splice; TLS, WebSocket, gRPC, H2, HTTPUpgrade transports
 - **HTTP** -- HTTP CONNECT outbound proxy with optional TLS and basic auth
 - **SOCKS5** -- SOCKS5 outbound proxy with optional TLS and auth
+- **Snell** -- v3/v4/v5 TCP, UDP-over-TCP, optional HTTP/TLS obfs; v4/v5 connection reuse
 - **Direct** -- Direct connection to destination
 - **Reject** -- Drop connections (with configurable behavior)
 
@@ -285,14 +286,25 @@ proxies:
     sni: example.com
     skip-cert-verify: false
 
+  - name: my-snell
+    type: snell
+    server: ss.example.com
+    port: 8443
+    psk: "your-psk"
+    version: 3
+    udp: true
+    obfs-opts:
+      mode: http
+      host: /
+
 proxy-groups:
   - name: Proxy
     type: select
-    proxies: [my-ss, my-trojan]
+    proxies: [my-ss, my-trojan, my-snell]
 
   - name: Auto
     type: url-test
-    proxies: [my-ss, my-trojan]
+    proxies: [my-ss, my-trojan, my-snell]
     url: http://www.gstatic.com/generate_204
     interval: 300
 

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -200,8 +200,8 @@ pub fn parse_proxy(
 
 /// Parse a `type: snell` proxy block.
 ///
-/// Aligned with opensnell's client-side surface — v4 / v5 wire only (older
-/// v1/v2/v3 are hard-rejected, mirroring opensnell's own scope decision).
+/// Mihomo-compatible Snell outbound. v3 uses the legacy Snell AEAD stream;
+/// v4/v5 use the newer Snell v4 TCP wire (v5 is client-side compatible).
 ///
 /// YAML schema (mihomo-compatible):
 ///
@@ -211,7 +211,7 @@ pub fn parse_proxy(
 ///   server: 1.2.3.4
 ///   port: 443
 ///   psk: shared-secret
-///   version: 4         # optional; default 4. Accepts 4, 5, "v4", "v5".
+///   version: 4         # optional; default 4. Accepts 3, 4, 5, "v3", "v4", "v5".
 ///   udp: true          # optional; UDP-over-TCP relay.
 ///   reuse: true        # optional; CommandConnectV2 + connection pool.
 ///   obfs-opts:         # optional
@@ -224,7 +224,7 @@ pub fn parse_proxy(
 /// - missing `server`, `port`, or `psk` — required by the protocol.
 /// - `port == 0` — never a valid endpoint.
 /// - empty `psk` — caught by [`meow_proxy::SnellAdapter::new`].
-/// - `version` ∈ {1, 2, 3} — opensnell does not implement those wires.
+/// - `version` ∈ {1, 2} — this adapter does not implement those wires.
 /// - `obfs-opts.mode` is not one of off / http / tls.
 #[cfg(feature = "snell")]
 fn parse_snell(
@@ -269,22 +269,22 @@ fn parse_snell(
                 s.to_string()
             } else {
                 return Err(format!(
-                    "snell[{name}]: version must be an integer or string (4 or 5)"
+                    "snell[{name}]: version must be an integer or string (3, 4 or 5)"
                 ));
             };
             match label.trim().to_ascii_lowercase().as_str() {
+                "3" | "v3" => SnellVersion::V3,
                 "" | "4" | "v4" => SnellVersion::V4,
                 "5" | "v5" => SnellVersion::V5,
-                "1" | "2" | "3" | "v1" | "v2" | "v3" => {
+                "1" | "2" | "v1" | "v2" => {
                     return Err(format!(
                         "snell[{name}]: version '{label}' is not supported; \
-                         this adapter implements the v4 / v5 wire only \
-                         (mihomo's older v1/v2/v3 are deprecated)"
+                         this adapter implements Snell v3 / v4 / v5 only"
                     ));
                 }
                 other => {
                     return Err(format!(
-                        "snell[{name}]: unknown version '{other}'; valid: 4, 5"
+                        "snell[{name}]: unknown version '{other}'; valid: 3, 4, 5"
                     ));
                 }
             }
@@ -1860,6 +1860,8 @@ tls: true
     #[test]
     fn parse_snell_version_aliases() {
         for yaml in &[
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 3\n",
+            "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: v3\n",
             "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 4\n",
             "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: v4\n",
             "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: V5\n",
@@ -1872,7 +1874,7 @@ tls: true
 
     #[cfg(feature = "snell")]
     #[test]
-    fn parse_snell_rejects_legacy_versions() {
+    fn parse_snell_rejects_unsupported_legacy_versions() {
         for (yaml, ver) in &[
             (
                 "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 1\n",
@@ -1883,17 +1885,13 @@ tls: true
                 "2",
             ),
             (
-                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: 3\n",
-                "3",
-            ),
-            (
                 "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nversion: v2\n",
                 "v2",
             ),
         ] {
             let cfg = snell_config(yaml);
             let Err(err) = parse_proxy(&cfg) else {
-                panic!("legacy version {ver} must hard-error (Class A)");
+                panic!("unsupported legacy version {ver} must hard-error (Class A)");
             };
             assert!(
                 err.contains("not supported"),

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -11,9 +11,9 @@ trojan = []
 vless = []
 vmess = ["dep:md-5", "dep:hmac", "dep:aes", "dep:aes-gcm", "dep:chacha20poly1305", "dep:crc32fast"]
 vless-vision = ["vless"]
-# Snell v4/v5 outbound — argon2id KDF + AES-128-GCM AEAD frames,
+# Snell v3/v4/v5 outbound — argon2id KDF + AES-128-GCM AEAD frames,
 # optional http/tls obfs (reused from the SS simple-obfs module),
-# UDP-over-TCP, and an opt-in reuse pool (CommandConnectV2).
+# UDP-over-TCP, and an opt-in v4/v5 reuse pool (CommandConnectV2).
 snell = ["dep:argon2", "dep:aes-gcm"]
 # Opt-in anytls outbound (uses the `anytls-rs` crate). Adds ~one extra TLS
 # provider to the binary because the upstream crate pins default rustls

--- a/crates/meow-proxy/src/snell/adapter.rs
+++ b/crates/meow-proxy/src/snell/adapter.rs
@@ -1,14 +1,8 @@
 //! Snell outbound adapter — implements `ProxyAdapter` for `type: snell`.
 //!
-//! Wires together the v4 AEAD codec, the optional simple-obfs (http/tls)
-//! layer, the snell request/response framing, and the optional reuse pool
-//! (`CommandConnectV2`).
-//!
-//! Version handling: opensnell's wire is v4 / v5 (both share the same TCP
-//! framing — v5 is identical on the client side, the difference is the
-//! server's optional QUIC mode). Older v1 / v2 / v3 wires are *not*
-//! supported (different AEAD and frame layout); the YAML parser hard-errors
-//! on those values.
+//! Wires together the v3/v4 AEAD codecs, the optional simple-obfs (http/tls)
+//! layer, the snell request/response framing, and the optional v4/v5 reuse
+//! pool (`CommandConnectV2`).
 
 use async_trait::async_trait;
 use meow_common::{
@@ -27,12 +21,11 @@ use super::pool::{drain_for_reuse, Pool, PoolStream};
 use super::protocol::{write_header, write_udp_header, Snell};
 use super::udp::SnellPacketConn;
 
-/// What snell version label the adapter announces. Today both labels
-/// produce identical wire framing — Snell v4 == v5 on the TCP side. The
-/// value is stored so future v5 QUIC support can switch on it without
-/// breaking config compatibility.
+/// What Snell version label the adapter uses. v5 servers are
+/// backward-compatible with the v4 TCP client wire, matching mihomo.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SnellVersion {
+    V3,
     V4,
     V5,
 }
@@ -40,9 +33,14 @@ pub enum SnellVersion {
 impl SnellVersion {
     pub fn as_str(self) -> &'static str {
         match self {
+            SnellVersion::V3 => "v3",
             SnellVersion::V4 => "v4",
             SnellVersion::V5 => "v5",
         }
+    }
+
+    fn supports_reuse(self) -> bool {
+        matches!(self, SnellVersion::V4 | SnellVersion::V5)
     }
 }
 
@@ -65,10 +63,6 @@ pub struct SnellAdapter {
     obfs: SnellObfs,
     support_udp: bool,
     pool: Option<Arc<Pool>>,
-    /// Currently informational — v4 and v5 share the same TCP wire. Stashed
-    /// so a future v5 QUIC outbound can branch on it without breaking config
-    /// compatibility.
-    #[allow(dead_code, reason = "reserved for v5 QUIC support")]
     version: SnellVersion,
     health: ProxyHealth,
 }
@@ -104,11 +98,12 @@ impl SnellAdapter {
             )));
         }
         let psk_bytes: Arc<[u8]> = Arc::from(psk.as_bytes());
+        let effective_reuse = reuse && version.supports_reuse();
         debug!(
             "snell '{}' configured: version={} reuse={} udp={} obfs={}",
             name,
             version.as_str(),
-            reuse,
+            effective_reuse,
             udp,
             match &obfs {
                 SnellObfs::None => "off",
@@ -124,7 +119,7 @@ impl SnellAdapter {
             psk: psk_bytes,
             obfs,
             support_udp: udp,
-            pool: if reuse {
+            pool: if effective_reuse {
                 Some(Arc::new(Pool::new()))
             } else {
                 None
@@ -146,7 +141,10 @@ impl SnellAdapter {
             SnellObfs::Http { host } => Box::new(HttpObfs::new(tcp, host.clone(), self.port)),
             SnellObfs::Tls { server } => Box::new(TlsObfs::new(tcp, server.clone())),
         };
-        Ok(Snell::new(inner, Arc::clone(&self.psk)))
+        Ok(match self.version {
+            SnellVersion::V3 => Snell::new_v3(inner, Arc::clone(&self.psk)),
+            SnellVersion::V4 | SnellVersion::V5 => Snell::new(inner, Arc::clone(&self.psk)),
+        })
     }
 
     /// Number of idle connections currently parked in the reuse pool.
@@ -238,7 +236,9 @@ impl ProxyAdapter for SnellAdapter {
         }
         let mut snell = self.dial_fresh().await?;
         write_udp_header(&mut snell).await.map_err(MeowError::Io)?;
-        snell.read_reply().await.map_err(MeowError::Io)?;
+        if self.version.supports_reuse() {
+            snell.read_reply().await.map_err(MeowError::Io)?;
+        }
         Ok(Box::new(SnellPacketConn::new(snell)))
     }
 

--- a/crates/meow-proxy/src/snell/mod.rs
+++ b/crates/meow-proxy/src/snell/mod.rs
@@ -1,8 +1,9 @@
-//! Snell v4 / v5 outbound proxy adapter.
+//! Snell v3 / v4 / v5 outbound proxy adapter.
 //!
 //! Port of the client side of [opensnell](https://github.com/missuo/opensnell):
 //!
 //! * [`cipher`] — Argon2id KDF + AES-128-GCM helpers.
+//! * [`v3`]    — Shadowsocks-AEAD-compatible Snell v3 codec.
 //! * [`v4`]    — AEAD frame codec (`v4Conn`) with padding interleave and
 //!   payload-limit ramp-up.
 //! * [`protocol`] — `Snell` stream wrapper with request/response handling.
@@ -10,13 +11,14 @@
 //! * [`pool`]  — bounded LIFO reuse pool for `CommandConnectV2` sessions.
 //! * [`adapter`] — `SnellAdapter` implementing [`meow_common::ProxyAdapter`].
 //!
-//! Older snell v1 / v2 / v3 wires are intentionally unsupported.
+//! Older snell v1 / v2 wires are intentionally unsupported.
 
 pub mod adapter;
 pub mod cipher;
 pub mod pool;
 pub mod protocol;
 pub mod udp;
+pub mod v3;
 pub mod v4;
 
 pub use adapter::{SnellAdapter, SnellObfs, SnellVersion};

--- a/crates/meow-proxy/src/snell/pool.rs
+++ b/crates/meow-proxy/src/snell/pool.rs
@@ -20,9 +20,7 @@ use std::time::{Duration, Instant};
 
 use meow_transport::Stream as TransportStream;
 
-use super::protocol::Snell;
-use super::v4::is_zero_chunk;
-use tokio::io::AsyncReadExt;
+use super::protocol::{is_zero_chunk, Snell};
 
 /// Type-erased snell stream used inside the pool. The underlying byte
 /// stream may be a plain TCP connection or an obfs-wrapped one — the pool
@@ -121,9 +119,9 @@ impl Default for Pool {
 /// reuse. Returns `true` when the zero-chunk was observed within
 /// `DRAIN_DEADLINE`, `false` otherwise (caller should discard the conn).
 ///
-/// Reads via the raw `V4Conn` (not the `Snell` wrapper): the wrapper maps
-/// the zero-chunk into a clean EOF, which is indistinguishable from the
-/// peer closing the TCP stream.
+/// Reads via the raw version-specific codec (not the `Snell` wrapper): the
+/// wrapper maps the zero-chunk into a clean EOF, which is indistinguishable
+/// from the peer closing the TCP stream.
 pub async fn drain_for_reuse(conn: &mut PoolStream) -> bool {
     let mut scratch = [0u8; 4096];
     let deadline = tokio::time::sleep(DRAIN_DEADLINE);
@@ -132,7 +130,7 @@ pub async fn drain_for_reuse(conn: &mut PoolStream) -> bool {
         tokio::select! {
             biased;
             () = &mut deadline => return false,
-            res = conn.v4_conn_mut().read(&mut scratch) => {
+            res = conn.read_raw_for_reuse(&mut scratch) => {
                 match res {
                     Ok(0) => return false, // peer closed underlying TCP
                     Ok(_) => continue,

--- a/crates/meow-proxy/src/snell/protocol.rs
+++ b/crates/meow-proxy/src/snell/protocol.rs
@@ -1,7 +1,7 @@
 //! Snell protocol constants and the high-level `Snell` stream wrapper.
 //!
-//! Port of opensnell `components/snell/protocol.go` + `conn.go`. Bridges the
-//! v4 AEAD codec to the snell request/response semantics:
+//! Bridges the version-specific AEAD codec to the snell request/response
+//! semantics:
 //!
 //! * The client writes a 5-byte `[ver | cmd | client-id-len=0 | host-len |
 //!   host... | port:u16 BE]` connect request after the salt is in flight.
@@ -18,7 +18,8 @@ use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 
-use super::v4::{is_zero_chunk, V4Conn, MAX_PAYLOAD_LENGTH};
+use super::v3::{is_zero_chunk as is_v3_zero_chunk, V3Conn};
+use super::v4::{is_zero_chunk as is_v4_zero_chunk, V4Conn, MAX_PAYLOAD_LENGTH};
 
 /// First byte of every Snell request — `0x01` since v1.
 pub const HEADER_VERSION: u8 = 1;
@@ -33,6 +34,11 @@ pub const COMMAND_UDP_FORWARD: u8 = 1;
 pub const RESPONSE_TUNNEL: u8 = 0;
 pub const RESPONSE_PONG: u8 = 1;
 pub const RESPONSE_ERROR: u8 = 2;
+
+/// True iff an error is a version-specific Snell zero-chunk half-close.
+pub fn is_zero_chunk(err: &io::Error) -> bool {
+    is_v3_zero_chunk(err) || is_v4_zero_chunk(err)
+}
 
 /// Application-layer error returned by the snell peer.
 #[derive(Debug, Clone)]
@@ -54,7 +60,7 @@ impl std::fmt::Display for AppError {
 impl std::error::Error for AppError {}
 
 /// Encode a TCP CONNECT request header. The bytes are written through the
-/// caller's stream (typically a `V4Conn`).
+/// caller's encrypted stream.
 pub async fn write_header<W: AsyncWrite + Unpin>(
     stream: &mut W,
     host: &str,
@@ -87,13 +93,52 @@ pub async fn write_udp_header<W: AsyncWrite + Unpin>(stream: &mut W) -> io::Resu
 }
 
 /// Emit a zero-chunk (`payload_len == 0 && padding_len == 0`) — the
-/// half-close signal recognized by the peer. The v4 codec turns a zero-byte
-/// `poll_write` into a zero-chunk frame, so this is a thin wrapper.
+/// half-close signal recognized by the peer. The Snell codecs turn a
+/// zero-byte `poll_write` into a zero-chunk frame, so this is a thin wrapper.
 pub async fn write_zero_chunk<W: AsyncWrite + Unpin>(stream: &mut W) -> io::Result<()> {
     stream.write_all(&[]).await
 }
 
 // ─── Snell stream wrapper ────────────────────────────────────────────────────
+
+enum SnellInner<S> {
+    V3(V3Conn<S>),
+    V4(V4Conn<S>),
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> SnellInner<S> {
+    fn poll_read_inner(
+        &mut self,
+        cx: &mut Context<'_>,
+        out: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self {
+            SnellInner::V3(conn) => Pin::new(conn).poll_read(cx, out),
+            SnellInner::V4(conn) => Pin::new(conn).poll_read(cx, out),
+        }
+    }
+
+    fn poll_write_inner(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        match self {
+            SnellInner::V3(conn) => Pin::new(conn).poll_write(cx, buf),
+            SnellInner::V4(conn) => Pin::new(conn).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush_inner(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self {
+            SnellInner::V3(conn) => Pin::new(conn).poll_flush(cx),
+            SnellInner::V4(conn) => Pin::new(conn).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown_inner(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self {
+            SnellInner::V3(conn) => Pin::new(conn).poll_shutdown(cx),
+            SnellInner::V4(conn) => Pin::new(conn).poll_shutdown(cx),
+        }
+    }
+}
 
 /// AEAD-wrapped stream with snell request/response semantics.
 ///
@@ -102,7 +147,7 @@ pub async fn write_zero_chunk<W: AsyncWrite + Unpin>(stream: &mut W) -> io::Resu
 /// through directly. The wrapper exposes [`Snell::write_packet_frame`] so
 /// the UDP relay can emit datagram-sized frames atomically.
 pub struct Snell<S> {
-    inner: V4Conn<S>,
+    inner: SnellInner<S>,
     /// Set to `true` after the reply byte has been consumed once. Reset to
     /// `false` by [`Snell::reset_reply_state`] when a pooled connection is
     /// re-used for a fresh request.
@@ -112,7 +157,14 @@ pub struct Snell<S> {
 impl<S> Snell<S> {
     pub fn from_v4(inner: V4Conn<S>) -> Self {
         Self {
-            inner,
+            inner: SnellInner::V4(inner),
+            reply_consumed: false,
+        }
+    }
+
+    pub fn from_v3(inner: V3Conn<S>) -> Self {
+        Self {
+            inner: SnellInner::V3(inner),
             reply_consumed: false,
         }
     }
@@ -122,7 +174,17 @@ impl<S> Snell<S> {
         S: AsyncRead + AsyncWrite + Unpin,
     {
         Self {
-            inner: V4Conn::new(inner, psk),
+            inner: SnellInner::V4(V4Conn::new(inner, psk)),
+            reply_consumed: false,
+        }
+    }
+
+    pub fn new_v3(inner: S, psk: Arc<[u8]>) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        Self {
+            inner: SnellInner::V3(V3Conn::new(inner, psk)),
             reply_consumed: false,
         }
     }
@@ -137,18 +199,9 @@ impl<S> Snell<S> {
         self.reply_consumed = true;
     }
 
-    /// Mutable access to the underlying v4 codec. The `AsyncRead` impl on
-    /// `Snell` maps the zero-chunk half-close into a clean EOF; the reuse
-    /// pool's drain must observe the *raw* tagged error instead, so it can
-    /// distinguish the peer's half-close (conn reusable) from a genuine TCP
-    /// close (conn dead).
-    pub fn v4_conn_mut(&mut self) -> &mut V4Conn<S> {
-        &mut self.inner
-    }
-
     /// Stage a single frame carrying `buf` verbatim as a UDP datagram
-    /// payload. The frame is written via the underlying `V4Conn` so the
-    /// codec keeps producing valid AEAD frames.
+    /// payload. v4 uses its packet-frame path to keep one datagram in one
+    /// frame; v3 mirrors mihomo and writes through the regular AEAD stream.
     pub async fn write_packet_frame(&mut self, buf: &[u8]) -> io::Result<usize>
     where
         S: AsyncRead + AsyncWrite + Unpin,
@@ -159,17 +212,37 @@ impl<S> Snell<S> {
                 "snell: packet frame too large",
             ));
         }
-        self.inner.stage_packet_frame(buf)?;
-        // Drain the staged frame to completion.
-        std::future::poll_fn(|cx| {
-            if self.inner.has_pending_write() {
-                Pin::new(&mut self.inner).poll_flush(cx)
-            } else {
-                Poll::Ready(Ok(()))
+        match &mut self.inner {
+            SnellInner::V3(conn) => {
+                conn.write_all(buf).await?;
+                conn.flush().await?;
             }
-        })
-        .await?;
+            SnellInner::V4(conn) => {
+                conn.stage_packet_frame(buf)?;
+                // Drain the staged frame to completion.
+                std::future::poll_fn(|cx| {
+                    if conn.has_pending_write() {
+                        Pin::new(&mut *conn).poll_flush(cx)
+                    } else {
+                        Poll::Ready(Ok(()))
+                    }
+                })
+                .await?;
+            }
+        }
         Ok(buf.len())
+    }
+
+    /// Read from the raw version-specific codec without the status-byte
+    /// guard or zero-chunk-to-EOF mapping. The reuse pool needs this so it
+    /// can tell a peer half-close from a dead TCP stream.
+    pub async fn read_raw_for_reuse(&mut self, buf: &mut [u8]) -> io::Result<usize>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let mut rb = ReadBuf::new(buf);
+        std::future::poll_fn(|cx| self.inner.poll_read_inner(cx, &mut rb)).await?;
+        Ok(rb.filled().len())
     }
 }
 
@@ -211,7 +284,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> Snell<S> {
         let mut filled = 0;
         while filled < buf.len() {
             let mut rb = ReadBuf::new(&mut buf[filled..]);
-            std::future::poll_fn(|cx| Pin::new(&mut self.inner).poll_read(cx, &mut rb)).await?;
+            std::future::poll_fn(|cx| self.inner.poll_read_inner(cx, &mut rb)).await?;
             let n = rb.filled().len();
             if n == 0 {
                 return Err(io::Error::new(
@@ -239,7 +312,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for Snell<S> {
         if !this.reply_consumed {
             let mut buf = [0u8; 1];
             let mut rb = ReadBuf::new(&mut buf);
-            match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+            match this.inner.poll_read_inner(cx, &mut rb) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                 Poll::Ready(Ok(())) => {}
@@ -273,7 +346,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for Snell<S> {
             }
         }
         // Map the v4 zero-chunk into a clean EOF for the caller.
-        match Pin::new(&mut this.inner).poll_read(cx, out) {
+        match this.inner.poll_read_inner(cx, out) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Err(e)) if is_zero_chunk(&e) => Poll::Ready(Ok(())),
             other => other,
@@ -287,13 +360,13 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for Snell<S> {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
+        self.inner.poll_write_inner(cx, buf)
     }
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
+        self.inner.poll_flush_inner(cx)
     }
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
+        self.inner.poll_shutdown_inner(cx)
     }
 }
 

--- a/crates/meow-proxy/src/snell/v3.rs
+++ b/crates/meow-proxy/src/snell/v3.rs
@@ -1,0 +1,518 @@
+//! Snell v3 AEAD stream codec.
+//!
+//! Mihomo implements Snell v3 by wrapping the TCP stream in its
+//! `shadowaead.NewConn` with a Snell-specific cipher: 16-byte salt,
+//! Argon2id-derived AES-128-GCM key, and the Shadowsocks AEAD stream frame
+//! layout. Each record is:
+//!
+//! 1. First write sends a 16-byte random salt.
+//! 2. Record header: AEAD-sealed 2-byte big-endian payload length.
+//! 3. Record body: AEAD-sealed payload bytes, omitted when length is zero.
+//! 4. Nonce: 12-byte little-endian counter incremented after each Seal/Open.
+//! 5. A zero-length header is the Snell half-close signal.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use aes_gcm::aead::generic_array::GenericArray;
+use aes_gcm::aead::AeadInPlace;
+use aes_gcm::Aes128Gcm;
+use rand::RngCore;
+use tokio::io::{AsyncRead, AsyncWrite, BufReader, ReadBuf};
+
+use super::cipher::{aes_gcm, snell_kdf};
+use super::v4::MAX_PAYLOAD_LENGTH;
+
+pub const V3_SALT_SIZE: usize = 16;
+pub const V3_NONCE_SIZE: usize = 12;
+const V3_LENGTH_PLAIN_SIZE: usize = 2;
+const V3_GCM_TAG: usize = 16;
+const V3_LENGTH_CIPHER_SIZE: usize = V3_LENGTH_PLAIN_SIZE + V3_GCM_TAG;
+const V3_READ_BUFFER_SIZE: usize = 64 * 1024;
+
+const ZERO_CHUNK_KIND: io::ErrorKind = io::ErrorKind::UnexpectedEof;
+const ZERO_CHUNK_MSG: &str = "snell v3: zero chunk";
+
+pub fn is_zero_chunk(err: &io::Error) -> bool {
+    err.kind() == ZERO_CHUNK_KIND
+        && err
+            .get_ref()
+            .is_some_and(|e| e.to_string() == ZERO_CHUNK_MSG)
+}
+
+fn zero_chunk_err() -> io::Error {
+    io::Error::new(ZERO_CHUNK_KIND, ZERO_CHUNK_MSG)
+}
+
+fn increment_nonce(nonce: &mut [u8; V3_NONCE_SIZE]) {
+    for byte in nonce.iter_mut() {
+        *byte = byte.wrapping_add(1);
+        if *byte != 0 {
+            return;
+        }
+    }
+}
+
+enum ReaderState {
+    NeedSalt {
+        salt_buf: [u8; V3_SALT_SIZE],
+        salt_progress: usize,
+    },
+    ReadingHeader {
+        aead: Arc<Aes128Gcm>,
+        nonce: [u8; V3_NONCE_SIZE],
+        header_buf: [u8; V3_LENGTH_CIPHER_SIZE],
+        header_progress: usize,
+    },
+    ReadingPayload {
+        aead: Arc<Aes128Gcm>,
+        nonce: [u8; V3_NONCE_SIZE],
+        payload_len: usize,
+        payload_buf: Vec<u8>,
+        payload_progress: usize,
+    },
+    Drain {
+        aead: Arc<Aes128Gcm>,
+        nonce: [u8; V3_NONCE_SIZE],
+        payload: Vec<u8>,
+        payload_off: usize,
+    },
+}
+
+struct Writer {
+    aead: Arc<Aes128Gcm>,
+    nonce: [u8; V3_NONCE_SIZE],
+    salt: [u8; V3_SALT_SIZE],
+    salt_sent: bool,
+    pending: Vec<u8>,
+    pending_off: usize,
+    pending_input: usize,
+}
+
+impl Writer {
+    fn new(psk: &[u8]) -> Self {
+        let mut salt = [0u8; V3_SALT_SIZE];
+        rand::rng().fill_bytes(&mut salt);
+        let aead = aes_gcm(&snell_kdf(psk, &salt, 16));
+        Self {
+            aead: Arc::new(aead),
+            nonce: [0u8; V3_NONCE_SIZE],
+            salt,
+            salt_sent: false,
+            pending: Vec::new(),
+            pending_off: 0,
+            pending_input: 0,
+        }
+    }
+
+    fn stage_record(&mut self, payload: &[u8]) -> io::Result<()> {
+        if payload.len() > MAX_PAYLOAD_LENGTH {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snell v3 record too large",
+            ));
+        }
+
+        let mut header = Vec::with_capacity(V3_LENGTH_CIPHER_SIZE);
+        header.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        seal_in_place(&self.aead, &self.nonce, &mut header)?;
+        increment_nonce(&mut self.nonce);
+
+        let mut body = Vec::new();
+        if !payload.is_empty() {
+            body.extend_from_slice(payload);
+            seal_in_place(&self.aead, &self.nonce, &mut body)?;
+            increment_nonce(&mut self.nonce);
+        }
+
+        let mut frame = Vec::with_capacity(
+            if self.salt_sent { 0 } else { V3_SALT_SIZE } + header.len() + body.len(),
+        );
+        if !self.salt_sent {
+            frame.extend_from_slice(&self.salt);
+            self.salt_sent = true;
+        }
+        frame.extend_from_slice(&header);
+        frame.extend_from_slice(&body);
+
+        self.pending = frame;
+        self.pending_off = 0;
+        Ok(())
+    }
+}
+
+fn seal_in_place(
+    aead: &Aes128Gcm,
+    nonce: &[u8; V3_NONCE_SIZE],
+    buf: &mut Vec<u8>,
+) -> io::Result<()> {
+    aead.encrypt_in_place(GenericArray::from_slice(nonce), b"", buf)
+        .map_err(|_| io::Error::other("snell v3 encrypt failed"))
+}
+
+fn open_in_place(
+    aead: &Aes128Gcm,
+    nonce: &[u8; V3_NONCE_SIZE],
+    buf: &mut Vec<u8>,
+) -> io::Result<()> {
+    aead.decrypt_in_place(GenericArray::from_slice(nonce), b"", buf)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "snell v3 decrypt failed"))
+}
+
+pub struct V3Conn<S> {
+    inner: BufReader<S>,
+    psk: Arc<[u8]>,
+    writer: Writer,
+    reader: ReaderState,
+}
+
+impl<S: AsyncRead> V3Conn<S> {
+    pub fn new(inner: S, psk: Arc<[u8]>) -> Self {
+        let writer = Writer::new(&psk);
+        Self {
+            inner: BufReader::with_capacity(V3_READ_BUFFER_SIZE, inner),
+            psk,
+            writer,
+            reader: ReaderState::NeedSalt {
+                salt_buf: [0u8; V3_SALT_SIZE],
+                salt_progress: 0,
+            },
+        }
+    }
+}
+
+impl<S> V3Conn<S> {
+    pub fn has_pending_write(&self) -> bool {
+        self.writer.pending_off < self.writer.pending.len()
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for V3Conn<S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        out: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        loop {
+            match &mut this.reader {
+                ReaderState::NeedSalt {
+                    salt_buf,
+                    salt_progress,
+                } => {
+                    let mut tmp = [0u8; V3_SALT_SIZE];
+                    let need = V3_SALT_SIZE - *salt_progress;
+                    let mut rb = ReadBuf::new(&mut tmp[..need]);
+                    match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Ready(Ok(())) => {}
+                    }
+                    let n = rb.filled().len();
+                    if n == 0 {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "snell v3 EOF before salt",
+                        )));
+                    }
+                    salt_buf[*salt_progress..*salt_progress + n].copy_from_slice(&tmp[..n]);
+                    *salt_progress += n;
+                    if *salt_progress < V3_SALT_SIZE {
+                        continue;
+                    }
+                    let aead = Arc::new(aes_gcm(&snell_kdf(&this.psk, &salt_buf[..], 16)));
+                    this.reader = ReaderState::ReadingHeader {
+                        aead,
+                        nonce: [0u8; V3_NONCE_SIZE],
+                        header_buf: [0u8; V3_LENGTH_CIPHER_SIZE],
+                        header_progress: 0,
+                    };
+                }
+                ReaderState::Drain {
+                    aead,
+                    nonce,
+                    payload,
+                    payload_off,
+                } => {
+                    let avail = &payload[*payload_off..];
+                    if avail.is_empty() {
+                        let aead = Arc::clone(aead);
+                        let nonce = *nonce;
+                        this.reader = ReaderState::ReadingHeader {
+                            aead,
+                            nonce,
+                            header_buf: [0u8; V3_LENGTH_CIPHER_SIZE],
+                            header_progress: 0,
+                        };
+                        continue;
+                    }
+                    let take = avail.len().min(out.remaining());
+                    out.put_slice(&avail[..take]);
+                    *payload_off += take;
+                    return Poll::Ready(Ok(()));
+                }
+                ReaderState::ReadingHeader {
+                    aead,
+                    nonce,
+                    header_buf,
+                    header_progress,
+                } => {
+                    let need = V3_LENGTH_CIPHER_SIZE - *header_progress;
+                    let mut tmp = [0u8; V3_LENGTH_CIPHER_SIZE];
+                    let mut rb = ReadBuf::new(&mut tmp[..need]);
+                    match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Ready(Ok(())) => {}
+                    }
+                    let n = rb.filled().len();
+                    if n == 0 {
+                        if *header_progress == 0 {
+                            return Poll::Ready(Ok(()));
+                        }
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "snell v3 EOF mid-header",
+                        )));
+                    }
+                    header_buf[*header_progress..*header_progress + n].copy_from_slice(&tmp[..n]);
+                    *header_progress += n;
+                    if *header_progress < V3_LENGTH_CIPHER_SIZE {
+                        continue;
+                    }
+                    let mut sealed = header_buf.to_vec();
+                    if let Err(e) = open_in_place(aead, nonce, &mut sealed) {
+                        return Poll::Ready(Err(e));
+                    }
+                    increment_nonce(nonce);
+                    if sealed.len() != V3_LENGTH_PLAIN_SIZE {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "snell v3 invalid length header",
+                        )));
+                    }
+                    let payload_len = usize::from(u16::from_be_bytes([sealed[0], sealed[1]]))
+                        & MAX_PAYLOAD_LENGTH;
+                    if payload_len == 0 {
+                        let aead_keep = Arc::clone(aead);
+                        let nonce_keep = *nonce;
+                        this.reader = ReaderState::ReadingHeader {
+                            aead: aead_keep,
+                            nonce: nonce_keep,
+                            header_buf: [0u8; V3_LENGTH_CIPHER_SIZE],
+                            header_progress: 0,
+                        };
+                        return Poll::Ready(Err(zero_chunk_err()));
+                    }
+                    let aead = Arc::clone(aead);
+                    let nonce = *nonce;
+                    this.reader = ReaderState::ReadingPayload {
+                        aead,
+                        nonce,
+                        payload_len,
+                        payload_buf: vec![0u8; payload_len + V3_GCM_TAG],
+                        payload_progress: 0,
+                    };
+                }
+                ReaderState::ReadingPayload {
+                    aead,
+                    nonce,
+                    payload_len,
+                    payload_buf,
+                    payload_progress,
+                } => {
+                    if *payload_progress < payload_buf.len() {
+                        let mut rb = ReadBuf::new(&mut payload_buf[*payload_progress..]);
+                        match Pin::new(&mut this.inner).poll_read(cx, &mut rb) {
+                            Poll::Pending => return Poll::Pending,
+                            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                            Poll::Ready(Ok(())) => {}
+                        }
+                        let n = rb.filled().len();
+                        if n == 0 {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "snell v3 EOF mid-payload",
+                            )));
+                        }
+                        *payload_progress += n;
+                        if *payload_progress < payload_buf.len() {
+                            continue;
+                        }
+                    }
+                    let mut payload = payload_buf.to_vec();
+                    if let Err(e) = open_in_place(aead, nonce, &mut payload) {
+                        return Poll::Ready(Err(e));
+                    }
+                    increment_nonce(nonce);
+                    debug_assert_eq!(payload.len(), *payload_len);
+                    let aead = Arc::clone(aead);
+                    let nonce = *nonce;
+                    this.reader = ReaderState::Drain {
+                        aead,
+                        nonce,
+                        payload,
+                        payload_off: 0,
+                    };
+                }
+            }
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for V3Conn<S> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = &mut *self;
+        if this.writer.pending_off < this.writer.pending.len() {
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {
+                    let consumed = std::mem::take(&mut this.writer.pending_input);
+                    return Poll::Ready(Ok(consumed));
+                }
+            }
+        }
+
+        if buf.is_empty() {
+            this.writer.pending_input = 0;
+            this.writer.stage_record(&[])?;
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(0)),
+            }
+        } else {
+            let take = buf.len().min(MAX_PAYLOAD_LENGTH);
+            this.writer.pending_input = take;
+            this.writer.stage_record(&buf[..take])?;
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {
+                    let consumed = std::mem::take(&mut this.writer.pending_input);
+                    Poll::Ready(Ok(consumed))
+                }
+            }
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        if this.writer.pending_off < this.writer.pending.len() {
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {}
+            }
+        }
+        Pin::new(&mut this.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        if this.writer.pending_off < this.writer.pending.len() {
+            match drain_writer(&mut this.writer, &mut this.inner, cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {}
+            }
+        }
+        Pin::new(&mut this.inner).poll_shutdown(cx)
+    }
+}
+
+fn drain_writer<S: AsyncWrite + Unpin>(
+    writer: &mut Writer,
+    inner: &mut S,
+    cx: &mut Context<'_>,
+) -> Poll<io::Result<()>> {
+    while writer.pending_off < writer.pending.len() {
+        let slice = &writer.pending[writer.pending_off..];
+        match Pin::new(&mut *inner).poll_write(cx, slice) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Ready(Ok(0)) => {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "snell v3: short write",
+                )));
+            }
+            Poll::Ready(Ok(n)) => writer.pending_off += n,
+        }
+    }
+    writer.pending.clear();
+    writer.pending_off = 0;
+    Poll::Ready(Ok(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn increment_nonce_wraps() {
+        let mut n = [0xFFu8; V3_NONCE_SIZE];
+        increment_nonce(&mut n);
+        assert_eq!(n, [0u8; V3_NONCE_SIZE]);
+    }
+
+    #[tokio::test]
+    async fn v3_round_trip_through_duplex() {
+        let (a, b) = tokio::io::duplex(1 << 18);
+        let psk: Arc<[u8]> = Arc::from(b"shared-secret".as_slice());
+        let mut alice = V3Conn::new(a, Arc::clone(&psk));
+        let mut bob = V3Conn::new(b, psk);
+
+        let small = b"hello-v3";
+        let large: Vec<u8> = (0..32_000u32).map(|i| (i % 251) as u8).collect();
+        let large_to_write = large.clone();
+
+        let writer = tokio::spawn(async move {
+            alice.write_all(small).await.unwrap();
+            alice.write_all(&large_to_write).await.unwrap();
+            alice.flush().await.unwrap();
+            alice
+        });
+
+        let mut got_small = vec![0u8; small.len()];
+        bob.read_exact(&mut got_small).await.unwrap();
+        assert_eq!(got_small, small);
+
+        let mut got_large = vec![0u8; 32_000];
+        bob.read_exact(&mut got_large).await.unwrap();
+        assert_eq!(got_large, large);
+
+        drop(writer.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn v3_zero_chunk_surfaces_as_tagged_error() {
+        let (a, b) = tokio::io::duplex(8192);
+        let psk: Arc<[u8]> = Arc::from(b"k".as_slice());
+        let mut alice = V3Conn::new(a, Arc::clone(&psk));
+        let mut bob = V3Conn::new(b, psk);
+
+        alice.write_all(b"abc").await.unwrap();
+        alice.flush().await.unwrap();
+        std::future::poll_fn(|cx| Pin::new(&mut alice).poll_write(cx, &[]))
+            .await
+            .unwrap();
+        alice.flush().await.unwrap();
+
+        let mut got = [0u8; 3];
+        bob.read_exact(&mut got).await.unwrap();
+        assert_eq!(&got, b"abc");
+
+        let mut scratch = [0u8; 1];
+        let err = bob.read(&mut scratch).await.unwrap_err();
+        assert!(is_zero_chunk(&err), "expected zero-chunk tag, got {err:?}");
+    }
+}

--- a/crates/meow-proxy/tests/snell_integration.rs
+++ b/crates/meow-proxy/tests/snell_integration.rs
@@ -1,17 +1,17 @@
 #![cfg(feature = "snell")]
 //! Integration tests for the Snell adapter.
 //!
-//! Uses an embedded mock Snell server: the v4 AEAD codec is symmetric (each
-//! direction sends its own salt and derives its own key), so `V4Conn::new`
-//! over an accepted `TcpStream` speaks the server side. No external binaries
-//! required.
+//! Uses embedded mock Snell servers: the AEAD codecs are symmetric (each
+//! direction sends its own salt and derives its own key), so wrapping an
+//! accepted `TcpStream` speaks the server side. No external binaries required.
 
 use meow_common::{MeowError, Metadata, Network, ProxyAdapter};
 use meow_proxy::snell::protocol::{
     write_header, AppError, Snell, COMMAND_CONNECT, COMMAND_CONNECT_V2, COMMAND_UDP,
     COMMAND_UDP_FORWARD, HEADER_VERSION, RESPONSE_ERROR, RESPONSE_TUNNEL,
 };
-use meow_proxy::snell::v4::{is_zero_chunk, V4Conn};
+use meow_proxy::snell::v3::{is_zero_chunk as is_v3_zero_chunk, V3Conn};
+use meow_proxy::snell::v4::{is_zero_chunk as is_v4_zero_chunk, V4Conn};
 use meow_proxy::snell::{SnellAdapter, SnellObfs, SnellVersion};
 use std::io::ErrorKind;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -67,11 +67,9 @@ impl MockServer {
     }
 }
 
-/// Emit a v4 zero-chunk (half-close) frame. `write_all(&[])` short-circuits
+/// Emit a Snell zero-chunk (half-close) frame. `write_all(&[])` short-circuits
 /// inside tokio without calling `poll_write`, so drive the poll by hand.
-async fn send_zero_chunk<S: AsyncRead + AsyncWrite + Unpin>(
-    conn: &mut V4Conn<S>,
-) -> std::io::Result<()> {
+async fn send_zero_chunk<S: AsyncRead + AsyncWrite + Unpin>(conn: &mut S) -> std::io::Result<()> {
     std::future::poll_fn(|cx| Pin::new(&mut *conn).poll_write(cx, &[])).await?;
     conn.flush().await
 }
@@ -83,7 +81,13 @@ async fn send_zero_chunk<S: AsyncRead + AsyncWrite + Unpin>(
 /// Runs inside a tokio-spawned task where panics would be swallowed, so
 /// protocol violations are reported as `Err(message)` and surfaced by
 /// [`MockServer::assert_no_violations`].
-async fn serve_udp_echo(conn: &mut V4Conn<TcpStream>) -> Result<(), String> {
+async fn serve_udp_echo<S>(
+    conn: &mut S,
+    is_zero_chunk: fn(&std::io::Error) -> bool,
+) -> Result<(), String>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let mut buf = vec![0u8; 64 * 1024];
     loop {
         let n = match conn.read(&mut buf).await {
@@ -137,9 +141,10 @@ async fn serve_udp_echo(conn: &mut V4Conn<TcpStream>) -> Result<(), String> {
 /// protocol violations are reported as `Err(message)` and surfaced by
 /// [`MockServer::assert_no_violations`].
 async fn serve_conn(
-    mut conn: V4Conn<TcpStream>,
+    mut conn: impl AsyncRead + AsyncWrite + Unpin,
     behavior: Behavior,
     requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    is_zero_chunk: fn(&std::io::Error) -> bool,
 ) -> Result<(), String> {
     loop {
         // Request header: [ver, cmd, client_id_len] then, for CONNECT
@@ -201,7 +206,7 @@ async fn serve_conn(
                     return Ok(());
                 }
                 if cmd == COMMAND_UDP {
-                    return serve_udp_echo(&mut conn).await;
+                    return serve_udp_echo(&mut conn, is_zero_chunk).await;
                 }
                 let mut buf = vec![0u8; 64 * 1024];
                 loop {
@@ -250,7 +255,44 @@ async fn start_mock_server(psk: &'static str, behavior: Behavior) -> MockServer 
             let requests_conn = Arc::clone(&requests_task);
             let violations_conn = Arc::clone(&violations_task);
             tokio::spawn(async move {
-                if let Err(violation) = serve_conn(conn, behavior, requests_conn).await {
+                if let Err(violation) =
+                    serve_conn(conn, behavior, requests_conn, is_v4_zero_chunk).await
+                {
+                    violations_conn.lock().unwrap().push(violation);
+                }
+            });
+        }
+    });
+    MockServer {
+        addr,
+        accepted,
+        requests,
+        violations,
+    }
+}
+
+async fn start_v3_mock_server(psk: &'static str, behavior: Behavior) -> MockServer {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accepted = Arc::new(AtomicUsize::new(0));
+    let requests: Arc<Mutex<Vec<RecordedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let violations: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let accepted_task = Arc::clone(&accepted);
+    let requests_task = Arc::clone(&requests);
+    let violations_task = Arc::clone(&violations);
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            accepted_task.fetch_add(1, Ordering::SeqCst);
+            let conn = V3Conn::new(stream, Arc::from(psk.as_bytes()));
+            let requests_conn = Arc::clone(&requests_task);
+            let violations_conn = Arc::clone(&violations_task);
+            tokio::spawn(async move {
+                if let Err(violation) =
+                    serve_conn(conn, behavior, requests_conn, is_v3_zero_chunk).await
+                {
                     violations_conn.lock().unwrap().push(violation);
                 }
             });
@@ -265,13 +307,23 @@ async fn start_mock_server(psk: &'static str, behavior: Behavior) -> MockServer 
 }
 
 fn make_adapter(server_port: u16, psk: &str, udp: bool, reuse: bool) -> SnellAdapter {
+    make_adapter_with_version(server_port, psk, SnellVersion::V4, udp, reuse)
+}
+
+fn make_adapter_with_version(
+    server_port: u16,
+    psk: &str,
+    version: SnellVersion,
+    udp: bool,
+    reuse: bool,
+) -> SnellAdapter {
     SnellAdapter::new(
         "snell-test",
         "127.0.0.1",
         server_port,
         psk,
         SnellObfs::None,
-        SnellVersion::V4,
+        version,
         udp,
         reuse,
     )
@@ -341,6 +393,36 @@ async fn tcp_connect_roundtrip_no_reuse() {
         assert_eq!(requests[0].host, "echo.example.com");
         assert_eq!(requests[0].port, 8080);
     }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn tcp_connect_roundtrip_v3_reuse_flag_ignored() {
+    let server = start_v3_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter_with_version(server.addr.port(), PSK, SnellVersion::V3, false, true);
+
+    let metadata = tcp_metadata("v3.example.com", 8443);
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial timed out")
+        .expect("dial failed");
+    roundtrip(&mut conn, b"hello snell v3").await;
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].cmd, COMMAND_CONNECT,
+            "Snell v3 must not use CommandConnectV2 even when reuse=true"
+        );
+        assert_eq!(requests[0].host, "v3.example.com");
+        assert_eq!(requests[0].port, 8443);
+    }
+    assert_eq!(
+        adapter.idle_pool_size(),
+        0,
+        "Snell v3 must not create a reuse pool"
+    );
     server.assert_no_violations();
 }
 
@@ -638,6 +720,46 @@ async fn udp_roundtrip_ipv4() {
 
     let dst: SocketAddr = "1.2.3.4:5353".parse().unwrap();
     let payload = b"dns-query-ipv4";
+    let n = timeout(TIMEOUT, pc.write_packet(payload, &dst))
+        .await
+        .expect("write_packet timed out")
+        .expect("write_packet failed");
+    assert_eq!(n, payload.len());
+
+    let mut buf = [0u8; 1500];
+    let (n, from) = timeout(TIMEOUT, pc.read_packet(&mut buf))
+        .await
+        .expect("read_packet timed out")
+        .expect("read_packet failed");
+    assert_eq!(&buf[..n], payload);
+    assert_eq!(from, dst, "echoed source address must round-trip");
+
+    {
+        let requests = server.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].cmd, COMMAND_UDP);
+    }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn udp_roundtrip_ipv4_v3() {
+    let server = start_v3_mock_server(PSK, Behavior::Echo).await;
+    let adapter = make_adapter_with_version(server.addr.port(), PSK, SnellVersion::V3, true, false);
+
+    let metadata = Metadata {
+        network: Network::Udp,
+        dst_ip: Some(IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4))),
+        dst_port: 53,
+        ..Default::default()
+    };
+    let pc = timeout(TIMEOUT, adapter.dial_udp(&metadata))
+        .await
+        .expect("dial_udp timed out")
+        .expect("dial_udp failed");
+
+    let dst: SocketAddr = "8.8.4.4:53".parse().unwrap();
+    let payload = b"dns-query-v3";
     let n = timeout(TIMEOUT, pc.write_packet(payload, &dst))
         .await
         .expect("write_packet timed out")

--- a/crates/meow-proxy/tests/snell_smoke.rs
+++ b/crates/meow-proxy/tests/snell_smoke.rs
@@ -4,90 +4,130 @@
 //! Example:
 //!
 //! ```bash
-//! SNELL_SMOKE=1 SNELL_SERVER=82.40.35.29:63689 SNELL_PSK=... \
+//! SNELL_SMOKE=1 SNELL_SERVER=82.40.35.29:63689 SNELL_PSK=... SNELL_VERSION=3 \
+//!     SNELL_OBFS_MODE=http SNELL_OBFS_HOST=/ \
 //!     cargo test -p meow-proxy --features snell --test snell_smoke -- --nocapture
 //! ```
 
 #![cfg(feature = "snell")]
 
-use meow_proxy::snell::protocol::{write_header, Snell};
-use std::io;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use meow_common::{Metadata, Network, ProxyAdapter};
+use meow_proxy::{SnellAdapter, SnellObfs, SnellVersion};
+use std::net::SocketAddr;
 use std::time::Duration;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
-use tokio::net::TcpStream;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 fn opt_env(key: &str) -> Option<String> {
     std::env::var(key).ok().filter(|v| !v.is_empty())
 }
 
-/// Transparent wrapper that prints every chunk of bytes that flows across
-/// the TCP stream in both directions. Useful for spotting wire-format bugs.
-struct Sniffer {
-    inner: TcpStream,
-    label: &'static str,
+fn split_server_addr(server_addr: &str) -> (&str, u16) {
+    let (host, port) = server_addr
+        .rsplit_once(':')
+        .expect("SNELL_SERVER must be host:port");
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    let port = port.parse().expect("SNELL_SERVER port must be a u16");
+    (host, port)
 }
 
-impl AsyncRead for Sniffer {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        let before = buf.filled().len();
-        match Pin::new(&mut self.inner).poll_read(cx, buf) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(e)) => {
-                eprintln!("[{}] READ ERR: {e}", self.label);
-                Poll::Ready(Err(e))
-            }
-            Poll::Ready(Ok(())) => {
-                let n = buf.filled().len() - before;
-                if n > 0 {
-                    let slice = &buf.filled()[before..];
-                    eprintln!(
-                        "[{}] READ {} bytes: {}",
-                        self.label,
-                        n,
-                        hex::encode(&slice[..slice.len().min(64)])
-                    );
-                } else {
-                    eprintln!("[{}] READ 0 (EOF)", self.label);
-                }
-                Poll::Ready(Ok(()))
-            }
-        }
+fn parse_version() -> SnellVersion {
+    match opt_env("SNELL_VERSION")
+        .unwrap_or_else(|| "4".to_string())
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "3" | "v3" => SnellVersion::V3,
+        "4" | "v4" => SnellVersion::V4,
+        "5" | "v5" => SnellVersion::V5,
+        other => panic!("SNELL_VERSION must be 3, 4, or 5; got {other}"),
     }
 }
 
-impl AsyncWrite for Sniffer {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        match Pin::new(&mut self.inner).poll_write(cx, buf) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Ready(Ok(n)) => {
-                eprintln!(
-                    "[{}] WRITE {} bytes: {}",
-                    self.label,
-                    n,
-                    hex::encode(&buf[..n.min(64)])
-                );
-                Poll::Ready(Ok(n))
-            }
-        }
+fn parse_obfs(server_host: &str) -> SnellObfs {
+    let mode = opt_env("SNELL_OBFS_MODE")
+        .unwrap_or_else(|| "off".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    let host = opt_env("SNELL_OBFS_HOST").unwrap_or_else(|| server_host.to_string());
+    match mode.as_str() {
+        "" | "off" | "none" => SnellObfs::None,
+        "http" => SnellObfs::Http { host },
+        "tls" => SnellObfs::Tls { server: host },
+        other => panic!("SNELL_OBFS_MODE must be off, http, or tls; got {other}"),
     }
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
+}
+
+fn bool_env(key: &str, default: bool) -> bool {
+    opt_env(key).map_or(default, |v| {
+        matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+    })
+}
+
+fn dns_query_for_example_com() -> Vec<u8> {
+    let mut query = Vec::with_capacity(29);
+    query.extend_from_slice(&[
+        0x4d, 0x57, // ID
+        0x01, 0x00, // standard recursive query
+        0x00, 0x01, // QDCOUNT
+        0x00, 0x00, // ANCOUNT
+        0x00, 0x00, // NSCOUNT
+        0x00, 0x00, // ARCOUNT
+    ]);
+    query.push(7);
+    query.extend_from_slice(b"example");
+    query.push(3);
+    query.extend_from_slice(b"com");
+    query.push(0);
+    query.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]); // A, IN
+    query
+}
+
+fn assert_dns_response(buf: &[u8]) {
+    assert!(
+        buf.len() >= 12,
+        "DNS response too short: {} bytes",
+        buf.len()
+    );
+    assert_eq!(&buf[..2], &[0x4d, 0x57], "DNS response ID mismatch");
+    assert_ne!(buf[2] & 0x80, 0, "DNS response QR bit not set");
+}
+
+async fn verify_udp(adapter: &SnellAdapter) {
+    let target: SocketAddr = opt_env("SNELL_UDP_TARGET")
+        .unwrap_or_else(|| "1.1.1.1:53".to_string())
+        .parse()
+        .expect("SNELL_UDP_TARGET must be a SocketAddr");
+    eprintln!("snell smoke: sending UDP DNS query via Snell to {target}");
+
+    let metadata = Metadata {
+        network: Network::Udp,
+        ..Default::default()
+    };
+    let packet_conn = tokio::time::timeout(Duration::from_secs(10), adapter.dial_udp(&metadata))
+        .await
+        .expect("snell udp dial timeout")
+        .expect("snell udp dial ok");
+
+    let query = dns_query_for_example_com();
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        packet_conn.write_packet(&query, &target),
+    )
+    .await
+    .expect("snell udp write timeout")
+    .expect("snell udp write ok");
+
+    let mut buf = [0u8; 1500];
+    let (n, from) =
+        tokio::time::timeout(Duration::from_secs(10), packet_conn.read_packet(&mut buf))
+            .await
+            .expect("snell udp read timeout")
+            .expect("snell udp read ok");
+    eprintln!("snell smoke: UDP response {n} bytes from {from}");
+    assert_eq!(from.port(), target.port(), "UDP response port mismatch");
+    assert_dns_response(&buf[..n]);
+    packet_conn.close().expect("snell udp close ok");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -99,6 +139,11 @@ async fn snell_dial_real_server() {
     let server_addr =
         opt_env("SNELL_SERVER").expect("SNELL_SERVER (host:port) required when SNELL_SMOKE=1");
     let psk = opt_env("SNELL_PSK").expect("SNELL_PSK required when SNELL_SMOKE=1");
+    let (server_host, server_port) = split_server_addr(&server_addr);
+    let version = parse_version();
+    let obfs = parse_obfs(server_host);
+    let udp = bool_env("SNELL_UDP", false);
+    let reuse = bool_env("SNELL_REUSE", false);
 
     let target_host = opt_env("SNELL_TARGET_HOST").unwrap_or_else(|| "httpbin.org".to_string());
     let target_port: u16 = opt_env("SNELL_TARGET_PORT")
@@ -106,42 +151,48 @@ async fn snell_dial_real_server() {
         .unwrap_or(80);
     let target_path = opt_env("SNELL_TARGET_PATH").unwrap_or_else(|| "/ip".to_string());
 
-    eprintln!("snell smoke: dialing {target_host}:{target_port} via {server_addr} (reuse=false)");
+    eprintln!(
+        "snell smoke: dialing {target_host}:{target_port} via {server_addr} \
+         (version={} udp={udp} reuse={reuse})",
+        version.as_str()
+    );
 
-    let tcp = tokio::time::timeout(Duration::from_secs(8), TcpStream::connect(&server_addr))
-        .await
-        .expect("tcp connect timeout")
-        .expect("tcp connect ok");
-    tcp.set_nodelay(true).ok();
-    let sniffer = Sniffer {
-        inner: tcp,
-        label: "snell-tcp",
+    let adapter = SnellAdapter::new(
+        "snell-smoke",
+        server_host,
+        server_port,
+        &psk,
+        obfs,
+        version,
+        udp,
+        reuse,
+    )
+    .expect("snell adapter config");
+    let metadata = Metadata {
+        network: Network::Tcp,
+        host: target_host.clone().into(),
+        dst_port: target_port,
+        ..Default::default()
     };
-
-    let mut snell = Snell::new(sniffer, Arc::from(psk.as_bytes()));
-
-    // Snell CONNECT request (reuse=false).
-    write_header(&mut snell, &target_host, target_port, false)
+    let mut conn = tokio::time::timeout(Duration::from_secs(10), adapter.dial_tcp(&metadata))
         .await
-        .expect("write snell header");
-    snell.flush().await.expect("flush snell header");
+        .expect("snell dial timeout")
+        .expect("snell dial ok");
 
     // HTTP/1.0 GET.
     let request =
         format!("GET {target_path} HTTP/1.0\r\nHost: {target_host}\r\nConnection: close\r\n\r\n");
-    snell
-        .write_all(request.as_bytes())
+    conn.write_all(request.as_bytes())
         .await
         .expect("write http req");
-    snell.flush().await.expect("flush http req");
+    conn.flush().await.expect("flush http req");
 
     // Read up to 4 KiB; we read in a loop so a mid-stream snell error
     // doesn't discard the bytes we already have.
     let mut buf = Vec::with_capacity(4096);
     let mut scratch = [0u8; 1024];
     loop {
-        let n = match tokio::time::timeout(Duration::from_secs(10), snell.read(&mut scratch)).await
-        {
+        let n = match tokio::time::timeout(Duration::from_secs(10), conn.read(&mut scratch)).await {
             Err(_) => {
                 eprintln!("read timed out after {} bytes", buf.len());
                 break;
@@ -170,4 +221,8 @@ async fn snell_dial_real_server() {
         "expected HTTP response head, got: {:?}",
         &head[..head.len().min(80)]
     );
+
+    if udp && bool_env("SNELL_VALIDATE_UDP", false) {
+        verify_udp(&adapter).await;
+    }
 }


### PR DESCRIPTION
## Summary

- Add a Snell v3 AEAD stream codec and wire it through the Snell adapter/protocol layer.
- Accept `version: 3` / `v3` in `type: snell` configs while keeping v4/v5 reuse semantics unchanged.
- Document Snell support in `README.md` and extend integration/smoke coverage for v3, obfs, TCP, and UDP-over-TCP framing.

## Why

Snell v3 is still widely used in existing user configs and subscriptions. Surge also tried removing v3 support and ultimately added it back, which is a practical signal that v3 compatibility still matters for real users.

## Validation

- `cargo fmt -- --check`
- `cargo test -p meow-proxy --features snell --lib`
- `cargo test -p meow-proxy --features snell --test snell_integration`
- `cargo test -p meow-proxy --features snell --test snell_smoke -- --nocapture`
- Real server TCP smoke with the provided Snell v3 + HTTP obfs config (`dialer-proxy` omitted): `example.com:80` returned `HTTP/1.1 200 OK`
- Real-server validation used the `geekdada/snell-server` Docker image: https://hub.docker.com/r/geekdada/snell-server/
- v3 UDP-over-TCP passes embedded mock integration; public DNS UDP smoke against the provided server timed out waiting for a response
- `cargo test -p meow-config --features snell --lib`
- `cargo clippy -p meow-proxy --features snell --all-targets`
- `cargo clippy -p meow-config --features snell --all-targets`
- `git diff --check`