### PR TITLE
feat(socks5): inbound UDP ASSOCIATE in the listener (HTTP/3 ingress)

### DIFF
--- a/crates/meow-listener/src/lib.rs
+++ b/crates/meow-listener/src/lib.rs
@@ -6,6 +6,8 @@ pub mod http_proxy;
 pub mod mixed;
 #[cfg(feature = "listener-socks5")]
 pub mod socks5;
+#[cfg(feature = "listener-socks5")]
+mod socks5_udp;
 #[cfg(feature = "listener-tproxy")]
 pub mod tproxy;
 

--- a/crates/meow-listener/src/socks5.rs
+++ b/crates/meow-listener/src/socks5.rs
@@ -13,7 +13,6 @@ const NO_AUTH: u8 = 0x00;
 const USER_PASS_AUTH: u8 = 0x02;
 const NO_ACCEPTABLE_METHODS: u8 = 0xFF;
 const CMD_CONNECT: u8 = 0x01;
-#[allow(dead_code)]
 const CMD_UDP_ASSOCIATE: u8 = 0x03;
 const ATYP_IPV4: u8 = 0x01;
 const ATYP_DOMAIN: u8 = 0x03;
@@ -29,7 +28,7 @@ pub async fn handle_socks5(
     in_name: &str,
     in_port: u16,
 ) {
-    if let Err(e) = handle_socks5_inner(
+    match handle_socks5_inner(
         tunnel,
         &mut stream,
         src_addr,
@@ -40,8 +39,27 @@ pub async fn handle_socks5(
     )
     .await
     {
-        debug!("SOCKS5 error from {}: {}", src_addr, e);
+        Ok(PostHandshake::Done) => {}
+        Ok(PostHandshake::UdpAssociate) => {
+            // The handshake (auth + request) is consumed; the control conn is
+            // now ours for the association's lifetime.
+            if let Err(e) =
+                crate::socks5_udp::handle_udp_associate(tunnel, stream, src_addr, in_name, in_port)
+                    .await
+            {
+                debug!("SOCKS5 UDP ASSOCIATE error from {}: {}", src_addr, e);
+            }
+        }
+        Err(e) => debug!("SOCKS5 error from {}: {}", src_addr, e),
     }
+}
+
+/// Outcome of the SOCKS5 handshake: a CONNECT was fully relayed, or the client
+/// requested UDP ASSOCIATE and the (owned) control connection must be handed to
+/// the UDP relay.
+enum PostHandshake {
+    Done,
+    UdpAssociate,
 }
 
 async fn handle_socks5_inner(
@@ -52,7 +70,7 @@ async fn handle_socks5_inner(
     auth: Option<&AuthConfig>,
     in_name: &str,
     in_port: u16,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<PostHandshake, Box<dyn std::error::Error + Send + Sync>> {
     // 1. Version/method negotiation
     let mut header = [0u8; 2];
     stream.read_exact(&mut header).await?;
@@ -119,8 +137,14 @@ async fn handle_socks5_inner(
     let cmd = req[1];
     let atyp = req[3];
 
-    // Parse address
+    // Parse address (for UDP ASSOCIATE this is the client's advertised source,
+    // which we ignore — the relay learns the real source from the first packet).
     let (host, dst_ip, dst_port) = parse_socks5_address(stream, atyp).await?;
+
+    if cmd == CMD_UDP_ASSOCIATE {
+        // Hand the control connection to the UDP relay; it writes its own reply.
+        return Ok(PostHandshake::UdpAssociate);
+    }
 
     if cmd != CMD_CONNECT {
         // Send command not supported
@@ -210,7 +234,7 @@ async fn handle_socks5_inner(
         Err(e) => warn!("{} SOCKS5 dial error: {}", metadata.remote_address(), e),
     }
 
-    Ok(())
+    Ok(PostHandshake::Done)
 }
 
 async fn parse_socks5_address(

--- a/crates/meow-listener/src/socks5_udp.rs
+++ b/crates/meow-listener/src/socks5_udp.rs
@@ -1,0 +1,331 @@
+//! SOCKS5 inbound `CMD UDP ASSOCIATE` (RFC 1928 §7) — relays client UDP
+//! (incl. QUIC / HTTP/3) through the tunnel's routing engine.
+//!
+//! Lifecycle: the association is bound to the TCP control connection. We bind a
+//! UDP relay socket on the same local IP the client reached us on, return its
+//! address in the reply, then relay until the control connection closes (at
+//! which point this future returns and every per-destination outbound conn +
+//! reply task is dropped).
+//!
+//! Routing mirrors `meow_tunnel::udp::handle_udp`: fake-IP rewrite → pre-resolve
+//! → port-53 DIRECT bypass → rule match → `dial_udp`. A small per-association
+//! NAT (`dst -> session`) dedups outbound conns; each session has a reply task
+//! that reads server→client datagrams and writes them back wrapped in the
+//! SOCKS5 UDP header.
+
+use std::collections::HashMap;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use meow_common::{ConnType, Metadata, Network, ProxyAdapter, ProxyPacketConn};
+use meow_tunnel::Tunnel;
+use smallvec::SmallVec;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpStream, UdpSocket};
+use tracing::debug;
+
+const SOCKS5_VERSION: u8 = 0x05;
+const REP_SUCCESS: u8 = 0x00;
+const RESERVED: u8 = 0x00;
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
+
+/// Per-destination outbound session within one association.
+struct Session {
+    conn: Arc<dyn ProxyPacketConn>,
+    /// Reply task (server→client); aborted when the session is dropped.
+    reply_task: tokio::task::AbortHandle,
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.reply_task.abort();
+    }
+}
+
+/// Handle a SOCKS5 UDP ASSOCIATE request. `control` is the TCP control
+/// connection (request already consumed by the caller); the advertised
+/// DST.ADDR/PORT is ignored per common practice (clients send `0.0.0.0:0`).
+pub async fn handle_udp_associate(
+    tunnel: &Tunnel,
+    mut control: TcpStream,
+    src_addr: SocketAddr,
+    in_name: &str,
+    in_port: u16,
+) -> io::Result<()> {
+    // Bind the relay on the same local IP the client reached us on, so the
+    // address we hand back is reachable by the client.
+    let local_ip = control.local_addr()?.ip();
+    let relay = Arc::new(UdpSocket::bind(SocketAddr::new(local_ip, 0)).await?);
+    let bnd = relay.local_addr()?;
+
+    write_associate_reply(&mut control, bnd).await?;
+    debug!("SOCKS5 UDP ASSOCIATE from {src_addr}: relay bound on {bnd}");
+
+    let mut nat: HashMap<SocketAddr, Session> = HashMap::new();
+    let mut buf = vec![0u8; 65535];
+    let mut ctrl_buf = [0u8; 16];
+
+    loop {
+        tokio::select! {
+            // The association ends when the control connection closes.
+            r = control.read(&mut ctrl_buf) => {
+                match r {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {} // ignore unexpected control-channel bytes
+                }
+            }
+            r = relay.recv_from(&mut buf) => {
+                let (n, client) = match r {
+                    Ok(v) => v,
+                    Err(e) => { debug!("SOCKS5 UDP recv error: {e}"); continue; }
+                };
+                if let Err(e) =
+                    handle_client_datagram(tunnel, &relay, &mut nat, &buf[..n], client, in_name, in_port).await
+                {
+                    debug!("SOCKS5 UDP datagram from {client}: {e}");
+                }
+            }
+        }
+    }
+
+    debug!(
+        "SOCKS5 UDP ASSOCIATE from {src_addr} closed; tearing down {} sessions",
+        nat.len()
+    );
+    Ok(())
+}
+
+/// Parse one inbound datagram, route it, and forward it through the (possibly
+/// newly-created) per-destination outbound session.
+async fn handle_client_datagram(
+    tunnel: &Tunnel,
+    relay: &Arc<UdpSocket>,
+    nat: &mut HashMap<SocketAddr, Session>,
+    datagram: &[u8],
+    client: SocketAddr,
+    in_name: &str,
+    in_port: u16,
+) -> Result<(), String> {
+    let (dst_ip, host, dst_port, data_off) = parse_udp_request(datagram)?;
+
+    let mut metadata = Metadata {
+        network: Network::Udp,
+        conn_type: ConnType::Socks5,
+        src_ip: Some(client.ip()),
+        src_port: client.port(),
+        dst_ip,
+        dst_port,
+        host: Metadata::lower_host(&host),
+        in_name: in_name.into(),
+        in_port,
+        ..Default::default()
+    };
+
+    let inner = tunnel.inner();
+    inner.pre_handle_metadata(&mut metadata);
+    inner.pre_resolve(&mut metadata).await;
+
+    let Some(dst_ip) = metadata.dst_ip else {
+        return Err(format!(
+            "dst_ip not resolved for {}",
+            metadata.remote_address()
+        ));
+    };
+    let dst_addr = SocketAddr::new(dst_ip, metadata.dst_port);
+    let payload = &datagram[data_off..];
+
+    // Fast path: existing session for this destination.
+    if let Some(session) = nat.get(&dst_addr) {
+        session
+            .conn
+            .write_packet(payload, &dst_addr)
+            .await
+            .map_err(|e| format!("udp write {dst_addr}: {e}"))?;
+        return Ok(());
+    }
+
+    // Slow path: pick an outbound and dial. Port 53 bypasses rule matching to
+    // DIRECT, mirroring meow_tunnel::udp::handle_udp (avoid looping client DNS
+    // back through a proxy / the in-process resolver).
+    let proxy: Arc<dyn ProxyAdapter> = if metadata.dst_port == 53 {
+        Arc::clone(&inner.direct) as Arc<dyn ProxyAdapter>
+    } else {
+        match inner.resolve_proxy(&metadata) {
+            Some((p, _rule, _payload)) => p,
+            None => {
+                return Err(format!(
+                    "no matching rule for {}",
+                    metadata.remote_address()
+                ))
+            }
+        }
+    };
+
+    let conn: Arc<dyn ProxyPacketConn> = Arc::from(
+        proxy
+            .dial_udp(&metadata)
+            .await
+            .map_err(|e| format!("dial_udp via {}: {e}", proxy.name()))?,
+    );
+
+    conn.write_packet(payload, &dst_addr)
+        .await
+        .map_err(|e| format!("udp initial write {dst_addr}: {e}"))?;
+
+    // Reply task: server→client. Wraps each datagram in the SOCKS5 UDP header
+    // and sends it back to the client's UDP source address.
+    let reply_task = {
+        let relay = Arc::clone(relay);
+        let conn = Arc::clone(&conn);
+        tokio::spawn(async move {
+            let mut rbuf = vec![0u8; 65535];
+            while let Ok((m, src)) = conn.read_packet(&mut rbuf).await {
+                let mut out: SmallVec<[u8; 1500]> = SmallVec::new();
+                encode_udp_header(&mut out, &src);
+                out.extend_from_slice(&rbuf[..m]);
+                if relay.send_to(&out, client).await.is_err() {
+                    break;
+                }
+            }
+        })
+        .abort_handle()
+    };
+
+    nat.insert(dst_addr, Session { conn, reply_task });
+    Ok(())
+}
+
+/// Write the `CMD UDP ASSOCIATE` success reply carrying the relay endpoint.
+async fn write_associate_reply(control: &mut TcpStream, bnd: SocketAddr) -> io::Result<()> {
+    let mut reply: SmallVec<[u8; 22]> = SmallVec::new();
+    reply.extend_from_slice(&[SOCKS5_VERSION, REP_SUCCESS, RESERVED]);
+    match bnd.ip() {
+        IpAddr::V4(v4) => {
+            reply.push(ATYP_IPV4);
+            reply.extend_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            reply.push(ATYP_IPV6);
+            reply.extend_from_slice(&v6.octets());
+        }
+    }
+    reply.extend_from_slice(&bnd.port().to_be_bytes());
+    control.write_all(&reply).await?;
+    Ok(())
+}
+
+/// Parse a SOCKS5 UDP request header (RFC 1928 §7):
+/// `RSV(2) FRAG(1) ATYP DST.ADDR DST.PORT DATA`. Returns
+/// `(dst_ip, host, port, data_offset)` — exactly one of `dst_ip`/`host` is set.
+fn parse_udp_request(buf: &[u8]) -> Result<(Option<IpAddr>, String, u16, usize), String> {
+    if buf.len() < 4 {
+        return Err("short UDP request".into());
+    }
+    // RSV(2) ignored. FRAG must be 0 — we don't reassemble fragments.
+    if buf[2] != 0 {
+        return Err("fragmented UDP datagram not supported".into());
+    }
+    let atyp = buf[3];
+    let mut pos = 4;
+    let (dst_ip, host) = match atyp {
+        ATYP_IPV4 => {
+            if buf.len() < pos + 4 + 2 {
+                return Err("truncated v4 UDP request".into());
+            }
+            let ip = IpAddr::from([buf[pos], buf[pos + 1], buf[pos + 2], buf[pos + 3]]);
+            pos += 4;
+            (Some(ip), String::new())
+        }
+        ATYP_IPV6 => {
+            if buf.len() < pos + 16 + 2 {
+                return Err("truncated v6 UDP request".into());
+            }
+            let mut o = [0u8; 16];
+            o.copy_from_slice(&buf[pos..pos + 16]);
+            pos += 16;
+            (Some(IpAddr::from(o)), String::new())
+        }
+        ATYP_DOMAIN => {
+            let dlen = *buf.get(4).ok_or("missing domain length")? as usize;
+            pos = 5;
+            if buf.len() < pos + dlen + 2 {
+                return Err("truncated domain UDP request".into());
+            }
+            let host = std::str::from_utf8(&buf[pos..pos + dlen])
+                .map_err(|_| "non-utf8 domain".to_string())?
+                .to_string();
+            pos += dlen;
+            (None, host)
+        }
+        other => return Err(format!("unknown atyp {other:#04x}")),
+    };
+    let port = u16::from_be_bytes([buf[pos], buf[pos + 1]]);
+    pos += 2;
+    Ok((dst_ip, host, port, pos))
+}
+
+/// Encode a SOCKS5 UDP reply header for `addr` (RFC 1928 §7):
+/// `RSV(2)=0 FRAG(1)=0 ATYP SRC.ADDR SRC.PORT`. DATA is appended by the caller.
+fn encode_udp_header(out: &mut SmallVec<[u8; 1500]>, addr: &SocketAddr) {
+    out.extend_from_slice(&[0, 0, 0]); // RSV(2) + FRAG(1)
+    match addr.ip() {
+        IpAddr::V4(v4) => {
+            out.push(ATYP_IPV4);
+            out.extend_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            out.push(ATYP_IPV6);
+            out.extend_from_slice(&v6.octets());
+        }
+    }
+    out.extend_from_slice(&addr.port().to_be_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_udp_request_ipv4() {
+        // RSV FRAG ATYP=1 1.2.3.4 :443 "hi"
+        let dg = [0, 0, 0, ATYP_IPV4, 1, 2, 3, 4, 0x01, 0xBB, b'h', b'i'];
+        let (ip, host, port, off) = parse_udp_request(&dg).unwrap();
+        assert_eq!(ip, Some(IpAddr::from([1, 2, 3, 4])));
+        assert!(host.is_empty());
+        assert_eq!(port, 443);
+        assert_eq!(&dg[off..], b"hi");
+    }
+
+    #[test]
+    fn parse_udp_request_domain() {
+        let mut dg = vec![0, 0, 0, ATYP_DOMAIN, 3, b'a', b'.', b'b', 0x00, 0x35];
+        dg.extend_from_slice(b"q");
+        let (ip, host, port, off) = parse_udp_request(&dg).unwrap();
+        assert_eq!(ip, None);
+        assert_eq!(host, "a.b");
+        assert_eq!(port, 53);
+        assert_eq!(&dg[off..], b"q");
+    }
+
+    #[test]
+    fn parse_udp_request_rejects_fragment_and_short() {
+        assert!(parse_udp_request(&[0, 0, 1, ATYP_IPV4, 1, 2, 3, 4, 0, 80]).is_err());
+        assert!(parse_udp_request(&[0, 0]).is_err());
+    }
+
+    #[test]
+    fn encode_udp_header_roundtrips_with_request_parser() {
+        let mut out: SmallVec<[u8; 1500]> = SmallVec::new();
+        let src: SocketAddr = "9.9.9.9:53".parse().unwrap();
+        encode_udp_header(&mut out, &src);
+        out.extend_from_slice(b"data");
+        let (ip, _host, port, off) = parse_udp_request(&out).unwrap();
+        assert_eq!(ip, Some(src.ip()));
+        assert_eq!(port, src.port());
+        assert_eq!(&out[off..], b"data");
+    }
+}

--- a/crates/meow-listener/tests/common/mod.rs
+++ b/crates/meow-listener/tests/common/mod.rs
@@ -1,4 +1,9 @@
-/// Shared test helpers for meow-listener integration tests.
+//! Shared test helpers for meow-listener integration tests.
+//!
+//! Each integration test binary compiles this module independently, so a
+//! helper used by only some of them looks "dead" to the others.
+#![allow(dead_code)]
+
 use meow_common::DnsMode;
 use meow_dns::Resolver;
 use meow_trie::DomainTrie;

--- a/crates/meow-listener/tests/socks5_udp_associate.rs
+++ b/crates/meow-listener/tests/socks5_udp_associate.rs
@@ -1,0 +1,118 @@
+//! Integration test: SOCKS5 inbound UDP ASSOCIATE round-trip.
+//!
+//!   client ──SOCKS5 UDP ASSOCIATE──► handle_socks5 ──DIRECT──► UDP echo server
+//!
+//! Drives the full `handle_socks5` UDP path: handshake → associate reply → a
+//! wrapped datagram is relayed to a real UDP echo server and the echoed reply
+//! flows back (unwrapped) to the client.
+#![cfg(feature = "listener-socks5")]
+
+mod common;
+
+use common::direct_tunnel;
+use std::net::SocketAddr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tokio::time::{timeout, Duration};
+
+/// Spawn a UDP echo server: echoes each datagram back to its sender.
+async fn spawn_udp_echo() -> SocketAddr {
+    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = sock.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut buf = [0u8; 2048];
+        loop {
+            let Ok((n, peer)) = sock.recv_from(&mut buf).await else {
+                break;
+            };
+            if sock.send_to(&buf[..n], peer).await.is_err() {
+                break;
+            }
+        }
+    });
+    addr
+}
+
+/// Wrap `data` for `target` in a SOCKS5 UDP request header (IPv4).
+fn wrap(target: SocketAddr, data: &[u8]) -> Vec<u8> {
+    let std::net::IpAddr::V4(ip) = target.ip() else {
+        panic!("ipv4 only in test");
+    };
+    let mut v = vec![0, 0, 0, 0x01]; // RSV(2) FRAG(1) ATYP=v4
+    v.extend_from_slice(&ip.octets());
+    v.extend_from_slice(&target.port().to_be_bytes());
+    v.extend_from_slice(data);
+    v
+}
+
+/// Parse a SOCKS5 UDP reply (IPv4) → (src, data).
+fn unwrap_reply(buf: &[u8]) -> (SocketAddr, &[u8]) {
+    assert_eq!(buf[2], 0, "FRAG must be 0");
+    assert_eq!(buf[3], 0x01, "expected v4 reply");
+    let ip = std::net::Ipv4Addr::new(buf[4], buf[5], buf[6], buf[7]);
+    let port = u16::from_be_bytes([buf[8], buf[9]]);
+    (SocketAddr::from((ip, port)), &buf[10..])
+}
+
+#[tokio::test]
+async fn socks5_udp_associate_relays_to_echo_server() {
+    let echo_addr = spawn_udp_echo().await;
+
+    // Loopback TCP pair feeding handle_socks5.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let ctrl_addr = listener.local_addr().unwrap();
+    let (accept_res, connect_res) = tokio::join!(listener.accept(), TcpStream::connect(ctrl_addr));
+    let (server_stream, client_peer) = accept_res.unwrap();
+    let mut client = connect_res.unwrap();
+
+    let tunnel = direct_tunnel();
+    tokio::spawn(async move {
+        meow_listener::socks5::handle_socks5(
+            &tunnel,
+            server_stream,
+            client_peer,
+            None,
+            None,
+            "socks-in",
+            ctrl_addr.port(),
+        )
+        .await;
+    });
+
+    // Handshake: greeting → NoAuth.
+    client.write_all(&[0x05, 0x01, 0x00]).await.unwrap();
+    let mut greet = [0u8; 2];
+    client.read_exact(&mut greet).await.unwrap();
+    assert_eq!(greet, [0x05, 0x00]);
+
+    // UDP ASSOCIATE request (advertised source 0.0.0.0:0).
+    client
+        .write_all(&[0x05, 0x03, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+        .await
+        .unwrap();
+    // Reply: VER REP RSV ATYP(v4) BND.ADDR(4) BND.PORT(2).
+    let mut reply = [0u8; 10];
+    client.read_exact(&mut reply).await.unwrap();
+    assert_eq!(reply[1], 0x00, "associate must succeed");
+    let relay = SocketAddr::from((
+        std::net::Ipv4Addr::new(reply[4], reply[5], reply[6], reply[7]),
+        u16::from_be_bytes([reply[8], reply[9]]),
+    ));
+
+    // Send a wrapped datagram targeting the echo server.
+    let udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    udp.send_to(&wrap(echo_addr, b"ping"), relay).await.unwrap();
+
+    // Receive the echoed reply, unwrap, and verify.
+    let mut rbuf = [0u8; 2048];
+    let (n, _from) = timeout(Duration::from_secs(2), udp.recv_from(&mut rbuf))
+        .await
+        .expect("relay reply timed out")
+        .unwrap();
+    let (src, data) = unwrap_reply(&rbuf[..n]);
+    assert_eq!(data, b"ping");
+    assert_eq!(src, echo_addr, "reply source must be the echo server");
+
+    // Keep `client` alive until here so the association stays open.
+    drop(client);
+}


### PR DESCRIPTION
Part 3 (final) of the HTTP/3-over-SOCKS5 audit. The SOCKS5 **inbound listener** rejected every non-CONNECT command, so HTTP/3/QUIC from local apps could not enter the tunnel via SOCKS5 (only the tun/FFI path accepted UDP). This implements `CMD UDP ASSOCIATE`.

## New module: `crates/meow-listener/src/socks5_udp.rs`

- Binds a UDP relay socket on the local IP the client reached us on, returns it in the associate reply, and relays until the TCP control connection closes — the association lifetime per RFC 1928 §7. On close, all per-destination outbound conns + reply tasks are dropped.
- Routing **mirrors `meow_tunnel::udp::handle_udp`**: fake-IP rewrite → `pre_resolve` → port-53 DIRECT bypass → rule match → `dial_udp`.
- A per-association NAT (`dst -> session`) dedups outbound conns. Each session spawns a reply task that reads server→client datagrams and writes them back wrapped in the SOCKS5 UDP header. Fragments (`FRAG!=0`) are rejected.

## `socks5.rs`

`handle_socks5_inner` now returns a `PostHandshake` outcome; on `CMD_UDP_ASSOCIATE` the owned control `TcpStream` is handed to `handle_udp_associate` (the handshake/auth is already consumed).

## Tests

- Unit: `parse_udp_request` (v4/domain), fragment/short rejection, header encode↔parse round-trip.
- Integration (`tests/socks5_udp_associate.rs`): full client handshake → UDP ASSOCIATE → wrapped datagram → DIRECT → real UDP echo server → unwrapped reply.

Regression bar green: fmt, three-way clippy `-D warnings`, doc, `meow-listener` tests (35) + full `cargo test --lib` (709; the one skipped `udp_client_times_out_on_unroutable` is a pre-existing no-egress-sandbox flake, fails identically on a clean tree).

This completes HTTP/3 support across SOCKS5 (inbound #220, outbound #219) and SIP003u (#218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)