### PR TITLE
fix(dns): dual-stack-correct fake-ip HTTPS/SVCB handling + RFC 9460 mandatory scrub (ADR-0013)

### DIFF
--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -1041,6 +1041,62 @@ mod tests {
         assert!(faked.fake_ip_active_for("example.com"));
     }
 
+    /// Dual-stack contract that the stripped-HTTPS path relies on: with the
+    /// IP hints removed, the client falls back to A/AAAA, so the per-family
+    /// fake synthesis must do the right thing for each pool configuration.
+    #[tokio::test]
+    async fn fake_ip_dual_stack_synthesis_is_per_family() {
+        use crate::fakeip::MemoryStore;
+
+        let v4_pool = || {
+            Arc::new(
+                Pool::new(
+                    "198.18.0.0/16".parse().unwrap(),
+                    Arc::new(MemoryStore::new(1024)),
+                )
+                .unwrap(),
+            )
+        };
+
+        // v4-only pool (the common default): A synthesises a v4 fake; AAAA is
+        // suppressed (None → server emits NOERROR-empty) so a dual-stack
+        // client cleanly falls back to the v4 fake instead of stalling.
+        let mut v4_only = Resolver::new(vec![], vec![], DnsMode::FakeIp, DomainTrie::new(), true);
+        v4_only.set_fakeip_v4(v4_pool());
+        let a = v4_only.lookup_ipv4("example.com").await;
+        assert!(
+            a.is_some_and(|ip| ip.is_ipv4() && v4_only.is_fake_ip(ip)),
+            "A must return a v4 fake IP"
+        );
+        assert_eq!(
+            v4_only.lookup_ipv6("example.com").await,
+            None,
+            "v4-only pool must suppress AAAA so the client uses the v4 fake"
+        );
+
+        // Dual pool: both families synthesise → Happy Eyeballs picks between
+        // two fakes, both of which route through the tunnel.
+        let mut dual = Resolver::new(vec![], vec![], DnsMode::FakeIp, DomainTrie::new(), true);
+        dual.set_fakeip_v4(v4_pool());
+        dual.set_fakeip_v6(Arc::new(
+            Pool::new(
+                "fc00::/64".parse().unwrap(),
+                Arc::new(MemoryStore::new(1024)),
+            )
+            .unwrap(),
+        ));
+        let a = dual.lookup_ipv4("example.com").await;
+        let aaaa = dual.lookup_ipv6("example.com").await;
+        assert!(
+            a.is_some_and(|ip| ip.is_ipv4() && dual.is_fake_ip(ip)),
+            "A must return a v4 fake IP"
+        );
+        assert!(
+            aaaa.is_some_and(|ip| ip.is_ipv6() && dual.is_fake_ip(ip)),
+            "AAAA must return a v6 fake IP when a v6 pool is configured"
+        );
+    }
+
     #[test]
     fn clamp_ttl_zero_returns_min() {
         assert_eq!(clamp_ttl(Duration::ZERO), Duration::from_secs(10));

--- a/crates/meow-dns/src/server.rs
+++ b/crates/meow-dns/src/server.rs
@@ -387,19 +387,47 @@ impl DnsServer {
 /// hints carry the origin's real addresses; stripping them forces an HTTP/3
 /// client back onto the A/AAAA records, which return fake IPs, so the
 /// connection stays inside fake-IP routing. All other SvcParams (alpn, port,
-/// ech, …) are preserved. Mirrors upstream mihomo's fake-IP HTTPS handling.
+/// ech, …) are preserved so HTTP/3 and ECH keep working — a deliberate, more
+/// surgical divergence from upstream mihomo, which returns an empty answer.
+/// See ADR-0013 for the dual-stack correctness analysis.
 fn strip_svc_ip_hints(rec: &Record) -> Record {
-    use hickory_proto::rr::rdata::svcb::{SvcParamKey, SVCB};
+    use hickory_proto::rr::rdata::svcb::{Mandatory, SvcParamKey, SvcParamValue, SVCB};
     use hickory_proto::rr::rdata::HTTPS;
     use hickory_proto::rr::RData;
 
+    fn is_hint(k: SvcParamKey) -> bool {
+        matches!(k, SvcParamKey::Ipv4Hint | SvcParamKey::Ipv6Hint)
+    }
+
     fn strip(svcb: &SVCB) -> SVCB {
-        let params = svcb
-            .svc_params
-            .iter()
-            .filter(|(k, _)| !matches!(k, SvcParamKey::Ipv4Hint | SvcParamKey::Ipv6Hint))
-            .cloned()
-            .collect();
+        let mut params = Vec::with_capacity(svcb.svc_params.len());
+        for (key, value) in &svcb.svc_params {
+            // Drop the address hints themselves.
+            if is_hint(*key) {
+                continue;
+            }
+            // RFC 9460 §8: a key listed in `mandatory` that is absent from the
+            // RR makes the whole record malformed, so the client discards it —
+            // which would take the `alpn` (HTTP/3) and `ech` params we want to
+            // keep with it. Scrub the hint keys out of the mandatory list, and
+            // drop `mandatory` entirely if nothing else remains (an empty
+            // mandatory list is itself malformed).
+            if let (SvcParamKey::Mandatory, SvcParamValue::Mandatory(Mandatory(keys))) =
+                (key, value)
+            {
+                let kept: Vec<SvcParamKey> =
+                    keys.iter().copied().filter(|k| !is_hint(*k)).collect();
+                if kept.is_empty() {
+                    continue;
+                }
+                params.push((
+                    SvcParamKey::Mandatory,
+                    SvcParamValue::Mandatory(Mandatory(kept)),
+                ));
+                continue;
+            }
+            params.push((*key, value.clone()));
+        }
         SVCB::new(svcb.svc_priority, svcb.target_name.clone(), params)
     }
 
@@ -482,6 +510,104 @@ mod tests {
         );
         assert!(keys.contains(&&SvcParamKey::Alpn), "alpn must be preserved");
         assert!(keys.contains(&&SvcParamKey::Port), "port must be preserved");
+    }
+
+    #[test]
+    fn strip_hints_preserves_ech_and_scrubs_mandatory_list() {
+        use hickory_proto::rr::rdata::svcb::{
+            Alpn, EchConfigList, IpHint, Mandatory, SvcParamKey, SvcParamValue, SVCB,
+        };
+        use hickory_proto::rr::rdata::{A, AAAA, HTTPS};
+        use hickory_proto::rr::{Name, RData};
+        use std::str::FromStr;
+
+        // `mandatory` lists ipv4hint, so a naive strip would leave a dangling
+        // mandatory key → malformed RR → client discards it, losing ech (which
+        // is only ever delivered via the HTTPS record). Verify we scrub it.
+        let params = vec![
+            (
+                SvcParamKey::Mandatory,
+                SvcParamValue::Mandatory(Mandatory(vec![SvcParamKey::Alpn, SvcParamKey::Ipv4Hint])),
+            ),
+            (
+                SvcParamKey::Alpn,
+                SvcParamValue::Alpn(Alpn(vec!["h3".to_string()])),
+            ),
+            (
+                SvcParamKey::EchConfigList,
+                SvcParamValue::EchConfigList(EchConfigList(vec![0xab, 0xcd])),
+            ),
+            (
+                SvcParamKey::Ipv4Hint,
+                SvcParamValue::Ipv4Hint(IpHint(vec![A::new(1, 2, 3, 4)])),
+            ),
+            (
+                SvcParamKey::Ipv6Hint,
+                SvcParamValue::Ipv6Hint(IpHint(vec![AAAA::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)])),
+            ),
+        ];
+        let name = Name::from_str("example.com.").unwrap();
+        let rec = Record::from_rdata(
+            name.clone(),
+            300,
+            RData::HTTPS(HTTPS(SVCB::new(1, name, params))),
+        );
+
+        let RData::HTTPS(https) = &strip_svc_ip_hints(&rec).data else {
+            panic!("expected HTTPS rdata");
+        };
+        let p = &https.0.svc_params;
+
+        // Hints gone.
+        assert!(!p.iter().any(|(k, _)| *k == SvcParamKey::Ipv4Hint));
+        assert!(!p.iter().any(|(k, _)| *k == SvcParamKey::Ipv6Hint));
+        // ECH and ALPN preserved — the whole point of not returning empty.
+        assert!(p.iter().any(|(k, _)| *k == SvcParamKey::EchConfigList));
+        assert!(p.iter().any(|(k, _)| *k == SvcParamKey::Alpn));
+        // `mandatory` survives but with the stripped hint scrubbed out, so the
+        // record stays well-formed (mandatory = [alpn] only).
+        let mandatory = p
+            .iter()
+            .find_map(|(k, v)| match (k, v) {
+                (SvcParamKey::Mandatory, SvcParamValue::Mandatory(Mandatory(keys))) => Some(keys),
+                _ => None,
+            })
+            .expect("mandatory must remain");
+        assert_eq!(mandatory, &vec![SvcParamKey::Alpn]);
+    }
+
+    #[test]
+    fn strip_hints_drops_mandatory_when_only_hints_were_mandatory() {
+        use hickory_proto::rr::rdata::svcb::{IpHint, Mandatory, SvcParamKey, SvcParamValue, SVCB};
+        use hickory_proto::rr::rdata::{A, HTTPS};
+        use hickory_proto::rr::{Name, RData};
+        use std::str::FromStr;
+
+        let params = vec![
+            (
+                SvcParamKey::Mandatory,
+                SvcParamValue::Mandatory(Mandatory(vec![SvcParamKey::Ipv4Hint])),
+            ),
+            (
+                SvcParamKey::Ipv4Hint,
+                SvcParamValue::Ipv4Hint(IpHint(vec![A::new(1, 2, 3, 4)])),
+            ),
+        ];
+        let name = Name::from_str("example.com.").unwrap();
+        let rec = Record::from_rdata(
+            name.clone(),
+            300,
+            RData::HTTPS(HTTPS(SVCB::new(1, name, params))),
+        );
+
+        let RData::HTTPS(https) = &strip_svc_ip_hints(&rec).data else {
+            panic!("expected HTTPS rdata");
+        };
+        // An empty mandatory list is itself malformed, so it must be dropped.
+        assert!(
+            https.0.svc_params.is_empty(),
+            "mandatory must be removed when only hint keys were listed"
+        );
     }
 
     #[test]

--- a/docs/adr/0013-fakeip-https-svcb-handling.md
+++ b/docs/adr/0013-fakeip-https-svcb-handling.md
@@ -1,0 +1,138 @@
+# ADR 0013: HTTPS/SVCB record handling in fake-IP mode (dual-stack)
+
+- **Status:** Accepted
+- **Date:** 2026-06-15
+- **Author:** Claude (on behalf of @madeye)
+- **Related:** PR #214 (direct UDP reply socket address family / QUIC), PR #215 (initial hint stripping), RFC 9460
+
+## Context
+
+Fake-IP mode hands clients a synthetic IP per hostname so the tunnel can route
+and sniff by **domain** rather than by destination IP. The reverse map
+(fake IP → host) only exists because the client was *forced* to connect to an
+address we control.
+
+DNS `HTTPS` (type 65) and `SVCB` (type 64) records (RFC 9460) break that
+assumption. Their `ipv4hint` / `ipv6hint` SvcParams carry the origin's **real**
+addresses, and an RFC 9460 client may connect straight to a hint address
+without ever querying A/AAAA. On a dual-stack network the client runs Happy
+Eyeballs across whatever families it can derive — so a leaked hint lets HTTP/3
+(`alpn=h3`) traffic bypass fake-IP entirely: no domain-based rule match, no
+sniffing, and on iOS the flow may not even traverse the tunnel correctly. This
+is the same leak family as the QUIC direct-UDP bug fixed in PR #214.
+
+Before this work, type-65/64 queries took the generic forward path and were
+re-emitted **verbatim**, hints intact.
+
+### What the reference implementation does
+
+Upstream mihomo returns an **empty answer** for these records in fake-IP mode:
+
+```go
+case D.TypeSVCB, D.TypeHTTPS:
+    return handleMsgWithEmptyAnswer(r), nil
+```
+
+This is correct for routing but blunt: it discards the **entire** record,
+including two params that have nothing to do with addressing —
+
+- `alpn` (e.g. `h3`): the client loses its DNS-level signal to try HTTP/3 on
+  the first flight and must rediscover it via an `Alt-Svc` response header.
+- `ech` (Encrypted ClientHello config): **only ever delivered via the
+  HTTPS/SVCB record.** Returning empty disables ECH for every fake-IP user.
+
+### RFC 9460 client behaviour (the dual-stack pivot)
+
+> If A and AAAA records for TargetName are locally available, the client SHOULD
+> ignore these hints. Otherwise, clients SHOULD perform A and/or AAAA queries
+> for TargetName … When selecting between IPv4 and IPv6 … clients may use an
+> approach such as Happy Eyeballs.
+
+So: **a record with no IP hints forces the client onto the A/AAAA path**, where
+our per-family fake synthesis already does the right thing. That is the lever
+this ADR pulls.
+
+## Decision
+
+In fake-IP mode, **strip `ipv4hint` and `ipv6hint` from HTTPS/SVCB answers and
+keep everything else** (`alpn`, `port`, `ech`, `mandatory`, …). Defer all
+address-family selection to the existing A/AAAA fake synthesis.
+
+Concretely:
+
+1. `Resolver::fake_ip_active_for(host)` — true when fake-IP synthesis applies to
+   `host` (fake-IP mode, ≥1 pool configured, host is not an explicit hosts-trie
+   mapping, skipper does not bypass). Mirrors the gating in `lookup_ipv4` /
+   `lookup_ipv6` so the HTTPS path and the A/AAAA path agree on *which* hosts are
+   faked. Skipper-bypassed / hosts-mapped domains keep their real hints.
+
+2. `strip_svc_ip_hints(record)` in the DNS server — for HTTPS/SVCB records,
+   drop the two hint params; any other record type passes through unchanged.
+
+3. **RFC 9460 §8 `mandatory` scrub.** A key listed in `mandatory` but absent
+   from the RR makes the whole record malformed, so the client discards it —
+   taking the `alpn`/`ech` we wanted to keep with it. So when a stripped hint
+   appears in the `mandatory` list we remove it from that list too, and drop
+   `mandatory` entirely if it would otherwise become empty (an empty mandatory
+   list is itself malformed).
+
+### Why this is correct on dual-stack — case analysis
+
+The stripped record carries no addresses, so the client always resolves
+A/AAAA. Correctness reduces to the per-family fake synthesis, which already
+behaves correctly for every pool configuration:
+
+| Fake pool | A query | AAAA query | Client outcome |
+|-----------|---------|------------|----------------|
+| v4-only (default) | v4 fake | `NOERROR`-empty (suppressed) | uses v4 fake; no stall |
+| v4 + v6 | v4 fake | v6 fake | Happy Eyeballs over two fakes, both routed |
+| v6-only | (no v4 pool → real v4 leak — pre-existing) | v6 fake | — |
+
+IPv6-only **client** networks (no IPv4 at all, NAT64/DNS64/464XLAT) are a
+confirmed non-goal for this app's deployments, so the v6-only-pool row and the
+RFC 7050 NAT64 hint-synthesis edge cases are explicitly out of scope rather
+than blocking. The supported matrix is v4-only (default) and dual-stack.
+
+Both routed families land on fake IPs, so the reverse map resolves and the
+tunnel re-resolves the real destination by domain at dial time (the real
+address family is decoupled from the family the client used — see PR #214).
+
+### Why strip rather than rewrite-to-fake
+
+Rewriting the hints to the fake IPs (`ipv4hint=[fake4]`, `ipv6hint=[fake6]`)
+would save the client a round trip, but is **less** correct on dual-stack:
+
+- It duplicates the per-family synthesis logic (incl. AAAA suppression for
+  v4-only pools) and risks divergence from the A/AAAA path.
+- Leaving only an `ipv4hint` (v4-only pool) invites RFC 9460's NAT64 behaviour:
+  the client may synthesize a v6 from the fake v4 (RFC 7050), producing an
+  address **outside** our fake pool that the reverse map cannot resolve.
+
+Stripping has a single source of truth (the A/AAAA path) and no NAT64 trap.
+
+### Why keep `alpn`/`ech` rather than return empty (mihomo)
+
+ECH config is delivered *only* via this record; returning empty disables ECH
+for all fake-IP users. ECH is relayed end-to-end (the tunnel forwards the
+ClientHello bytes), so keeping it is both safe and a privacy win. Keeping
+`alpn=h3` lets the client attempt HTTP/3 on the first flight — which now works
+end-to-end thanks to PR #214. This is a deliberate, documented divergence from
+upstream (per ADR-0002 divergence policy).
+
+## Consequences
+
+- HTTP/3 and ECH keep working in fake-IP mode; no IP can be derived from an
+  HTTPS/SVCB answer for a faked host.
+- One extra A/AAAA round trip vs. rewriting hints — acceptable, and the records
+  are short-TTL cached.
+- Coverage: `strip_hints_*` (hint removal, ech/alpn preservation, mandatory
+  scrub, empty-mandatory drop, non-SVCB passthrough),
+  `fake_ip_active_for_gates_on_mode_pool_and_skipper`, and
+  `fake_ip_dual_stack_synthesis_is_per_family` (the per-family A/AAAA contract
+  this design rests on).
+
+## Alternatives considered
+
+- **Empty answer (mihomo).** Simplest; kills ECH + DNS-level h3. Rejected.
+- **Rewrite hints to fake IPs.** NAT64 trap + logic duplication. Rejected.
+- **Forward verbatim (status quo ante).** The leak this ADR closes.


### PR DESCRIPTION
Follow-up to #215. Establishes and documents the correct fake-ip HTTPS/SVCB strategy for **dual-stack** networks, and closes a real RFC 9460 correctness gap in the hint stripping.

## Decision (ADR-0013)

In fake-ip mode, **strip `ipv4hint`/`ipv6hint` and keep everything else** (`alpn`, `port`, `ech`, `mandatory`), deferring all address-family selection to the existing per-family A/AAAA fake synthesis. With no hints present, an RFC 9460 client must fall back to A/AAAA — where our synthesis already does the right thing for every supported pool config:

| Fake pool | A | AAAA | Client outcome |
|-----------|---|------|----------------|
| v4-only (default) | v4 fake | `NOERROR`-empty | uses v4 fake; no stall |
| v4 + v6 | v4 fake | v6 fake | Happy Eyeballs over two routed fakes |

This is **more correct** than rewriting hints to fake IPs (duplicates per-family logic; hits the RFC 7050 NAT64 trap when only an `ipv4hint` is left) and **more capable** than upstream mihomo's blanket empty-answer, which kills HTTP/3-from-DNS and **ECH** (ECH config is delivered *only* via this record, relayed end-to-end).

## Correctness fix

**RFC 9460 §8:** a key listed in `mandatory` but absent from the RR makes the whole record malformed, so the client discards it — taking the `alpn`/`ech` we wanted to keep with it. `strip_svc_ip_hints` now scrubs stripped hint keys out of the `mandatory` list, and drops `mandatory` entirely if it would otherwise empty (an empty mandatory list is itself malformed).

## Scope

IPv6-only **client** networks (NAT64/DNS64/464XLAT) are a confirmed non-goal for this app, so the v6-only-pool and NAT64 hint-synthesis edge cases are documented as out of scope. Supported matrix: v4-only (default) and dual-stack.

## Tests

- `strip_hints_preserves_ech_and_scrubs_mandatory_list`
- `strip_hints_drops_mandatory_when_only_hints_were_mandatory`
- `fake_ip_dual_stack_synthesis_is_per_family` — the A/AAAA per-family contract this design rests on.

Regression bar green: `cargo fmt --check`, three-way `clippy -D warnings`, `cargo doc -D warnings`, `cargo test --lib` (one pre-existing network test, `udp_client_times_out_on_unroutable`, fails only in the no-egress sandbox — confirmed failing on a clean tree too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)