### PR TITLE
fix(dns): strip ipv4hint/ipv6hint from HTTPS/SVCB answers in fake-ip mode

### DIFF
--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -899,6 +899,28 @@ impl Resolver {
         self.cache.reverse_lookup(ip)
     }
 
+    /// True when fake-IP synthesis applies to `host` — i.e. its A/AAAA
+    /// answers will be synthetic. Mirrors the gating in [`Self::lookup_ipv4`] /
+    /// [`Self::lookup_ipv6`]: fake-IP mode, at least one pool configured, the
+    /// host is not an explicit hosts-trie mapping, and the skipper does not
+    /// bypass it.
+    ///
+    /// The DNS server uses this to strip `ipv4hint` / `ipv6hint` SvcParams
+    /// from HTTPS/SVCB answers for the same host. Those hints carry the
+    /// origin's *real* addresses; an HTTP/3 client that reads them connects
+    /// straight to the real IP, bypassing the fake-IP mapping the tunnel
+    /// relies on for domain-based routing and sniffing.
+    pub fn fake_ip_active_for(&self, host: &str) -> bool {
+        if self.mode != DnsMode::FakeIp {
+            return false;
+        }
+        // Explicit hosts-trie mappings are never rewritten to fake IPs.
+        if self.use_hosts && self.hosts.search(host).is_some() {
+            return false;
+        }
+        (self.fakeip_v4.is_some() || self.fakeip_v6.is_some()) && !self.skipper_bypasses(host)
+    }
+
     /// True if `ip` is an active fake-IP allocation (either family).
     pub fn is_fake_ip(&self, ip: IpAddr) -> bool {
         if let Some(pool) = &self.fakeip_v4 {
@@ -982,6 +1004,41 @@ mod tests {
             .cache
             .put("cached.test", &[real], Duration::from_secs(60));
         assert_eq!(resolver.resolve_ip("cached.test").await, Some(real));
+    }
+
+    #[test]
+    fn fake_ip_active_for_gates_on_mode_pool_and_skipper() {
+        use crate::fakeip::{MemoryStore, SkipperMode};
+
+        let new_hosts = || -> DomainTrie<Vec<IpAddr>> { DomainTrie::new() };
+
+        // Normal mode: never active.
+        let normal = Resolver::new(vec![], vec![], DnsMode::Normal, new_hosts(), true);
+        assert!(!normal.fake_ip_active_for("example.com"));
+
+        // Fake-IP mode but no pool configured: not active.
+        let no_pool = Resolver::new(vec![], vec![], DnsMode::FakeIp, new_hosts(), true);
+        assert!(!no_pool.fake_ip_active_for("example.com"));
+
+        // Fake-IP mode with a v4 pool: active.
+        let mut faked = Resolver::new(vec![], vec![], DnsMode::FakeIp, new_hosts(), true);
+        let pool = Arc::new(
+            Pool::new(
+                "198.18.0.0/16".parse().unwrap(),
+                Arc::new(MemoryStore::new(1024)),
+            )
+            .unwrap(),
+        );
+        faked.set_fakeip_v4(pool);
+        assert!(faked.fake_ip_active_for("example.com"));
+
+        // A skipper-bypassed host falls back to real resolution → not faked.
+        faked.set_fakeip_skipper(Skipper::new(
+            &["+.direct.example".to_string()],
+            SkipperMode::BlackList,
+        ));
+        assert!(!faked.fake_ip_active_for("api.direct.example"));
+        assert!(faked.fake_ip_active_for("example.com"));
     }
 
     #[test]

--- a/crates/meow-dns/src/server.rs
+++ b/crates/meow-dns/src/server.rs
@@ -1,6 +1,6 @@
 use crate::resolver::Resolver;
 use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
-use hickory_proto::rr::RecordType;
+use hickory_proto::rr::{Record, RecordType};
 use meow_common::DnsMode;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -182,8 +182,17 @@ impl DnsServer {
         match lookup {
             Some(l) => {
                 resp.metadata.response_code = ResponseCode::NoError;
+                // In fake-IP mode, drop ipv4hint/ipv6hint from HTTPS/SVCB
+                // answers for faked hosts so an HTTP/3 client cannot read a
+                // real origin IP out of the hint and bypass the fake-IP
+                // routing the tunnel depends on.
+                let strip_hints = resolver.fake_ip_active_for(domain);
                 for rec in &l.answers {
-                    resp.add_answer(rec.clone());
+                    if strip_hints {
+                        resp.add_answer(strip_svc_ip_hints(rec));
+                    } else {
+                        resp.add_answer(rec.clone());
+                    }
                 }
             }
             None => {
@@ -371,6 +380,38 @@ impl DnsServer {
     }
 }
 
+/// Return a copy of `rec` with `ipv4hint` / `ipv6hint` SvcParams removed when
+/// it is an HTTPS or SVCB record; any other record type is cloned unchanged.
+///
+/// Used only in fake-IP mode (see [`Resolver::fake_ip_active_for`]). Those
+/// hints carry the origin's real addresses; stripping them forces an HTTP/3
+/// client back onto the A/AAAA records, which return fake IPs, so the
+/// connection stays inside fake-IP routing. All other SvcParams (alpn, port,
+/// ech, …) are preserved. Mirrors upstream mihomo's fake-IP HTTPS handling.
+fn strip_svc_ip_hints(rec: &Record) -> Record {
+    use hickory_proto::rr::rdata::svcb::{SvcParamKey, SVCB};
+    use hickory_proto::rr::rdata::HTTPS;
+    use hickory_proto::rr::RData;
+
+    fn strip(svcb: &SVCB) -> SVCB {
+        let params = svcb
+            .svc_params
+            .iter()
+            .filter(|(k, _)| !matches!(k, SvcParamKey::Ipv4Hint | SvcParamKey::Ipv6Hint))
+            .cloned()
+            .collect();
+        SVCB::new(svcb.svc_priority, svcb.target_name.clone(), params)
+    }
+
+    let new_rdata = match &rec.data {
+        RData::HTTPS(https) => RData::HTTPS(HTTPS(strip(&https.0))),
+        RData::SVCB(svcb) => RData::SVCB(strip(svcb)),
+        // Not an HTTPS/SVCB record (e.g. a CNAME in the chain) — leave intact.
+        _ => return rec.clone(),
+    };
+    Record::from_rdata(rec.name.clone(), rec.ttl, new_rdata)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,6 +434,69 @@ mod tests {
         q.extend_from_slice(&qtype.to_be_bytes()); // QTYPE
         q.extend_from_slice(&[0x00, 0x01]); // QCLASS IN
         q
+    }
+
+    fn https_record_with_hints() -> Record {
+        use hickory_proto::rr::rdata::svcb::{Alpn, IpHint, SvcParamKey, SvcParamValue, SVCB};
+        use hickory_proto::rr::rdata::{A, AAAA, HTTPS};
+        use hickory_proto::rr::{Name, RData};
+        use std::str::FromStr;
+
+        let params = vec![
+            (
+                SvcParamKey::Alpn,
+                SvcParamValue::Alpn(Alpn(vec!["h3".to_string(), "h2".to_string()])),
+            ),
+            (SvcParamKey::Port, SvcParamValue::Port(443)),
+            (
+                SvcParamKey::Ipv4Hint,
+                SvcParamValue::Ipv4Hint(IpHint(vec![A::new(1, 2, 3, 4)])),
+            ),
+            (
+                SvcParamKey::Ipv6Hint,
+                SvcParamValue::Ipv6Hint(IpHint(vec![AAAA::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)])),
+            ),
+        ];
+        let name = Name::from_str("example.com.").unwrap();
+        let svcb = SVCB::new(1, name.clone(), params);
+        Record::from_rdata(name, 300, RData::HTTPS(HTTPS(svcb)))
+    }
+
+    #[test]
+    fn strip_hints_drops_ip_hints_keeps_alpn_and_port() {
+        use hickory_proto::rr::rdata::svcb::SvcParamKey;
+        use hickory_proto::rr::RData;
+
+        let stripped = strip_svc_ip_hints(&https_record_with_hints());
+        let RData::HTTPS(https) = &stripped.data else {
+            panic!("expected HTTPS rdata");
+        };
+        let keys: Vec<&SvcParamKey> = https.0.svc_params.iter().map(|(k, _)| k).collect();
+        assert!(
+            !keys.contains(&&SvcParamKey::Ipv4Hint),
+            "ipv4hint must be stripped"
+        );
+        assert!(
+            !keys.contains(&&SvcParamKey::Ipv6Hint),
+            "ipv6hint must be stripped"
+        );
+        assert!(keys.contains(&&SvcParamKey::Alpn), "alpn must be preserved");
+        assert!(keys.contains(&&SvcParamKey::Port), "port must be preserved");
+    }
+
+    #[test]
+    fn strip_hints_passes_through_non_svc_records() {
+        use hickory_proto::rr::rdata::A;
+        use hickory_proto::rr::{Name, RData};
+        use std::str::FromStr;
+
+        let rec = Record::from_rdata(
+            Name::from_str("example.com.").unwrap(),
+            300,
+            RData::A(A::new(93, 184, 216, 34)),
+        );
+        let out = strip_svc_ip_hints(&rec);
+        assert_eq!(out, rec, "non-HTTPS/SVCB records must be unchanged");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In fake-ip mode, A/AAAA queries return synthetic IPs so the tunnel can route and sniff by domain. But **type-65 (HTTPS) / type-64 (SVCB)** queries took the generic forward path (`server.rs` → `handle_generic_forward`) and were re-emitted **verbatim** — so the answer still carried the origin's *real* addresses in its `ipv4hint` / `ipv6hint` SvcParams.

An HTTP/3-capable client (Chrome, Safari) reads those hints and connects **straight to the real IP**, bypassing the fake-IP mapping entirely. Domain-based rule matching, DNS snooping, and proxy selection all silently break — for exactly the dual-stack HTTP/3 origins. Same leak family as the QUIC direct-UDP fix (#214); the `alpn=h3` SvcParam is also what advertises HTTP/3 in the first place.

## Fix

- Add `Resolver::fake_ip_active_for(host)`, mirroring the `lookup_ipv4`/`lookup_ipv6` gating: fake-ip mode + at least one pool configured + host is not an explicit hosts-trie mapping + skipper does not bypass it.
- In `handle_generic_forward`, when that returns true, drop the `Ipv4Hint`/`Ipv6Hint` SvcParams from HTTPS/SVCB answers (keeping `alpn`, `port`, `ech`, …) so the client falls back to the A/AAAA records — which return fake IPs. Other record types pass through unchanged.

Mirrors upstream mihomo's fake-IP HTTPS handling.

## Tests

- `strip_hints_drops_ip_hints_keeps_alpn_and_port`
- `strip_hints_passes_through_non_svc_records`
- `fake_ip_active_for_gates_on_mode_pool_and_skipper`

Regression bar green: `cargo fmt --check`, three-way `clippy -D warnings`, `cargo doc -D warnings`, `cargo test --lib` (697 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)