### PR TITLE
feat(proxy): implement hysteria2 outbound in-tree on Quinn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,11 @@ jobs:
       - name: Trojan integration tests
         run: cargo test --test trojan_integration -- --nocapture
 
+      - name: Hysteria2 Docker integration tests
+        env:
+          MEOW_REQUIRE_DOCKER: "1"
+        run: cargo test -p meow-proxy --features hysteria2 --test hysteria2_integration -- --nocapture
+
       - name: v2ray-plugin integration tests
         run: cargo test --test v2ray_plugin_integration -- --nocapture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3",
+ "quinn",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,12 +2207,16 @@ dependencies = [
  "argon2",
  "async-trait",
  "base64",
+ "blake2",
  "bytes",
  "chacha20poly1305",
  "crc32fast",
  "futures",
+ "h3",
+ "h3-quinn",
  "hex",
  "hmac",
+ "http",
  "libc",
  "md-5",
  "meow-common",
@@ -2202,6 +2234,7 @@ dependencies = [
  "smol_str",
  "socket2 0.5.10",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2721,6 +2754,7 @@ checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ shadowsocks = { version = "1.21", default-features = false, features = ["aead-ci
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 quinn = { version = "0.11", default-features = false, features = ["log", "ring", "runtime-tokio", "rustls-ring"] }
+h3 = "0.0.8"
+h3-quinn = "0.0.10"
 webpki-roots = "0.26"
 
 # DNS — only hickory-proto for wire-format encode/decode; the upstream
@@ -115,6 +117,7 @@ iprange = "0.6"
 
 # Crypto
 sha2 = "0.10"
+blake2 = "0.10"
 md-5 = "0.10"
 hmac = "0.12"
 aes = "0.8"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A high-performance Rust implementation of the [mihomo](https://github.com/MetaCu
 ### Proxy Protocols
 - **Shadowsocks** -- TCP and UDP relay, AEAD and stream ciphers (aes-256-gcm, chacha20-ietf-poly1305, etc.)
 - **Trojan** -- TLS 1.2/1.3 via rustls, SNI, optional skip-cert-verify
+- **Hysteria2** -- QUIC-based TCP and UDP relay, Salamander obfs, port hopping, down bandwidth auth hint, SNI, skip-cert-verify, and certificate pinning
 - **VLESS** -- Plain VLESS and XTLS-Vision splice; TLS, WebSocket, gRPC, H2, HTTPUpgrade transports
 - **HTTP** -- HTTP CONNECT outbound proxy with optional TLS and basic auth
 - **SOCKS5** -- SOCKS5 outbound proxy with optional TLS and auth
@@ -297,14 +298,29 @@ proxies:
       mode: http
       host: /
 
+  - name: my-hy2
+    type: hysteria2
+    server: hy2.example.com
+    port: 443
+    ports: "443,8443-8445"
+    hop-interval: 30
+    password: "secret"
+    sni: hy2.example.com
+    skip-cert-verify: false
+    udp: true
+    up: "100 Mbps"
+    down: "100 Mbps"
+    obfs: salamander
+    obfs-password: "obfs-secret"
+
 proxy-groups:
   - name: Proxy
     type: select
-    proxies: [my-ss, my-trojan, my-snell]
+    proxies: [my-ss, my-trojan, my-snell, my-hy2]
 
   - name: Auto
     type: url-test
-    proxies: [my-ss, my-trojan, my-snell]
+    proxies: [my-ss, my-trojan, my-snell, my-hy2]
     url: http://www.gstatic.com/generate_204
     interval: 300
 
@@ -333,6 +349,9 @@ cargo test --test config_persistence_test
 
 # Trojan integration tests (embedded mock server, no external deps)
 cargo test --test trojan_integration
+
+# Hysteria2 Docker integration tests (requires Docker)
+MEOW_REQUIRE_DOCKER=1 cargo test -p meow-proxy --features hysteria2 --test hysteria2_integration -- --nocapture
 
 # Shadowsocks integration tests (requires ssserver)
 cargo install shadowsocks-rust --features "stream-cipher aead-cipher-2022" --locked

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -17,6 +17,7 @@ vless = ["meow-config/vless", "meow-proxy/vless"]
 vless-vision = ["vless", "meow-config/vless-vision", "meow-proxy/vless-vision"]
 vmess = ["meow-config/vmess", "meow-proxy/vmess"]
 snell = ["meow-config/snell", "meow-proxy/snell"]
+hysteria2 = ["meow-config/hysteria2", "meow-proxy/hysteria2"]
 ech-tls-tunnel = [
     "ss",
     "meow-config/ech-tls-tunnel",
@@ -36,7 +37,7 @@ listener-mixed = ["meow-listener/listener-mixed"]
 # Convenience bundles
 minimal = ["ss", "trojan", "dns-server", "listener-mixed"]
 full = [
-    "ss", "trojan", "vless", "vless-vision", "vmess", "snell", "ech-tls-tunnel",
+    "ss", "trojan", "vless", "vless-vision", "vmess", "snell", "hysteria2", "ech-tls-tunnel",
     "dns-server", "dns-encrypted",
     "listener-http", "listener-socks5", "listener-tproxy", "listener-mixed",
 ]

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell"]
+default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell", "hysteria2"]
 ss = ["meow-proxy/ss"]
 trojan = ["meow-proxy/trojan"]
 vless = ["meow-proxy/vless"]

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -551,17 +551,19 @@ fn parse_anytls(
     meow_proxy::AnytlsAdapter::new(name, server, port, password, sni, skip_cert_verify)
 }
 
-/// Parse a `type: hysteria2` proxy block (issue #72, tracer-bullet PR).
+/// Parse a `type: hysteria2` proxy block.
 ///
-/// Required fields: `server`, `port`, `password`. Optional: `sni`,
-/// `skip-cert-verify`. Bigger surface (obfs, fast-open, congestion
-/// control overrides) lands once the data plane is implemented.
+/// Required fields: `server`, `port`, `password`. Optional fields follow the
+/// mihomo surface supported by the in-tree Rust backend: `up`, `down`,
+/// `obfs: salamander`, `obfs-password`, `ports`, `hop-interval`, `sni`,
+/// `skip-cert-verify`, `fingerprint`, `udp`, and `fast-open`.
 ///
 /// # Hard errors (Class A per ADR-0002)
 ///
 /// - missing `server`, `port`, or `password`.
 /// - `port == 0`.
 /// - empty `password` — caught downstream by `Hy2Adapter::new`.
+/// - unsupported security/transport options (`gecko`, mTLS, ECH, realm).
 ///
 /// upstream: `adapter/outbound/hysteria2.go`
 #[cfg(feature = "hysteria2")]
@@ -569,14 +571,13 @@ fn parse_hysteria2(
     name: &str,
     config: &HashMap<String, serde_yaml::Value>,
 ) -> std::result::Result<meow_proxy::Hy2Adapter, String> {
+    use meow_proxy::{Hy2HopInterval, Hy2Obfs, Hy2Options};
+
     let server = config
         .get("server")
         .and_then(|v| v.as_str())
         .ok_or_else(|| format!("hysteria2[{name}]: missing server"))?;
-    let port = config
-        .get("port")
-        .and_then(serde_yaml::Value::as_u64)
-        .ok_or_else(|| format!("hysteria2[{name}]: missing port"))? as u16;
+    let port = parse_hy2_port(name, config.get("port"))?;
     if port == 0 {
         return Err(format!("hysteria2[{name}]: port must be non-zero"));
     }
@@ -589,8 +590,362 @@ fn parse_hysteria2(
         .get("skip-cert-verify")
         .and_then(serde_yaml::Value::as_bool)
         .unwrap_or(false);
+    let udp = config
+        .get("udp")
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(true);
+    let up_bps = parse_hy2_bandwidth_field(name, "up", config.get("up"))?;
+    let down_bps = parse_hy2_bandwidth_field(name, "down", config.get("down"))?;
 
-    meow_proxy::Hy2Adapter::new(name, server, port, password, sni, skip_cert_verify)
+    let obfs_raw = optional_nonempty_str(config, "obfs");
+    let obfs = match obfs_raw.as_deref() {
+        None => None,
+        Some("salamander") => Some(Hy2Obfs::Salamander),
+        Some("gecko") => {
+            return Err(format!(
+                "hysteria2[{name}]: obfs 'gecko' is not supported by the Rust backend"
+            ));
+        }
+        Some(other) => return Err(format!("hysteria2[{name}]: unknown obfs type: {other}")),
+    };
+    let obfs_password = optional_nonempty_str(config, "obfs-password");
+    if obfs.is_some() && obfs_password.is_none() {
+        return Err(format!("hysteria2[{name}]: missing obfs-password"));
+    }
+
+    let ports = optional_nonempty_str(config, "ports");
+    if let Some(ports) = &ports {
+        validate_hy2_ports(name, ports)?;
+    }
+    let hop_interval = parse_hy2_hop_interval(name, config.get("hop-interval"))?;
+    let fingerprint = parse_hy2_fingerprint(name, config.get("fingerprint"))?;
+    let fast_open = config
+        .get("fast-open")
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(true);
+    validate_hy2_alpn(name, config.get("alpn"))?;
+    reject_unsupported_hy2_options(name, config)?;
+
+    meow_proxy::Hy2Adapter::new(Hy2Options {
+        name: name.to_string(),
+        server: server.to_string(),
+        port,
+        password: password.to_string(),
+        sni: sni.map(str::to_string),
+        skip_cert_verify,
+        udp,
+        up_bps,
+        down_bps,
+        obfs,
+        obfs_password,
+        ports,
+        hop_interval: hop_interval
+            .map(|(min_secs, max_secs)| Hy2HopInterval { min_secs, max_secs }),
+        fingerprint,
+        fast_open,
+    })
+}
+
+#[cfg(feature = "hysteria2")]
+const HY2_MIN_HOP_INTERVAL_SECS: u64 = 5;
+#[cfg(feature = "hysteria2")]
+const HY2_DEFAULT_HOP_INTERVAL_SECS: u64 = 30;
+
+#[cfg(feature = "hysteria2")]
+fn parse_hy2_port(
+    name: &str,
+    value: Option<&serde_yaml::Value>,
+) -> std::result::Result<u16, String> {
+    let port = value
+        .and_then(serde_yaml::Value::as_u64)
+        .ok_or_else(|| format!("hysteria2[{name}]: missing port"))?;
+    u16::try_from(port).map_err(|_| format!("hysteria2[{name}]: port out of range: {port}"))
+}
+
+#[cfg(feature = "hysteria2")]
+fn optional_nonempty_str(config: &HashMap<String, serde_yaml::Value>, key: &str) -> Option<String> {
+    config
+        .get(key)
+        .and_then(serde_yaml::Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(feature = "hysteria2")]
+fn parse_hy2_bandwidth_field(
+    name: &str,
+    field: &str,
+    value: Option<&serde_yaml::Value>,
+) -> std::result::Result<u64, String> {
+    let Some(value) = value else {
+        return Ok(0);
+    };
+    if let Some(v) = value.as_u64() {
+        return Ok(mbps_to_bytes_per_second(v));
+    }
+    if let Some(s) = value.as_str() {
+        return parse_hy2_bandwidth(s).map_err(|e| format!("hysteria2[{name}]: {field}: {e}"));
+    }
+    Err(format!(
+        "hysteria2[{name}]: {field} must be a string like '30 Mbps' or an integer Mbps value"
+    ))
+}
+
+#[cfg(feature = "hysteria2")]
+fn parse_hy2_bandwidth(input: &str) -> std::result::Result<u64, String> {
+    static RATE_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"^(\d+)\s*([KMGTkmgt]?)([Bb])ps$").expect("valid rate regex")
+    });
+
+    let s = input.trim();
+    if s.is_empty() || s == "0" {
+        return Ok(0);
+    }
+    if let Ok(mbps) = s.parse::<u64>() {
+        return Ok(mbps_to_bytes_per_second(mbps));
+    }
+
+    let Some(caps) = RATE_RE.captures(s) else {
+        return Err(format!(
+            "invalid bandwidth '{input}', expected integer Mbps or e.g. '30 Mbps'"
+        ));
+    };
+    let value = caps[1]
+        .parse::<u64>()
+        .map_err(|e| format!("invalid number: {e}"))?;
+    let multiplier = match caps[2].to_ascii_uppercase().as_str() {
+        "" => 1,
+        "K" => 1_000,
+        "M" => 1_000_000,
+        "G" => 1_000_000_000,
+        "T" => 1_000_000_000_000,
+        _ => unreachable!("regex restricts unit prefix"),
+    };
+    let bytes = value
+        .checked_mul(multiplier)
+        .ok_or_else(|| "bandwidth overflows u64".to_string())?;
+    if &caps[3] == "b" {
+        Ok(bytes / 8)
+    } else {
+        Ok(bytes)
+    }
+}
+
+#[cfg(feature = "hysteria2")]
+fn mbps_to_bytes_per_second(mbps: u64) -> u64 {
+    mbps.saturating_mul(1_000_000) / 8
+}
+
+#[cfg(feature = "hysteria2")]
+fn validate_hy2_ports(name: &str, ports: &str) -> std::result::Result<(), String> {
+    let ports = ports.trim();
+    if ports == "*" || ports.eq_ignore_ascii_case("all") {
+        return Ok(());
+    }
+    for part in ports.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(format!("hysteria2[{name}]: invalid ports '{ports}'"));
+        }
+        if let Some((start, end)) = part.split_once('-') {
+            parse_hy2_port_part(name, start)?;
+            parse_hy2_port_part(name, end)?;
+        } else {
+            parse_hy2_port_part(name, part)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "hysteria2")]
+fn parse_hy2_port_part(name: &str, value: &str) -> std::result::Result<u16, String> {
+    value
+        .trim()
+        .parse::<u16>()
+        .map_err(|e| format!("hysteria2[{name}]: invalid port '{value}': {e}"))
+}
+
+#[cfg(feature = "hysteria2")]
+fn parse_hy2_hop_interval(
+    name: &str,
+    value: Option<&serde_yaml::Value>,
+) -> std::result::Result<Option<(u64, u64)>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let raw = if let Some(n) = value.as_u64() {
+        n.to_string()
+    } else {
+        value
+            .as_str()
+            .ok_or_else(|| format!("hysteria2[{name}]: hop-interval must be a number or range"))?
+            .trim()
+            .to_string()
+    };
+    if raw.is_empty() {
+        return Err(format!("hysteria2[{name}]: hop-interval must not be empty"));
+    }
+    if raw.contains(',') {
+        return Err(format!(
+            "hysteria2[{name}]: hop-interval only supports one range"
+        ));
+    }
+    if let Some((start, end)) = raw.split_once('-') {
+        let start = parse_hy2_u64(name, "hop-interval", start)?;
+        let end = parse_hy2_u64(name, "hop-interval", end)?;
+        Ok(Some(normalize_hy2_hop_interval(start, end)))
+    } else {
+        let start = parse_hy2_u64(name, "hop-interval", &raw)?;
+        Ok(Some(normalize_hy2_hop_interval(start, 0)))
+    }
+}
+
+#[cfg(feature = "hysteria2")]
+fn parse_hy2_u64(name: &str, field: &str, value: &str) -> std::result::Result<u64, String> {
+    value
+        .trim()
+        .parse::<u64>()
+        .map_err(|e| format!("hysteria2[{name}]: invalid {field} '{value}': {e}"))
+}
+
+#[cfg(feature = "hysteria2")]
+fn normalize_hy2_hop_interval(start: u64, end: u64) -> (u64, u64) {
+    let start = if start == 0 {
+        HY2_DEFAULT_HOP_INTERVAL_SECS
+    } else {
+        start.max(HY2_MIN_HOP_INTERVAL_SECS)
+    };
+    let end = if end == 0 { start } else { end.max(start) };
+    (start, end)
+}
+
+#[cfg(feature = "hysteria2")]
+fn parse_hy2_fingerprint(
+    name: &str,
+    value: Option<&serde_yaml::Value>,
+) -> std::result::Result<Option<String>, String> {
+    let Some(raw) = value.and_then(serde_yaml::Value::as_str) else {
+        return Ok(None);
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    let raw = raw.rsplit_once('=').map_or(raw, |(_, fp)| fp.trim());
+    let hex: String = raw
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != ':')
+        .collect();
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "hysteria2[{name}]: fingerprint must be a SHA-256 hex digest"
+        ));
+    }
+    Ok(Some(raw.to_string()))
+}
+
+#[cfg(feature = "hysteria2")]
+fn validate_hy2_alpn(
+    name: &str,
+    value: Option<&serde_yaml::Value>,
+) -> std::result::Result<(), String> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let mut alpns = Vec::new();
+    if let Some(items) = value.as_sequence() {
+        for item in items {
+            let alpn = item
+                .as_str()
+                .ok_or_else(|| format!("hysteria2[{name}]: alpn entries must be strings"))?;
+            alpns.push(alpn);
+        }
+    } else if let Some(alpn) = value.as_str() {
+        alpns.push(alpn);
+    } else {
+        return Err(format!(
+            "hysteria2[{name}]: alpn must be a string or string list"
+        ));
+    }
+    if alpns.iter().any(|alpn| *alpn != "h3") {
+        return Err(format!(
+            "hysteria2[{name}]: custom alpn is unsupported; only 'h3' is allowed"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "hysteria2")]
+fn reject_unsupported_hy2_options(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<(), String> {
+    for key in [
+        "certificate",
+        "private-key",
+        "obfs-min-packet-size",
+        "obfs-max-packet-size",
+    ] {
+        if config.contains_key(key) {
+            return Err(format!(
+                "hysteria2[{name}]: '{key}' is not supported by the Rust backend"
+            ));
+        }
+    }
+    reject_enabled_hy2_map(name, config, "ech-opts")?;
+    reject_enabled_hy2_map(name, config, "realm-opts")?;
+    reject_nonzero_hy2_option(name, config, "cwnd")?;
+    reject_nonzero_hy2_option(name, config, "udp-mtu")?;
+    reject_nonzero_hy2_option(name, config, "initial-stream-receive-window")?;
+    reject_nonzero_hy2_option(name, config, "max-stream-receive-window")?;
+    reject_nonzero_hy2_option(name, config, "initial-connection-receive-window")?;
+    reject_nonzero_hy2_option(name, config, "max-connection-receive-window")?;
+    if optional_nonempty_str(config, "bbr-profile").is_some() {
+        return Err(format!(
+            "hysteria2[{name}]: 'bbr-profile' is not supported by the Rust backend"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "hysteria2")]
+fn reject_enabled_hy2_map(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+    key: &str,
+) -> std::result::Result<(), String> {
+    if let Some(value) = config.get(key) {
+        let enabled = value
+            .as_mapping()
+            .and_then(|map| map.get(serde_yaml::Value::String("enable".into())))
+            .and_then(serde_yaml::Value::as_bool)
+            .unwrap_or(true);
+        if enabled {
+            return Err(format!(
+                "hysteria2[{name}]: '{key}' is not supported by the Rust backend"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "hysteria2")]
+fn reject_nonzero_hy2_option(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+    key: &str,
+) -> std::result::Result<(), String> {
+    if let Some(value) = config.get(key) {
+        let nonzero =
+            value.as_u64().is_some_and(|v| v != 0) || value.as_i64().is_some_and(|v| v != 0);
+        if nonzero {
+            return Err(format!(
+                "hysteria2[{name}]: '{key}' is not supported by the Rust backend"
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Parse the `strategy` field for a `load-balance` group.
@@ -1569,7 +1924,7 @@ tls: true
         assert!(err.contains("port must be non-zero"), "msg: {err}");
     }
 
-    // ─── hysteria2 parser (issue #72, tracer bullet) ─────────────────────────
+    // ─── hysteria2 parser ────────────────────────────────────────────────────
 
     #[cfg(feature = "hysteria2")]
     fn hy2_config(yaml: &str) -> HashMap<String, serde_yaml::Value> {
@@ -1616,6 +1971,106 @@ tls: true
             panic!("must hard-error");
         };
         assert!(err.contains("password must not be empty"), "msg: {err}");
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_accepts_mihomo_common_fields() {
+        let cfg = hy2_config(
+            "name: jp-hy2\n\
+             type: hysteria2\n\
+             server: 1.2.3.4\n\
+             port: 443\n\
+             password: secret\n\
+             udp: true\n\
+             up: '30 Mbps'\n\
+             down: 100\n\
+             obfs: salamander\n\
+             obfs-password: obfs-secret\n\
+             ports: '443,8443-8444'\n\
+             hop-interval: '15-30'\n\
+             sni: example.com\n\
+             skip-cert-verify: true\n\
+             fingerprint: 'SHA256 Fingerprint=00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00'\n\
+             alpn:\n\
+               - h3\n",
+        );
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_bandwidth_matches_mihomo_units() {
+        assert_eq!(parse_hy2_bandwidth("8 Mbps").unwrap(), 1_000_000);
+        assert_eq!(parse_hy2_bandwidth("8 MBps").unwrap(), 8_000_000);
+        assert_eq!(parse_hy2_bandwidth("10").unwrap(), 1_250_000);
+        assert_eq!(parse_hy2_bandwidth("").unwrap(), 0);
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_rejects_gecko_obfs() {
+        let cfg = hy2_config(
+            "name: jp-hy2\n\
+             type: hysteria2\n\
+             server: 1.2.3.4\n\
+             port: 443\n\
+             password: secret\n\
+             obfs: gecko\n\
+             obfs-password: secret\n",
+        );
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("must hard-error");
+        };
+        assert!(err.contains("gecko"), "msg: {err}");
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_rejects_obfs_without_password() {
+        let cfg = hy2_config(
+            "name: jp-hy2\n\
+             type: hysteria2\n\
+             server: 1.2.3.4\n\
+             port: 443\n\
+             password: secret\n\
+             obfs: salamander\n",
+        );
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("must hard-error");
+        };
+        assert!(err.contains("missing obfs-password"), "msg: {err}");
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_rejects_unsupported_mtls() {
+        let cfg = hy2_config(
+            "name: jp-hy2\n\
+             type: hysteria2\n\
+             server: 1.2.3.4\n\
+             port: 443\n\
+             password: secret\n\
+             certificate: ./client.crt\n",
+        );
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("must hard-error");
+        };
+        assert!(err.contains("certificate"), "msg: {err}");
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_hop_interval_matches_mihomo_floor() {
+        assert_eq!(parse_hy2_hop_interval("hy2", None).unwrap(), None);
+        assert_eq!(
+            parse_hy2_hop_interval("hy2", Some(&serde_yaml::Value::from(0))).unwrap(),
+            Some((30, 30))
+        );
+        assert_eq!(
+            parse_hy2_hop_interval("hy2", Some(&serde_yaml::Value::from("1-2"))).unwrap(),
+            Some((5, 5))
+        );
     }
 
     // ─── Load-balance strategy parser (F1-F7) ────────────────────────────────

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell"]
+default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell", "hysteria2"]
 ss = ["dep:shadowsocks"]
 trojan = []
 vless = []
@@ -20,10 +20,8 @@ snell = ["dep:argon2", "dep:aes-gcm"]
 # features — accept the bloat in exchange for not re-implementing the
 # wire protocol. Off by default.
 anytls = ["dep:anytls-rs"]
-# Hysteria 2 outbound (issue #72). Tracer-bullet implementation: parser
-# wired and QUIC dial path stubbed, but the HTTP/3 auth handshake and
-# the data-stream framing land in follow-up PRs. Off by default.
-hysteria2 = ["dep:quinn"]
+# Hysteria2 outbound implemented in-tree on top of Quinn.
+hysteria2 = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:blake2"]
 # Native client for the `ech-tls-tunnel` SIP003 plugin
 # (https://github.com/shadowsocks/ech-tls-tunnel). Requires ECH on rustls,
 # which pulls aws-lc-rs in via meow-transport.
@@ -36,6 +34,9 @@ meow-transport = { workspace = true }
 tokio = { workspace = true }
 anytls-rs = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
+h3 = { workspace = true, optional = true }
+h3-quinn = { workspace = true, optional = true }
+blake2 = { workspace = true, optional = true }
 shadowsocks = { workspace = true, optional = true }
 argon2 = { workspace = true, optional = true }
 tokio-rustls = { workspace = true }
@@ -55,6 +56,8 @@ socket2 = { workspace = true }
 libc = "0.2"
 smol_str = { workspace = true }
 smallvec = { workspace = true }
+http = { workspace = true }
+thiserror = { workspace = true }
 md-5 = { workspace = true, optional = true }
 hmac = { workspace = true, optional = true }
 aes = { workspace = true, optional = true }

--- a/crates/meow-proxy/src/hysteria2/client.rs
+++ b/crates/meow-proxy/src/hysteria2/client.rs
@@ -1,0 +1,311 @@
+use super::config::Config;
+use super::socket::Hy2UdpSocket;
+use super::tcp::{self, DuplexStream};
+use super::tls;
+use super::udp::{self, UdpRouter, UdpSession};
+use super::{Error, Result};
+use bytes::Buf;
+use h3::client::SendRequest;
+use h3_quinn::OpenStreams;
+use quinn::Runtime;
+use quinn::{Connection, Endpoint};
+use std::future::pending;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::atomic::AtomicU16;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::time::{timeout, Duration};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub struct ReconnectableClient {
+    cfg: Arc<Config>,
+    conn: Mutex<Option<Arc<ClientConnection>>>,
+}
+
+impl ReconnectableClient {
+    pub fn new(cfg: Config) -> Self {
+        Self {
+            cfg: Arc::new(cfg),
+            conn: Mutex::new(None),
+        }
+    }
+
+    pub async fn tcp_connect(&self, target: &str) -> Result<DuplexStream> {
+        let client = self.connection().await?;
+        let (mut send, recv) = client
+            .connection
+            .open_bi()
+            .await
+            .map_err(|e| Error::Quic(e.to_string()))?;
+
+        if !self.cfg.fast_open {
+            tcp::write_initial_request(&mut send, target).await?;
+        }
+
+        Ok(DuplexStream::new(
+            send,
+            recv,
+            target.to_string(),
+            !self.cfg.fast_open,
+        ))
+    }
+
+    pub async fn udp(&self) -> Result<UdpSession> {
+        let client = self.connection().await?;
+        UdpSession::new(client)
+    }
+
+    async fn connection(&self) -> Result<Arc<ClientConnection>> {
+        let mut guard = self.conn.lock().await;
+        if let Some(conn) = guard.as_ref() {
+            if conn.is_active() {
+                return Ok(Arc::clone(conn));
+            }
+        }
+
+        let conn = Arc::new(connect_new(Arc::clone(&self.cfg)).await?);
+        *guard = Some(Arc::clone(&conn));
+        Ok(conn)
+    }
+}
+
+pub(crate) struct ClientConnection {
+    pub(crate) connection: Connection,
+    _endpoint: Endpoint,
+    h3_driver: tokio::task::JoinHandle<()>,
+    udp_driver: Option<tokio::task::JoinHandle<()>>,
+    pub(crate) udp_enabled: bool,
+    pub(crate) udp_router: Arc<UdpRouter>,
+    pub(crate) next_session_id: std::sync::atomic::AtomicU32,
+    pub(crate) next_packet_id: AtomicU16,
+}
+
+impl ClientConnection {
+    fn is_active(&self) -> bool {
+        self.connection.close_reason().is_none()
+    }
+}
+
+impl Drop for ClientConnection {
+    fn drop(&mut self) {
+        self.h3_driver.abort();
+        if let Some(driver) = &self.udp_driver {
+            driver.abort();
+        }
+    }
+}
+
+async fn connect_new(cfg: Arc<Config>) -> Result<ClientConnection> {
+    let server = ServerTarget::parse(&cfg.server_addr)?;
+    let addrs = meow_common::resolve_host_all(&server.host, server.port)
+        .await
+        .map_err(|e| Error::Resolve(format!("{}:{}: {e}", server.host, server.port)))?;
+    let server_name = if cfg.server_name.trim().is_empty() {
+        server.host.clone()
+    } else {
+        cfg.server_name.trim().to_string()
+    };
+
+    let mut last_error = None;
+    for addr in addrs {
+        match connect_addr(Arc::clone(&cfg), addr, &server_name).await {
+            Ok(conn) => return Ok(conn),
+            Err(e) => last_error = Some(e),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| Error::Resolve("no address resolved".into())))
+}
+
+async fn connect_addr(
+    cfg: Arc<Config>,
+    server_addr: SocketAddr,
+    server_name: &str,
+) -> Result<ClientConnection> {
+    let needs_custom_socket = !cfg.obfs_password.is_empty() || !cfg.hop_ports.trim().is_empty();
+    let mut endpoint = if needs_custom_socket {
+        let socket = Hy2UdpSocket::bind(
+            server_addr,
+            &cfg.hop_ports,
+            cfg.hop_interval_min_secs,
+            cfg.hop_interval_max_secs,
+            &cfg.obfs_password,
+        )
+        .await?;
+        let mut endpoint_cfg = quinn::EndpointConfig::default();
+        endpoint_cfg.grease_quic_bit(false);
+        Endpoint::new_with_abstract_socket(
+            endpoint_cfg,
+            None,
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        )?
+    } else {
+        let bind_addr = if server_addr.is_ipv4() {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+        } else {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+        };
+        let std_sock = std::net::UdpSocket::bind(bind_addr).map_err(Error::Io)?;
+        let runtime = Arc::new(quinn::TokioRuntime);
+        let socket = runtime.wrap_udp_socket(std_sock)?;
+        let mut endpoint_cfg = quinn::EndpointConfig::default();
+        endpoint_cfg.grease_quic_bit(false);
+        Endpoint::new_with_abstract_socket(endpoint_cfg, None, socket, runtime)?
+    };
+    let client_cfg = tls::build_client_config(&cfg)?;
+    endpoint.set_default_client_config(client_cfg);
+    let connecting = endpoint
+        .connect(server_addr, server_name)
+        .map_err(|e| Error::Quic(format!("connect start: {e}")))?;
+    let connection = timeout(CONNECT_TIMEOUT, connecting)
+        .await
+        .map_err(|_| Error::Quic(format!("connect timeout after {CONNECT_TIMEOUT:?}")))?
+        .map_err(|e| Error::Quic(format!("connect: {e}")))?;
+
+    let (h3_conn, mut send_request) =
+        h3::client::new(h3_quinn::Connection::new(connection.clone()))
+            .await
+            .map_err(|e| Error::Http3(e.to_string()))?;
+    let h3_driver = tokio::spawn(async move {
+        // Keep the HTTP/3 session alive for the lifetime of the QUIC connection.
+        // Driving `poll_close` here would tear down the connection and break
+        // proxied TCP/UDP streams opened via `open_bi`.
+        let _ = h3_conn;
+        pending::<()>().await;
+    });
+
+    let udp_enabled = match authenticate(&cfg, &mut send_request).await {
+        Ok(udp_enabled) => udp_enabled,
+        Err(e) => {
+            connection.close(0u32.into(), b"auth failed");
+            h3_driver.abort();
+            return Err(e);
+        }
+    };
+
+    let udp_router = Arc::new(UdpRouter::new());
+    let udp_driver =
+        udp_enabled.then(|| udp::spawn_receiver(connection.clone(), Arc::clone(&udp_router)));
+
+    Ok(ClientConnection {
+        connection,
+        _endpoint: endpoint,
+        h3_driver,
+        udp_driver,
+        udp_enabled,
+        udp_router,
+        next_session_id: std::sync::atomic::AtomicU32::new(0),
+        next_packet_id: AtomicU16::new(0),
+    })
+}
+
+async fn authenticate(
+    cfg: &Config,
+    send_request: &mut SendRequest<OpenStreams, bytes::Bytes>,
+) -> Result<bool> {
+    let padding = super::proto::auth_request_padding();
+    let request = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://hysteria/auth")
+        .header(http::header::HOST, "hysteria")
+        .header("Hysteria-Auth", cfg.auth.as_str())
+        .header("Hysteria-CC-RX", cfg.rx_bps.to_string())
+        .header("Hysteria-Padding", padding)
+        .body(())
+        .map_err(|e| Error::Http3(format!("auth request build: {e}")))?;
+
+    let mut stream = send_request
+        .send_request(request)
+        .await
+        .map_err(|e| Error::Http3(format!("auth send: {e}")))?;
+    stream
+        .finish()
+        .await
+        .map_err(|e| Error::Http3(format!("auth finish: {e}")))?;
+
+    let response = stream
+        .recv_response()
+        .await
+        .map_err(|e| Error::Http3(format!("auth response: {e}")))?;
+    if response.status().as_u16() != 233 {
+        return Err(Error::Auth(format!(
+            "authentication failed, status code: {}",
+            response.status()
+        )));
+    }
+
+    let udp_enabled = response
+        .headers()
+        .get("Hysteria-UDP")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value.eq_ignore_ascii_case("true") || value == "1" || value.eq_ignore_ascii_case("yes")
+        });
+
+    while let Some(mut chunk) = stream
+        .recv_data()
+        .await
+        .map_err(|e| Error::Http3(format!("auth body: {e}")))?
+    {
+        chunk.advance(chunk.remaining());
+    }
+
+    Ok(udp_enabled)
+}
+
+struct ServerTarget {
+    host: String,
+    port: u16,
+}
+
+impl ServerTarget {
+    fn parse(addr: &str) -> Result<Self> {
+        if let Ok(socket_addr) = addr.parse::<SocketAddr>() {
+            return Ok(Self {
+                host: socket_addr.ip().to_string(),
+                port: socket_addr.port(),
+            });
+        }
+
+        let (host, port) = addr
+            .rsplit_once(':')
+            .ok_or_else(|| Error::config(format!("server address has no port: {addr}")))?;
+        if host.is_empty() || host.contains(':') {
+            return Err(Error::config(format!(
+                "invalid server address, bracket IPv6 literals: {addr}"
+            )));
+        }
+        let port = port
+            .parse::<u16>()
+            .map_err(|e| Error::config(format!("invalid server port in '{addr}': {e}")))?;
+        if port == 0 {
+            return Err(Error::config("server port must be non-zero"));
+        }
+
+        Ok(Self {
+            host: host.to_string(),
+            port,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_domain_server_target() {
+        let target = ServerTarget::parse("example.com:443").unwrap();
+        assert_eq!(target.host, "example.com");
+        assert_eq!(target.port, 443);
+    }
+
+    #[test]
+    fn parses_bracketed_ipv6_server_target() {
+        let target = ServerTarget::parse("[::1]:443").unwrap();
+        assert_eq!(target.host, "::1");
+        assert_eq!(target.port, 443);
+    }
+}

--- a/crates/meow-proxy/src/hysteria2/config.rs
+++ b/crates/meow-proxy/src/hysteria2/config.rs
@@ -1,0 +1,14 @@
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+    pub server_addr: String,
+    pub server_name: String,
+    pub auth: String,
+    pub insecure: bool,
+    pub rx_bps: u64,
+    pub obfs_password: String,
+    pub hop_ports: String,
+    pub hop_interval_min_secs: u64,
+    pub hop_interval_max_secs: u64,
+    pub pin_sha256: String,
+    pub fast_open: bool,
+}

--- a/crates/meow-proxy/src/hysteria2/error.rs
+++ b/crates/meow-proxy/src/hysteria2/error.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    #[error("config: {0}")]
+    Config(String),
+
+    #[error("resolve: {0}")]
+    Resolve(String),
+
+    #[error("tls: {0}")]
+    Tls(String),
+
+    #[error("quic: {0}")]
+    Quic(String),
+
+    #[error("http3: {0}")]
+    Http3(String),
+
+    #[error("auth: {0}")]
+    Auth(String),
+
+    #[error("protocol: {0}")]
+    Protocol(String),
+
+    #[error("closed")]
+    Closed,
+}
+
+impl Error {
+    pub fn config(message: impl Into<String>) -> Self {
+        Self::Config(message.into())
+    }
+
+    pub fn tls(message: impl Into<String>) -> Self {
+        Self::Tls(message.into())
+    }
+
+    pub fn protocol(message: impl Into<String>) -> Self {
+        Self::Protocol(message.into())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/meow-proxy/src/hysteria2/mod.rs
+++ b/crates/meow-proxy/src/hysteria2/mod.rs
@@ -1,0 +1,14 @@
+mod client;
+mod config;
+mod error;
+mod proto;
+mod socket;
+mod tcp;
+mod tls;
+mod udp;
+
+pub use client::ReconnectableClient;
+pub use config::Config;
+pub use error::{Error, Result};
+pub use tcp::DuplexStream;
+pub use udp::UdpSession;

--- a/crates/meow-proxy/src/hysteria2/proto.rs
+++ b/crates/meow-proxy/src/hysteria2/proto.rs
@@ -1,0 +1,255 @@
+use super::{Error, Result};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+pub const FRAME_TYPE_TCP_REQUEST: u64 = 0x401;
+pub const MAX_ADDRESS_LENGTH: usize = 2048;
+pub const MAX_MESSAGE_LENGTH: usize = 2048;
+pub const MAX_PADDING_LENGTH: usize = 4096;
+pub const MAX_UDP_SIZE: usize = 4096;
+pub const DEFAULT_UDP_MTU: usize = 1200 - 3;
+
+const AUTH_PADDING_CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+/// Random padding for the hysteria2 auth HTTP/3 request (256..2048 bytes).
+pub fn auth_request_padding() -> String {
+    let len = 256 + (rand::random::<u16>() as usize % (2048 - 256));
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        let idx = usize::from(rand::random::<u8>()) % AUTH_PADDING_CHARS.len();
+        out.push(AUTH_PADDING_CHARS[idx] as char);
+    }
+    out
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UdpMessage {
+    pub session_id: u32,
+    pub packet_id: u16,
+    pub frag_id: u8,
+    pub frag_count: u8,
+    pub addr: String,
+    pub data: Vec<u8>,
+}
+
+pub fn encode_tcp_request(addr: &str, payload: &[u8]) -> Result<Vec<u8>> {
+    if addr.is_empty() || addr.len() > MAX_ADDRESS_LENGTH {
+        return Err(Error::protocol("invalid TCP request address length"));
+    }
+
+    let mut out = Vec::with_capacity(
+        varint_len(FRAME_TYPE_TCP_REQUEST)
+            + varint_len(addr.len() as u64)
+            + addr.len()
+            + 1
+            + payload.len(),
+    );
+    put_varint(FRAME_TYPE_TCP_REQUEST, &mut out)?;
+    put_varint(addr.len() as u64, &mut out)?;
+    out.extend_from_slice(addr.as_bytes());
+    put_varint(0, &mut out)?;
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+pub async fn read_tcp_response<R>(reader: &mut R) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let status = reader.read_u8().await?;
+    let message_len = read_varint_async(reader).await? as usize;
+    if message_len > MAX_MESSAGE_LENGTH {
+        return Err(Error::protocol("invalid TCP response message length"));
+    }
+
+    let mut message = vec![0u8; message_len];
+    if message_len > 0 {
+        reader.read_exact(&mut message).await?;
+    }
+
+    let padding_len = read_varint_async(reader).await? as usize;
+    if padding_len > MAX_PADDING_LENGTH {
+        return Err(Error::protocol("invalid TCP response padding length"));
+    }
+    if padding_len > 0 {
+        let mut padding = vec![0u8; padding_len];
+        reader.read_exact(&mut padding).await?;
+    }
+
+    match status {
+        0 => Ok(()),
+        1 => Err(Error::protocol(format!(
+            "remote TCP error: {}",
+            String::from_utf8_lossy(&message)
+        ))),
+        _ => Err(Error::protocol("invalid TCP response status")),
+    }
+}
+
+pub fn udp_header_len(addr: &str) -> Result<usize> {
+    if addr.is_empty() || addr.len() > MAX_ADDRESS_LENGTH {
+        return Err(Error::protocol("invalid UDP address length"));
+    }
+    Ok(8 + varint_len(addr.len() as u64) + addr.len())
+}
+
+pub fn encode_udp_message(message: &UdpMessage) -> Result<Vec<u8>> {
+    let header_len = udp_header_len(&message.addr)?;
+    let size = header_len
+        .checked_add(message.data.len())
+        .ok_or_else(|| Error::protocol("UDP message size overflow"))?;
+    if size > MAX_UDP_SIZE + header_len {
+        return Err(Error::protocol("UDP payload is too large"));
+    }
+
+    let mut out = Vec::with_capacity(size);
+    out.extend_from_slice(&message.session_id.to_be_bytes());
+    out.extend_from_slice(&message.packet_id.to_be_bytes());
+    out.push(message.frag_id);
+    out.push(message.frag_count);
+    put_varint(message.addr.len() as u64, &mut out)?;
+    out.extend_from_slice(message.addr.as_bytes());
+    out.extend_from_slice(&message.data);
+    Ok(out)
+}
+
+pub fn decode_udp_message(input: &[u8]) -> Result<UdpMessage> {
+    if input.len() < 9 {
+        return Err(Error::protocol("UDP message too short"));
+    }
+
+    let session_id = u32::from_be_bytes(input[0..4].try_into().expect("fixed slice"));
+    let packet_id = u16::from_be_bytes(input[4..6].try_into().expect("fixed slice"));
+    let frag_id = input[6];
+    let frag_count = input[7];
+    let mut pos = 8;
+    let addr_len = read_varint(input, &mut pos)? as usize;
+    if addr_len == 0 || addr_len > MAX_ADDRESS_LENGTH {
+        return Err(Error::protocol("invalid UDP address length"));
+    }
+    let addr_end = pos
+        .checked_add(addr_len)
+        .ok_or_else(|| Error::protocol("UDP address length overflow"))?;
+    if addr_end > input.len() {
+        return Err(Error::protocol("truncated UDP address"));
+    }
+    let addr = std::str::from_utf8(&input[pos..addr_end])
+        .map_err(|_| Error::protocol("UDP address is not UTF-8"))?
+        .to_string();
+    Ok(UdpMessage {
+        session_id,
+        packet_id,
+        frag_id,
+        frag_count,
+        addr,
+        data: input[addr_end..].to_vec(),
+    })
+}
+
+pub fn put_varint(value: u64, out: &mut Vec<u8>) -> Result<()> {
+    match value {
+        0..=63 => out.push(value as u8),
+        64..=16_383 => {
+            out.push(((value >> 8) as u8) | 0x40);
+            out.push(value as u8);
+        }
+        16_384..=1_073_741_823 => {
+            out.push(((value >> 24) as u8) | 0x80);
+            out.push((value >> 16) as u8);
+            out.push((value >> 8) as u8);
+            out.push(value as u8);
+        }
+        1_073_741_824..=4_611_686_018_427_387_903 => {
+            out.push(((value >> 56) as u8) | 0xc0);
+            out.push((value >> 48) as u8);
+            out.push((value >> 40) as u8);
+            out.push((value >> 32) as u8);
+            out.push((value >> 24) as u8);
+            out.push((value >> 16) as u8);
+            out.push((value >> 8) as u8);
+            out.push(value as u8);
+        }
+        _ => return Err(Error::protocol("QUIC varint overflow")),
+    }
+    Ok(())
+}
+
+pub fn varint_len(value: u64) -> usize {
+    match value {
+        0..=63 => 1,
+        64..=16_383 => 2,
+        16_384..=1_073_741_823 => 4,
+        _ => 8,
+    }
+}
+
+pub fn read_varint(input: &[u8], pos: &mut usize) -> Result<u64> {
+    if *pos >= input.len() {
+        return Err(Error::protocol("truncated QUIC varint"));
+    }
+    let first = input[*pos];
+    let len = 1usize << (first >> 6);
+    if input.len().saturating_sub(*pos) < len {
+        return Err(Error::protocol("truncated QUIC varint"));
+    }
+    let mut value = u64::from(first & 0x3f);
+    for b in &input[*pos + 1..*pos + len] {
+        value = (value << 8) | u64::from(*b);
+    }
+    *pos += len;
+    Ok(value)
+}
+
+async fn read_varint_async<R>(reader: &mut R) -> Result<u64>
+where
+    R: AsyncRead + Unpin,
+{
+    let first = reader.read_u8().await?;
+    let len = 1usize << (first >> 6);
+    let mut value = u64::from(first & 0x3f);
+    for _ in 1..len {
+        value = (value << 8) | u64::from(reader.read_u8().await?);
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quic_varint_round_trip_boundaries() {
+        for value in [0, 63, 64, 16_383, 16_384, 1_073_741_823, 1_073_741_824] {
+            let mut encoded = Vec::new();
+            put_varint(value, &mut encoded).unwrap();
+            let mut pos = 0;
+            assert_eq!(read_varint(&encoded, &mut pos).unwrap(), value);
+            assert_eq!(pos, encoded.len());
+        }
+    }
+
+    #[test]
+    fn tcp_request_layout_starts_with_frame_type() {
+        let encoded = encode_tcp_request("example.com:443", b"hello").unwrap();
+        let mut pos = 0;
+        assert_eq!(
+            read_varint(&encoded, &mut pos).unwrap(),
+            FRAME_TYPE_TCP_REQUEST
+        );
+        assert_eq!(read_varint(&encoded, &mut pos).unwrap(), 15);
+        assert_eq!(&encoded[pos..pos + 15], b"example.com:443");
+    }
+
+    #[test]
+    fn udp_message_round_trip() {
+        let message = UdpMessage {
+            session_id: 7,
+            packet_id: 9,
+            frag_id: 1,
+            frag_count: 2,
+            addr: "127.0.0.1:53".into(),
+            data: b"payload".to_vec(),
+        };
+        let encoded = encode_udp_message(&message).unwrap();
+        assert_eq!(decode_udp_message(&encoded).unwrap(), message);
+    }
+}

--- a/crates/meow-proxy/src/hysteria2/socket.rs
+++ b/crates/meow-proxy/src/hysteria2/socket.rs
@@ -1,0 +1,438 @@
+use super::{Error, Result};
+use blake2::{
+    digest::{Update, VariableOutput},
+    Blake2bVar,
+};
+use quinn::{
+    udp::{RecvMeta, Transmit},
+    AsyncUdpSocket, Runtime, UdpPoller,
+};
+use std::{
+    fmt,
+    io::{self, IoSliceMut},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+const SALAMANDER_SALT_LEN: usize = 8;
+const MAX_DATAGRAM_SIZE: usize = 65_535;
+const HY2_MIN_HOP_INTERVAL_SECS: u64 = 5;
+const HY2_DEFAULT_HOP_INTERVAL_SECS: u64 = 30;
+
+#[derive(Debug)]
+pub struct Hy2UdpSocket {
+    inner: Arc<dyn AsyncUdpSocket>,
+    server_addr: SocketAddr,
+    hop: Option<Mutex<HopState>>,
+    obfs: Option<Salamander>,
+}
+
+impl Hy2UdpSocket {
+    pub async fn bind(
+        server_addr: SocketAddr,
+        hop_ports: &str,
+        hop_interval_min_secs: u64,
+        hop_interval_max_secs: u64,
+        obfs_password: &str,
+    ) -> Result<Arc<Self>> {
+        let bind_addr = if server_addr.is_ipv4() {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+        } else {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+        };
+        let std_sock = std::net::UdpSocket::bind(bind_addr).map_err(Error::Io)?;
+        let runtime = quinn::TokioRuntime;
+        let inner = runtime.wrap_udp_socket(std_sock)?;
+        Ok(Arc::new(Self {
+            inner,
+            server_addr,
+            hop: HopState::new(hop_ports, hop_interval_min_secs, hop_interval_max_secs)?
+                .map(Mutex::new),
+            obfs: (!obfs_password.is_empty()).then(|| Salamander::new(obfs_password.as_bytes())),
+        }))
+    }
+
+    fn outgoing_destination(&self, destination: SocketAddr) -> SocketAddr {
+        let Some(hop) = &self.hop else {
+            return destination;
+        };
+        if destination.ip() != self.server_addr.ip()
+            || destination.port() != self.server_addr.port()
+        {
+            return destination;
+        }
+        let mut destination = destination;
+        let mut hop = hop.lock().expect("hysteria2 hop mutex poisoned");
+        destination.set_port(hop.current_port());
+        destination
+    }
+
+    fn incoming_source(&self, source: SocketAddr) -> SocketAddr {
+        let Some(hop) = &self.hop else {
+            return source;
+        };
+        if source.ip() != self.server_addr.ip() {
+            return source;
+        }
+        let hop = hop.lock().expect("hysteria2 hop mutex poisoned");
+        if !hop.contains(source.port()) {
+            return source;
+        }
+        let mut source = source;
+        source.set_port(self.server_addr.port());
+        source
+    }
+}
+
+impl AsyncUdpSocket for Hy2UdpSocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        Arc::clone(&self.inner).create_io_poller()
+    }
+
+    fn try_send(&self, transmit: &Transmit<'_>) -> io::Result<()> {
+        let destination = self.outgoing_destination(transmit.destination);
+        let rewritten = Transmit {
+            destination,
+            ecn: None,
+            contents: transmit.contents,
+            segment_size: transmit.segment_size,
+            src_ip: transmit.src_ip,
+        };
+        let Some(obfs) = &self.obfs else {
+            return self.inner.try_send(&rewritten);
+        };
+
+        let segment_size = rewritten.segment_size.unwrap_or(rewritten.contents.len());
+        if segment_size == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "zero UDP segment size",
+            ));
+        }
+
+        for chunk in rewritten.contents.chunks(segment_size) {
+            let encoded = obfs.encode(chunk);
+            let rewritten = Transmit {
+                destination,
+                ecn: None,
+                contents: &encoded,
+                segment_size: None,
+                src_ip: rewritten.src_ip,
+            };
+            self.inner.try_send(&rewritten)?;
+        }
+        Ok(())
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        let Some(obfs) = &self.obfs else {
+            let n = match self.inner.poll_recv(cx, bufs, meta) {
+                Poll::Ready(Ok(n)) => n,
+                other => return other,
+            };
+            for item in meta.iter_mut().take(n) {
+                item.addr = self.incoming_source(item.addr);
+            }
+            return Poll::Ready(Ok(n));
+        };
+
+        if bufs.is_empty() || meta.is_empty() {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "missing receive buffer",
+            )));
+        }
+
+        loop {
+            let mut encrypted = vec![0u8; MAX_DATAGRAM_SIZE];
+            let mut encrypted_bufs = [IoSliceMut::new(&mut encrypted)];
+            let mut encrypted_meta = [RecvMeta::default()];
+            let n = match self
+                .inner
+                .poll_recv(cx, &mut encrypted_bufs, &mut encrypted_meta)
+            {
+                Poll::Ready(Ok(n)) => n,
+                other => return other,
+            };
+            if n == 0 {
+                return Poll::Ready(Ok(0));
+            }
+
+            let raw_len = encrypted_meta[0].len;
+            let stride = encrypted_meta[0].stride.max(raw_len);
+            let mut offset = 0usize;
+            while offset < raw_len {
+                let end = (offset + stride).min(raw_len);
+                let received = &encrypted[offset..end];
+                let Some(plain) = obfs.decode(received) else {
+                    offset = end;
+                    continue;
+                };
+
+                if plain.len() > bufs[0].len() {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "received UDP datagram exceeds buffer",
+                    )));
+                }
+                bufs[0][..plain.len()].copy_from_slice(&plain);
+                let source = self.incoming_source(encrypted_meta[0].addr);
+                meta[0] = RecvMeta {
+                    addr: source,
+                    len: plain.len(),
+                    stride: plain.len(),
+                    ecn: encrypted_meta[0].ecn,
+                    dst_ip: encrypted_meta[0].dst_ip,
+                };
+                return Poll::Ready(Ok(1));
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.inner.local_addr()
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        if self.obfs.is_some() {
+            1
+        } else {
+            self.inner.max_transmit_segments()
+        }
+    }
+
+    fn max_receive_segments(&self) -> usize {
+        if self.obfs.is_some() {
+            1
+        } else {
+            self.inner.max_receive_segments()
+        }
+    }
+
+    fn may_fragment(&self) -> bool {
+        self.inner.may_fragment()
+    }
+}
+
+#[derive(Debug)]
+struct Salamander {
+    password: Vec<u8>,
+}
+
+impl Salamander {
+    fn new(password: &[u8]) -> Self {
+        Self {
+            password: password.to_vec(),
+        }
+    }
+
+    fn encode(&self, payload: &[u8]) -> Vec<u8> {
+        let salt: [u8; SALAMANDER_SALT_LEN] = rand::random();
+        let key = self.key(&salt);
+        let mut out = Vec::with_capacity(SALAMANDER_SALT_LEN + payload.len());
+        out.extend_from_slice(&salt);
+        out.extend(
+            payload
+                .iter()
+                .enumerate()
+                .map(|(i, b)| b ^ key[i % key.len()]),
+        );
+        out
+    }
+
+    fn decode(&self, payload: &[u8]) -> Option<Vec<u8>> {
+        if payload.len() <= SALAMANDER_SALT_LEN {
+            return None;
+        }
+        let (salt, ciphertext) = payload.split_at(SALAMANDER_SALT_LEN);
+        let key = self.key(salt);
+        Some(
+            ciphertext
+                .iter()
+                .enumerate()
+                .map(|(i, b)| b ^ key[i % key.len()])
+                .collect(),
+        )
+    }
+
+    fn key(&self, salt: &[u8]) -> [u8; 32] {
+        let mut hasher = Blake2bVar::new(32).expect("valid BLAKE2b output length");
+        hasher.update(&self.password);
+        hasher.update(salt);
+        let mut key = [0u8; 32];
+        hasher
+            .finalize_variable(&mut key)
+            .expect("BLAKE2b output buffer has requested length");
+        key
+    }
+}
+
+#[derive(Debug)]
+struct HopState {
+    ports: HopPorts,
+    min: Duration,
+    max: Duration,
+    current: u16,
+    next: Instant,
+}
+
+impl HopState {
+    fn new(raw_ports: &str, min_secs: u64, max_secs: u64) -> Result<Option<Self>> {
+        let Some(ports) = HopPorts::parse(raw_ports)? else {
+            return Ok(None);
+        };
+        let min_secs = if min_secs == 0 {
+            HY2_DEFAULT_HOP_INTERVAL_SECS
+        } else {
+            min_secs.max(HY2_MIN_HOP_INTERVAL_SECS)
+        };
+        let max_secs = max_secs.max(min_secs);
+        let mut state = Self {
+            ports,
+            min: Duration::from_secs(min_secs),
+            max: Duration::from_secs(max_secs),
+            current: 0,
+            next: Instant::now(),
+        };
+        state.rotate(Instant::now());
+        Ok(Some(state))
+    }
+
+    fn current_port(&mut self) -> u16 {
+        let now = Instant::now();
+        if now >= self.next {
+            self.rotate(now);
+        }
+        self.current
+    }
+
+    fn contains(&self, port: u16) -> bool {
+        self.ports.contains(port)
+    }
+
+    fn rotate(&mut self, now: Instant) {
+        self.current = self.ports.random_port();
+        self.next = now + self.next_interval();
+    }
+
+    fn next_interval(&self) -> Duration {
+        if self.min >= self.max {
+            return self.min;
+        }
+        let min = self.min.as_secs();
+        let span = self.max.as_secs() - min + 1;
+        Duration::from_secs(min + rand::random::<u64>() % span)
+    }
+}
+
+#[derive(Clone)]
+enum HopPorts {
+    All,
+    List(Vec<u16>),
+}
+
+impl fmt::Debug for HopPorts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::All => f.write_str("All"),
+            Self::List(ports) => f.debug_tuple("List").field(ports).finish(),
+        }
+    }
+}
+
+impl HopPorts {
+    fn parse(raw: &str) -> Result<Option<Self>> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Ok(None);
+        }
+        if raw == "*" || raw.eq_ignore_ascii_case("all") {
+            return Ok(Some(Self::All));
+        }
+
+        let mut ports = Vec::new();
+        for part in raw.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                return Err(Error::config(format!("invalid hop ports '{raw}'")));
+            }
+            if let Some((start, end)) = part.split_once('-') {
+                let start = parse_port(start)?;
+                let end = parse_port(end)?;
+                if start > end {
+                    return Err(Error::config(format!("invalid hop port range '{part}'")));
+                }
+                ports.extend(start..=end);
+            } else {
+                ports.push(parse_port(part)?);
+            }
+        }
+        ports.sort_unstable();
+        ports.dedup();
+        if ports.is_empty() {
+            return Err(Error::config("empty hop port set"));
+        }
+        Ok(Some(Self::List(ports)))
+    }
+
+    fn contains(&self, port: u16) -> bool {
+        match self {
+            Self::All => port != 0,
+            Self::List(ports) => ports.binary_search(&port).is_ok(),
+        }
+    }
+
+    fn random_port(&self) -> u16 {
+        match self {
+            Self::All => {
+                let value = 1 + rand::random::<u16>() % u16::MAX;
+                value.max(1)
+            }
+            Self::List(ports) => {
+                let index = rand::random::<u64>() as usize % ports.len();
+                ports[index]
+            }
+        }
+    }
+}
+
+fn parse_port(raw: &str) -> Result<u16> {
+    let port = raw
+        .trim()
+        .parse::<u16>()
+        .map_err(|e| Error::config(format!("invalid hop port '{raw}': {e}")))?;
+    if port == 0 {
+        return Err(Error::config("hop port must be non-zero"));
+    }
+    Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn salamander_round_trip() {
+        let obfs = Salamander::new(b"secret");
+        let encoded = obfs.encode(b"payload");
+        assert_ne!(&encoded[SALAMANDER_SALT_LEN..], b"payload");
+        assert_eq!(obfs.decode(&encoded).unwrap(), b"payload");
+    }
+
+    #[test]
+    fn hop_ports_parse_ranges() {
+        let ports = HopPorts::parse("443,8443-8445").unwrap().unwrap();
+        assert!(ports.contains(443));
+        assert!(ports.contains(8443));
+        assert!(ports.contains(8445));
+        assert!(!ports.contains(8446));
+    }
+}

--- a/crates/meow-proxy/src/hysteria2/tcp.rs
+++ b/crates/meow-proxy/src/hysteria2/tcp.rs
@@ -1,0 +1,245 @@
+use super::{proto, Error, Result};
+use quinn::{RecvStream, SendStream};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+type ReadResponseFuture = Pin<Box<dyn Future<Output = (RecvStream, Result<()>)> + Send>>;
+type WriteOpenFuture = Pin<Box<dyn Future<Output = (SendStream, io::Result<()>)> + Send>>;
+
+pub struct DuplexStream {
+    target: String,
+    read_state: ReadState,
+    write_state: WriteState,
+}
+
+impl DuplexStream {
+    pub(crate) fn new(
+        send: SendStream,
+        recv: RecvStream,
+        target: String,
+        request_written: bool,
+    ) -> Self {
+        Self {
+            target,
+            read_state: ReadState::NeedResponse(Some(recv)),
+            write_state: if request_written {
+                WriteState::Open(send)
+            } else {
+                WriteState::NeedRequest(Some(send))
+            },
+        }
+    }
+
+    fn poll_open_write(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.write_state {
+                WriteState::Open(_) => return Poll::Ready(Ok(())),
+                WriteState::NeedRequest(_) => {
+                    return Poll::Ready(Ok(()));
+                }
+                WriteState::Opening { future, .. } => {
+                    let (send, result) = match future.as_mut().poll(cx) {
+                        Poll::Ready(result) => result,
+                        Poll::Pending => return Poll::Pending,
+                    };
+                    this.write_state = match result {
+                        Ok(()) => WriteState::Open(send),
+                        Err(e) => WriteState::Failed(e.kind()),
+                    };
+                }
+                WriteState::Failed(kind) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        *kind,
+                        "hysteria2 TCP stream write failed",
+                    )));
+                }
+            }
+        }
+    }
+}
+
+impl AsyncRead for DuplexStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.read_state {
+                ReadState::NeedResponse(recv) => {
+                    let recv = recv
+                        .take()
+                        .ok_or_else(|| io::Error::other("hysteria2 TCP receive stream missing"))?;
+                    this.read_state = ReadState::Reading(read_response(recv));
+                }
+                ReadState::Reading(future) => {
+                    let (recv, result) = match future.as_mut().poll(cx) {
+                        Poll::Ready(result) => result,
+                        Poll::Pending => return Poll::Pending,
+                    };
+                    match result {
+                        Ok(()) => this.read_state = ReadState::Open(recv),
+                        Err(e) => {
+                            this.read_state = ReadState::Failed;
+                            return Poll::Ready(Err(error_to_io(e)));
+                        }
+                    }
+                }
+                ReadState::Open(recv) => return Pin::new(recv).poll_read(cx, buf),
+                ReadState::Failed => {
+                    return Poll::Ready(Err(io::Error::other("hysteria2 TCP stream read failed")));
+                }
+            }
+        }
+    }
+}
+
+impl AsyncWrite for DuplexStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.write_state {
+                WriteState::NeedRequest(send) => {
+                    let send = send
+                        .take()
+                        .ok_or_else(|| io::Error::other("hysteria2 TCP send stream missing"))?;
+                    let frame =
+                        proto::encode_tcp_request(&this.target, buf).map_err(error_to_io)?;
+                    let payload_len = buf.len();
+                    this.write_state = WriteState::Opening {
+                        future: write_open(send, frame),
+                        payload_len,
+                    };
+                }
+                WriteState::Opening {
+                    future,
+                    payload_len,
+                } => {
+                    let (send, result) = match future.as_mut().poll(cx) {
+                        Poll::Ready(result) => result,
+                        Poll::Pending => return Poll::Pending,
+                    };
+                    match result {
+                        Ok(()) => {
+                            let n = *payload_len;
+                            this.write_state = WriteState::Open(send);
+                            return Poll::Ready(Ok(n));
+                        }
+                        Err(e) => {
+                            let kind = e.kind();
+                            this.write_state = WriteState::Failed(kind);
+                            return Poll::Ready(Err(e));
+                        }
+                    }
+                }
+                WriteState::Open(send) => {
+                    return tokio::io::AsyncWrite::poll_write(Pin::new(send), cx, buf);
+                }
+                WriteState::Failed(kind) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        *kind,
+                        "hysteria2 TCP stream write failed",
+                    )));
+                }
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut this = self;
+        match this.as_mut().poll_open_write(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Pending => return Poll::Pending,
+        }
+
+        match &mut this.get_mut().write_state {
+            WriteState::Open(send) => Pin::new(send).poll_flush(cx),
+            WriteState::NeedRequest(_) => Poll::Ready(Ok(())),
+            WriteState::Opening { .. } => Poll::Pending,
+            WriteState::Failed(kind) => Poll::Ready(Err(io::Error::new(
+                *kind,
+                "hysteria2 TCP stream write failed",
+            ))),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut this = self;
+        match this.as_mut().poll_open_write(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Pending => return Poll::Pending,
+        }
+
+        match &mut this.get_mut().write_state {
+            WriteState::Open(send) => Pin::new(send).poll_shutdown(cx),
+            WriteState::NeedRequest(send) => {
+                let Some(mut send) = send.take() else {
+                    return Poll::Ready(Err(io::Error::other("hysteria2 TCP send stream missing")));
+                };
+                Poll::Ready(send.finish().map_err(io::Error::from))
+            }
+            WriteState::Opening { .. } => Poll::Pending,
+            WriteState::Failed(kind) => Poll::Ready(Err(io::Error::new(
+                *kind,
+                "hysteria2 TCP stream write failed",
+            ))),
+        }
+    }
+}
+
+impl Unpin for DuplexStream {}
+
+enum ReadState {
+    NeedResponse(Option<RecvStream>),
+    Reading(ReadResponseFuture),
+    Open(RecvStream),
+    Failed,
+}
+
+enum WriteState {
+    NeedRequest(Option<SendStream>),
+    Opening {
+        future: WriteOpenFuture,
+        payload_len: usize,
+    },
+    Open(SendStream),
+    Failed(io::ErrorKind),
+}
+
+fn read_response(mut recv: RecvStream) -> ReadResponseFuture {
+    Box::pin(async move {
+        let result = proto::read_tcp_response(&mut recv).await;
+        (recv, result)
+    })
+}
+
+fn write_open(mut send: SendStream, frame: Vec<u8>) -> WriteOpenFuture {
+    Box::pin(async move {
+        let result = send.write_all(&frame).await.map_err(io::Error::from);
+        (send, result)
+    })
+}
+
+pub(crate) async fn write_initial_request(send: &mut SendStream, target: &str) -> Result<()> {
+    let frame = proto::encode_tcp_request(target, &[])?;
+    send.write_all(&frame).await.map_err(io::Error::from)?;
+    Ok(())
+}
+
+fn error_to_io(error: Error) -> io::Error {
+    match error {
+        Error::Io(e) => e,
+        other => io::Error::other(other),
+    }
+}

--- a/crates/meow-proxy/src/hysteria2/tls.rs
+++ b/crates/meow-proxy/src/hysteria2/tls.rs
@@ -1,0 +1,232 @@
+use super::{Config, Error, Result};
+use quinn::{ClientConfig, TransportConfig, VarInt};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, RootCertStore, SignatureScheme};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::Duration;
+
+const ALPN_H3: &[u8] = b"h3";
+const DEFAULT_STREAM_RECEIVE_WINDOW: u32 = 8_388_608;
+const DEFAULT_CONN_RECEIVE_WINDOW: u32 = DEFAULT_STREAM_RECEIVE_WINDOW * 5 / 2;
+const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_KEEP_ALIVE: Duration = Duration::from_secs(10);
+const DATAGRAM_BUFFER_SIZE: usize = 1024 * 1024;
+
+pub fn build_client_config(config: &Config) -> Result<ClientConfig> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let pin = parse_sha256_pin(&config.pin_sha256)?;
+
+    let builder = rustls::ClientConfig::builder();
+    let mut tls_config = if config.insecure {
+        builder
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerify))
+            .with_no_client_auth()
+    } else if let Some(expected) = pin {
+        let roots = root_store();
+        let inner = rustls::client::WebPkiServerVerifier::builder_with_provider(
+            Arc::new(roots),
+            Arc::new(rustls::crypto::ring::default_provider()),
+        )
+        .build()
+        .map_err(|e| Error::tls(format!("webpki verifier setup: {e}")))?;
+        builder
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(PinVerifier { inner, expected }))
+            .with_no_client_auth()
+    } else {
+        builder
+            .with_root_certificates(root_store())
+            .with_no_client_auth()
+    };
+
+    tls_config.alpn_protocols = vec![ALPN_H3.to_vec()];
+
+    let crypto = quinn::crypto::rustls::QuicClientConfig::try_from(Arc::new(tls_config))
+        .map_err(|e| Error::tls(format!("quinn rustls setup: {e}")))?;
+    let mut client = ClientConfig::new(Arc::new(crypto));
+
+    let mut transport = TransportConfig::default();
+    transport.keep_alive_interval(Some(DEFAULT_KEEP_ALIVE));
+    transport.max_idle_timeout(Some(
+        DEFAULT_MAX_IDLE_TIMEOUT
+            .try_into()
+            .map_err(|e| Error::tls(format!("quic idle timeout setup: {e}")))?,
+    ));
+    transport.stream_receive_window(VarInt::from_u32(DEFAULT_STREAM_RECEIVE_WINDOW));
+    transport.receive_window(VarInt::from_u32(DEFAULT_CONN_RECEIVE_WINDOW));
+    transport.max_concurrent_bidi_streams(VarInt::from_u32(1024));
+    transport.max_concurrent_uni_streams(VarInt::from_u32(1024));
+    transport.datagram_receive_buffer_size(Some(DATAGRAM_BUFFER_SIZE));
+    transport.datagram_send_buffer_size(DATAGRAM_BUFFER_SIZE);
+    client.transport_config(Arc::new(transport));
+
+    Ok(client)
+}
+
+fn root_store() -> RootCertStore {
+    RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    }
+}
+
+fn parse_sha256_pin(raw: &str) -> Result<Option<[u8; 32]>> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+
+    let without_prefix = raw
+        .strip_prefix("sha256=")
+        .or_else(|| raw.strip_prefix("SHA256="))
+        .unwrap_or(raw);
+    let normalized: String = without_prefix
+        .chars()
+        .filter(|c| !c.is_ascii_whitespace() && *c != ':')
+        .flat_map(char::to_lowercase)
+        .collect();
+    if normalized.len() != 64 || !normalized.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Error::config(
+            "pin-sha256/fingerprint must be a SHA-256 hex digest",
+        ));
+    }
+
+    let decoded = hex::decode(normalized)
+        .map_err(|e| Error::config(format!("invalid SHA-256 fingerprint: {e}")))?;
+    let mut pin = [0u8; 32];
+    pin.copy_from_slice(&decoded);
+    Ok(Some(pin))
+}
+
+#[derive(Debug)]
+struct NoVerify;
+
+impl ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        all_schemes()
+    }
+}
+
+#[derive(Debug)]
+struct PinVerifier {
+    inner: Arc<rustls::client::WebPkiServerVerifier>,
+    expected: [u8; 32],
+}
+
+impl ServerCertVerifier for PinVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+        self.inner.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        )?;
+        let actual = Sha256::digest(end_entity.as_ref());
+        if actual.as_slice() == self.expected {
+            Ok(ServerCertVerified::assertion())
+        } else {
+            Err(rustls::Error::General(
+                "server certificate SHA-256 fingerprint mismatch".into(),
+            ))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.inner.supported_verify_schemes()
+    }
+}
+
+fn all_schemes() -> Vec<SignatureScheme> {
+    use rustls::SignatureScheme::*;
+    vec![
+        RSA_PKCS1_SHA256,
+        ECDSA_NISTP256_SHA256,
+        RSA_PKCS1_SHA384,
+        ECDSA_NISTP384_SHA384,
+        RSA_PKCS1_SHA512,
+        ECDSA_NISTP521_SHA512,
+        RSA_PSS_SHA256,
+        RSA_PSS_SHA384,
+        RSA_PSS_SHA512,
+        ED25519,
+        ED448,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_sha256_pin_variants() {
+        let raw = "sha256=AA:BB cc";
+        let mut padded = String::from(raw);
+        padded.push_str(&"00".repeat(29));
+        let pin = parse_sha256_pin(&padded).unwrap().unwrap();
+        assert_eq!(pin[0], 0xaa);
+        assert_eq!(pin[1], 0xbb);
+        assert_eq!(pin[2], 0xcc);
+    }
+
+    #[test]
+    fn rejects_invalid_sha256_pin() {
+        assert!(parse_sha256_pin("abc").is_err());
+    }
+}

--- a/crates/meow-proxy/src/hysteria2/udp.rs
+++ b/crates/meow-proxy/src/hysteria2/udp.rs
@@ -1,0 +1,313 @@
+use super::client::ClientConnection;
+use super::proto::{self, UdpMessage, DEFAULT_UDP_MTU, MAX_UDP_SIZE};
+use super::{Error, Result};
+use bytes::Bytes;
+use quinn::{Connection, SendDatagramError};
+use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+
+const UDP_SESSION_QUEUE: usize = 64;
+const FRAGMENT_TTL: Duration = Duration::from_secs(10);
+
+pub struct UdpSession {
+    conn: Arc<ClientConnection>,
+    session_id: u32,
+    packets: mpsc::Receiver<UdpMessage>,
+    defragger: UdpDefragger,
+}
+
+impl UdpSession {
+    pub(crate) fn new(conn: Arc<ClientConnection>) -> Result<Self> {
+        if !conn.udp_enabled {
+            return Err(Error::protocol("UDP disabled by hysteria2 server"));
+        }
+
+        let session_id = conn.next_session_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = mpsc::channel(UDP_SESSION_QUEUE);
+        conn.udp_router.register(session_id, tx)?;
+        Ok(Self {
+            conn,
+            session_id,
+            packets: rx,
+            defragger: UdpDefragger::new(),
+        })
+    }
+
+    pub fn send(&self, data: &[u8], addr: &str) -> Result<()> {
+        if data.len() > MAX_UDP_SIZE {
+            return Err(Error::protocol("UDP payload is too large"));
+        }
+
+        let packet_id = self.conn.next_packet_id.fetch_add(1, Ordering::Relaxed);
+        let max_datagram_size = self
+            .conn
+            .connection
+            .max_datagram_size()
+            .unwrap_or(DEFAULT_UDP_MTU)
+            .clamp(1, DEFAULT_UDP_MTU);
+        let header_len = proto::udp_header_len(addr)?;
+        let payload_limit = max_datagram_size
+            .checked_sub(header_len)
+            .filter(|n| *n > 0)
+            .ok_or_else(|| Error::protocol("UDP address is too long for QUIC datagram"))?;
+
+        if data.len() <= payload_limit {
+            let message = UdpMessage {
+                session_id: self.session_id,
+                packet_id,
+                frag_id: 0,
+                frag_count: 1,
+                addr: addr.to_string(),
+                data: data.to_vec(),
+            };
+            return self.send_message(&message);
+        }
+
+        let frag_count = data.len().div_ceil(payload_limit);
+        if frag_count > u8::MAX as usize {
+            return Err(Error::protocol("UDP payload needs too many fragments"));
+        }
+
+        for (frag_id, chunk) in data.chunks(payload_limit).enumerate() {
+            let message = UdpMessage {
+                session_id: self.session_id,
+                packet_id,
+                frag_id: frag_id as u8,
+                frag_count: frag_count as u8,
+                addr: addr.to_string(),
+                data: chunk.to_vec(),
+            };
+            self.send_message(&message)?;
+        }
+        Ok(())
+    }
+
+    pub async fn recv(&mut self) -> Result<(Vec<u8>, String)> {
+        loop {
+            let message = self.packets.recv().await.ok_or(Error::Closed)?;
+            if let Some(message) = self.defragger.feed(message)? {
+                return Ok((message.data, message.addr));
+            }
+        }
+    }
+
+    fn send_message(&self, message: &UdpMessage) -> Result<()> {
+        let encoded = proto::encode_udp_message(message)?;
+        self.conn
+            .connection
+            .send_datagram(Bytes::from(encoded))
+            .map_err(datagram_error)
+    }
+}
+
+impl Drop for UdpSession {
+    fn drop(&mut self) {
+        self.conn.udp_router.unregister(self.session_id);
+    }
+}
+
+pub(crate) struct UdpRouter {
+    sessions: Mutex<HashMap<u32, mpsc::Sender<UdpMessage>>>,
+}
+
+impl UdpRouter {
+    pub(crate) fn new() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn register(&self, session_id: u32, tx: mpsc::Sender<UdpMessage>) -> Result<()> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| Error::protocol("UDP session map mutex poisoned"))?;
+        sessions.insert(session_id, tx);
+        Ok(())
+    }
+
+    fn unregister(&self, session_id: u32) {
+        if let Ok(mut sessions) = self.sessions.lock() {
+            sessions.remove(&session_id);
+        }
+    }
+
+    fn route(&self, message: UdpMessage) {
+        let tx = self
+            .sessions
+            .lock()
+            .ok()
+            .and_then(|sessions| sessions.get(&message.session_id).cloned());
+        if let Some(tx) = tx {
+            let _ = tx.try_send(message);
+        }
+    }
+
+    fn close_all(&self) {
+        if let Ok(mut sessions) = self.sessions.lock() {
+            sessions.clear();
+        }
+    }
+}
+
+pub(crate) fn spawn_receiver(
+    connection: Connection,
+    router: Arc<UdpRouter>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let datagram = match connection.read_datagram().await {
+                Ok(datagram) => datagram,
+                Err(e) => {
+                    tracing::debug!("hysteria2 UDP receive loop stopped: {e}");
+                    router.close_all();
+                    return;
+                }
+            };
+            match proto::decode_udp_message(&datagram) {
+                Ok(message) => router.route(message),
+                Err(e) => tracing::debug!("dropping malformed hysteria2 UDP datagram: {e}"),
+            }
+        }
+    })
+}
+
+struct UdpDefragger {
+    packets: HashMap<u16, FragmentPacket>,
+}
+
+impl UdpDefragger {
+    fn new() -> Self {
+        Self {
+            packets: HashMap::new(),
+        }
+    }
+
+    fn feed(&mut self, message: UdpMessage) -> Result<Option<UdpMessage>> {
+        self.evict_stale();
+        if message.frag_count <= 1 {
+            return Ok(Some(message));
+        }
+        if message.frag_id >= message.frag_count {
+            return Ok(None);
+        }
+
+        let total = usize::from(message.frag_count);
+        let item = self
+            .packets
+            .entry(message.packet_id)
+            .or_insert_with(|| FragmentPacket::new(total));
+        if item.fragments.len() != total {
+            *item = FragmentPacket::new(total);
+        }
+
+        let index = usize::from(message.frag_id);
+        if item.fragments[index].is_some() {
+            return Ok(None);
+        }
+        item.fragments[index] = Some(message);
+        item.received += 1;
+
+        if item.received != total {
+            return Ok(None);
+        }
+
+        let packet_id = item.fragments[0]
+            .as_ref()
+            .expect("complete packet has first fragment")
+            .packet_id;
+        let item = self
+            .packets
+            .remove(&packet_id)
+            .expect("fragment packet exists");
+        reassemble(item).map(Some)
+    }
+
+    fn evict_stale(&mut self) {
+        let now = Instant::now();
+        self.packets
+            .retain(|_, item| now.duration_since(item.created) <= FRAGMENT_TTL);
+    }
+}
+
+struct FragmentPacket {
+    created: Instant,
+    fragments: Vec<Option<UdpMessage>>,
+    received: usize,
+}
+
+impl FragmentPacket {
+    fn new(total: usize) -> Self {
+        Self {
+            created: Instant::now(),
+            fragments: vec![None; total],
+            received: 0,
+        }
+    }
+}
+
+fn reassemble(item: FragmentPacket) -> Result<UdpMessage> {
+    let mut fragments: Vec<UdpMessage> = item
+        .fragments
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| Error::protocol("incomplete UDP fragments"))?;
+    let first = fragments
+        .first()
+        .ok_or_else(|| Error::protocol("empty UDP fragment set"))?
+        .clone();
+    let mut data = Vec::new();
+    for fragment in fragments.drain(..) {
+        data.extend_from_slice(&fragment.data);
+    }
+    if data.len() > MAX_UDP_SIZE {
+        return Err(Error::protocol("reassembled UDP payload is too large"));
+    }
+    Ok(UdpMessage {
+        session_id: first.session_id,
+        packet_id: first.packet_id,
+        frag_id: 0,
+        frag_count: 1,
+        addr: first.addr,
+        data,
+    })
+}
+
+fn datagram_error(error: SendDatagramError) -> Error {
+    match error {
+        SendDatagramError::TooLarge => Error::protocol("UDP datagram is too large"),
+        SendDatagramError::UnsupportedByPeer | SendDatagramError::Disabled => {
+            Error::protocol("UDP datagrams are not available")
+        }
+        SendDatagramError::ConnectionLost(e) => Error::Quic(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defragger_reassembles_in_order() {
+        let mut defragger = UdpDefragger::new();
+        let first = UdpMessage {
+            session_id: 1,
+            packet_id: 2,
+            frag_id: 0,
+            frag_count: 2,
+            addr: "127.0.0.1:53".into(),
+            data: b"he".to_vec(),
+        };
+        let second = UdpMessage {
+            frag_id: 1,
+            data: b"llo".to_vec(),
+            ..first.clone()
+        };
+        assert!(defragger.feed(first).unwrap().is_none());
+        let complete = defragger.feed(second).unwrap().unwrap();
+        assert_eq!(complete.data, b"hello");
+    }
+}

--- a/crates/meow-proxy/src/hysteria2_adapter.rs
+++ b/crates/meow-proxy/src/hysteria2_adapter.rs
@@ -1,79 +1,326 @@
-//! Hysteria 2 outbound (issue #72) — **tracer-bullet implementation**.
+//! Hysteria2 outbound proxy adapter.
 //!
-//! What ships in this PR:
-//! - QUIC varint codec (RFC 9000 §16).
-//! - Hy2 TCPRequest / TCPResponse frame codec (pure-Rust, no I/O).
-//! - YAML parser entry, `AdapterType::Hysteria2` variant, feature flag.
-//! - `Hy2Adapter::new` builds a `quinn` `ClientConfig` with ALPN `h3` +
-//!   SNI handling.
-//! - `dial_tcp` opens a QUIC connection (cached on the adapter) but
-//!   returns an explicit "auth not implemented yet" error before the
-//!   HTTP/3 handshake. **The data plane is wired in a follow-up PR.**
-//!
-//! What's intentionally NOT yet implemented (next session):
-//! - HTTP/3 POST `/auth` handshake (requires the `h3` + `h3-quinn` crates).
-//! - Reading the `Hysteria-CC-RX` server response header and applying any
-//!   congestion-control parameter overrides.
-//! - Stream wrapper that types a `quinn::SendStream` + `quinn::RecvStream`
-//!   pair as a single `Box<dyn ProxyConn>`.
-//! - UDP-over-QUIC datagram path (`fragment_id`/`packet_id` reassembly).
-//!
-//! Spec: <https://v2.hysteria.network/docs/developers/Protocol/>
+//! The wire protocol, HTTP/3 authentication, TCP stream framing, UDP datagrams,
+//! Salamander obfuscation and port hopping live in the in-tree `hysteria2`
+//! module. This module adapts that client to meow-rs' `ProxyAdapter` contracts.
 
 use async_trait::async_trait;
-use std::sync::Arc;
-
+use bytes::Bytes;
 use meow_common::{
     AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
 };
+use smol_str::SmolStr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing::debug;
 
-/// Hy2 frame IDs (QUIC varint values; see spec §"TCPRequest").
-const FRAME_ID_TCP_REQUEST: u64 = 0x401;
+const UDP_COMMAND_QUEUE: usize = 128;
+const UDP_PACKET_QUEUE: usize = 1024;
 
-/// Hy2 TCPResponse status byte values.
-const TCP_STATUS_OK: u8 = 0x00;
-const TCP_STATUS_ERROR: u8 = 0x01;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Hy2Obfs {
+    Salamander,
+}
 
-#[allow(dead_code)] // used by the dial path landing in the follow-up
-pub(crate) const HY2_ALPN: &[u8] = b"h3";
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Hy2HopInterval {
+    pub min_secs: u64,
+    pub max_secs: u64,
+}
 
-/// Hysteria 2 outbound adapter.
+#[derive(Debug, Clone)]
+pub struct Hy2Options {
+    pub name: String,
+    pub server: String,
+    pub port: u16,
+    pub password: String,
+    pub sni: Option<String>,
+    pub skip_cert_verify: bool,
+    pub udp: bool,
+    pub up_bps: u64,
+    pub down_bps: u64,
+    pub obfs: Option<Hy2Obfs>,
+    pub obfs_password: Option<String>,
+    pub ports: Option<String>,
+    pub hop_interval: Option<Hy2HopInterval>,
+    pub fingerprint: Option<String>,
+    pub fast_open: bool,
+}
+
+impl Hy2Options {
+    fn into_hysteria_config(
+        self,
+    ) -> std::result::Result<(String, bool, crate::hysteria2::Config), String> {
+        if self.password.is_empty() {
+            return Err(format!(
+                "hysteria2[{}]: password must not be empty",
+                self.name
+            ));
+        }
+        if self.port == 0 {
+            return Err(format!("hysteria2[{}]: port must be non-zero", self.name));
+        }
+
+        let obfs_password = match self.obfs {
+            Some(Hy2Obfs::Salamander) => self.obfs_password.unwrap_or_default(),
+            None => String::new(),
+        };
+        let hop_interval = self.hop_interval.unwrap_or(Hy2HopInterval {
+            min_secs: 0,
+            max_secs: 0,
+        });
+        let addr = hy2_server_addr(&self.server, self.port);
+        let cfg = crate::hysteria2::Config {
+            server_addr: addr.clone(),
+            server_name: self.sni.unwrap_or_default(),
+            auth: self.password,
+            insecure: self.skip_cert_verify,
+            rx_bps: self.down_bps,
+            obfs_password,
+            hop_ports: self.ports.unwrap_or_default(),
+            hop_interval_min_secs: hop_interval.min_secs,
+            hop_interval_max_secs: hop_interval.max_secs,
+            pin_sha256: self.fingerprint.unwrap_or_default(),
+            fast_open: self.fast_open,
+        };
+        Ok((addr, self.udp, cfg))
+    }
+}
+
 pub struct Hy2Adapter {
-    name: String,
+    name: SmolStr,
     addr: String,
+    support_udp: bool,
     health: ProxyHealth,
-    #[allow(dead_code)] // wired into the follow-up's dial path
-    password: String,
-    #[allow(dead_code)]
-    sni: String,
-    #[allow(dead_code)]
-    skip_cert_verify: bool,
+    client: Arc<crate::hysteria2::ReconnectableClient>,
 }
 
 impl Hy2Adapter {
-    pub fn new(
-        name: &str,
-        server: &str,
-        port: u16,
-        password: &str,
-        sni: Option<&str>,
-        skip_cert_verify: bool,
-    ) -> std::result::Result<Self, String> {
-        if password.is_empty() {
-            return Err(format!("hysteria2[{name}]: password must not be empty"));
-        }
-        let effective_sni = sni
-            .filter(|s| !s.trim().is_empty())
-            .unwrap_or(server)
-            .to_string();
+    pub fn new(options: Hy2Options) -> std::result::Result<Self, String> {
+        let name = options.name.clone();
+        let (addr, support_udp, cfg) = options.into_hysteria_config()?;
         Ok(Self {
-            name: name.to_string(),
-            addr: format!("{server}:{port}"),
+            name: SmolStr::from(name),
+            addr,
+            support_udp,
             health: ProxyHealth::new(),
-            password: password.to_string(),
-            sni: effective_sni,
-            skip_cert_verify,
+            client: Arc::new(crate::hysteria2::ReconnectableClient::new(cfg)),
         })
+    }
+}
+
+fn hy2_server_addr(server: &str, port: u16) -> String {
+    if let Ok(ip) = server.parse::<IpAddr>() {
+        return SocketAddr::new(ip, port).to_string();
+    }
+    format!("{server}:{port}")
+}
+
+fn target_from_metadata(metadata: &Metadata) -> Result<String> {
+    if metadata.dst_port == 0 {
+        return Err(MeowError::Proxy(
+            "hysteria2: metadata has no destination port".into(),
+        ));
+    }
+    if !metadata.host.is_empty() {
+        if let Ok(ip) = metadata.host.parse::<IpAddr>() {
+            return Ok(SocketAddr::new(ip, metadata.dst_port).to_string());
+        }
+        return Ok(format!("{}:{}", metadata.host, metadata.dst_port));
+    }
+    if let Some(ip) = metadata.dst_ip {
+        return Ok(SocketAddr::new(ip, metadata.dst_port).to_string());
+    }
+    Err(MeowError::Proxy(
+        "hysteria2: metadata has no destination".into(),
+    ))
+}
+
+fn hy2_error(context: &str, err: crate::hysteria2::Error) -> MeowError {
+    match err {
+        crate::hysteria2::Error::Io(e) => MeowError::Io(e),
+        other => MeowError::Proxy(format!("hysteria2 {context}: {other}")),
+    }
+}
+
+struct Hy2Conn {
+    inner: std::sync::Mutex<Pin<Box<crate::hysteria2::DuplexStream>>>,
+    remote: String,
+}
+
+impl Hy2Conn {
+    fn new(stream: crate::hysteria2::DuplexStream, remote: String) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(Box::pin(stream)),
+            remote,
+        }
+    }
+}
+
+impl AsyncRead for Hy2Conn {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return Poll::Ready(Err(std::io::Error::other(
+                "hysteria2 stream mutex poisoned",
+            )));
+        };
+        inner.as_mut().poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for Hy2Conn {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return Poll::Ready(Err(std::io::Error::other(
+                "hysteria2 stream mutex poisoned",
+            )));
+        };
+        inner.as_mut().poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return Poll::Ready(Err(std::io::Error::other(
+                "hysteria2 stream mutex poisoned",
+            )));
+        };
+        inner.as_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return Poll::Ready(Err(std::io::Error::other(
+                "hysteria2 stream mutex poisoned",
+            )));
+        };
+        inner.as_mut().poll_shutdown(cx)
+    }
+}
+
+impl Unpin for Hy2Conn {}
+
+impl ProxyConn for Hy2Conn {
+    fn remote_destination(&self) -> String {
+        self.remote.clone()
+    }
+}
+
+enum UdpCommand {
+    Send {
+        data: Bytes,
+        addr: String,
+        done: oneshot::Sender<Result<usize>>,
+    },
+    Close,
+}
+
+pub struct Hy2PacketConn {
+    commands: mpsc::Sender<UdpCommand>,
+    packets: Mutex<mpsc::Receiver<Result<(Bytes, SocketAddr)>>>,
+}
+
+impl Hy2PacketConn {
+    fn new(session: crate::hysteria2::UdpSession) -> Self {
+        let (command_tx, command_rx) = mpsc::channel(UDP_COMMAND_QUEUE);
+        let (packet_tx, packet_rx) = mpsc::channel(UDP_PACKET_QUEUE);
+        tokio::spawn(run_udp_session(session, command_rx, packet_tx));
+        Self {
+            commands: command_tx,
+            packets: Mutex::new(packet_rx),
+        }
+    }
+}
+
+async fn run_udp_session(
+    mut session: crate::hysteria2::UdpSession,
+    mut commands: mpsc::Receiver<UdpCommand>,
+    packets: mpsc::Sender<Result<(Bytes, SocketAddr)>>,
+) {
+    loop {
+        tokio::select! {
+            command = commands.recv() => {
+                match command {
+                    Some(UdpCommand::Send { data, addr, done }) => {
+                        let len = data.len();
+                        let result = session
+                            .send(&data, &addr)
+                            .map(|()| len)
+                            .map_err(|e| hy2_error("udp send", e));
+                        let _ = done.send(result);
+                    }
+                    Some(UdpCommand::Close) | None => return,
+                }
+            }
+            received = session.recv() => {
+                match received {
+                    Ok((data, addr)) => {
+                        let parsed = addr.parse::<SocketAddr>().map_err(|e| {
+                            MeowError::Proxy(format!("hysteria2 udp: invalid source address '{addr}': {e}"))
+                        });
+                        let packet = parsed.map(|src| (Bytes::from(data), src));
+                        if packets.send(packet).await.is_err() {
+                            return;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = packets.send(Err(hy2_error("udp recv", e))).await;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ProxyPacketConn for Hy2PacketConn {
+    async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        let mut packets = self.packets.lock().await;
+        match packets.recv().await {
+            Some(Ok((data, addr))) => {
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                Ok((n, addr))
+            }
+            Some(Err(e)) => Err(e),
+            None => Err(MeowError::Proxy("hysteria2 udp: session closed".into())),
+        }
+    }
+
+    async fn write_packet(&self, buf: &[u8], addr: &SocketAddr) -> Result<usize> {
+        let (done_tx, done_rx) = oneshot::channel();
+        self.commands
+            .send(UdpCommand::Send {
+                data: Bytes::copy_from_slice(buf),
+                addr: addr.to_string(),
+                done: done_tx,
+            })
+            .await
+            .map_err(|_| MeowError::Proxy("hysteria2 udp: session closed".into()))?;
+        done_rx
+            .await
+            .map_err(|_| MeowError::Proxy("hysteria2 udp: send task stopped".into()))?
+    }
+
+    fn local_addr(&self) -> Result<SocketAddr> {
+        Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
+    }
+
+    fn close(&self) -> Result<()> {
+        let _ = self.commands.try_send(UdpCommand::Close);
+        Ok(())
     }
 }
 
@@ -92,23 +339,37 @@ impl ProxyAdapter for Hy2Adapter {
     }
 
     fn support_udp(&self) -> bool {
-        // UDP-over-QUIC datagrams land in a follow-up PR.
-        false
+        self.support_udp
     }
 
-    async fn dial_tcp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
-        Err(MeowError::Proxy(
-            "hysteria2: data plane not implemented yet — this PR only ships the \
-             frame codec and config wiring (issue #72). HTTP/3 auth + QUIC streaming \
-             land in the next PR."
-                .to_string(),
-        ))
+    async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        let target = target_from_metadata(metadata)?;
+        debug!("Hysteria2 connecting to {} via {}", target, self.addr);
+        let stream = self
+            .client
+            .tcp_connect(&target)
+            .await
+            .map_err(|e| hy2_error("tcp connect", e))?;
+        Ok(Box::new(Hy2Conn::new(stream, target)))
     }
 
-    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        Err(MeowError::Proxy(
-            "hysteria2: UDP not implemented yet".to_string(),
-        ))
+    async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        if !self.support_udp {
+            return Err(MeowError::NotSupported(
+                "Hysteria2 UDP is disabled for this proxy".into(),
+            ));
+        }
+        debug!(
+            "Hysteria2 UDP-associating for {} via {}",
+            metadata.remote_address(),
+            self.addr
+        );
+        let session = self
+            .client
+            .udp()
+            .await
+            .map_err(|e| hy2_error("udp associate", e))?;
+        Ok(Box::new(Hy2PacketConn::new(session)))
     }
 
     fn health(&self) -> &ProxyHealth {
@@ -116,328 +377,93 @@ impl ProxyAdapter for Hy2Adapter {
     }
 }
 
-// ───────────────────────────────────────────────────────────────────────
-// QUIC varint codec (RFC 9000 §16). The leading two bits encode the
-// length: 00→1 byte, 01→2 bytes, 10→4 bytes, 11→8 bytes. Reused by the
-// hy2 frame codec below and by the UDP datagram codec in the follow-up.
-// ───────────────────────────────────────────────────────────────────────
-
-/// Maximum value representable as a QUIC varint.
-pub const VARINT_MAX: u64 = (1u64 << 62) - 1;
-
-/// Append a QUIC varint encoding of `value` to `out`. Panics in debug if
-/// `value` exceeds `VARINT_MAX`; in release the upper two bits are
-/// truncated and the decoded result will be wrong — callers must validate.
-pub fn varint_encode(out: &mut Vec<u8>, value: u64) {
-    debug_assert!(value <= VARINT_MAX, "varint value out of range");
-    if value < 0x40 {
-        out.push(value as u8);
-    } else if value < 0x4000 {
-        out.extend_from_slice(&((value as u16) | 0x4000).to_be_bytes());
-    } else if value < 0x4000_0000 {
-        out.extend_from_slice(&((value as u32) | 0x8000_0000).to_be_bytes());
-    } else {
-        out.extend_from_slice(&(value | 0xC000_0000_0000_0000).to_be_bytes());
-    }
-}
-
-/// Try to decode a QUIC varint at the start of `buf`. Returns
-/// `Some((value, bytes_consumed))` on success or `None` if the buffer is
-/// short for the indicated length.
-pub fn varint_decode(buf: &[u8]) -> Option<(u64, usize)> {
-    let first = *buf.first()?;
-    let len = 1usize << (first >> 6);
-    if buf.len() < len {
-        return None;
-    }
-    let raw = match len {
-        1 => u64::from(first & 0x3F),
-        2 => u64::from(u16::from_be_bytes([buf[0], buf[1]]) & 0x3FFF),
-        4 => u64::from(u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) & 0x3FFF_FFFF),
-        8 => {
-            u64::from_be_bytes([
-                buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
-            ]) & 0x3FFF_FFFF_FFFF_FFFF
-        }
-        _ => unreachable!("len derived from 2-bit tag"),
-    };
-    Some((raw, len))
-}
-
-// ───────────────────────────────────────────────────────────────────────
-// Hy2 frame codec.
-// ───────────────────────────────────────────────────────────────────────
-
-/// Encode a TCPRequest frame: `[0x401 varint][addr_len varint][addr][pad_len varint][padding]`.
-///
-/// `target` is the proxied destination in `host:port` form.
-/// `padding` is appended literally; pass an empty slice to send no
-/// padding. Callers usually generate the padding from the protocol-
-/// negotiated padding scheme (TBD in the follow-up).
-pub fn encode_tcp_request(target: &str, padding: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(target.len() + padding.len() + 16);
-    varint_encode(&mut out, FRAME_ID_TCP_REQUEST);
-    varint_encode(&mut out, target.len() as u64);
-    out.extend_from_slice(target.as_bytes());
-    varint_encode(&mut out, padding.len() as u64);
-    out.extend_from_slice(padding);
-    out
-}
-
-/// Decoded TCPResponse frame.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TcpResponse {
-    pub ok: bool,
-    pub message: String,
-    /// Whole-frame consumed byte count (for stream framing).
-    pub consumed: usize,
-}
-
-/// Decode a TCPResponse: `[u8 status][msg_len varint][msg][pad_len varint][padding]`.
-///
-/// Returns `Ok(Some(response))` on a full frame, `Ok(None)` when the
-/// buffer is short of a complete frame, or `Err(...)` if the bytes are
-/// malformed (unknown status, message length truncates the buffer,
-/// non-UTF-8 message string, etc.).
-pub fn decode_tcp_response(buf: &[u8]) -> std::result::Result<Option<TcpResponse>, String> {
-    let mut cursor = 0usize;
-    let status = match buf.first() {
-        Some(b) => *b,
-        None => return Ok(None),
-    };
-    cursor += 1;
-    let ok = match status {
-        TCP_STATUS_OK => true,
-        TCP_STATUS_ERROR => false,
-        other => return Err(format!("hysteria2: unknown TCPResponse status {other:#x}")),
-    };
-
-    let Some((msg_len, n)) = varint_decode(&buf[cursor..]) else {
-        return Ok(None);
-    };
-    cursor += n;
-    let msg_len = msg_len as usize;
-    if buf.len() < cursor + msg_len {
-        return Ok(None);
-    }
-    let message = std::str::from_utf8(&buf[cursor..cursor + msg_len])
-        .map_err(|e| format!("hysteria2: TCPResponse message is not UTF-8: {e}"))?
-        .to_string();
-    cursor += msg_len;
-
-    let Some((pad_len, n)) = varint_decode(&buf[cursor..]) else {
-        return Ok(None);
-    };
-    cursor += n;
-    let pad_len = pad_len as usize;
-    if buf.len() < cursor + pad_len {
-        return Ok(None);
-    }
-    cursor += pad_len;
-
-    Ok(Some(TcpResponse {
-        ok,
-        message,
-        consumed: cursor,
-    }))
-}
-
-// ───────────────────────────────────────────────────────────────────────
-// quinn ClientConfig builder. Kept private until the dial path uses it;
-// exported via `pub(crate)` so the follow-up PR's tests can reach it.
-// ───────────────────────────────────────────────────────────────────────
-
-#[cfg(feature = "hysteria2")]
-#[allow(dead_code)] // wired into the follow-up's dial path
-pub(crate) fn build_quic_client_config(
-    skip_cert_verify: bool,
-) -> std::result::Result<quinn::ClientConfig, String> {
-    use rustls::RootCertStore;
-
-    let root_store = RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    };
-
-    let provider = Arc::new(rustls::crypto::ring::default_provider());
-    let mut tls = rustls::ClientConfig::builder_with_provider(provider)
-        .with_safe_default_protocol_versions()
-        .map_err(|e| format!("rustls builder: {e}"))?
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-    tls.alpn_protocols = vec![HY2_ALPN.to_vec()];
-
-    if skip_cert_verify {
-        use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified};
-        use rustls::pki_types::{CertificateDer, ServerName as RsServerName, UnixTime};
-        use rustls::{DigitallySignedStruct, SignatureScheme};
-        #[derive(Debug)]
-        struct NoVerify;
-        impl rustls::client::danger::ServerCertVerifier for NoVerify {
-            fn verify_server_cert(
-                &self,
-                _: &CertificateDer<'_>,
-                _: &[CertificateDer<'_>],
-                _: &RsServerName<'_>,
-                _: &[u8],
-                _: UnixTime,
-            ) -> std::result::Result<ServerCertVerified, rustls::Error> {
-                Ok(ServerCertVerified::assertion())
-            }
-            fn verify_tls12_signature(
-                &self,
-                _: &[u8],
-                _: &CertificateDer<'_>,
-                _: &DigitallySignedStruct,
-            ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
-                Ok(HandshakeSignatureValid::assertion())
-            }
-            fn verify_tls13_signature(
-                &self,
-                _: &[u8],
-                _: &CertificateDer<'_>,
-                _: &DigitallySignedStruct,
-            ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
-                Ok(HandshakeSignatureValid::assertion())
-            }
-            fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-                vec![
-                    SignatureScheme::ECDSA_NISTP256_SHA256,
-                    SignatureScheme::ECDSA_NISTP384_SHA384,
-                    SignatureScheme::ED25519,
-                    SignatureScheme::RSA_PSS_SHA256,
-                    SignatureScheme::RSA_PSS_SHA384,
-                    SignatureScheme::RSA_PSS_SHA512,
-                    SignatureScheme::RSA_PKCS1_SHA256,
-                    SignatureScheme::RSA_PKCS1_SHA384,
-                    SignatureScheme::RSA_PKCS1_SHA512,
-                ]
-            }
-        }
-        tls.dangerous().set_certificate_verifier(Arc::new(NoVerify));
-    }
-
-    let quic_tls = quinn::crypto::rustls::QuicClientConfig::try_from(tls)
-        .map_err(|e| format!("quinn rustls adapter: {e}"))?;
-    Ok(quinn::ClientConfig::new(Arc::new(quic_tls)))
-}
-
-// ───────────────────────────────────────────────────────────────────────
-// Tests for the wire codec — fast, deterministic, no network.
-// ───────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn varint_roundtrip_corner_cases() {
-        for v in [
-            0u64,
-            1,
-            0x3F,
-            0x40,
-            0x3FFF,
-            0x4000,
-            0x3FFF_FFFF,
-            0x4000_0000,
-        ] {
-            let mut buf = Vec::new();
-            varint_encode(&mut buf, v);
-            let (got, n) = varint_decode(&buf).expect("decode");
-            assert_eq!(got, v, "value");
-            assert_eq!(n, buf.len(), "consumed");
+    fn base_options() -> Hy2Options {
+        Hy2Options {
+            name: "hy2".into(),
+            server: "example.com".into(),
+            port: 443,
+            password: "secret".into(),
+            sni: None,
+            skip_cert_verify: false,
+            udp: true,
+            up_bps: 0,
+            down_bps: 0,
+            obfs: None,
+            obfs_password: None,
+            ports: None,
+            hop_interval: None,
+            fingerprint: None,
+            fast_open: true,
         }
     }
 
     #[test]
-    fn varint_decode_truncated_returns_none() {
-        // A 2-byte varint with only the first byte present.
-        let mut buf = Vec::new();
-        varint_encode(&mut buf, 0x100);
-        buf.truncate(1);
-        assert!(varint_decode(&buf).is_none());
-    }
-
-    #[test]
-    fn tcp_request_frame_shape() {
-        let frame = encode_tcp_request("example.com:443", b"abc");
-        // Hy2 frame id 0x401 → 2-byte varint 0x4401 → bytes 0x44, 0x01.
-        assert_eq!(&frame[..2], &[0x44, 0x01], "frame ID prefix");
-        // Address length 15 → 1-byte varint 0x0F.
-        assert_eq!(frame[2], 0x0F, "address length varint");
-        assert_eq!(&frame[3..3 + 15], b"example.com:443");
-        // Padding length 3 → 1-byte varint 0x03.
-        assert_eq!(frame[3 + 15], 0x03);
-        assert_eq!(&frame[3 + 15 + 1..], b"abc");
-    }
-
-    #[test]
-    fn tcp_response_ok_round_trip() {
-        // status=OK, msg="", pad=""
-        let bytes = [TCP_STATUS_OK, 0x00, 0x00];
-        let resp = decode_tcp_response(&bytes).unwrap().unwrap();
-        assert!(resp.ok);
-        assert_eq!(resp.message, "");
-        assert_eq!(resp.consumed, 3);
-    }
-
-    #[test]
-    fn tcp_response_error_with_message() {
-        // status=Error, msg="bad", pad=""
-        let bytes = [TCP_STATUS_ERROR, 0x03, b'b', b'a', b'd', 0x00];
-        let resp = decode_tcp_response(&bytes).unwrap().unwrap();
-        assert!(!resp.ok);
-        assert_eq!(resp.message, "bad");
-        assert_eq!(resp.consumed, 6);
-    }
-
-    #[test]
-    fn tcp_response_short_buffer_yields_none() {
-        // Status byte only — needs message length next.
-        let bytes = [TCP_STATUS_OK];
-        assert!(decode_tcp_response(&bytes).unwrap().is_none());
-    }
-
-    #[test]
-    fn tcp_response_invalid_status_errors() {
-        let bytes = [0x05, 0x00, 0x00];
-        let err = decode_tcp_response(&bytes).unwrap_err();
-        assert!(err.contains("unknown TCPResponse status"), "got: {err}");
-    }
-
-    #[test]
-    fn tcp_response_non_utf8_message_errors() {
-        // msg_len=2, bytes are invalid UTF-8 (0xFF, 0xFE)
-        let bytes = [TCP_STATUS_OK, 0x02, 0xFF, 0xFE, 0x00];
-        let err = decode_tcp_response(&bytes).unwrap_err();
-        assert!(err.contains("not UTF-8"), "got: {err}");
-    }
-
-    #[test]
     fn adapter_constructor_rejects_empty_password() {
-        let Err(err) = Hy2Adapter::new("name", "1.2.3.4", 443, "", None, false) else {
+        let options = Hy2Options {
+            password: String::new(),
+            ..base_options()
+        };
+        let Err(err) = Hy2Adapter::new(options) else {
             panic!("must fail");
         };
         assert!(err.contains("password must not be empty"));
     }
 
     #[test]
-    fn adapter_constructor_defaults_sni_to_server() {
-        let a = Hy2Adapter::new("n", "example.com", 443, "secret", None, false).unwrap();
-        assert_eq!(a.sni, "example.com");
+    fn adapter_constructor_builds_hysteria_config() {
+        let adapter = Hy2Adapter::new(Hy2Options {
+            server: "127.0.0.1".into(),
+            sni: Some("example.com".into()),
+            up_bps: 10,
+            down_bps: 20,
+            obfs: Some(Hy2Obfs::Salamander),
+            obfs_password: Some("obfs-secret".into()),
+            ports: Some("443,8443".into()),
+            hop_interval: Some(Hy2HopInterval {
+                min_secs: 15,
+                max_secs: 30,
+            }),
+            fingerprint: Some("00".repeat(32)),
+            ..base_options()
+        })
+        .unwrap();
+        assert_eq!(adapter.name(), "hy2");
+        assert_eq!(adapter.addr(), "127.0.0.1:443");
+        assert!(adapter.support_udp());
     }
 
     #[test]
-    fn adapter_constructor_uses_explicit_sni() {
-        let a = Hy2Adapter::new(
-            "n",
-            "1.2.3.4",
-            443,
-            "secret",
-            Some("masq.example.com"),
-            false,
-        )
-        .unwrap();
-        assert_eq!(a.sni, "masq.example.com");
+    fn target_prefers_host() {
+        let md = Metadata {
+            host: "example.com".into(),
+            dst_ip: Some("127.0.0.1".parse().unwrap()),
+            dst_port: 443,
+            ..Default::default()
+        };
+        assert_eq!(target_from_metadata(&md).unwrap(), "example.com:443");
+    }
+
+    #[test]
+    fn target_formats_ipv6_socket_addr() {
+        let md = Metadata {
+            dst_ip: Some("::1".parse().unwrap()),
+            dst_port: 443,
+            ..Default::default()
+        };
+        assert_eq!(target_from_metadata(&md).unwrap(), "[::1]:443");
+    }
+
+    #[test]
+    fn target_brackets_ipv6_host_literal() {
+        let md = Metadata {
+            host: "::1".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        assert_eq!(target_from_metadata(&md).unwrap(), "[::1]:443");
     }
 }

--- a/crates/meow-proxy/src/lib.rs
+++ b/crates/meow-proxy/src/lib.rs
@@ -32,9 +32,11 @@ pub mod anytls_adapter;
 pub use anytls_adapter::AnytlsAdapter;
 
 #[cfg(feature = "hysteria2")]
+mod hysteria2;
+#[cfg(feature = "hysteria2")]
 pub mod hysteria2_adapter;
 #[cfg(feature = "hysteria2")]
-pub use hysteria2_adapter::Hy2Adapter;
+pub use hysteria2_adapter::{Hy2Adapter, Hy2HopInterval, Hy2Obfs, Hy2Options};
 
 #[cfg(feature = "vless")]
 pub(crate) mod vless;

--- a/crates/meow-proxy/tests/hysteria2_integration.rs
+++ b/crates/meow-proxy/tests/hysteria2_integration.rs
@@ -1,0 +1,356 @@
+#![cfg(feature = "hysteria2")]
+
+use meow_common::{Metadata, Network, ProxyAdapter, ProxyPacketConn};
+use meow_proxy::{Hy2Adapter, Hy2Options};
+use std::fs::File;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, UdpSocket};
+use tokio::time::{sleep, timeout, Duration, Instant};
+
+const IMAGE_HYSTERIA: &str = "tobyxdd/hysteria:v2.9.2";
+const PASSWORD: &str = "test-hysteria2-password";
+const T: Duration = Duration::from_secs(30);
+
+fn docker_required() -> bool {
+    std::env::var_os("MEOW_REQUIRE_DOCKER").is_some()
+        || std::env::var_os("MIHOMO_REQUIRE_INTEGRATION_BINS").is_some()
+}
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("info")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+fn skip_or_panic(reason: impl AsRef<str>) -> bool {
+    let reason = reason.as_ref();
+    if docker_required() {
+        panic!("{reason}");
+    }
+    eprintln!("skipping hysteria2 docker integration test: {reason}");
+    false
+}
+
+fn free_udp_port() -> u16 {
+    let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    socket.local_addr().unwrap().port()
+}
+
+struct HysteriaServer {
+    _dir: TempDir,
+    child: std::process::Child,
+    log_path: PathBuf,
+}
+
+impl HysteriaServer {
+    fn logs(&self) -> String {
+        std::fs::read_to_string(&self.log_path).unwrap_or_default()
+    }
+}
+
+impl Drop for HysteriaServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn write_server_files(dir: &Path, port: u16) -> PathBuf {
+    let status = Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            "server.key",
+            "-out",
+            "server.crt",
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+        ])
+        .current_dir(dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap_or_else(|e| {
+            panic!("openssl must be available for hysteria2 integration test: {e}")
+        });
+    assert!(status.success(), "openssl certificate generation failed");
+
+    let cert = dir.join("server.crt");
+    let key = dir.join("server.key");
+    let config_path = dir.join("config.yaml");
+    let config = format!(
+        concat!(
+            "listen: 127.0.0.1:{port}\n",
+            "tls:\n",
+            "  cert: {cert}\n",
+            "  key: {key}\n",
+            "auth:\n",
+            "  type: password\n",
+            "  password: {password}\n",
+            "disableUDP: false\n",
+            "masquerade:\n",
+            "  type: string\n",
+            "  string:\n",
+            "    content: meow-rs hysteria2 integration\n",
+            "    headers:\n",
+            "      content-type: text/plain\n",
+            "    statusCode: 200\n",
+        ),
+        port = port,
+        cert = cert.display(),
+        key = key.display(),
+        password = PASSWORD,
+    );
+    std::fs::write(&config_path, config).unwrap();
+    config_path
+}
+
+fn ensure_hysteria_binary(dir: &Path) -> Option<PathBuf> {
+    let bin = dir.join("hysteria");
+    if bin.exists() {
+        return Some(bin);
+    }
+
+    let pull = Command::new("docker")
+        .args(["pull", IMAGE_HYSTERIA])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    if pull.is_err() || !pull.unwrap_or_default().success() {
+        return None;
+    }
+
+    let extract_name = format!("meow-hy2-extract-{}", std::process::id());
+    let _ = Command::new("docker")
+        .args(["rm", "-f", &extract_name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    let create = Command::new("docker")
+        .args(["create", "--name", &extract_name, IMAGE_HYSTERIA])
+        .output()
+        .ok()?;
+    if !create.status.success() {
+        return None;
+    }
+
+    let copy = Command::new("docker")
+        .args([
+            "cp",
+            &format!("{extract_name}:/usr/local/bin/hysteria"),
+            &bin.to_string_lossy(),
+        ])
+        .output()
+        .ok()?;
+    let _ = Command::new("docker")
+        .args(["rm", "-f", &extract_name])
+        .status();
+    if !copy.status.success() {
+        return None;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(&bin) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o755);
+            let _ = std::fs::set_permissions(&bin, perms);
+        }
+    }
+    Some(bin)
+}
+
+fn start_hysteria_server(port: u16) -> Option<HysteriaServer> {
+    if !cfg!(target_os = "linux") {
+        skip_or_panic("test requires Linux");
+        return None;
+    }
+    if !docker_available() {
+        skip_or_panic("docker daemon is not available");
+        return None;
+    }
+
+    let dir = TempDir::new().unwrap();
+    let Some(hysteria_bin) = ensure_hysteria_binary(dir.path()) else {
+        skip_or_panic("failed to extract hysteria server binary from docker image");
+        return None;
+    };
+    let config_path = write_server_files(dir.path(), port);
+    let log_path = dir.path().join("server.log");
+    let log_file = match File::create(&log_path) {
+        Ok(file) => file,
+        Err(e) => {
+            skip_or_panic(format!("failed to create hysteria server log file: {e}"));
+            return None;
+        }
+    };
+
+    // Run hysteria in-process on the test host. Quinn cannot complete the QUIC
+    // handshake against a server started with `docker --network container:…`
+    // in nested container environments (e.g. Gitpod), while quic-go clients
+    // such as mihomo are unaffected.
+    let stdout = log_file.try_clone().map_or(Stdio::null(), Stdio::from);
+    let child = match Command::new(&hysteria_bin)
+        .args(["server", "-c", &config_path.to_string_lossy()])
+        .stdout(stdout)
+        .stderr(Stdio::from(log_file))
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => {
+            skip_or_panic(format!("failed to start hysteria server process: {e}"));
+            return None;
+        }
+    };
+
+    Some(HysteriaServer {
+        _dir: dir,
+        child,
+        log_path,
+    })
+}
+
+async fn start_tcp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    let n = match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => n,
+                    };
+                    if stream.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    (addr, handle)
+}
+
+async fn start_udp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = socket.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let mut buf = [0u8; 4096];
+        while let Ok((n, peer)) = socket.recv_from(&mut buf).await {
+            let _ = socket.send_to(&buf[..n], peer).await;
+        }
+    });
+    (addr, handle)
+}
+
+fn adapter(port: u16) -> Hy2Adapter {
+    Hy2Adapter::new(Hy2Options {
+        name: "docker-hy2".into(),
+        server: "127.0.0.1".into(),
+        port,
+        password: PASSWORD.into(),
+        sni: Some("localhost".into()),
+        skip_cert_verify: true,
+        udp: true,
+        up_bps: 10_000_000,
+        down_bps: 10_000_000,
+        obfs: None,
+        obfs_password: None,
+        ports: None,
+        hop_interval: None,
+        fingerprint: None,
+        fast_open: true,
+    })
+    .expect("hysteria2 adapter must build")
+}
+
+fn metadata_for(addr: SocketAddr, network: Network) -> Metadata {
+    Metadata {
+        network,
+        host: addr.ip().to_string().into(),
+        dst_port: addr.port(),
+        ..Default::default()
+    }
+}
+
+async fn dial_tcp_with_retry(
+    adapter: &Hy2Adapter,
+    metadata: &Metadata,
+) -> meow_common::Result<Box<dyn meow_common::ProxyConn>> {
+    let deadline = Instant::now() + T;
+    loop {
+        match adapter.dial_tcp(metadata).await {
+            Ok(conn) => return Ok(conn),
+            Err(e) if Instant::now() >= deadline => return Err(e),
+            Err(_) => {}
+        }
+        sleep(Duration::from_millis(250)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hysteria2_docker_tcp_and_udp_round_trip() {
+    let server_port = free_udp_port();
+    let Some(server) = start_hysteria_server(server_port) else {
+        return;
+    };
+    sleep(Duration::from_millis(500)).await;
+    let (tcp_echo, _tcp_h) = start_tcp_echo_server().await;
+    let (udp_echo, _udp_h) = start_udp_echo_server().await;
+    let adapter = adapter(server_port);
+
+    let tcp_metadata = metadata_for(tcp_echo, Network::Tcp);
+    let mut conn = match timeout(T, dial_tcp_with_retry(&adapter, &tcp_metadata)).await {
+        Ok(Ok(conn)) => conn,
+        Ok(Err(e)) => panic!("hysteria2 TCP dial failed: {e}\n{}", server.logs()),
+        Err(_) => panic!("hysteria2 TCP dial timed out\n{}", server.logs()),
+    };
+
+    let tcp_payload = b"meow hysteria2 tcp";
+    timeout(T, conn.write_all(tcp_payload))
+        .await
+        .expect("tcp write timed out")
+        .expect("tcp write failed");
+    timeout(T, conn.flush())
+        .await
+        .expect("tcp flush timed out")
+        .expect("tcp flush failed");
+    let mut tcp_buf = vec![0u8; tcp_payload.len()];
+    timeout(T, conn.read_exact(&mut tcp_buf))
+        .await
+        .expect("tcp read timed out")
+        .expect("tcp read failed");
+    assert_eq!(&tcp_buf, tcp_payload);
+
+    let udp_metadata = metadata_for(udp_echo, Network::Udp);
+    let packet_conn: Box<dyn ProxyPacketConn> = timeout(T, adapter.dial_udp(&udp_metadata))
+        .await
+        .expect("udp associate timed out")
+        .unwrap_or_else(|e| panic!("udp associate failed: {e}\n{}", server.logs()));
+    let udp_payload = b"meow hysteria2 udp";
+    timeout(T, packet_conn.write_packet(udp_payload, &udp_echo))
+        .await
+        .expect("udp write timed out")
+        .expect("udp write failed");
+    let mut udp_buf = [0u8; 1500];
+    let (n, src) = timeout(T, packet_conn.read_packet(&mut udp_buf))
+        .await
+        .expect("udp read timed out")
+        .expect("udp read failed");
+    assert_eq!(src, udp_echo);
+    assert_eq!(&udp_buf[..n], udp_payload);
+}


### PR DESCRIPTION
本实现经 Composer 2.5 与 GPT-5.5 xhigh 审计。 Cursor 里没额度跑 claude 了 :)

## Summary

- 在 `meow-proxy` 内实现 Hysteria2 出站客户端（基于 Quinn），覆盖 HTTP/3 认证、TCP 流帧、UDP datagram、Salamander 混淆与端口跳跃。
- 认证后保持 HTTP/3 session 存活，避免 `poll_close` 过早关闭 QUIC 连接导致代理流失败。
- 新增 `hysteria2_integration` 集成测试：从官方 Docker 镜像提取 hysteria server 二进制并以宿主机子进程运行（Quinn 在嵌套容器 `docker --network container:…` 环境下无法完成握手）。
- 扩展 `meow-config` 解析与 README/CI 说明。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib`
- [x] `cargo test --test hysteria2_integration --features hysteria2`
- [x] CI green on `codex/hysteria2`


Made with [Cursor](https://cursor.com)