### PR TITLE
feat(socks5): implement outbound UDP ASSOCIATE (HTTP/3 egress)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shadowsocks",
+ "smallvec",
  "smol_str",
  "socket2 0.5.10",
  "tempfile",

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -392,9 +392,7 @@ fn parse_http(
 ///
 /// - `username` set without `password` (or vice versa) — orphaned credential.
 ///
-/// # Warn-once (Class B per ADR-0002)
-///
-/// - `udp: true` — SOCKS5 UDP ASSOCIATE is deferred to M1.x.
+/// `udp: true` enables SOCKS5 UDP ASSOCIATE (HTTP/3 / QUIC relay).
 ///
 /// upstream: `adapter/outbound/socks5.go`
 fn parse_socks5(
@@ -431,27 +429,12 @@ fn parse_socks5(
         }
     };
 
-    // Warn-once if UDP is requested (deferred, ADR-0002 Class B).
-    if config
+    let udp = config
         .get("udp")
         .and_then(serde_yaml::Value::as_bool)
-        .unwrap_or(false)
-    {
-        tracing::warn!(
-            proxy = name,
-            "socks5: `udp: true` is not supported in M1 (SOCKS5 UDP ASSOCIATE deferred); \
-             treating as false. Class B — ADR-0002."
-        );
-    }
+        .unwrap_or(false);
 
-    Ok(Socks5Adapter::new(
-        name,
-        server,
-        port,
-        auth,
-        tls,
-        skip_cert_verify,
-    ))
+    Ok(Socks5Adapter::new(name, server, port, auth, tls, skip_cert_verify).with_udp(udp))
 }
 
 /// Parse a `type: direct` proxy block into a [`DirectAdapter`].

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = { workspace = true }
 socket2 = { workspace = true }
 libc = "0.2"
 smol_str = { workspace = true }
+smallvec = { workspace = true }
 md-5 = { workspace = true, optional = true }
 hmac = { workspace = true, optional = true }
 aes = { workspace = true, optional = true }

--- a/crates/meow-proxy/src/socks5_adapter.rs
+++ b/crates/meow-proxy/src/socks5_adapter.rs
@@ -5,26 +5,25 @@
 //! - `CMD CONNECT` (0x01) — TCP tunnel.
 //! - `atyp` 0x03 (domain) preferred when `metadata.host` is set;
 //!   0x01 (IPv4) or 0x04 (IPv6) otherwise.
-//! - Optional TLS-wrapping of the TCP connection to the proxy server.
-//! - `udp: true` is accepted at parse time and silently ignored (warn-once);
-//!   `support_udp()` always returns `false` in M1.
-//!
-//! # Divergences from upstream (ADR-0002)
-//!
-//! | # | Case | Class |
-//! |---|------|:-----:|
-//! | 1 | SOCKS5 UDP ASSOCIATE deferred | B |
+//! - Optional TLS-wrapping of the TCP control connection to the proxy server.
+//! - `CMD UDP ASSOCIATE` (0x03) when `udp: true` — relays UDP (incl. QUIC /
+//!   HTTP/3) via a side UDP socket, wrapping each datagram in the RFC 1928 §7
+//!   header. The TCP control connection is held open for the association's
+//!   lifetime. The UDP relay path is plain (not TLS-wrapped), per the SOCKS5
+//!   spec.
 //!
 //! upstream: `adapter/outbound/socks5.go`
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use async_trait::async_trait;
 use meow_common::{
     AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
 };
+use smallvec::SmallVec;
 use smol_str::SmolStr;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UdpSocket;
 use tracing::debug;
 
 use crate::stream_conn::StreamConn;
@@ -33,6 +32,7 @@ use crate::stream_conn::StreamConn;
 
 const VERSION: u8 = 0x05;
 const CMD_CONNECT: u8 = 0x01;
+const CMD_UDP_ASSOCIATE: u8 = 0x03;
 const RESERVED: u8 = 0x00;
 const ATYP_IPV4: u8 = 0x01;
 const ATYP_DOMAIN: u8 = 0x03;
@@ -60,14 +60,14 @@ pub struct Socks5Adapter {
     /// Built once at construction (rustls ClientConfig + root store are
     /// expensive); `TlsLayer::connect` is safe to call concurrently.
     tls_layer: Option<meow_transport::tls::TlsLayer>,
+    /// Whether `udp: true` was configured — gates UDP ASSOCIATE.
+    udp: bool,
     health: ProxyHealth,
 }
 
 impl Socks5Adapter {
-    /// Create a `Socks5Adapter`.
-    ///
-    /// `udp` is ignored in M1 (SOCKS5 UDP ASSOCIATE deferred, ADR-0002 Class B).
-    /// Warn-once at parse time if `udp: true` is configured.
+    /// Create a `Socks5Adapter`. UDP ASSOCIATE is disabled by default; call
+    /// [`Self::with_udp`] to enable it (set from `udp: true` in config).
     pub fn new(
         name: &str,
         server: &str,
@@ -96,8 +96,16 @@ impl Socks5Adapter {
             port,
             auth,
             tls_layer,
+            udp: false,
             health: ProxyHealth::new(),
         }
+    }
+
+    /// Enable SOCKS5 UDP ASSOCIATE (HTTP/3 / QUIC relay). Off by default.
+    #[must_use]
+    pub fn with_udp(mut self, udp: bool) -> Self {
+        self.udp = udp;
+        self
     }
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
@@ -132,13 +140,9 @@ impl Socks5Adapter {
     where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
     {
-        // ── Pre-flight length guards ───────────────────────────────────────────
-        //
         // SOCKS5 ATYP 0x03 encodes the hostname length as a single byte (0–255).
-        // RFC 1929 §2 encodes the username and password lengths as single bytes.
         // Casting `len() as u8` when len > 255 silently truncates and produces a
         // malformed frame; we reject early instead.
-        //
         // ADR-0002 Class A divergence: upstream socks5.go does not guard these.
         if !target_host.is_empty() && target_host.len() > 255 {
             return Err(MeowError::Proxy(format!(
@@ -146,89 +150,8 @@ impl Socks5Adapter {
                 target_host.len()
             )));
         }
-        if let Some((user, pass)) = &self.auth {
-            if user.len() > 255 {
-                return Err(MeowError::Proxy(format!(
-                    "socks5: username too long ({} bytes, max 255 per RFC 1929)",
-                    user.len()
-                )));
-            }
-            if pass.len() > 255 {
-                return Err(MeowError::Proxy(format!(
-                    "socks5: password too long ({} bytes, max 255 per RFC 1929)",
-                    pass.len()
-                )));
-            }
-        }
 
-        // ── Step 1: Method negotiation ────────────────────────────────────────
-        let methods: &[u8] = if self.auth.is_some() {
-            &[METHOD_NO_AUTH, METHOD_USER_PASS]
-        } else {
-            &[METHOD_NO_AUTH]
-        };
-
-        let greeting_len = 2 + methods.len();
-        let mut greeting = [0u8; 4];
-        greeting[0] = VERSION;
-        greeting[1] = methods.len() as u8;
-        greeting[2..greeting_len].copy_from_slice(methods);
-        stream
-            .write_all(&greeting[..greeting_len])
-            .await
-            .map_err(MeowError::Io)?;
-
-        let mut server_choice = [0u8; 2];
-        stream
-            .read_exact(&mut server_choice)
-            .await
-            .map_err(MeowError::Io)?;
-
-        if server_choice[0] != VERSION {
-            return Err(MeowError::Proxy(format!(
-                "socks5: unexpected version byte {:#04x} in method selection",
-                server_choice[0]
-            )));
-        }
-
-        let chosen = server_choice[1];
-        if chosen == METHOD_NO_ACCEPTABLE {
-            return Err(MeowError::NoAcceptableMethod);
-        }
-
-        // ── Step 2: Username/password sub-negotiation (if server chose 0x02) ──
-        //
-        // upstream: socks5.go::handshake — if server picks no-auth even when
-        // credentials were offered, proceed WITHOUT sub-negotiation.
-        // NOT Err(NoAcceptableMethod). NOT panic.
-        if chosen == METHOD_USER_PASS {
-            let (user, pass) = self
-                .auth
-                .as_ref()
-                .expect("auth set when METHOD_USER_PASS offered");
-
-            let auth_len = 3 + user.len() + pass.len();
-            let mut auth_buf = [0u8; 515];
-            auth_buf[0] = AUTH_VERSION;
-            auth_buf[1] = user.len() as u8;
-            auth_buf[2..2 + user.len()].copy_from_slice(user.as_bytes());
-            auth_buf[2 + user.len()] = pass.len() as u8;
-            auth_buf[3 + user.len()..auth_len].copy_from_slice(pass.as_bytes());
-            stream
-                .write_all(&auth_buf[..auth_len])
-                .await
-                .map_err(MeowError::Io)?;
-
-            let mut auth_resp = [0u8; 2];
-            stream
-                .read_exact(&mut auth_resp)
-                .await
-                .map_err(MeowError::Io)?;
-
-            if auth_resp[1] != AUTH_SUCCESS {
-                return Err(MeowError::ProxyAuthFailed);
-            }
-        }
+        self.negotiate_and_auth(stream).await?;
 
         // ── Step 3: CONNECT request ───────────────────────────────────────────
         //
@@ -296,6 +219,156 @@ impl Socks5Adapter {
 
         Ok(())
     }
+
+    /// Method negotiation + optional RFC 1929 username/password sub-negotiation.
+    /// Shared by CONNECT ([`Self::run_handshake`]) and UDP ASSOCIATE
+    /// ([`Self::run_udp_associate`]).
+    async fn negotiate_and_auth<S>(&self, stream: &mut S) -> Result<()>
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        // RFC 1929 §2 encodes username/password lengths as single bytes.
+        if let Some((user, pass)) = &self.auth {
+            if user.len() > 255 {
+                return Err(MeowError::Proxy(format!(
+                    "socks5: username too long ({} bytes, max 255 per RFC 1929)",
+                    user.len()
+                )));
+            }
+            if pass.len() > 255 {
+                return Err(MeowError::Proxy(format!(
+                    "socks5: password too long ({} bytes, max 255 per RFC 1929)",
+                    pass.len()
+                )));
+            }
+        }
+
+        // ── Step 1: Method negotiation ────────────────────────────────────────
+        let methods: &[u8] = if self.auth.is_some() {
+            &[METHOD_NO_AUTH, METHOD_USER_PASS]
+        } else {
+            &[METHOD_NO_AUTH]
+        };
+
+        let greeting_len = 2 + methods.len();
+        let mut greeting = [0u8; 4];
+        greeting[0] = VERSION;
+        greeting[1] = methods.len() as u8;
+        greeting[2..greeting_len].copy_from_slice(methods);
+        stream
+            .write_all(&greeting[..greeting_len])
+            .await
+            .map_err(MeowError::Io)?;
+
+        let mut server_choice = [0u8; 2];
+        stream
+            .read_exact(&mut server_choice)
+            .await
+            .map_err(MeowError::Io)?;
+
+        if server_choice[0] != VERSION {
+            return Err(MeowError::Proxy(format!(
+                "socks5: unexpected version byte {:#04x} in method selection",
+                server_choice[0]
+            )));
+        }
+
+        let chosen = server_choice[1];
+        if chosen == METHOD_NO_ACCEPTABLE {
+            return Err(MeowError::NoAcceptableMethod);
+        }
+
+        // ── Step 2: Username/password sub-negotiation (if server chose 0x02) ──
+        //
+        // upstream: socks5.go::handshake — if the server picks no-auth even when
+        // credentials were offered, proceed WITHOUT sub-negotiation.
+        if chosen == METHOD_USER_PASS {
+            let (user, pass) = self
+                .auth
+                .as_ref()
+                .expect("auth set when METHOD_USER_PASS offered");
+
+            let auth_len = 3 + user.len() + pass.len();
+            let mut auth_buf = [0u8; 515];
+            auth_buf[0] = AUTH_VERSION;
+            auth_buf[1] = user.len() as u8;
+            auth_buf[2..2 + user.len()].copy_from_slice(user.as_bytes());
+            auth_buf[2 + user.len()] = pass.len() as u8;
+            auth_buf[3 + user.len()..auth_len].copy_from_slice(pass.as_bytes());
+            stream
+                .write_all(&auth_buf[..auth_len])
+                .await
+                .map_err(MeowError::Io)?;
+
+            let mut auth_resp = [0u8; 2];
+            stream
+                .read_exact(&mut auth_resp)
+                .await
+                .map_err(MeowError::Io)?;
+
+            if auth_resp[1] != AUTH_SUCCESS {
+                return Err(MeowError::ProxyAuthFailed);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Run a UDP ASSOCIATE handshake over the (already TLS-wrapped, if
+    /// configured) control stream and return the relay endpoint the proxy
+    /// expects UDP datagrams on.
+    ///
+    /// The DST.ADDR/DST.PORT in the request is the wildcard `0.0.0.0:0`: per
+    /// RFC 1928 it advertises the address the client will send from, which we
+    /// don't know ahead of the first packet — `0.0.0.0:0` tells the server not
+    /// to restrict the association to a specific source.
+    ///
+    /// A `BND.ADDR` of `0.0.0.0` / `::` (some servers return the wildcard
+    /// meaning "same host as this control connection") is rewritten to the
+    /// proxy server's own address.
+    async fn run_udp_associate<S>(&self, stream: &mut S) -> Result<SocketAddr>
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        self.negotiate_and_auth(stream).await?;
+
+        // Request: VER CMD RSV ATYP(v4) 0.0.0.0 0
+        let req = [
+            VERSION,
+            CMD_UDP_ASSOCIATE,
+            RESERVED,
+            ATYP_IPV4,
+            0,
+            0,
+            0,
+            0, // DST.ADDR 0.0.0.0
+            0,
+            0, // DST.PORT 0
+        ];
+        stream.write_all(&req).await.map_err(MeowError::Io)?;
+
+        // Response header: VER REP RSV ATYP
+        let mut resp_hdr = [0u8; 4];
+        stream
+            .read_exact(&mut resp_hdr)
+            .await
+            .map_err(MeowError::Io)?;
+        if resp_hdr[1] != REPLY_SUCCESS {
+            return Err(MeowError::Socks5ConnectFailed(resp_hdr[1]));
+        }
+
+        let relay = read_socks5_addr(stream, resp_hdr[3]).await?;
+        // Rewrite a wildcard bound address to the proxy server's own address.
+        if relay.ip().is_unspecified() {
+            let candidates = meow_common::resolve_host_all(&self.server, relay.port())
+                .await
+                .map_err(MeowError::Io)?;
+            return candidates.into_iter().next().ok_or_else(|| {
+                MeowError::Proxy(format!("socks5: cannot resolve relay host {}", self.server))
+            });
+        }
+        Ok(relay)
+    }
 }
 
 /// Read and discard the bound address + port from a SOCKS5 response.
@@ -328,6 +401,117 @@ async fn drain_socks5_addr<S: tokio::io::AsyncRead + Unpin>(
     Ok(())
 }
 
+/// Read a SOCKS5 address (`atyp` already consumed) into a concrete
+/// `SocketAddr`. A domain `atyp` is resolved via the protected resolver; this
+/// is only used for the UDP-ASSOCIATE bound address, which servers normally
+/// return as an IP literal.
+async fn read_socks5_addr<S: tokio::io::AsyncRead + Unpin>(
+    stream: &mut S,
+    atyp: u8,
+) -> Result<SocketAddr> {
+    match atyp {
+        ATYP_IPV4 => {
+            let mut b = [0u8; 6];
+            stream.read_exact(&mut b).await.map_err(MeowError::Io)?;
+            let ip = IpAddr::from([b[0], b[1], b[2], b[3]]);
+            Ok(SocketAddr::new(ip, u16::from_be_bytes([b[4], b[5]])))
+        }
+        ATYP_IPV6 => {
+            let mut b = [0u8; 18];
+            stream.read_exact(&mut b).await.map_err(MeowError::Io)?;
+            let mut o = [0u8; 16];
+            o.copy_from_slice(&b[..16]);
+            Ok(SocketAddr::new(
+                IpAddr::from(o),
+                u16::from_be_bytes([b[16], b[17]]),
+            ))
+        }
+        ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            stream.read_exact(&mut len).await.map_err(MeowError::Io)?;
+            let mut dbuf = vec![0u8; len[0] as usize + 2];
+            stream.read_exact(&mut dbuf).await.map_err(MeowError::Io)?;
+            let host = std::str::from_utf8(&dbuf[..len[0] as usize])
+                .map_err(|_| MeowError::Proxy("socks5: non-utf8 bound domain".into()))?;
+            let port = u16::from_be_bytes([dbuf[len[0] as usize], dbuf[len[0] as usize + 1]]);
+            meow_common::resolve_host_all(host, port)
+                .await
+                .map_err(MeowError::Io)?
+                .into_iter()
+                .next()
+                .ok_or_else(|| MeowError::Proxy(format!("socks5: cannot resolve bound {host}")))
+        }
+        other => Err(MeowError::Proxy(format!(
+            "socks5: unknown atyp {other:#04x} in response"
+        ))),
+    }
+}
+
+/// Encode a SOCKS5 UDP request header for `addr` into `out` (RFC 1928 §7):
+/// `RSV(2)=0 FRAG(1)=0 ATYP DST.ADDR DST.PORT`. The DATA is appended by the
+/// caller.
+fn encode_udp_header(out: &mut SmallVec<[u8; 1500]>, addr: &SocketAddr) {
+    out.extend_from_slice(&[0, 0, 0]); // RSV(2) + FRAG(1)
+    match addr.ip() {
+        IpAddr::V4(v4) => {
+            out.push(ATYP_IPV4);
+            out.extend_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            out.push(ATYP_IPV6);
+            out.extend_from_slice(&v6.octets());
+        }
+    }
+    out.extend_from_slice(&addr.port().to_be_bytes());
+}
+
+/// Parse a received SOCKS5 UDP datagram in place: validate the header, return
+/// the source `SocketAddr`, and shift the DATA portion to the front of `buf`.
+/// Returns `(data_len, src)`.
+fn decode_udp_datagram(buf: &mut [u8], n: usize) -> Result<(usize, SocketAddr)> {
+    if n < 4 {
+        return Err(MeowError::Proxy("socks5: short UDP datagram".into()));
+    }
+    // RSV(2) ignored. FRAG must be 0 — we don't reassemble fragments.
+    if buf[2] != 0 {
+        return Err(MeowError::Proxy(
+            "socks5: fragmented UDP datagram not supported".into(),
+        ));
+    }
+    let (src, header_len) = match buf[3] {
+        ATYP_IPV4 => {
+            if n < 10 {
+                return Err(MeowError::Proxy("socks5: truncated v4 UDP header".into()));
+            }
+            let ip = IpAddr::from([buf[4], buf[5], buf[6], buf[7]]);
+            (
+                SocketAddr::new(ip, u16::from_be_bytes([buf[8], buf[9]])),
+                10,
+            )
+        }
+        ATYP_IPV6 => {
+            if n < 22 {
+                return Err(MeowError::Proxy("socks5: truncated v6 UDP header".into()));
+            }
+            let mut o = [0u8; 16];
+            o.copy_from_slice(&buf[4..20]);
+            (
+                SocketAddr::new(IpAddr::from(o), u16::from_be_bytes([buf[20], buf[21]])),
+                22,
+            )
+        }
+        // Domain-form source in a reply is degenerate (servers echo the IP).
+        other => {
+            return Err(MeowError::Proxy(format!(
+                "socks5: unsupported UDP reply atyp {other:#04x}"
+            )));
+        }
+    };
+    let data_len = n - header_len;
+    buf.copy_within(header_len..n, 0);
+    Ok((data_len, src))
+}
+
 // ─── ProxyAdapter ─────────────────────────────────────────────────────────────
 
 #[async_trait]
@@ -345,8 +529,7 @@ impl ProxyAdapter for Socks5Adapter {
     }
 
     fn support_udp(&self) -> bool {
-        // SOCKS5 UDP ASSOCIATE deferred to M1.x. ADR-0002 Class B.
-        false
+        self.udp
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
@@ -367,10 +550,34 @@ impl ProxyAdapter for Socks5Adapter {
     }
 
     async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        // SOCKS5 UDP ASSOCIATE not implemented in M1. ADR-0002 Class B.
-        Err(MeowError::NotSupported(
-            "socks5: UDP ASSOCIATE not supported in M1 (deferred)".into(),
-        ))
+        if !self.udp {
+            return Err(MeowError::NotSupported(
+                "socks5: UDP ASSOCIATE not enabled (set `udp: true`)".into(),
+            ));
+        }
+
+        // The UDP association is bound to the lifetime of this TCP control
+        // connection (RFC 1928 §7): the server tears the association down when
+        // the control conn closes. We keep it open via `ControlGuard`.
+        let mut control = self.dial_stream().await?;
+        let relay = self.run_udp_associate(&mut control).await?;
+        debug!(
+            "socks5: UDP ASSOCIATE via {}:{} → relay {}",
+            self.server, self.port, relay
+        );
+
+        let bind: SocketAddr = if relay.is_ipv4() {
+            "0.0.0.0:0".parse().expect("static")
+        } else {
+            "[::]:0".parse().expect("static")
+        };
+        let socket = meow_common::bind_udp(bind).await.map_err(MeowError::Io)?;
+        socket.connect(relay).await.map_err(MeowError::Io)?;
+
+        Ok(Box::new(Socks5UdpConn {
+            socket,
+            _control: ControlGuard::spawn(control),
+        }))
     }
 
     /// Run the SOCKS5 handshake over an already-established stream.
@@ -400,6 +607,69 @@ impl ProxyAdapter for Socks5Adapter {
 
     fn health(&self) -> &ProxyHealth {
         &self.health
+    }
+}
+
+// ─── UDP ASSOCIATE relay conn ──────────────────────────────────────────────────
+
+/// Keeps the SOCKS5 UDP-ASSOCIATE control connection open for the lifetime of
+/// the relay. RFC 1928 §7 ties the association to the control conn, so the
+/// task holds it and drains anything the server sends; dropping the guard
+/// aborts the task, closing the conn and ending the association.
+struct ControlGuard(tokio::task::AbortHandle);
+
+impl ControlGuard {
+    fn spawn(control: Box<dyn meow_transport::Stream>) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut control = control;
+            let mut sink = [0u8; 16];
+            // Block until the proxy closes the control conn (or we're aborted).
+            loop {
+                match control.read(&mut sink).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {} // ignore unexpected control-channel bytes
+                }
+            }
+        });
+        ControlGuard(handle.abort_handle())
+    }
+}
+
+impl Drop for ControlGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// A SOCKS5 UDP-ASSOCIATE relay socket. Each datagram is wrapped/unwrapped in
+/// the RFC 1928 §7 UDP request header; the socket is `connect()`ed to the
+/// proxy's relay endpoint.
+struct Socks5UdpConn {
+    socket: UdpSocket,
+    _control: ControlGuard,
+}
+
+#[async_trait]
+impl ProxyPacketConn for Socks5UdpConn {
+    async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        let n = self.socket.recv(buf).await.map_err(MeowError::Io)?;
+        decode_udp_datagram(buf, n)
+    }
+
+    async fn write_packet(&self, data: &[u8], addr: &SocketAddr) -> Result<usize> {
+        let mut pkt: SmallVec<[u8; 1500]> = SmallVec::new();
+        encode_udp_header(&mut pkt, addr);
+        pkt.extend_from_slice(data);
+        self.socket.send(&pkt).await.map_err(MeowError::Io)?;
+        Ok(data.len())
+    }
+
+    fn local_addr(&self) -> Result<SocketAddr> {
+        self.socket.local_addr().map_err(MeowError::Io)
+    }
+
+    fn close(&self) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -805,23 +1075,138 @@ mod tests {
         );
     }
 
-    // ─── socks5_udp_returns_not_supported ─────────────────────────────────────
-    // ADR-0002 Class B: UDP deferred.
+    // ─── UDP ASSOCIATE: disabled by default ────────────────────────────────────
 
     #[tokio::test]
-    async fn socks5_udp_returns_not_supported() {
+    async fn socks5_udp_disabled_by_default() {
         let adapter = make_adapter("127.0.0.1", 1080, None);
-        assert!(!adapter.support_udp(), "support_udp must be false in M1");
+        assert!(
+            !adapter.support_udp(),
+            "udp must be off unless with_udp(true)"
+        );
         let meta = meta_with_host("example.com", 53);
         let err = adapter
             .dial_udp(&meta)
             .await
             .err()
-            .expect("dial_udp should return Err");
+            .expect("dial_udp should return Err when udp disabled");
         assert!(
             matches!(err, MeowError::NotSupported(_)),
-            "dial_udp must return NotSupported; got {err:?}"
+            "dial_udp must return NotSupported when disabled; got {err:?}"
         );
+    }
+
+    #[test]
+    fn with_udp_toggles_support() {
+        let off = make_adapter("127.0.0.1", 1080, None);
+        assert!(!off.support_udp());
+        let on = make_adapter("127.0.0.1", 1080, None).with_udp(true);
+        assert!(on.support_udp());
+    }
+
+    // ─── UDP datagram header codec (RFC 1928 §7) ───────────────────────────────
+
+    #[test]
+    fn udp_header_roundtrip_v4_and_v6() {
+        for target in [
+            "1.2.3.4:443".parse::<SocketAddr>().unwrap(),
+            "[2001:db8::1]:443".parse::<SocketAddr>().unwrap(),
+        ] {
+            let mut pkt: SmallVec<[u8; 1500]> = SmallVec::new();
+            encode_udp_header(&mut pkt, &target);
+            pkt.extend_from_slice(b"payload");
+            // Datagram is RSV(2)=0 FRAG(1)=0 then atyp/addr/port/data.
+            assert_eq!(&pkt[0..3], &[0, 0, 0]);
+
+            let mut buf = pkt.to_vec();
+            let n = buf.len();
+            let (data_len, src) = decode_udp_datagram(&mut buf, n).unwrap();
+            assert_eq!(src, target);
+            assert_eq!(&buf[..data_len], b"payload");
+        }
+    }
+
+    #[test]
+    fn udp_decode_rejects_fragments_and_short() {
+        // FRAG != 0 → unsupported.
+        let mut frag = vec![0, 0, 1, ATYP_IPV4, 1, 2, 3, 4, 0, 80];
+        let n = frag.len();
+        assert!(decode_udp_datagram(&mut frag, n).is_err());
+        // Too short for even the fixed header.
+        let mut short = vec![0, 0];
+        assert!(decode_udp_datagram(&mut short, 2).is_err());
+    }
+
+    // ─── UDP ASSOCIATE end-to-end against a mock relay ─────────────────────────
+
+    #[tokio::test]
+    async fn socks5_udp_associate_round_trip() {
+        use tokio::net::UdpSocket;
+        use tokio::time::{timeout, Duration};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let ctrl_addr = listener.local_addr().unwrap();
+
+        // Mock SOCKS5 server: no-auth negotiation, UDP ASSOCIATE, then a UDP
+        // relay that echoes each datagram verbatim (header + data) back to the
+        // client — standing in for a remote that echoes.
+        tokio::spawn(async move {
+            let (mut s, _) = listener.accept().await.unwrap();
+            // Method negotiation.
+            let mut hdr = [0u8; 2];
+            s.read_exact(&mut hdr).await.unwrap();
+            let mut methods = vec![0u8; hdr[1] as usize];
+            s.read_exact(&mut methods).await.unwrap();
+            s.write_all(&[VERSION, METHOD_NO_AUTH]).await.unwrap();
+            // UDP ASSOCIATE request: VER CMD RSV ATYP(v4) addr(4) port(2).
+            let mut req = [0u8; 10];
+            s.read_exact(&mut req).await.unwrap();
+            assert_eq!(req[1], CMD_UDP_ASSOCIATE);
+
+            let relay = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let rport = relay.local_addr().unwrap().port();
+            s.write_all(&[
+                VERSION,
+                REPLY_SUCCESS,
+                RESERVED,
+                ATYP_IPV4,
+                127,
+                0,
+                0,
+                1,
+                (rport >> 8) as u8,
+                (rport & 0xFF) as u8,
+            ])
+            .await
+            .unwrap();
+
+            // Echo loop. Hold `s` (control conn) alive by keeping it in scope.
+            let mut buf = [0u8; 2048];
+            loop {
+                let (n, peer) = relay.recv_from(&mut buf).await.unwrap();
+                relay.send_to(&buf[..n], peer).await.unwrap();
+            }
+        });
+
+        let adapter = make_adapter("127.0.0.1", ctrl_addr.port(), None).with_udp(true);
+        assert!(adapter.support_udp());
+        let conn = adapter
+            .dial_udp(&Metadata::default())
+            .await
+            .expect("dial_udp");
+
+        let target: SocketAddr = "1.2.3.4:443".parse().unwrap();
+        conn.write_packet(b"quic-hello", &target)
+            .await
+            .expect("write_packet");
+
+        let mut buf = [0u8; 256];
+        let (n, src) = timeout(Duration::from_secs(2), conn.read_packet(&mut buf))
+            .await
+            .expect("read timed out")
+            .expect("read_packet");
+        assert_eq!(&buf[..n], b"quic-hello");
+        assert_eq!(src, target, "decoded source must be the datagram target");
     }
 
     // ─── socks5_connect_over_relay ────────────────────────────────────────────


### PR DESCRIPTION
Part 2 of the HTTP/3-over-SOCKS5 audit. The SOCKS5 **outbound** adapter rejected `dial_udp` (`support_udp()=false`, ADR-0002 Class B deferral), so HTTP/3/QUIC could not egress through an upstream SOCKS5 proxy. This implements it.

## Changes

- `udp: true` (via `Socks5Adapter::with_udp`) enables UDP ASSOCIATE; `support_udp()` reflects it.
- `dial_udp`:
  - Runs the UDP ASSOCIATE handshake over the TCP control connection (via a new `negotiate_and_auth` helper shared with CONNECT).
  - Binds a side UDP socket `connect()`ed to the returned relay endpoint (family-matched).
  - Keeps the control connection open for the association's lifetime via `ControlGuard` — dropping it aborts the task → closes the conn → ends the association (RFC 1928 §7).
  - Rewrites a wildcard `BND.ADDR` (`0.0.0.0`/`::`) to the proxy server's address.
- `Socks5UdpConn` wraps/unwraps each datagram in the RFC 1928 §7 UDP header (`RSV/FRAG/ATYP/DST.ADDR/DST.PORT`). `read_packet` parses and shifts data in place (no per-packet alloc); `write_packet` builds the header in a `SmallVec<[u8;1500]>` (stack for typical QUIC). Fragments (`FRAG!=0`) and domain-form reply sources are rejected.
- UDP relay path is plain per the SOCKS5 spec; TLS only wraps the control conn.

## Tests

- `udp_header_roundtrip_v4_and_v6`, `udp_decode_rejects_fragments_and_short`
- `with_udp_toggles_support`, `socks5_udp_disabled_by_default`
- `socks5_udp_associate_round_trip` — full handshake + echo against a mock relay.

Regression bar green: fmt, three-way clippy `-D warnings`, doc, `meow-proxy`/`meow-config` lib + socks5 integration tests.

Inbound SOCKS5 UDP ASSOCIATE (listener) is the remaining follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)