### PR TITLE
feat(udp): expose UdpSession::touch/idle_for for out-of-crate reply readers

### DIFF
--- a/crates/meow-tunnel/src/udp.rs
+++ b/crates/meow-tunnel/src/udp.rs
@@ -37,12 +37,20 @@ impl UdpSession {
         }
     }
 
-    fn touch(&self) {
+    /// Mark the session active as of now. Called on every outbound fast-path
+    /// forward so [`spawn_nat_sweeper`] keeps the entry alive. `pub` so an
+    /// out-of-crate reply reader (e.g. the meow-ios FFI, which owns the
+    /// inbound read loop) can refresh the same clock on server→app traffic —
+    /// otherwise a receive-active / send-quiet session is wrongly swept.
+    pub fn touch(&self) {
         self.last_activity_ms
             .store(monotonic_ms(), Ordering::Relaxed);
     }
 
-    fn idle_for(&self) -> Duration {
+    /// Time since the last [`touch`](Self::touch). `pub` so an out-of-crate
+    /// reply reader can gate its own idle backstop on the same bidirectional
+    /// clock the sweeper uses, instead of a one-directional wall-clock timer.
+    pub fn idle_for(&self) -> Duration {
         let now = monotonic_ms();
         let last = self.last_activity_ms.load(Ordering::Relaxed);
         Duration::from_millis(now.saturating_sub(last))


### PR DESCRIPTION
## Summary

Makes `UdpSession::touch()` and `UdpSession::idle_for()` `pub` so an out-of-crate reply reader (the meow-ios FFI, which owns the UDP inbound read loop) can refresh the same NAT idle clock the sweeper uses.

## Problem

The meow-ios FFI owns the UDP inbound read loop — its reply reader holds its own `Arc<UdpSession>` and reads `session.conn` directly — but `touch()` / `idle_for()` were private. So the FFI could not refresh the NAT idle clock on inbound replies, leaving the sweeper's clock **outbound-only**: a receive-active / send-quiet session (e.g. a game in spectator/lobby state) got swept at 60s even while data was still flowing, and the FFI's own backstop diverged from the sweeper.

## Change

Make both methods `pub` (no behavioural change inside meow-tunnel). The FFI calls `session.touch()` on each inbound reply and gates its idle backstop on `idle_for()`, keeping a single bidirectional clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)