### PR TITLE
feat(vless): support Reality Vision transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,6 +2264,7 @@ dependencies = [
 name = "meow-transport"
 version = "0.14.0"
 dependencies = [
+ "aes-gcm",
  "async-trait",
  "base64",
  "boring",
@@ -2271,6 +2272,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "h2",
+ "hmac",
  "http",
  "httparse",
  "md5",
@@ -2278,6 +2280,7 @@ dependencies = [
  "rcgen 0.13.2",
  "regex",
  "rustls",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-boring",

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -972,7 +972,7 @@ fn parse_lb_strategy(strategy: Option<&str>) -> std::result::Result<LbStrategy, 
 ///
 /// - `flow: xtls-rprx-direct` / `xtls-rprx-splice` — deprecated and insecure
 /// - Unknown `flow` values — may skip expected security processing
-/// - `reality-opts` present — Reality transport not implemented
+/// - `reality-opts` malformed, used without TLS, or missing `client-fingerprint`
 /// - `flow: xtls-rprx-vision` + no TLS-enforcing transport
 /// - `encryption: <non-empty non-"none">` — unsupported cipher
 /// - `uuid` invalid
@@ -1043,12 +1043,15 @@ fn parse_vless(
         .unwrap_or("tcp");
     let client_fingerprint = config.get("client-fingerprint").and_then(|v| v.as_str());
 
-    // ── Hard error: reality-opts present (Class A) ────────────────────────
-    if config.contains_key("reality-opts") {
-        return Err("vless: reality-opts is not yet implemented; \
-             Reality transport is tracked for post-M1. \
-             Remove reality-opts or wait for the Reality spec to land."
-            .into());
+    // ── Reality opts ──────────────────────────────────────────────────────
+    let reality = parse_vless_reality_opts(config)?;
+    if reality.is_some() {
+        if !tls {
+            return Err("vless: reality-opts requires `tls: true`".into());
+        }
+        if client_fingerprint.is_none() {
+            return Err("vless: REALITY is based on uTLS, please set a client-fingerprint".into());
+        }
     }
 
     // ── Hard error: encryption != "" / "none" ─────────────────────────────
@@ -1179,6 +1182,7 @@ fn parse_vless(
             alpn
         };
         tls_cfg.fingerprint = client_fingerprint.map(std::string::ToString::to_string);
+        tls_cfg.reality = reality;
 
         // ── ECH opts ────────────────────────────────────────────────────
         // DNS-sourced ECH (`enable: true` without `config:`) is resolved by
@@ -1339,6 +1343,75 @@ fn parse_vless(
     Ok(VlessAdapter::new(
         name, server, port, uuid_bytes, flow, udp, chain,
     ))
+}
+
+/// Parse VLESS `reality-opts` into transport-layer REALITY parameters.
+///
+/// Matches mihomo's wire-facing fields: `public-key` is base64 RawURL X25519,
+/// `short-id` is hex-decoded and zero-padded to eight bytes, and
+/// `support-x25519mlkem768` is a capability flag. The TLS layer currently
+/// offers X25519 only; keeping the flag in config preserves the public surface
+/// for future fingerprint-specific ClientHello work.
+#[cfg(feature = "vless")]
+fn parse_vless_reality_opts(
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<Option<meow_transport::tls::RealityConfig>, String> {
+    let Some(opts) = config.get("reality-opts") else {
+        return Ok(None);
+    };
+
+    let public_key_str = opts
+        .get("public-key")
+        .and_then(serde_yaml::Value::as_str)
+        .ok_or_else(|| "vless: reality-opts.public-key is required".to_string())?;
+
+    use base64::Engine;
+    let public_key_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(public_key_str)
+        .map_err(|_| "vless: invalid REALITY public key".to_string())?;
+    if public_key_bytes.len() != 32 {
+        return Err("vless: invalid REALITY public key".into());
+    }
+    let mut public_key = [0u8; 32];
+    public_key.copy_from_slice(&public_key_bytes);
+
+    let short_id_str = match opts.get("short-id") {
+        Some(value) => value
+            .as_str()
+            .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?,
+        None => "",
+    };
+    let short_id_vec = parse_reality_short_id(short_id_str)?;
+    let mut short_id = [0u8; 8];
+    short_id[..short_id_vec.len()].copy_from_slice(&short_id_vec);
+
+    let support_x25519_mlkem768 = opts
+        .get("support-x25519mlkem768")
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(false);
+
+    Ok(Some(meow_transport::tls::RealityConfig {
+        public_key,
+        short_id,
+        support_x25519_mlkem768,
+    }))
+}
+
+#[cfg(feature = "vless")]
+fn parse_reality_short_id(s: &str) -> std::result::Result<Vec<u8>, String> {
+    if s.len() % 2 != 0 || s.len() / 2 > 8 {
+        return Err("vless: invalid REALITY short ID".into());
+    }
+
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for chunk in s.as_bytes().chunks(2) {
+        let hex = std::str::from_utf8(chunk)
+            .map_err(|_| "vless: invalid REALITY short ID".to_string())?;
+        let byte = u8::from_str_radix(hex, 16)
+            .map_err(|_| "vless: invalid REALITY short ID".to_string())?;
+        out.push(byte);
+    }
+    Ok(out)
 }
 
 /// Parse a UUID string (dashed or hex-only) into a 16-byte array.

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1399,7 +1399,7 @@ fn parse_vless_reality_opts(
 
 #[cfg(feature = "vless")]
 fn parse_reality_short_id(s: &str) -> std::result::Result<Vec<u8>, String> {
-    if s.len() % 2 != 0 || s.len() / 2 > 8 {
+    if !s.len().is_multiple_of(2) || s.len() / 2 > 8 {
         return Err("vless: invalid REALITY short ID".into());
     }
 

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -18,7 +18,7 @@ use meow_rules::{
 };
 use parking_lot::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 use crate::internal_http;
 use crate::raw::RawRuleProvider;
@@ -106,7 +106,7 @@ impl RuleProvider {
         let new_rules: Arc<dyn RuleSet> = Arc::from(boxed);
         *self.rules.write() = new_rules;
         self.touch();
-        info!(provider = %self.name, "rule-provider refreshed: {} rules", count);
+        debug!(provider = %self.name, "rule-provider refreshed: {} rules", count);
         Ok(())
     }
 
@@ -140,7 +140,7 @@ pub fn load_providers(
     for (name, cfg) in raw_providers {
         match load_one(name, cfg, cache_dir, ctx, download_proxy) {
             Ok(provider) => {
-                info!(
+                debug!(
                     "Loaded rule-provider '{}' ({}/{}): {} entries",
                     name,
                     provider.provider_type,
@@ -484,7 +484,7 @@ fn write_cache(path: &Path, bytes: &[u8]) {
             e
         );
     } else {
-        info!("rule-provider cache updated: {}", path.display());
+        debug!("rule-provider cache updated: {}", path.display());
     }
 }
 

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -14,7 +14,7 @@
 //! | D6  | `parse_vless_flow_unknown_hard_errors`           — unknown flow → hard error |
 //! | D7  | `parse_vless_flow_deprecated_direct_hard_errors` — xtls-rprx-direct → hard error |
 //! | D8  | `parse_vless_flow_deprecated_splice_hard_errors` — xtls-rprx-splice → hard error |
-//! | D9  | `parse_vless_reality_opts_hard_errors`           — reality-opts → hard error |
+//! | D9  | `parse_vless_reality_opts_*`                     — REALITY config validation |
 //! | D10 | `parse_vless_tls_false_plain_warns_once`         — tls: false warns + loads |
 //! | D11 | `parse_vless_tls_false_no_duplicate_warn`        — warn fires once per load (not globally) |
 //! | D12 | `parse_vless_vision_without_tls_hard_errors`     — vision + no TLS → hard error |
@@ -304,15 +304,14 @@ proxies:
     );
 }
 
-// ─── D9: reality-opts present → proxy skipped ────────────────────────────────
+// ─── D9: reality-opts parsing ────────────────────────────────────────────────
 
-/// D9: `parse_vless_reality_opts_hard_errors`
+/// D9: `parse_vless_reality_opts_requires_fingerprint`
 ///
-/// `reality-opts:` block → proxy parse error; proxy absent from config.
-/// upstream: `adapter/outbound/vless.go` routes to Reality transport.
-/// NOT silent ignore — Class A per ADR-0002: user assumes Reality, gets plain-TLS.
+/// Reality is tied to a uTLS fingerprint upstream; require the field at config
+/// time so the user cannot accidentally get plain TLS semantics.
 #[tokio::test]
-async fn parse_vless_reality_opts_hard_errors() {
+async fn parse_vless_reality_opts_requires_fingerprint() {
     let yaml = r#"
 proxies:
   - name: v
@@ -320,6 +319,52 @@ proxies:
     server: example.com
     port: 443
     uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("config load must succeed (warn-and-skip)");
+    assert!(
+        !config.proxies.contains_key("v"),
+        "proxy with reality-opts but no client-fingerprint must be skipped"
+    );
+}
+
+#[tokio::test]
+async fn parse_vless_reality_opts_requires_tls_true() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("config load must succeed (warn-and-skip)");
+    assert!(
+        !config.proxies.contains_key("v"),
+        "proxy with reality-opts but tls=false must be skipped"
+    );
+}
+
+#[tokio::test]
+async fn parse_vless_reality_opts_invalid_public_key_skipped() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    client-fingerprint: chrome
     reality-opts:
       public-key: abc123
 "#;
@@ -328,7 +373,57 @@ proxies:
         .expect("config load must succeed (warn-and-skip)");
     assert!(
         !config.proxies.contains_key("v"),
-        "proxy with reality-opts must be skipped (not implemented — Class A)"
+        "proxy with invalid REALITY public key must be skipped"
+    );
+}
+
+#[tokio::test]
+async fn parse_vless_reality_opts_invalid_short_id_skipped() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+      short-id: 001122334455667788
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("config load must succeed (warn-and-skip)");
+    assert!(
+        !config.proxies.contains_key("v"),
+        "proxy with >8-byte REALITY short-id must be skipped"
+    );
+}
+
+#[cfg(feature = "boring-tls")]
+#[tokio::test]
+async fn parse_vless_reality_opts_valid_loads_with_boring_tls() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+      short-id: 0011223344556677
+      support-x25519mlkem768: false
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("valid REALITY VLESS config must load");
+    assert!(
+        config.proxies.contains_key("v"),
+        "valid REALITY VLESS proxy must be registered"
     );
 }
 

--- a/crates/meow-proxy/src/vless/conn.rs
+++ b/crates/meow-proxy/src/vless/conn.rs
@@ -57,6 +57,14 @@ impl VlessConn {
             response_pending: true,
         })
     }
+
+    pub(crate) fn enable_raw_read_passthrough(&mut self) -> bool {
+        meow_transport::enable_raw_read_passthrough(&mut *self.inner)
+    }
+
+    pub(crate) fn enable_raw_write_passthrough(&mut self) -> bool {
+        meow_transport::enable_raw_write_passthrough(&mut *self.inner)
+    }
 }
 
 // ─── AsyncRead / AsyncWrite pass-through ──────────────────────────────────────

--- a/crates/meow-proxy/src/vless/vision.rs
+++ b/crates/meow-proxy/src/vless/vision.rs
@@ -1,130 +1,312 @@
-//! XTLS-Vision splice wrapper for VLESS.
-//!
-//! `VisionConn` wraps a `VlessConn` and intercepts the first application-layer
-//! write.  If the first 5 bytes are a TLS handshake record
-//! (`byte[0] == 0x16 && byte[1] == 0x03`), Vision mode is entered:
-//!
-//! 1. Buffer the full ClientHello (5-byte header + `uint16_BE(bytes[3..5])` body).
-//! 2. Write a Vision padding header (disguised as a TLS AppData record) to inner.
-//! 3. Write the full ClientHello to inner.
-//! 4. Pass all subsequent writes through to inner unchanged.
-//!
-//! If the first 5 bytes are NOT a TLS record, pass-through mode is entered
-//! immediately (no padding, no buffering beyond the initial peek).
-//!
-//! # Padding header wire format
-//!
-//! ```text
-//! 0x17                  TLS AppData record type (disguise)
-//! 0x03 0x03             TLS 1.2 version (always these bytes)
-//! len_be(2)             2-byte big-endian length of the payload below
-//! 0x00                  Vision marker byte (server recognises this)
-//! random(N)             N in PADDING_RANGE
-//! ```
-//!
-//! upstream: transport/vless/vision/vision.go::sendPaddingMessage
-// upstream SHA: xray-core/xray-core main (2024) — pin before Vision PR merges
+//! XTLS-Vision padding wrapper for VLESS.
 
+use std::collections::VecDeque;
 use std::io;
-use std::ops::RangeInclusive;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use meow_common::ProxyConn;
+use rand::RngCore;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use super::conn::VlessConn;
 
-// ─── Upstream-pinned constant ────────────────────────────────────────────────
+const UUID_LEN: usize = 16;
+const PADDING_HEADER_LEN: usize = UUID_LEN + 1 + 2 + 2;
+const COMMAND_PADDING_CONTINUE: u8 = 0x00;
+const COMMAND_PADDING_END: u8 = 0x01;
+const COMMAND_PADDING_DIRECT: u8 = 0x02;
+const TLS_HANDSHAKE: u8 = 0x16;
+const TLS_APPLICATION_DATA: u8 = 0x17;
+const TLS_MAJOR: u8 = 0x03;
+const TLS_CLIENT_HELLO: u8 = 0x01;
+const TLS_SERVER_HELLO: u8 = 0x02;
+const TLS13_SUPPORTED_VERSIONS_EXT: [u8; 6] = [0x00, 0x2b, 0x00, 0x02, 0x03, 0x04];
+const TLS13_CIPHER_SUITES: [u16; 4] = [0x1301, 0x1302, 0x1303, 0x1304];
+const TLS_FILTER_PACKETS: usize = 8;
 
-/// Padding payload random-byte count range.
-///
-/// upstream: transport/vless/vision/vision.go — const `paddingMaxLen = 900`.
-/// The padding payload is `[0x00] + random(N)` where N ∈ PADDING_RANGE.
-/// Byte-exact match with the upstream constant is required (servers check the
-/// marker byte and reject malformed padding).
-pub const PADDING_RANGE: RangeInclusive<usize> = 0..=900;
-
-// ─── State machine ────────────────────────────────────────────────────────────
-
-enum WriteState {
-    /// Buffering the first 5 bytes of application data.
-    Peek(Vec<u8>),
-    /// TLS ClientHello detected; buffering the body (beyond the 5-byte peek).
-    Body {
-        peek5: [u8; 5],
-        body: Vec<u8>,
-        need_more: usize,
+enum ReadState {
+    Header {
+        buf: Vec<u8>,
+        need_uuid: bool,
     },
-    /// Draining the prebuilt [padding_header + clienthello] buffer to inner.
-    Drain { to_send: Vec<u8>, pos: usize },
-    /// Passthrough — no more buffering.
+    Content {
+        command: u8,
+        remaining_content: usize,
+        remaining_padding: usize,
+    },
+    Padding {
+        command: u8,
+        remaining_padding: usize,
+    },
     Through,
 }
 
-/// Vision-mode wrapper around `VlessConn`.
-///
-/// Returns `VisionConn` when `flow = xtls-rprx-vision` and the outer transport
-/// provides TLS. See module-level docs for the splice algorithm.
+struct PendingWrite {
+    frame: Vec<u8>,
+    pos: usize,
+    consumed: usize,
+    command: u8,
+    end_padding_after_drain: bool,
+}
+
 pub struct VisionConn {
     inner: VlessConn,
-    write_state: WriteState,
-    /// Set to true once we entered Vision mode (padding header emitted).
-    /// Used only in test assertions and the C11 log-noise guard.
-    #[allow(dead_code)]
+    user_uuid: [u8; UUID_LEN],
+    read_state: ReadState,
+    read_plain: VecDeque<u8>,
+    write_pending: Option<PendingWrite>,
+    write_padding: bool,
+    write_sent_uuid: bool,
+    write_seen_tls: bool,
+    write_direct_enabled: bool,
+    read_tls_filter: ServerHelloFilter,
     vision_entered: bool,
 }
 
 impl VisionConn {
-    pub fn new(inner: VlessConn) -> Self {
+    pub fn new(inner: VlessConn, user_uuid: [u8; UUID_LEN]) -> Self {
         Self {
             inner,
-            write_state: WriteState::Peek(Vec::with_capacity(5)),
+            user_uuid,
+            read_state: ReadState::Header {
+                buf: Vec::with_capacity(PADDING_HEADER_LEN),
+                need_uuid: true,
+            },
+            read_plain: VecDeque::new(),
+            write_pending: None,
+            write_padding: true,
+            write_sent_uuid: false,
+            write_seen_tls: false,
+            write_direct_enabled: false,
+            read_tls_filter: ServerHelloFilter::new(),
             vision_entered: false,
         }
     }
 
-    /// Whether Vision mode was triggered (first 5 bytes were a TLS record).
-    /// Used in tests and log-noise guards.
     #[allow(dead_code)]
     pub fn vision_entered(&self) -> bool {
         self.vision_entered
     }
-}
 
-// ─── Padding header builder ───────────────────────────────────────────────────
+    fn drain_pending_write(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<Option<usize>>> {
+        let Some(pending) = &mut self.write_pending else {
+            return Poll::Ready(Ok(None));
+        };
 
-/// Build the Vision padding header.
-///
-/// Wire format:
-/// ```text
-/// 0x17  0x03  0x03  len_hi  len_lo  0x00  random...
-/// ```
-/// upstream: transport/vless/vision/vision.go::sendPaddingMessage
-fn build_padding_header() -> Vec<u8> {
-    use rand::RngCore;
-    let mut rng = rand::rng();
-    let n = {
-        let mut b = [0u8; 4];
-        rng.fill_bytes(&mut b);
-        (u32::from_le_bytes(b) as usize) % (*PADDING_RANGE.end() + 1)
-    };
-    let payload_len = 1 + n; // marker byte + random bytes
-    let len = payload_len as u16;
-    let mut buf = Vec::with_capacity(5 + payload_len);
-    buf.push(0x17); // TLS AppData type
-    buf.push(0x03); // TLS 1.2 major
-    buf.push(0x03); // TLS 1.2 minor
-    buf.push((len >> 8) as u8);
-    buf.push((len & 0xFF) as u8);
-    buf.push(0x00); // Vision marker byte
-    for _ in 0..n {
-        buf.push(rng.next_u32() as u8);
+        while pending.pos < pending.frame.len() {
+            match Pin::new(&mut self.inner).poll_write(cx, &pending.frame[pending.pos..])? {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(0) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "vision: zero write during frame drain",
+                    )));
+                }
+                Poll::Ready(n) => pending.pos += n,
+            }
+        }
+
+        let pending = self.write_pending.take().expect("pending checked above");
+        if pending.end_padding_after_drain {
+            self.write_padding = false;
+            if pending.command == COMMAND_PADDING_DIRECT {
+                if !self.enable_inner_raw_write_passthrough() {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "vision: DIRECT requested but transport cannot switch to raw passthrough",
+                    )));
+                }
+                tracing::debug!("XTLS Vision direct write passthrough enabled");
+            }
+        }
+        Poll::Ready(Ok(Some(pending.consumed)))
     }
-    buf
+
+    fn build_write_frame(&mut self, buf: &[u8]) {
+        let contains_tls_handshake = contains_tls_client_hello(buf);
+        let starts_tls_app_data =
+            buf.len() >= 3 && buf[0] == TLS_APPLICATION_DATA && buf[1] == TLS_MAJOR;
+        if contains_tls_handshake {
+            self.write_seen_tls = true;
+            self.vision_entered = true;
+        }
+
+        let padding_tls = self.write_seen_tls;
+        let mut command = COMMAND_PADDING_CONTINUE;
+        let mut end_after_drain = false;
+        if starts_tls_app_data && self.write_seen_tls {
+            command = if self.write_direct_enabled {
+                COMMAND_PADDING_DIRECT
+            } else {
+                COMMAND_PADDING_END
+            };
+            end_after_drain = true;
+        } else if !self.write_seen_tls && !contains_tls_handshake {
+            command = COMMAND_PADDING_END;
+            end_after_drain = true;
+        }
+
+        let frame = build_padding_frame(
+            command,
+            (!self.write_sent_uuid).then_some(&self.user_uuid),
+            buf,
+            padding_tls,
+        );
+        tracing::debug!(
+            command,
+            content_len = buf.len(),
+            frame_len = frame.len(),
+            padding_tls,
+            contains_tls_handshake,
+            starts_tls_app_data,
+            "XTLS Vision write padding"
+        );
+        self.write_sent_uuid = true;
+        self.write_pending = Some(PendingWrite {
+            frame,
+            pos: 0,
+            consumed: buf.len(),
+            command,
+            end_padding_after_drain: end_after_drain,
+        });
+    }
+
+    fn drain_read_plain(&mut self, buf: &mut ReadBuf<'_>) -> bool {
+        if self.read_plain.is_empty() {
+            return false;
+        }
+        let n = buf.remaining().min(self.read_plain.len());
+        for b in self.read_plain.drain(..n) {
+            buf.put_slice(&[b]);
+        }
+        true
+    }
+
+    fn enable_inner_raw_read_passthrough(&mut self) -> bool {
+        self.inner.enable_raw_read_passthrough()
+    }
+
+    fn enable_inner_raw_write_passthrough(&mut self) -> bool {
+        self.inner.enable_raw_write_passthrough()
+    }
+
+    fn filter_server_tls(&mut self, chunk: &[u8]) {
+        if !self.write_direct_enabled && self.read_tls_filter.observe(chunk) {
+            self.write_direct_enabled = true;
+            tracing::debug!("XTLS Vision found TLS 1.3, direct enabled");
+        }
+    }
 }
 
-// ─── AsyncRead ────────────────────────────────────────────────────────────────
+fn contains_tls_client_hello(buf: &[u8]) -> bool {
+    buf.windows(6)
+        .any(|w| w[0] == TLS_HANDSHAKE && w[1] == TLS_MAJOR && w[5] == TLS_CLIENT_HELLO)
+}
+
+struct ServerHelloFilter {
+    packets_left: usize,
+    expected_len: Option<usize>,
+    buffer: Vec<u8>,
+    done: bool,
+}
+
+impl ServerHelloFilter {
+    fn new() -> Self {
+        Self {
+            packets_left: TLS_FILTER_PACKETS,
+            expected_len: None,
+            buffer: Vec::new(),
+            done: false,
+        }
+    }
+
+    fn observe(&mut self, chunk: &[u8]) -> bool {
+        if self.done || self.packets_left == 0 || chunk.is_empty() {
+            return false;
+        }
+        self.packets_left -= 1;
+
+        if self.expected_len.is_none() {
+            self.buffer.extend_from_slice(chunk);
+            let Some(pos) = find_tls_server_hello_start(&self.buffer) else {
+                return false;
+            };
+            if pos > 0 {
+                self.buffer.drain(..pos);
+            }
+            let record_len = u16::from_be_bytes([self.buffer[3], self.buffer[4]]) as usize;
+            self.expected_len = Some(5 + record_len);
+        } else {
+            self.buffer.extend_from_slice(chunk);
+        }
+
+        let expected_len = self.expected_len.unwrap_or(self.buffer.len());
+        if self.buffer.len() < expected_len {
+            return false;
+        }
+
+        self.done = true;
+        let hello = &self.buffer[..expected_len];
+        let Some(cipher) = tls_server_hello_cipher_suite(hello) else {
+            return false;
+        };
+        TLS13_CIPHER_SUITES.contains(&cipher)
+            && hello
+                .windows(TLS13_SUPPORTED_VERSIONS_EXT.len())
+                .any(|w| w == TLS13_SUPPORTED_VERSIONS_EXT)
+    }
+}
+
+fn find_tls_server_hello_start(buf: &[u8]) -> Option<usize> {
+    buf.windows(6).position(|w| {
+        w[0] == TLS_HANDSHAKE && w[1] == TLS_MAJOR && w[2] == TLS_MAJOR && w[5] == TLS_SERVER_HELLO
+    })
+}
+
+fn tls_server_hello_cipher_suite(record: &[u8]) -> Option<u16> {
+    if record.len() < 46 || !matches!(find_tls_server_hello_start(record), Some(0)) {
+        return None;
+    }
+    let session_id_len = *record.get(43)? as usize;
+    let cipher_offset = 44 + session_id_len;
+    let bytes = record.get(cipher_offset..cipher_offset + 2)?;
+    Some(u16::from_be_bytes([bytes[0], bytes[1]]))
+}
+
+fn build_padding_frame(
+    command: u8,
+    user_uuid: Option<&[u8; UUID_LEN]>,
+    content: &[u8],
+    padding_tls: bool,
+) -> Vec<u8> {
+    let padding_len = if content.len() < 900 {
+        let mut rng = rand::rng();
+        if padding_tls {
+            (rng.next_u32() as usize % 500) + 900 - content.len()
+        } else {
+            rng.next_u32() as usize % 256
+        }
+    } else {
+        0
+    };
+
+    let header_len = if user_uuid.is_some() {
+        PADDING_HEADER_LEN
+    } else {
+        PADDING_HEADER_LEN - UUID_LEN
+    };
+    let mut frame = Vec::with_capacity(header_len + content.len() + padding_len);
+    if let Some(uuid) = user_uuid {
+        frame.extend_from_slice(uuid);
+    }
+    frame.push(command);
+    frame.extend_from_slice(&(content.len() as u16).to_be_bytes());
+    frame.extend_from_slice(&(padding_len as u16).to_be_bytes());
+    frame.extend_from_slice(content);
+    frame.resize(frame.len() + padding_len, 0);
+    frame
+}
 
 impl AsyncRead for VisionConn {
     fn poll_read(
@@ -132,11 +314,221 @@ impl AsyncRead for VisionConn {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_read(cx, buf)
+        if self.drain_read_plain(buf) {
+            return Poll::Ready(Ok(()));
+        }
+
+        loop {
+            let state = std::mem::replace(&mut self.read_state, ReadState::Through);
+            match state {
+                ReadState::Through => {
+                    self.read_state = ReadState::Through;
+                    return Pin::new(&mut self.inner).poll_read(cx, buf);
+                }
+                ReadState::Header {
+                    buf: mut h,
+                    need_uuid,
+                } => {
+                    let need = if need_uuid {
+                        PADDING_HEADER_LEN
+                    } else {
+                        PADDING_HEADER_LEN - UUID_LEN
+                    };
+                    while h.len() < need {
+                        let mut tmp = [0u8; PADDING_HEADER_LEN];
+                        let want = (need - h.len()).min(tmp.len());
+                        let mut rb = ReadBuf::new(&mut tmp[..want]);
+                        match Pin::new(&mut self.inner).poll_read(cx, &mut rb) {
+                            Poll::Pending => {
+                                self.read_state = ReadState::Header { buf: h, need_uuid };
+                                return Poll::Pending;
+                            }
+                            Poll::Ready(Err(e)) => {
+                                self.read_state = ReadState::Header { buf: h, need_uuid };
+                                return Poll::Ready(Err(e));
+                            }
+                            Poll::Ready(Ok(())) => {
+                                let n = rb.filled().len();
+                                if n == 0 {
+                                    self.read_state = ReadState::Header { buf: h, need_uuid };
+                                    return Poll::Ready(Err(io::Error::new(
+                                        io::ErrorKind::UnexpectedEof,
+                                        "vision: EOF while reading padding header",
+                                    )));
+                                }
+                                h.extend_from_slice(rb.filled());
+                            }
+                        }
+                    }
+
+                    let offset = if need_uuid {
+                        if h[..UUID_LEN] != self.user_uuid {
+                            self.read_state = ReadState::Header { buf: h, need_uuid };
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "vision: server responded with unknown UUID",
+                            )));
+                        }
+                        UUID_LEN
+                    } else {
+                        0
+                    };
+                    let command = h[offset];
+                    let content_len = u16::from_be_bytes([h[offset + 1], h[offset + 2]]) as usize;
+                    let padding_len = u16::from_be_bytes([h[offset + 3], h[offset + 4]]) as usize;
+                    tracing::debug!(
+                        command,
+                        content_len,
+                        padding_len,
+                        need_uuid,
+                        "XTLS Vision read padding"
+                    );
+                    self.read_state = ReadState::Content {
+                        command,
+                        remaining_content: content_len,
+                        remaining_padding: padding_len,
+                    };
+                }
+                ReadState::Content {
+                    command,
+                    mut remaining_content,
+                    remaining_padding,
+                } => {
+                    if remaining_content == 0 {
+                        self.read_state = ReadState::Padding {
+                            command,
+                            remaining_padding,
+                        };
+                        continue;
+                    }
+                    if buf.remaining() == 0 {
+                        self.read_state = ReadState::Content {
+                            command,
+                            remaining_content,
+                            remaining_padding,
+                        };
+                        return Poll::Ready(Ok(()));
+                    }
+
+                    let mut tmp = vec![0u8; remaining_content.min(buf.remaining()).min(8192)];
+                    let mut rb = ReadBuf::new(&mut tmp);
+                    match Pin::new(&mut self.inner).poll_read(cx, &mut rb) {
+                        Poll::Pending => {
+                            self.read_state = ReadState::Content {
+                                command,
+                                remaining_content,
+                                remaining_padding,
+                            };
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(e)) => {
+                            self.read_state = ReadState::Content {
+                                command,
+                                remaining_content,
+                                remaining_padding,
+                            };
+                            return Poll::Ready(Err(e));
+                        }
+                        Poll::Ready(Ok(())) => {
+                            let n = rb.filled().len();
+                            if n == 0 {
+                                self.read_state = ReadState::Content {
+                                    command,
+                                    remaining_content,
+                                    remaining_padding,
+                                };
+                                return Poll::Ready(Err(io::Error::new(
+                                    io::ErrorKind::UnexpectedEof,
+                                    "vision: EOF while reading padded content",
+                                )));
+                            }
+                            remaining_content -= n;
+                            self.filter_server_tls(rb.filled());
+                            buf.put_slice(rb.filled());
+                            self.read_state = if remaining_content == 0 {
+                                ReadState::Padding {
+                                    command,
+                                    remaining_padding,
+                                }
+                            } else {
+                                ReadState::Content {
+                                    command,
+                                    remaining_content,
+                                    remaining_padding,
+                                }
+                            };
+                            return Poll::Ready(Ok(()));
+                        }
+                    }
+                }
+                ReadState::Padding {
+                    command,
+                    mut remaining_padding,
+                } => {
+                    while remaining_padding > 0 {
+                        let mut tmp = [0u8; 1024];
+                        let want = remaining_padding.min(tmp.len());
+                        let mut rb = ReadBuf::new(&mut tmp[..want]);
+                        match Pin::new(&mut self.inner).poll_read(cx, &mut rb) {
+                            Poll::Pending => {
+                                self.read_state = ReadState::Padding {
+                                    command,
+                                    remaining_padding,
+                                };
+                                return Poll::Pending;
+                            }
+                            Poll::Ready(Err(e)) => {
+                                self.read_state = ReadState::Padding {
+                                    command,
+                                    remaining_padding,
+                                };
+                                return Poll::Ready(Err(e));
+                            }
+                            Poll::Ready(Ok(())) => {
+                                let n = rb.filled().len();
+                                if n == 0 {
+                                    self.read_state = ReadState::Padding {
+                                        command,
+                                        remaining_padding,
+                                    };
+                                    return Poll::Ready(Err(io::Error::new(
+                                        io::ErrorKind::UnexpectedEof,
+                                        "vision: EOF while reading padding",
+                                    )));
+                                }
+                                remaining_padding -= n;
+                            }
+                        }
+                    }
+
+                    self.read_state = match command {
+                        COMMAND_PADDING_CONTINUE => ReadState::Header {
+                            buf: Vec::with_capacity(PADDING_HEADER_LEN - UUID_LEN),
+                            need_uuid: false,
+                        },
+                        COMMAND_PADDING_END => ReadState::Through,
+                        COMMAND_PADDING_DIRECT => {
+                            if !self.enable_inner_raw_read_passthrough() {
+                                return Poll::Ready(Err(io::Error::new(
+                                    io::ErrorKind::Unsupported,
+                                    "vision: DIRECT requested but transport cannot switch to raw passthrough",
+                                )));
+                            }
+                            tracing::debug!("XTLS Vision direct passthrough enabled");
+                            ReadState::Through
+                        }
+                        other => {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("vision: unknown padding command {other}"),
+                            )));
+                        }
+                    };
+                }
+            }
+        }
     }
 }
-
-// ─── AsyncWrite (state machine) ───────────────────────────────────────────────
 
 impl AsyncWrite for VisionConn {
     fn poll_write(
@@ -145,134 +537,41 @@ impl AsyncWrite for VisionConn {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
-
-        // `src_pos` tracks how many bytes of `buf` have been "consumed" by this
-        // call.  States that buffer (Peek/Body) advance it; Drain/Through write to
-        // inner from their own buffers or from the unconsumed remainder of buf.
-        let mut src_pos = 0usize;
-
-        loop {
-            match &mut this.write_state {
-                // ── Peek: collect first 5 bytes ────────────────────────────
-                WriteState::Peek(pbuf) => {
-                    let need = 5 - pbuf.len();
-                    let take = need.min(buf[src_pos..].len());
-                    pbuf.extend_from_slice(&buf[src_pos..src_pos + take]);
-                    src_pos += take;
-
-                    if pbuf.len() < 5 {
-                        // Still buffering; return what we consumed from buf.
-                        return Poll::Ready(Ok(src_pos));
-                    }
-
-                    // We now have exactly 5 bytes.
-                    let is_tls = pbuf[0] == 0x16 && pbuf[1] == 0x03;
-                    let peek5: [u8; 5] = pbuf[..5].try_into().unwrap();
-
-                    if is_tls {
-                        let body_len = u16::from_be_bytes([pbuf[3], pbuf[4]]) as usize;
-                        this.vision_entered = true;
-
-                        if body_len == 0 {
-                            // Zero-length body — unlikely but handle it.
-                            let mut to_send = build_padding_header();
-                            to_send.extend_from_slice(&peek5);
-                            this.write_state = WriteState::Drain { to_send, pos: 0 };
-                        } else {
-                            this.write_state = WriteState::Body {
-                                peek5,
-                                body: Vec::with_capacity(body_len),
-                                need_more: body_len,
-                            };
-                        }
-                    } else {
-                        // Not TLS — passthrough mode.  Drain the peek bytes first.
-                        let to_send = peek5.to_vec();
-                        this.write_state = WriteState::Drain { to_send, pos: 0 };
-                    }
-
-                    // Continue into the new state (Body or Drain) within this
-                    // same poll_write call so the caller sees data forwarded to
-                    // inner as soon as possible.
-                }
-
-                // ── Body: accumulate full ClientHello ─────────────────────
-                WriteState::Body {
-                    peek5,
-                    body,
-                    need_more,
-                } => {
-                    let remaining_body = *need_more - body.len();
-                    let take = remaining_body.min(buf[src_pos..].len());
-                    body.extend_from_slice(&buf[src_pos..src_pos + take]);
-                    src_pos += take;
-
-                    if body.len() == *need_more {
-                        // Full ClientHello assembled.  Build drain buffer and
-                        // continue to Drain in this same poll_write so that the
-                        // prebuilt buffer is flushed to inner before we return.
-                        let mut to_send = build_padding_header();
-                        to_send.extend_from_slice(peek5);
-                        to_send.extend_from_slice(body);
-                        this.write_state = WriteState::Drain { to_send, pos: 0 };
-                        // continue → Drain
-                    } else {
-                        // Still accumulating body bytes; return what we consumed.
-                        return Poll::Ready(Ok(src_pos));
-                    }
-                }
-
-                // ── Drain: write prebuilt buffer to inner ──────────────────
-                WriteState::Drain { to_send, pos } => {
-                    let remaining = &to_send[*pos..];
-                    if remaining.is_empty() {
-                        this.write_state = WriteState::Through;
-                        continue; // loop → Through
-                    }
-
-                    match Pin::new(&mut this.inner).poll_write(cx, remaining)? {
-                        Poll::Pending => {
-                            // Inner can't accept right now.  Return any buf bytes
-                            // already consumed (if any); otherwise propagate Pending.
-                            if src_pos > 0 {
-                                return Poll::Ready(Ok(src_pos));
-                            }
-                            return Poll::Pending;
-                        }
-                        Poll::Ready(0) => {
-                            return Poll::Ready(Err(io::Error::new(
-                                io::ErrorKind::WriteZero,
-                                "vision: zero write during padding drain",
-                            )));
-                        }
-                        Poll::Ready(n) => {
-                            *pos += n;
-                            // Loop: either drain more or switch to Through.
-                        }
-                    }
-                }
-
-                // ── Through: transparent passthrough ──────────────────────
-                WriteState::Through => {
-                    let remaining_buf = &buf[src_pos..];
-                    if remaining_buf.is_empty() {
-                        // All buf bytes were consumed by earlier states; nothing
-                        // left to forward.  Return the total consumed count.
-                        return Poll::Ready(Ok(src_pos));
-                    }
-                    return Pin::new(&mut this.inner)
-                        .poll_write(cx, remaining_buf)
-                        .map(|r| r.map(|n| src_pos + n));
-                }
+        if let Poll::Ready(done) = this.drain_pending_write(cx) {
+            if let Some(n) = done? {
+                return Poll::Ready(Ok(n));
             }
+        } else {
+            return Poll::Pending;
+        }
+
+        if !this.write_padding {
+            return Pin::new(&mut this.inner).poll_write(cx, buf);
+        }
+        this.build_write_frame(buf);
+        match this.drain_pending_write(cx) {
+            Poll::Ready(Ok(Some(n))) => Poll::Ready(Ok(n)),
+            Poll::Ready(Ok(None)) => Poll::Ready(Ok(0)),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
         }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if let Poll::Ready(done) = self.drain_pending_write(cx) {
+            done?;
+        } else {
+            return Poll::Pending;
+        }
         Pin::new(&mut self.inner).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if let Poll::Ready(done) = self.drain_pending_write(cx) {
+            done?;
+        } else {
+            return Poll::Pending;
+        }
         Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 }
@@ -281,438 +580,112 @@ impl Unpin for VisionConn {}
 
 impl ProxyConn for VisionConn {}
 
-// ─── Unit tests (§C) ─────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::VecDeque;
-    use std::sync::{Arc, Mutex};
-    use tokio::io::AsyncWriteExt;
 
-    // ─── Minimal mock inner stream ────────────────────────────────────────────
+    const UUID: [u8; UUID_LEN] = [0x11; UUID_LEN];
 
-    /// Records what was written to it.
-    struct RecordingStream {
-        written: Arc<Mutex<Vec<Vec<u8>>>>,
-        /// Bytes to deliver on read.
-        read_buf: VecDeque<u8>,
-    }
-
-    impl RecordingStream {
-        fn new(written: Arc<Mutex<Vec<Vec<u8>>>>) -> Self {
-            Self {
-                written,
-                read_buf: VecDeque::new(),
-            }
-        }
-    }
-
-    impl AsyncRead for RecordingStream {
-        fn poll_read(
-            mut self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            buf: &mut ReadBuf<'_>,
-        ) -> Poll<io::Result<()>> {
-            let n = buf.remaining().min(self.read_buf.len());
-            if n == 0 {
-                return Poll::Pending;
-            }
-            for b in self.read_buf.drain(..n) {
-                buf.put_slice(&[b]);
-            }
-            Poll::Ready(Ok(()))
-        }
-    }
-
-    impl AsyncWrite for RecordingStream {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<io::Result<usize>> {
-            self.get_mut().written.lock().unwrap().push(buf.to_vec());
-            Poll::Ready(Ok(buf.len()))
-        }
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-    }
-
-    impl Unpin for RecordingStream {}
-
-    /// Build a `VisionConn` wrapping a `RecordingStream`.
-    fn vision_over_recorder(written: Arc<Mutex<Vec<Vec<u8>>>>) -> VisionConn {
-        let recorder = Box::new(RecordingStream::new(written));
-        let vless = VlessConn {
-            inner: recorder,
-            response_pending: false,
-        };
-        VisionConn::new(vless)
-    }
-
-    // ─── C1: padding header matches reference ────────────────────────────────
-
-    /// Padding header must match the upstream wire format from
-    /// transport/vless/vision/vision.go::sendPaddingMessage.
-    /// NOT arbitrary bytes — byte-exact marker at payload[0].
     #[test]
-    fn vision_padding_header_matches_reference() {
-        for _ in 0..100 {
-            let hdr = build_padding_header();
-            assert!(
-                hdr.len() >= 5,
-                "padding header must have 5-byte record prefix"
-            );
-            assert_eq!(hdr[0], 0x17, "byte[0] must be TLS AppData 0x17");
-            assert_eq!(hdr[1], 0x03, "byte[1] must be 0x03 (TLS 1.2 major)");
-            assert_eq!(hdr[2], 0x03, "byte[2] must be 0x03 (TLS 1.2 minor)");
-            let payload_len = u16::from_be_bytes([hdr[3], hdr[4]]) as usize;
-            assert_eq!(
-                hdr.len(),
-                5 + payload_len,
-                "record length must match actual bytes"
-            );
-            assert!(
-                payload_len >= 1,
-                "payload must have at least the marker byte"
-            );
-            assert_eq!(hdr[5], 0x00, "payload[0] must be Vision marker 0x00");
-            let n = payload_len - 1;
-            assert!(
-                PADDING_RANGE.contains(&n),
-                "random byte count {n} not in PADDING_RANGE {PADDING_RANGE:?}"
-            );
-        }
+    fn padding_frame_with_uuid_matches_mihomo_layout() {
+        let content = b"\x16\x03\x01\x00\x01\x01";
+        let frame = build_padding_frame(COMMAND_PADDING_CONTINUE, Some(&UUID), content, true);
+
+        assert_eq!(&frame[..UUID_LEN], &UUID);
+        assert_eq!(frame[UUID_LEN], COMMAND_PADDING_CONTINUE);
+
+        let content_len = u16::from_be_bytes([frame[UUID_LEN + 1], frame[UUID_LEN + 2]]) as usize;
+        let padding_len = u16::from_be_bytes([frame[UUID_LEN + 3], frame[UUID_LEN + 4]]) as usize;
+
+        assert_eq!(content_len, content.len());
+        assert_eq!(
+            &frame[PADDING_HEADER_LEN..PADDING_HEADER_LEN + content.len()],
+            content
+        );
+        assert_eq!(
+            frame.len(),
+            PADDING_HEADER_LEN + content.len() + padding_len
+        );
+        assert!(padding_len >= 900 - content.len());
+        assert!(padding_len < 1400 - content.len());
     }
 
-    // ─── C2: PADDING_RANGE matches upstream constant ─────────────────────────
-
-    /// upstream: transport/vless/vision/vision.go paddingMaxLen = 900
     #[test]
-    fn vision_padding_range_is_upstream_constant() {
-        assert_eq!(
-            *PADDING_RANGE.start(),
-            0,
-            "PADDING_RANGE lower bound must be 0"
-        );
-        assert_eq!(
-            *PADDING_RANGE.end(),
-            900,
-            "PADDING_RANGE upper bound must be 900 (upstream paddingMaxLen)"
-        );
+    fn padding_frame_without_uuid_uses_short_header() {
+        let content = b"abc";
+        let frame = build_padding_frame(COMMAND_PADDING_END, None, content, false);
+
+        assert_eq!(frame[0], COMMAND_PADDING_END);
+        let content_len = u16::from_be_bytes([frame[1], frame[2]]) as usize;
+        let padding_len = u16::from_be_bytes([frame[3], frame[4]]) as usize;
+
+        assert_eq!(content_len, content.len());
+        assert_eq!(&frame[5..8], content);
+        assert_eq!(frame.len(), 5 + content.len() + padding_len);
+        assert!(padding_len < 256);
     }
 
-    // ─── C3: Vision mode on TLS first 5 bytes ────────────────────────────────
-
-    #[tokio::test]
-    async fn vision_detects_inner_tls_by_first_5_bytes() {
-        let written = Arc::new(Mutex::new(Vec::new()));
-        let mut conn = vision_over_recorder(Arc::clone(&written));
-
-        // Write exactly 5 bytes: TLS handshake record type + TLS 1.2 version.
-        // ClientHello body_len = 0x0001 (1 byte body).
-        let first5 = [0x16u8, 0x03, 0x01, 0x00, 0x01];
-        conn.write_all(&first5).await.unwrap();
-
-        // We've fed 5 bytes — Vision should now be in Body state (need 1 more byte).
-        // Feed the body byte.
-        conn.write_all(&[0x42]).await.unwrap();
-
-        // Now Vision should have emitted padding + peek5 + body to inner.
-        let w = written.lock().unwrap();
-        let combined: Vec<u8> = w.iter().flat_map(|v| v.iter().copied()).collect();
-
-        // The combined output must start with the padding header (0x17 ...).
-        assert_eq!(
-            combined[0], 0x17,
-            "output must start with padding header 0x17"
-        );
-        // Marker byte must be 0x00.
-        let payload_len = u16::from_be_bytes([combined[3], combined[4]]) as usize;
-        assert_eq!(
-            combined[5], 0x00,
-            "Vision marker byte must be 0x00; got: {:#04x}",
-            combined[5]
-        );
-        // After the padding header (5 + payload_len bytes), the ClientHello follows.
-        let ch_start = 5 + payload_len;
-        assert_eq!(
-            &combined[ch_start..ch_start + 5],
-            &first5,
-            "ClientHello must follow padding header verbatim"
-        );
-        assert_eq!(combined[ch_start + 5], 0x42, "ClientHello body must follow");
-    }
-
-    // ─── C4: passthrough on non-TLS first byte ───────────────────────────────
-
-    #[tokio::test]
-    async fn vision_passthrough_on_non_tls_first_byte() {
-        let written = Arc::new(Mutex::new(Vec::new()));
-        let mut conn = vision_over_recorder(Arc::clone(&written));
-
-        // 0x47 = 'G' — first byte of "GET /"
-        let data = [0x47u8, 0x45, 0x54, 0x20, 0x2F];
-        conn.write_all(&data).await.unwrap();
-
-        // Drain state transitions to Through after emitting the 5 peek bytes.
-        let w = written.lock().unwrap();
-        let combined: Vec<u8> = w.iter().flat_map(|v| v.iter().copied()).collect();
-
-        // Must NOT start with 0x17 (no padding header emitted).
-        assert_ne!(
-            combined[0], 0x17,
-            "passthrough must NOT emit padding header 0x17"
-        );
-        // The 5 data bytes must appear verbatim (no extra prefix).
-        assert!(
-            combined.windows(5).any(|w| w == data),
-            "passthrough must forward the 5 original bytes; got {combined:?}"
-        );
-        assert!(
-            !conn.vision_entered,
-            "vision_entered must be false for non-TLS data"
-        );
-    }
-
-    // ─── C5: passthrough on TLS type but wrong version ───────────────────────
-
-    /// byte[0] = 0x16 (TLS handshake) but byte[1] = 0x04 (not 0x03).
-    /// Guards against checking only byte[0].
-    #[tokio::test]
-    async fn vision_passthrough_on_tls_type_but_wrong_version() {
-        let written = Arc::new(Mutex::new(Vec::new()));
-        let mut conn = vision_over_recorder(Arc::clone(&written));
-
-        let data = [0x16u8, 0x04, 0x00, 0x00, 0x00]; // TLS type, version major 0x04
-        conn.write_all(&data).await.unwrap();
-
-        assert!(
-            !conn.vision_entered,
-            "vision must NOT be entered when byte[1] != 0x03"
-        );
-    }
-
-    // ─── C6: passthrough on EOF before 5 bytes ───────────────────────────────
-
-    #[tokio::test]
-    async fn vision_passthrough_on_empty_stream() {
-        let written = Arc::new(Mutex::new(Vec::new()));
-        let mut conn = vision_over_recorder(Arc::clone(&written));
-
-        // Write only 3 bytes and then nothing more.
-        conn.write_all(&[0x16, 0x03, 0x01]).await.unwrap();
-        // This is an incomplete peek (< 5 bytes buffered).
-        // No panic, no panic, graceful partial handling.
-        assert!(
-            !conn.vision_entered,
-            "vision must not be entered on partial data"
-        );
-    }
-
-    // ─── C7: full ClientHello buffered before sending ─────────────────────────
-
-    /// "Stage a ClientHello arriving in two poll_write chunks; assert VisionConn
-    ///  does not emit any bytes to the underlying writer until the full record is
-    ///  buffered."
-    /// upstream: transport/vless/vision/vision.go::ReadClientHelloRecord
-    /// NOT partial-send on first chunk — truncated ClientHello breaks inner TLS.
-    #[tokio::test]
-    async fn vision_reads_full_clienthello_before_sending() {
-        let written = Arc::new(Mutex::new(Vec::new()));
-        let mut conn = vision_over_recorder(Arc::clone(&written));
-
-        // ClientHello: 5-byte header claiming body_length=4.
-        let hdr = [0x16u8, 0x03, 0x01, 0x00, 0x04];
-        conn.write_all(&hdr).await.unwrap();
-
-        // After the 5-byte peek, nothing should have been written to inner yet.
-        {
-            let w = written.lock().unwrap();
-            let combined: Vec<u8> = w.iter().flat_map(|v| v.iter().copied()).collect();
-            assert!(
-                combined.is_empty(),
-                "must NOT write to inner after only the 5-byte header; got {combined:?}"
-            );
-        }
-
-        // Supply the first 2 body bytes.
-        conn.write_all(&[0xAA, 0xBB]).await.unwrap();
-        {
-            let w = written.lock().unwrap();
-            let combined: Vec<u8> = w.iter().flat_map(|v| v.iter().copied()).collect();
-            assert!(
-                combined.is_empty(),
-                "must NOT write to inner after partial body (2/4 bytes); got {combined:?}"
-            );
-        }
-
-        // Supply remaining 2 body bytes — full record complete.
-        conn.write_all(&[0xCC, 0xDD]).await.unwrap();
-        {
-            let w = written.lock().unwrap();
-            assert!(
-                w.iter().any(|v| !v.is_empty()),
-                "must write to inner once full ClientHello is assembled"
-            );
-        }
-    }
-
-    // ─── C8: body_length parsed from bytes[3..5] ──────────────────────────────
-
-    /// Feed ClientHello where uint16_BE(bytes[3..5]) = 512.
-    /// Guards against off-by-one or wrong byte range.
-    #[tokio::test]
-    async fn vision_clienthello_body_length_from_bytes_3_4() {
-        let written = Arc::new(Mutex::new(Vec::new()));
-        let mut conn = vision_over_recorder(Arc::clone(&written));
-
-        // body_length = 512 = 0x0200
-        let hdr = [0x16u8, 0x03, 0x01, 0x02, 0x00];
-        conn.write_all(&hdr).await.unwrap();
-
-        // Nothing written yet.
-        assert!(
-            written.lock().unwrap().is_empty(),
-            "no write after 5-byte peek"
-        );
-
-        // Supply 511 bytes (not enough).
-        conn.write_all(&vec![0u8; 511]).await.unwrap();
-        assert!(
-            written.lock().unwrap().iter().all(std::vec::Vec::is_empty)
-                || written.lock().unwrap().is_empty(),
-            "partial body must not trigger send"
-        );
-
-        // Wait — check more carefully.
-        {
-            let w = written.lock().unwrap();
-            let combined: Vec<u8> = w.iter().flat_map(|v| v.iter().copied()).collect();
-            assert!(
-                combined.is_empty(),
-                "must not write after 511/512 body bytes; got {} bytes",
-                combined.len()
-            );
-        }
-
-        // Supply the last byte.
-        conn.write_all(&[0xFE]).await.unwrap();
-        let w = written.lock().unwrap();
-        assert!(
-            w.iter().any(|v| !v.is_empty()),
-            "must write after all 512 body bytes"
-        );
-    }
-
-    // ─── C9: padding header precedes ClientHello in output ───────────────────
-
-    #[tokio::test]
-    async fn vision_sends_padding_then_clienthello_in_order() {
-        let written = Arc::new(Mutex::new(Vec::new()));
-        let mut conn = vision_over_recorder(Arc::clone(&written));
-
-        let hdr = [0x16u8, 0x03, 0x01, 0x00, 0x02]; // body_len = 2
-        conn.write_all(&hdr).await.unwrap();
-        conn.write_all(&[0xAB, 0xCD]).await.unwrap();
-
-        let w = written.lock().unwrap();
-        let combined: Vec<u8> = w.iter().flat_map(|v| v.iter().copied()).collect();
-        assert!(!combined.is_empty(), "must have written something");
-
-        // First byte must be 0x17 (padding header).
-        assert_eq!(combined[0], 0x17, "padding header 0x17 must come first");
-
-        // Locate the ClientHello (bytes [0x16, 0x03, 0x01, 0x00, 0x02]) in output.
-        let search = [0x16u8, 0x03, 0x01, 0x00, 0x02];
-        let ch_pos = combined
-            .windows(5)
-            .position(|w| w == search)
-            .expect("ClientHello must appear in output");
-
-        // The padding header (at offset 0) must come before the ClientHello.
-        assert_eq!(combined[0], 0x17, "padding header at offset 0");
-        assert!(ch_pos > 0, "ClientHello must follow the padding header");
-
-        // The body bytes must follow the ClientHello header.
-        assert_eq!(combined[ch_pos + 5], 0xAB);
-        assert_eq!(combined[ch_pos + 6], 0xCD);
-    }
-
-    // ─── C11: non-TLS passthrough emits no warn/error logs ───────────────────
-
-    /// Feed non-TLS data in passthrough mode.  Assert no `warn!` or `error!` logged.
-    /// Vision passthrough is the expected path for HTTP-over-VLESS — must not spam logs.
     #[test]
-    fn vision_no_inner_tls_no_log_noise() {
-        use std::sync::Mutex as StdMutex;
-        use tracing_subscriber::fmt::MakeWriter;
+    fn detects_client_hello_inside_vless_prefixed_payload() {
+        let mut payload = vec![0u8; 56];
+        payload.extend_from_slice(&[0x16, 0x03, 0x01, 0x00, 0x01, 0x01]);
 
-        let lines: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
-        let line_buf: Arc<StdMutex<String>> = Arc::new(StdMutex::new(String::new()));
+        assert!(contains_tls_client_hello(&payload));
+        assert!(!contains_tls_client_hello(b"GET / HTTP/1.1\r\n"));
+    }
 
-        #[derive(Clone)]
-        struct CapWriter(Arc<StdMutex<Vec<String>>>, Arc<StdMutex<String>>);
-        impl std::io::Write for CapWriter {
-            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-                let s = String::from_utf8_lossy(buf).to_string();
-                let mut lb = self.1.lock().unwrap();
-                lb.push_str(&s);
-                if lb.contains('\n') {
-                    let mut log = self.0.lock().unwrap();
-                    for line in lb.split('\n') {
-                        let t = line.trim();
-                        if !t.is_empty() {
-                            log.push(t.to_string());
-                        }
-                    }
-                    lb.clear();
-                }
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> io::Result<()> {
-                Ok(())
-            }
-        }
-        impl<'a> MakeWriter<'a> for CapWriter {
-            type Writer = Self;
-            fn make_writer(&'a self) -> Self {
-                self.clone()
-            }
-        }
+    #[test]
+    fn server_hello_filter_detects_tls13() {
+        let mut filter = ServerHelloFilter::new();
 
-        let cap = CapWriter(Arc::clone(&lines), line_buf);
-        let sub = tracing_subscriber::fmt()
-            .with_writer(cap)
-            .with_ansi(false)
-            .with_level(true)
-            .finish();
+        assert!(filter.observe(&tls13_server_hello(0x1301)));
+    }
 
-        tracing::subscriber::with_default(sub, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .unwrap();
-            rt.block_on(async {
-                let written = Arc::new(Mutex::new(Vec::new()));
-                let mut conn = vision_over_recorder(written);
-                // HTTP data — not TLS.
-                conn.write_all(b"GET / HTTP/1.1\r\n").await.unwrap();
-            });
-        });
+    #[test]
+    fn server_hello_filter_handles_fragmented_record_header() {
+        let hello = tls13_server_hello(0x1301);
+        let mut filter = ServerHelloFilter::new();
 
-        let captured = lines.lock().unwrap();
-        let bad_lines: Vec<&str> = captured
-            .iter()
-            .filter(|l| l.contains("WARN") || l.contains("ERROR"))
-            .map(std::string::String::as_str)
-            .collect();
-        assert!(
-            bad_lines.is_empty(),
-            "passthrough must not emit WARN/ERROR logs; got: {bad_lines:?}"
-        );
+        assert!(!filter.observe(&hello[..3]));
+        assert!(filter.observe(&hello[3..]));
+    }
+
+    #[test]
+    fn server_hello_filter_rejects_non_tls13_cipher() {
+        let mut filter = ServerHelloFilter::new();
+
+        assert!(!filter.observe(&tls13_server_hello(0xc02f)));
+    }
+
+    fn tls13_server_hello(cipher_suite: u16) -> Vec<u8> {
+        let supported_versions = TLS13_SUPPORTED_VERSIONS_EXT;
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0x03, 0x03]);
+        body.extend_from_slice(&[0x42; 32]);
+        body.push(0);
+        body.extend_from_slice(&cipher_suite.to_be_bytes());
+        body.push(0);
+        body.extend_from_slice(&(supported_versions.len() as u16).to_be_bytes());
+        body.extend_from_slice(&supported_versions);
+
+        let mut handshake = Vec::new();
+        handshake.push(TLS_SERVER_HELLO);
+        handshake.extend_from_slice(&[
+            ((body.len() >> 16) & 0xff) as u8,
+            ((body.len() >> 8) & 0xff) as u8,
+            (body.len() & 0xff) as u8,
+        ]);
+        handshake.extend_from_slice(&body);
+
+        let mut record = Vec::new();
+        record.extend_from_slice(&[
+            TLS_HANDSHAKE,
+            TLS_MAJOR,
+            TLS_MAJOR,
+            ((handshake.len() >> 8) & 0xff) as u8,
+            (handshake.len() & 0xff) as u8,
+        ]);
+        record.extend_from_slice(&handshake);
+        record
     }
 }

--- a/crates/meow-proxy/src/vless_adapter.rs
+++ b/crates/meow-proxy/src/vless_adapter.rs
@@ -148,10 +148,9 @@ impl ProxyAdapter for VlessAdapter {
         )
         .await?;
 
-        // Wrap in VisionConn if Vision flow requested.
         match self.flow {
             #[cfg(feature = "vless-vision")]
-            Some(VlessFlow::XtlsRprxVision) => Ok(Box::new(VisionConn::new(conn))),
+            Some(VlessFlow::XtlsRprxVision) => Ok(Box::new(VisionConn::new(conn, self.uuid_bytes))),
             _ => Ok(Box::new(StreamConn(Box::new(conn)))),
         }
     }

--- a/crates/meow-transport/Cargo.toml
+++ b/crates/meow-transport/Cargo.toml
@@ -62,6 +62,9 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 bytes = { workspace = true }
+aes-gcm = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
 
 # tls feature
 tokio-rustls    = { workspace = true, optional = true }

--- a/crates/meow-transport/src/lib.rs
+++ b/crates/meow-transport/src/lib.rs
@@ -20,6 +20,8 @@
 //! * No server-side code (`accept`/`bind`/`listen`/`TcpListener`) in `src/`.
 //!   Test helpers in `tests/support/` are whitelisted.
 
+use std::any::Any;
+
 use tokio::io::{AsyncRead, AsyncWrite};
 
 pub use error::TransportError;
@@ -28,6 +30,9 @@ mod error;
 
 #[cfg(feature = "tls")]
 pub mod tls;
+
+#[cfg(all(feature = "tls", feature = "boring-tls"))]
+mod reality_tls;
 
 #[cfg(feature = "ws")]
 pub mod ws;
@@ -51,8 +56,53 @@ pub mod httpupgrade;
 /// requires `Sync` for connection-table access.  All concrete stream types
 /// we use (`TcpStream`, `TlsStream`, `WsStream`) are `Sync`; the bound
 /// adds no real restriction in practice.
-pub trait Stream: AsyncRead + AsyncWrite + Unpin + Send + Sync {}
-impl<T: AsyncRead + AsyncWrite + Unpin + Send + Sync> Stream for T {}
+pub trait Stream: AsyncRead + AsyncWrite + Unpin + Send + Sync + Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + Sync + Any> Stream for T {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+pub fn enable_raw_passthrough(stream: &mut dyn Stream) -> bool {
+    let read = enable_raw_read_passthrough(stream);
+    let write = enable_raw_write_passthrough(stream);
+    read || write
+}
+
+pub fn enable_raw_read_passthrough(stream: &mut dyn Stream) -> bool {
+    #[cfg(all(feature = "tls", feature = "boring-tls"))]
+    {
+        if let Some(reality) = stream
+            .as_any_mut()
+            .downcast_mut::<reality_tls::RealityTlsStream>()
+        {
+            reality.enable_raw_read_passthrough();
+            return true;
+        }
+    }
+
+    let _ = stream;
+    false
+}
+
+pub fn enable_raw_write_passthrough(stream: &mut dyn Stream) -> bool {
+    #[cfg(all(feature = "tls", feature = "boring-tls"))]
+    {
+        if let Some(reality) = stream
+            .as_any_mut()
+            .downcast_mut::<reality_tls::RealityTlsStream>()
+        {
+            reality.enable_raw_write_passthrough();
+            return true;
+        }
+    }
+
+    let _ = stream;
+    false
+}
 
 /// A transport layer that wraps an inner [`Stream`] and produces a new one.
 ///

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -1,0 +1,1296 @@
+use std::{
+    collections::VecDeque,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use aes_gcm::{
+    aead::{AeadInPlace, KeyInit},
+    Aes128Gcm, Aes256Gcm, Nonce, Tag,
+};
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256, Sha512};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+
+use crate::{
+    tls::{RealityConfig, TlsConfig},
+    Result, Stream, Transport, TransportError,
+};
+
+type HmacSha256 = Hmac<Sha256>;
+type HmacSha512 = Hmac<Sha512>;
+
+const TLS_RECORD_HANDSHAKE: u8 = 22;
+const TLS_RECORD_APPLICATION_DATA: u8 = 23;
+const TLS_RECORD_ALERT: u8 = 21;
+const TLS_RECORD_CHANGE_CIPHER_SPEC: u8 = 20;
+
+const HS_CLIENT_HELLO: u8 = 1;
+const HS_SERVER_HELLO: u8 = 2;
+const HS_NEW_SESSION_TICKET: u8 = 4;
+const HS_ENCRYPTED_EXTENSIONS: u8 = 8;
+const HS_CERTIFICATE: u8 = 11;
+const HS_CERTIFICATE_VERIFY: u8 = 15;
+const HS_FINISHED: u8 = 20;
+
+const TLS_AES_128_GCM_SHA256: u16 = 0x1301;
+
+const GROUP_X25519: u16 = 0x001d;
+
+#[derive(Clone)]
+pub(crate) struct RealityTlsLayer {
+    server_name: String,
+    alpn: Vec<String>,
+    reality: RealityConfig,
+}
+
+impl RealityTlsLayer {
+    pub(crate) fn new(config: &TlsConfig) -> Result<Self> {
+        let server_name = config.sni.clone().ok_or_else(|| {
+            TransportError::Config(
+                "Reality TLS requires sni to be Some; set `servername` or `server`.".into(),
+            )
+        })?;
+        let reality = config.reality.clone().ok_or_else(|| {
+            TransportError::Config("RealityTlsLayer requires TlsConfig.reality".into())
+        })?;
+
+        if config.ech.is_some() {
+            return Err(TransportError::Config(
+                "reality-opts cannot be combined with ech-opts on the same TLS layer".into(),
+            ));
+        }
+        if config.client_cert.is_some() {
+            return Err(TransportError::Config(
+                "Reality TLS client certificates are not supported".into(),
+            ));
+        }
+        if config.skip_cert_verify {
+            tracing::warn!(
+                "skip-cert-verify=true is ignored for Reality TLS; Reality HMAC authentication is still required"
+            );
+        }
+
+        Ok(Self {
+            server_name,
+            alpn: config.alpn.clone(),
+            reality,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Transport for RealityTlsLayer {
+    async fn connect(&self, inner: Box<dyn Stream>) -> Result<Box<dyn Stream>> {
+        let state = reality_handshake(inner, &self.server_name, &self.alpn, &self.reality).await?;
+        Ok(spawn_reality_stream(state))
+    }
+}
+
+struct RealityConnected {
+    inner: Box<dyn Stream>,
+    read_key: RecordKey,
+    write_key: RecordKey,
+}
+
+async fn reality_handshake(
+    mut inner: Box<dyn Stream>,
+    server_name: &str,
+    alpn: &[String],
+    reality: &RealityConfig,
+) -> Result<RealityConnected> {
+    let mut client_private = rand::random::<[u8; 32]>();
+    clamp_x25519_private(&mut client_private);
+    let client_public = x25519_public_from_private(&client_private);
+    let auth_key = x25519(&client_private, &reality.public_key)?;
+
+    let mut client_random = rand::random::<[u8; 32]>();
+    let (client_hello, reality_auth_key) = build_reality_client_hello(
+        server_name,
+        alpn,
+        &client_random,
+        &client_public,
+        &auth_key,
+        reality,
+    )?;
+    inner
+        .write_all(&wrap_plain_record(TLS_RECORD_HANDSHAKE, &client_hello)?)
+        .await?;
+    inner.flush().await?;
+
+    let mut transcript = Vec::with_capacity(4096);
+    transcript.extend_from_slice(&client_hello);
+
+    let server_hello = read_plain_handshake(&mut inner, HS_SERVER_HELLO).await?;
+    let parsed_server_hello = parse_server_hello(&server_hello)?;
+    tracing::debug!(
+        cipher_suite = format_args!("0x{:04x}", parsed_server_hello.cipher_suite),
+        session_id_len = parsed_server_hello.session_id.len(),
+        "Reality TLS received ServerHello"
+    );
+    if parsed_server_hello.session_id != client_hello[39..71] {
+        return Err(TransportError::Tls(
+            "Reality TLS: server did not echo ClientHello session_id".into(),
+        ));
+    }
+    let shared_secret = x25519(&client_private, &parsed_server_hello.key_share)?;
+    transcript.extend_from_slice(&server_hello);
+
+    let cipher = CipherSuite::try_from(parsed_server_hello.cipher_suite)?;
+    let hs = HandshakeKeys::derive(cipher, &shared_secret, &transcript);
+    let mut server_hs = hs.server;
+    let mut client_hs = hs.client;
+
+    let mut handshake_buf = VecDeque::new();
+    let mut leaf_cert = None;
+    let mut saw_encrypted_extensions = false;
+    let mut saw_certificate_verify = false;
+    let server_finished;
+
+    loop {
+        fill_decrypted_handshake(&mut inner, &mut server_hs, &mut handshake_buf).await?;
+        let msg = pop_handshake_message(&mut handshake_buf).ok_or_else(|| {
+            TransportError::Tls("Reality TLS: decrypted empty handshake record".into())
+        })?;
+        match msg.typ {
+            HS_ENCRYPTED_EXTENSIONS => {
+                transcript.extend_from_slice(&msg.raw);
+                saw_encrypted_extensions = true;
+            }
+            HS_CERTIFICATE => {
+                leaf_cert = Some(parse_leaf_certificate(&msg.body)?);
+                transcript.extend_from_slice(&msg.raw);
+            }
+            HS_CERTIFICATE_VERIFY => {
+                transcript.extend_from_slice(&msg.raw);
+                saw_certificate_verify = true;
+            }
+            HS_FINISHED => {
+                server_finished = msg.raw;
+                verify_finished(&hs.server_secret, &transcript, &msg.body)?;
+                break;
+            }
+            HS_NEW_SESSION_TICKET => {
+                // Some servers are eager with post-handshake tickets. Ignore.
+            }
+            other => {
+                return Err(TransportError::Tls(format!(
+                    "Reality TLS: unexpected handshake message {other}"
+                )));
+            }
+        }
+    }
+
+    if !saw_encrypted_extensions || !saw_certificate_verify {
+        return Err(TransportError::Tls(
+            "Reality TLS: incomplete server handshake".into(),
+        ));
+    }
+    let leaf_cert =
+        leaf_cert.ok_or_else(|| TransportError::Tls("Reality TLS: missing certificate".into()))?;
+    verify_reality_certificate(&leaf_cert, &reality_auth_key)?;
+
+    transcript.extend_from_slice(&server_finished);
+    let app = ApplicationKeys::derive(cipher, &hs.master_secret, &transcript);
+
+    let client_finished_body = finished_verify_data(&hs.client_secret, &transcript);
+    let mut client_finished = Vec::with_capacity(4 + client_finished_body.len());
+    client_finished.push(HS_FINISHED);
+    put_u24(client_finished_body.len(), &mut client_finished);
+    client_finished.extend_from_slice(&client_finished_body);
+    let encrypted_finished = client_hs.seal(TLS_RECORD_HANDSHAKE, &client_finished)?;
+    inner.write_all(&encrypted_finished).await?;
+    inner.flush().await?;
+
+    client_random.fill(0);
+    client_private.fill(0);
+
+    tracing::info!("Reality TLS handshake complete");
+    Ok(RealityConnected {
+        inner,
+        read_key: app.server,
+        write_key: app.client,
+    })
+}
+
+pub(crate) struct RealityTlsStream {
+    inner: Box<dyn Stream>,
+    read_key: RecordKey,
+    write_key: RecordKey,
+    read_raw_passthrough: bool,
+    write_raw_passthrough: bool,
+    read_plain: VecDeque<u8>,
+    read_state: StreamReadState,
+    write_pending: Option<StreamPendingWrite>,
+}
+
+impl RealityTlsStream {
+    pub(crate) fn enable_raw_read_passthrough(&mut self) {
+        self.read_raw_passthrough = true;
+        tracing::debug!("Reality TLS raw read passthrough enabled");
+    }
+
+    pub(crate) fn enable_raw_write_passthrough(&mut self) {
+        self.write_raw_passthrough = true;
+        tracing::debug!("Reality TLS raw write passthrough enabled");
+    }
+
+    fn drain_read_plain(&mut self, buf: &mut ReadBuf<'_>) -> bool {
+        if self.read_plain.is_empty() {
+            return false;
+        }
+        let n = buf.remaining().min(self.read_plain.len());
+        for b in self.read_plain.drain(..n) {
+            buf.put_slice(&[b]);
+        }
+        true
+    }
+
+    fn drain_pending_write(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let Some(pending) = &mut self.write_pending else {
+            return Poll::Ready(Ok(()));
+        };
+
+        while pending.pos < pending.frame.len() {
+            match Pin::new(&mut self.inner).poll_write(cx, &pending.frame[pending.pos..])? {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(0) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "reality tls: zero write",
+                    )));
+                }
+                Poll::Ready(n) => pending.pos += n,
+            }
+        }
+
+        self.write_pending.take().expect("pending checked above");
+        Poll::Ready(Ok(()))
+    }
+}
+
+enum StreamReadState {
+    Header {
+        buf: [u8; 5],
+        pos: usize,
+    },
+    Payload {
+        header: [u8; 5],
+        typ: u8,
+        payload: Vec<u8>,
+        pos: usize,
+    },
+}
+
+struct StreamPendingWrite {
+    frame: Vec<u8>,
+    pos: usize,
+}
+
+impl AsyncRead for RealityTlsStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if self.read_raw_passthrough {
+            return Pin::new(&mut self.inner).poll_read(cx, buf);
+        }
+        if self.drain_read_plain(buf) {
+            return Poll::Ready(Ok(()));
+        }
+
+        loop {
+            let state = std::mem::replace(
+                &mut self.read_state,
+                StreamReadState::Header {
+                    buf: [0; 5],
+                    pos: 0,
+                },
+            );
+            match state {
+                StreamReadState::Header {
+                    buf: mut h,
+                    mut pos,
+                } => {
+                    while pos < h.len() {
+                        let mut rb = ReadBuf::new(&mut h[pos..]);
+                        match Pin::new(&mut self.inner).poll_read(cx, &mut rb) {
+                            Poll::Pending => {
+                                self.read_state = StreamReadState::Header { buf: h, pos };
+                                return Poll::Pending;
+                            }
+                            Poll::Ready(Err(e)) => {
+                                self.read_state = StreamReadState::Header { buf: h, pos };
+                                return Poll::Ready(Err(e));
+                            }
+                            Poll::Ready(Ok(())) => {
+                                let n = rb.filled().len();
+                                if n == 0 {
+                                    self.read_state = StreamReadState::Header { buf: h, pos };
+                                    return Poll::Ready(Ok(()));
+                                }
+                                pos += n;
+                            }
+                        }
+                    }
+
+                    let len = u16::from_be_bytes([h[3], h[4]]) as usize;
+                    if len > 18 * 1024 {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("TLS record too large: {len}"),
+                        )));
+                    }
+                    self.read_state = StreamReadState::Payload {
+                        header: h,
+                        typ: h[0],
+                        payload: vec![0; len],
+                        pos: 0,
+                    };
+                }
+                StreamReadState::Payload {
+                    header,
+                    typ,
+                    mut payload,
+                    mut pos,
+                } => {
+                    while pos < payload.len() {
+                        let mut rb = ReadBuf::new(&mut payload[pos..]);
+                        match Pin::new(&mut self.inner).poll_read(cx, &mut rb) {
+                            Poll::Pending => {
+                                self.read_state = StreamReadState::Payload {
+                                    header,
+                                    typ,
+                                    payload,
+                                    pos,
+                                };
+                                return Poll::Pending;
+                            }
+                            Poll::Ready(Err(e)) => {
+                                self.read_state = StreamReadState::Payload {
+                                    header,
+                                    typ,
+                                    payload,
+                                    pos,
+                                };
+                                return Poll::Ready(Err(e));
+                            }
+                            Poll::Ready(Ok(())) => {
+                                let n = rb.filled().len();
+                                if n == 0 {
+                                    self.read_state = StreamReadState::Payload {
+                                        header,
+                                        typ,
+                                        payload,
+                                        pos,
+                                    };
+                                    return Poll::Ready(Ok(()));
+                                }
+                                pos += n;
+                            }
+                        }
+                    }
+
+                    self.read_state = StreamReadState::Header {
+                        buf: [0; 5],
+                        pos: 0,
+                    };
+                    if typ != TLS_RECORD_APPLICATION_DATA {
+                        continue;
+                    }
+                    let (inner_type, plaintext) = self
+                        .read_key
+                        .open(&header, &payload)
+                        .map_err(transport_io_error)?;
+                    match inner_type {
+                        TLS_RECORD_APPLICATION_DATA => {
+                            self.read_plain.extend(plaintext);
+                            if self.drain_read_plain(buf) {
+                                return Poll::Ready(Ok(()));
+                            }
+                        }
+                        TLS_RECORD_HANDSHAKE => {
+                            continue;
+                        }
+                        TLS_RECORD_ALERT => return Poll::Ready(Ok(())),
+                        _ => continue,
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl AsyncWrite for RealityTlsStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        if let Poll::Ready(done) = self.drain_pending_write(cx) {
+            done?;
+        } else {
+            return Poll::Pending;
+        }
+
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        if self.write_raw_passthrough {
+            return Pin::new(&mut self.inner).poll_write(cx, buf);
+        }
+
+        let frame = self
+            .write_key
+            .seal(TLS_RECORD_APPLICATION_DATA, buf)
+            .map_err(transport_io_error)?;
+        self.write_pending = Some(StreamPendingWrite { frame, pos: 0 });
+        match self.drain_pending_write(cx) {
+            Poll::Ready(Ok(())) | Poll::Pending => Poll::Ready(Ok(buf.len())),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        if let Poll::Ready(done) = self.drain_pending_write(cx) {
+            done?;
+        } else {
+            return Poll::Pending;
+        }
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        if let Poll::Ready(done) = self.drain_pending_write(cx) {
+            done?;
+        } else {
+            return Poll::Pending;
+        }
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+fn spawn_reality_stream(state: RealityConnected) -> Box<dyn Stream> {
+    Box::new(RealityTlsStream {
+        inner: state.inner,
+        read_key: state.read_key,
+        write_key: state.write_key,
+        read_raw_passthrough: false,
+        write_raw_passthrough: false,
+        read_plain: VecDeque::new(),
+        read_state: StreamReadState::Header {
+            buf: [0; 5],
+            pos: 0,
+        },
+        write_pending: None,
+    })
+}
+
+fn transport_io_error(e: TransportError) -> io::Error {
+    io::Error::other(e)
+}
+
+fn build_reality_client_hello(
+    server_name: &str,
+    alpn: &[String],
+    random: &[u8; 32],
+    key_share: &[u8; 32],
+    auth_key: &[u8; 32],
+    reality: &RealityConfig,
+) -> Result<(Vec<u8>, [u8; 32])> {
+    let mut body = Vec::with_capacity(512);
+    body.extend_from_slice(&[0x03, 0x03]);
+    body.extend_from_slice(random);
+    body.push(32);
+    body.extend_from_slice(&[0u8; 32]);
+
+    let ciphers = [TLS_AES_128_GCM_SHA256];
+    put_u16((ciphers.len() * 2) as u16, &mut body);
+    for cipher in ciphers {
+        put_u16(cipher, &mut body);
+    }
+    body.extend_from_slice(&[1, 0]);
+
+    let mut exts = Vec::new();
+    push_ext(&mut exts, 0, &server_name_ext(server_name)?);
+    push_ext(
+        &mut exts,
+        10,
+        &u16_list_ext(&[GROUP_X25519, 0x0017, 0x0018]),
+    );
+    push_ext(&mut exts, 11, &[1, 0]);
+    push_ext(
+        &mut exts,
+        13,
+        &u16_list_ext(&[0x0807, 0x0403, 0x0804, 0x0805]),
+    );
+    if !alpn.is_empty() {
+        push_ext(&mut exts, 16, &alpn_ext(alpn)?);
+    }
+    push_ext(&mut exts, 35, &[]);
+    push_ext(&mut exts, 43, &[4, 0x03, 0x04, 0x03, 0x03]);
+    push_ext(&mut exts, 45, &[1, 1]);
+    push_ext(&mut exts, 51, &key_share_ext(key_share));
+
+    put_u16(exts.len() as u16, &mut body);
+    body.extend_from_slice(&exts);
+
+    let mut hello = Vec::with_capacity(4 + body.len());
+    hello.push(HS_CLIENT_HELLO);
+    put_u24(body.len(), &mut hello);
+    hello.extend_from_slice(&body);
+
+    let auth_key = hkdf_sha256(auth_key, &hello[4 + 2..4 + 2 + 20], b"REALITY", 32)?;
+    let mut aead_key = [0u8; 32];
+    aead_key.copy_from_slice(&auth_key);
+
+    let mut reality_plain = [0u8; 16];
+    let unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| TransportError::Tls(format!("system clock before UNIX_EPOCH: {e}")))?
+        .as_secs() as u32;
+    reality_plain[0] = 1;
+    reality_plain[1] = 8;
+    reality_plain[2] = 2;
+    reality_plain[3] = 0;
+    reality_plain[4..8].copy_from_slice(&unix.to_be_bytes());
+    reality_plain[8..16].copy_from_slice(&reality.short_id);
+
+    let cipher = Aes256Gcm::new_from_slice(&aead_key)
+        .map_err(|e| TransportError::Tls(format!("Reality AES-GCM key: {e}")))?;
+    let nonce = Nonce::from_slice(&random[20..32]);
+    let mut session_id = reality_plain.to_vec();
+    let tag = cipher
+        .encrypt_in_place_detached(nonce, &hello, &mut session_id)
+        .map_err(|e| TransportError::Tls(format!("Reality session_id seal: {e}")))?;
+    session_id.extend_from_slice(&tag);
+    if session_id.len() != 32 {
+        return Err(TransportError::Tls(
+            "Reality session_id must be exactly 32 bytes".into(),
+        ));
+    }
+    hello[39..71].copy_from_slice(&session_id);
+    Ok((hello, aead_key))
+}
+
+fn server_name_ext(server_name: &str) -> Result<Vec<u8>> {
+    if server_name.len() > u16::MAX as usize {
+        return Err(TransportError::Config("SNI is too long".into()));
+    }
+    let mut name = Vec::new();
+    name.push(0);
+    put_u16(server_name.len() as u16, &mut name);
+    name.extend_from_slice(server_name.as_bytes());
+
+    let mut out = Vec::new();
+    put_u16(name.len() as u16, &mut out);
+    out.extend_from_slice(&name);
+    Ok(out)
+}
+
+fn alpn_ext(alpn: &[String]) -> Result<Vec<u8>> {
+    let mut list = Vec::new();
+    for protocol in alpn {
+        let bytes = protocol.as_bytes();
+        if bytes.len() > u8::MAX as usize {
+            return Err(TransportError::Config(format!(
+                "ALPN protocol id '{protocol}' is too long"
+            )));
+        }
+        list.push(bytes.len() as u8);
+        list.extend_from_slice(bytes);
+    }
+    let mut out = Vec::new();
+    put_u16(list.len() as u16, &mut out);
+    out.extend_from_slice(&list);
+    Ok(out)
+}
+
+fn u16_list_ext(values: &[u16]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(2 + values.len() * 2);
+    put_u16((values.len() * 2) as u16, &mut out);
+    for value in values {
+        put_u16(*value, &mut out);
+    }
+    out
+}
+
+fn key_share_ext(public_key: &[u8; 32]) -> Vec<u8> {
+    let mut entry = Vec::with_capacity(4 + public_key.len());
+    put_u16(GROUP_X25519, &mut entry);
+    put_u16(public_key.len() as u16, &mut entry);
+    entry.extend_from_slice(public_key);
+
+    let mut out = Vec::with_capacity(2 + entry.len());
+    put_u16(entry.len() as u16, &mut out);
+    out.extend_from_slice(&entry);
+    out
+}
+
+fn push_ext(out: &mut Vec<u8>, typ: u16, data: &[u8]) {
+    put_u16(typ, out);
+    put_u16(data.len() as u16, out);
+    out.extend_from_slice(data);
+}
+
+fn wrap_plain_record(typ: u8, payload: &[u8]) -> Result<Vec<u8>> {
+    if payload.len() > u16::MAX as usize {
+        return Err(TransportError::Tls("TLS record payload too large".into()));
+    }
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(typ);
+    out.extend_from_slice(&[0x03, 0x01]);
+    put_u16(payload.len() as u16, &mut out);
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+async fn read_plain_handshake<R: AsyncRead + Unpin>(r: &mut R, expected: u8) -> Result<Vec<u8>> {
+    loop {
+        let record = read_record(r).await?.ok_or_else(|| {
+            TransportError::Tls("Reality TLS: EOF while reading ServerHello".into())
+        })?;
+        if record.typ == TLS_RECORD_CHANGE_CIPHER_SPEC {
+            continue;
+        }
+        if record.typ != TLS_RECORD_HANDSHAKE {
+            return Err(TransportError::Tls(format!(
+                "Reality TLS: expected handshake record, got {}",
+                record.typ
+            )));
+        }
+        if record.payload.len() < 4 || record.payload[0] != expected {
+            return Err(TransportError::Tls(
+                "Reality TLS: unexpected plaintext handshake".into(),
+            ));
+        }
+        let len = read_u24(&record.payload[1..4]);
+        if record.payload.len() != 4 + len {
+            return Err(TransportError::Tls(
+                "Reality TLS: fragmented plaintext ServerHello is not supported".into(),
+            ));
+        }
+        return Ok(record.payload);
+    }
+}
+
+async fn fill_decrypted_handshake<R: AsyncRead + Unpin>(
+    r: &mut R,
+    key: &mut RecordKey,
+    out: &mut VecDeque<u8>,
+) -> Result<()> {
+    loop {
+        let record = read_record(r).await?.ok_or_else(|| {
+            TransportError::Tls("Reality TLS: EOF during encrypted handshake".into())
+        })?;
+        if record.typ == TLS_RECORD_CHANGE_CIPHER_SPEC {
+            continue;
+        }
+        if record.typ != TLS_RECORD_APPLICATION_DATA {
+            return Err(TransportError::Tls(format!(
+                "Reality TLS: expected encrypted record, got {}",
+                record.typ
+            )));
+        }
+        tracing::debug!(
+            record_version = format_args!("{:02x}{:02x}", record.header[1], record.header[2]),
+            record_len = record.payload.len(),
+            "Reality TLS decrypting encrypted handshake record"
+        );
+        let (inner_type, plaintext) = key.open(&record.header, &record.payload)?;
+        match inner_type {
+            TLS_RECORD_HANDSHAKE => {
+                out.extend(plaintext);
+                return Ok(());
+            }
+            TLS_RECORD_ALERT => {
+                return Err(TransportError::Tls("Reality TLS: server alert".into()));
+            }
+            _ => {}
+        }
+    }
+}
+
+struct TlsRecord {
+    header: [u8; 5],
+    typ: u8,
+    payload: Vec<u8>,
+}
+
+async fn read_record<R: AsyncRead + Unpin>(r: &mut R) -> Result<Option<TlsRecord>> {
+    let mut header = [0u8; 5];
+    match r.read_exact(&mut header).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e.into()),
+    }
+    let len = u16::from_be_bytes([header[3], header[4]]) as usize;
+    if len > 18 * 1024 {
+        return Err(TransportError::Tls(format!("TLS record too large: {len}")));
+    }
+    let mut payload = vec![0u8; len];
+    r.read_exact(&mut payload).await?;
+    Ok(Some(TlsRecord {
+        header,
+        typ: header[0],
+        payload,
+    }))
+}
+
+struct ParsedServerHello {
+    cipher_suite: u16,
+    session_id: Vec<u8>,
+    key_share: [u8; 32],
+}
+
+fn parse_server_hello(raw: &[u8]) -> Result<ParsedServerHello> {
+    if raw.len() < 42 || raw[0] != HS_SERVER_HELLO {
+        return Err(TransportError::Tls("invalid ServerHello".into()));
+    }
+    let body_len = read_u24(&raw[1..4]);
+    if raw.len() != 4 + body_len {
+        return Err(TransportError::Tls("truncated ServerHello".into()));
+    }
+    let body = &raw[4..];
+    if body[0..2] != [0x03, 0x03] {
+        return Err(TransportError::Tls(
+            "Reality TLS: server selected a non-TLS1.3 legacy version".into(),
+        ));
+    }
+    if body[2..34]
+        == [
+            0xcf, 0x21, 0xad, 0x74, 0xe5, 0x9a, 0x61, 0x11, 0xbe, 0x1d, 0x8c, 0x02, 0x1e, 0x65,
+            0xb8, 0x91, 0xc2, 0xa2, 0x11, 0x16, 0x7a, 0xbb, 0x8c, 0x5e, 0x07, 0x9e, 0x09, 0xe2,
+            0xc8, 0xa8, 0x33, 0x9c,
+        ]
+    {
+        return Err(TransportError::Tls(
+            "Reality TLS: HelloRetryRequest is not supported".into(),
+        ));
+    }
+    let mut pos = 34;
+    let sid_len = take_u8(body, &mut pos)? as usize;
+    let session_id = take(body, &mut pos, sid_len)?.to_vec();
+    let cipher_suite = take_u16(body, &mut pos)?;
+    let compression = take_u8(body, &mut pos)?;
+    if compression != 0 {
+        return Err(TransportError::Tls(
+            "Reality TLS: invalid ServerHello compression".into(),
+        ));
+    }
+    let ext_len = take_u16(body, &mut pos)? as usize;
+    let exts = take(body, &mut pos, ext_len)?;
+    let mut key_share = None;
+    let mut tls13 = false;
+    let mut epos = 0;
+    while epos < exts.len() {
+        let typ = take_u16(exts, &mut epos)?;
+        let len = take_u16(exts, &mut epos)? as usize;
+        let data = take(exts, &mut epos, len)?;
+        match typ {
+            43 => tls13 = data == [0x03, 0x04],
+            51 => {
+                let mut p = 0;
+                let group = take_u16(data, &mut p)?;
+                let klen = take_u16(data, &mut p)? as usize;
+                let bytes = take(data, &mut p, klen)?;
+                tracing::debug!(
+                    group = format_args!("0x{group:04x}"),
+                    key_len = bytes.len(),
+                    "Reality TLS ServerHello key_share"
+                );
+                if group == GROUP_X25519 && bytes.len() == 32 {
+                    let mut share = [0u8; 32];
+                    share.copy_from_slice(bytes);
+                    key_share = Some(share);
+                }
+            }
+            _ => {}
+        }
+    }
+    if !tls13 {
+        return Err(TransportError::Tls(
+            "Reality TLS: server did not negotiate TLS 1.3".into(),
+        ));
+    }
+    Ok(ParsedServerHello {
+        cipher_suite,
+        session_id,
+        key_share: key_share
+            .ok_or_else(|| TransportError::Tls("Reality TLS: missing X25519 key share".into()))?,
+    })
+}
+
+struct HandshakeMessage {
+    typ: u8,
+    body: Vec<u8>,
+    raw: Vec<u8>,
+}
+
+fn pop_handshake_message(buf: &mut VecDeque<u8>) -> Option<HandshakeMessage> {
+    if buf.len() < 4 {
+        return None;
+    }
+    let header: Vec<u8> = buf.iter().copied().take(4).collect();
+    let len = read_u24(&header[1..4]);
+    if buf.len() < 4 + len {
+        return None;
+    }
+    let raw = buf.drain(..4 + len).collect::<Vec<_>>();
+    let body = raw[4..].to_vec();
+    Some(HandshakeMessage {
+        typ: raw[0],
+        body,
+        raw,
+    })
+}
+
+fn parse_leaf_certificate(body: &[u8]) -> Result<Vec<u8>> {
+    let mut pos = 0;
+    let ctx_len = take_u8(body, &mut pos)? as usize;
+    take(body, &mut pos, ctx_len)?;
+    let list_len = take_u24(body, &mut pos)?;
+    let list = take(body, &mut pos, list_len)?;
+    let mut list_pos = 0;
+    let cert_len = take_u24(list, &mut list_pos)?;
+    let cert = take(list, &mut list_pos, cert_len)?.to_vec();
+    Ok(cert)
+}
+
+fn verify_reality_certificate(cert_der: &[u8], auth_key: &[u8; 32]) -> Result<()> {
+    let Some((ed25519_pubkey, cert_signature)) = extract_ed25519_cert_parts(cert_der) else {
+        return Err(TransportError::Tls(
+            "Reality authentication failed: leaf certificate is not Ed25519".into(),
+        ));
+    };
+    let mut h = <HmacSha512 as Mac>::new_from_slice(auth_key)
+        .map_err(|e| TransportError::Tls(format!("Reality HMAC-SHA512 init: {e}")))?;
+    h.update(&ed25519_pubkey);
+    let expected = h.finalize().into_bytes();
+    if expected.as_slice() == cert_signature.as_slice() {
+        Ok(())
+    } else {
+        Err(TransportError::Tls(
+            "Reality authentication failed: certificate signature HMAC mismatch".into(),
+        ))
+    }
+}
+
+fn extract_ed25519_cert_parts(cert: &[u8]) -> Option<([u8; 32], Vec<u8>)> {
+    let mut pos = 0;
+    let cert_seq = der_read(cert, &mut pos)?;
+    if cert_seq.tag != 0x30 {
+        return None;
+    }
+    let mut cpos = 0;
+    let tbs = der_read(cert_seq.value, &mut cpos)?;
+    let _sig_alg = der_read(cert_seq.value, &mut cpos)?;
+    let sig = der_read(cert_seq.value, &mut cpos)?;
+    if tbs.tag != 0x30 || sig.tag != 0x03 || sig.value.first().copied()? != 0 {
+        return None;
+    }
+
+    let mut children = Vec::new();
+    let mut tpos = 0;
+    while tpos < tbs.value.len() {
+        children.push(der_read(tbs.value, &mut tpos)?);
+    }
+    let base = if children.first().is_some_and(|n| n.tag == 0xa0) {
+        1
+    } else {
+        0
+    };
+    let spki = *children.get(base + 5)?;
+    let pubkey = extract_ed25519_spki(spki.value)?;
+    Some((pubkey, sig.value[1..].to_vec()))
+}
+
+fn extract_ed25519_spki(spki_value: &[u8]) -> Option<[u8; 32]> {
+    let mut pos = 0;
+    let alg = der_read(spki_value, &mut pos)?;
+    let bit_string = der_read(spki_value, &mut pos)?;
+    if alg.tag != 0x30 || bit_string.tag != 0x03 {
+        return None;
+    }
+    let mut alg_pos = 0;
+    let oid = der_read(alg.value, &mut alg_pos)?;
+    if oid.tag != 0x06 || oid.value != [0x2b, 0x65, 0x70] {
+        return None;
+    }
+    if bit_string.value.len() != 33 || bit_string.value[0] != 0 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bit_string.value[1..]);
+    Some(out)
+}
+
+#[derive(Clone, Copy)]
+struct DerNode<'a> {
+    tag: u8,
+    value: &'a [u8],
+}
+
+fn der_read<'a>(input: &'a [u8], pos: &mut usize) -> Option<DerNode<'a>> {
+    let tag = *input.get(*pos)?;
+    *pos += 1;
+    let first_len = *input.get(*pos)?;
+    *pos += 1;
+    let len = if first_len & 0x80 == 0 {
+        first_len as usize
+    } else {
+        let count = (first_len & 0x7f) as usize;
+        if count == 0 || count > 4 {
+            return None;
+        }
+        let mut len = 0usize;
+        for _ in 0..count {
+            len = (len << 8) | (*input.get(*pos)? as usize);
+            *pos += 1;
+        }
+        len
+    };
+    let end = pos.checked_add(len)?;
+    let value = input.get(*pos..end)?;
+    *pos = end;
+    Some(DerNode { tag, value })
+}
+
+#[derive(Clone, Copy)]
+enum CipherSuite {
+    Aes128GcmSha256,
+}
+
+impl CipherSuite {
+    fn try_from(value: u16) -> Result<Self> {
+        match value {
+            TLS_AES_128_GCM_SHA256 => Ok(Self::Aes128GcmSha256),
+            other => Err(TransportError::Tls(format!(
+                "Reality TLS: unsupported cipher suite 0x{other:04x}"
+            ))),
+        }
+    }
+
+    fn key_len(self) -> usize {
+        match self {
+            Self::Aes128GcmSha256 => 16,
+        }
+    }
+}
+
+struct HandshakeKeys {
+    client: RecordKey,
+    server: RecordKey,
+    client_secret: [u8; 32],
+    server_secret: [u8; 32],
+    master_secret: [u8; 32],
+}
+
+impl HandshakeKeys {
+    fn derive(cipher: CipherSuite, shared_secret: &[u8; 32], transcript: &[u8]) -> Self {
+        let zero = [0u8; 32];
+        let empty_hash = Sha256::digest([]);
+        let early_secret = hkdf_extract(&zero, &zero);
+        let derived = derive_secret(&early_secret, b"derived", &empty_hash);
+        let handshake_secret = hkdf_extract(&derived, shared_secret);
+        let transcript_hash = Sha256::digest(transcript);
+        let client_secret = derive_secret(&handshake_secret, b"c hs traffic", &transcript_hash);
+        let server_secret = derive_secret(&handshake_secret, b"s hs traffic", &transcript_hash);
+        let derived = derive_secret(&handshake_secret, b"derived", &empty_hash);
+        let master_secret = hkdf_extract(&derived, &zero);
+        Self {
+            client: RecordKey::new(cipher, &client_secret),
+            server: RecordKey::new(cipher, &server_secret),
+            client_secret,
+            server_secret,
+            master_secret,
+        }
+    }
+}
+
+struct ApplicationKeys {
+    client: RecordKey,
+    server: RecordKey,
+}
+
+impl ApplicationKeys {
+    fn derive(cipher: CipherSuite, master_secret: &[u8; 32], transcript: &[u8]) -> Self {
+        let transcript_hash = Sha256::digest(transcript);
+        let client_secret = derive_secret(master_secret, b"c ap traffic", &transcript_hash);
+        let server_secret = derive_secret(master_secret, b"s ap traffic", &transcript_hash);
+        Self {
+            client: RecordKey::new(cipher, &client_secret),
+            server: RecordKey::new(cipher, &server_secret),
+        }
+    }
+}
+
+enum AeadCipher {
+    Aes128(Box<Aes128Gcm>),
+}
+
+struct RecordKey {
+    cipher: AeadCipher,
+    iv: [u8; 12],
+    seq: u64,
+}
+
+impl RecordKey {
+    fn new(cipher_suite: CipherSuite, secret: &[u8; 32]) -> Self {
+        let key = hkdf_expand_label(secret, b"key", &[], cipher_suite.key_len());
+        let iv = hkdf_expand_label(secret, b"iv", &[], 12);
+        let mut iv_arr = [0u8; 12];
+        iv_arr.copy_from_slice(&iv);
+        let cipher = match cipher_suite {
+            CipherSuite::Aes128GcmSha256 => AeadCipher::Aes128(Box::new(
+                Aes128Gcm::new_from_slice(&key).expect("AES-128 key"),
+            )),
+        };
+        Self {
+            cipher,
+            iv: iv_arr,
+            seq: 0,
+        }
+    }
+
+    fn seal(&mut self, inner_type: u8, plaintext: &[u8]) -> Result<Vec<u8>> {
+        let mut body = Vec::with_capacity(plaintext.len() + 1 + 16);
+        body.extend_from_slice(plaintext);
+        body.push(inner_type);
+
+        let record_len = body.len() + 16;
+        let mut header = Vec::with_capacity(5);
+        header.push(TLS_RECORD_APPLICATION_DATA);
+        header.extend_from_slice(&[0x03, 0x03]);
+        put_u16(record_len as u16, &mut header);
+        let nonce = self.next_nonce();
+        let tag = self.encrypt_detached(&nonce, &header, &mut body)?;
+        let mut out = header;
+        out.extend_from_slice(&body);
+        out.extend_from_slice(&tag);
+        Ok(out)
+    }
+
+    fn open(&mut self, header: &[u8; 5], ciphertext: &[u8]) -> Result<(u8, Vec<u8>)> {
+        if ciphertext.len() < 16 {
+            return Err(TransportError::Tls("TLS ciphertext too short".into()));
+        }
+        let split = ciphertext.len() - 16;
+        let mut body = ciphertext[..split].to_vec();
+        let tag = Tag::from_slice(&ciphertext[split..]);
+        let nonce = self.next_nonce();
+        self.decrypt_detached(&nonce, header, &mut body, tag)?;
+
+        let Some(pos) = body.iter().rposition(|b| *b != 0) else {
+            return Err(TransportError::Tls(
+                "TLS inner plaintext missing type".into(),
+            ));
+        };
+        let inner_type = body[pos];
+        body.truncate(pos);
+        Ok((inner_type, body))
+    }
+
+    fn next_nonce(&mut self) -> [u8; 12] {
+        let mut nonce = self.iv;
+        let seq = self.seq.to_be_bytes();
+        for (dst, src) in nonce[4..].iter_mut().zip(seq) {
+            *dst ^= src;
+        }
+        self.seq += 1;
+        nonce
+    }
+
+    fn encrypt_detached(&self, nonce: &[u8; 12], aad: &[u8], body: &mut [u8]) -> Result<Tag> {
+        match &self.cipher {
+            AeadCipher::Aes128(c) => c
+                .encrypt_in_place_detached(Nonce::from_slice(nonce), aad, body)
+                .map_err(|e| TransportError::Tls(format!("TLS AES-128-GCM encrypt: {e}"))),
+        }
+    }
+
+    fn decrypt_detached(
+        &self,
+        nonce: &[u8; 12],
+        aad: &[u8],
+        body: &mut [u8],
+        tag: &Tag,
+    ) -> Result<()> {
+        match &self.cipher {
+            AeadCipher::Aes128(c) => c
+                .decrypt_in_place_detached(Nonce::from_slice(nonce), aad, body, tag)
+                .map_err(|e| TransportError::Tls(format!("TLS AES-128-GCM decrypt: {e}"))),
+        }
+    }
+}
+
+fn verify_finished(secret: &[u8; 32], transcript: &[u8], received: &[u8]) -> Result<()> {
+    let expected = finished_verify_data(secret, transcript);
+    if expected.as_slice() == received {
+        Ok(())
+    } else {
+        Err(TransportError::Tls(
+            "Reality TLS: server Finished verify_data mismatch".into(),
+        ))
+    }
+}
+
+fn finished_verify_data(secret: &[u8; 32], transcript: &[u8]) -> Vec<u8> {
+    let finished_key = hkdf_expand_label(secret, b"finished", &[], 32);
+    let transcript_hash = Sha256::digest(transcript);
+    let mut h = <HmacSha256 as Mac>::new_from_slice(&finished_key).expect("HMAC key");
+    h.update(&transcript_hash);
+    h.finalize().into_bytes().to_vec()
+}
+
+fn derive_secret(secret: &[u8; 32], label: &[u8], transcript_hash: &[u8]) -> [u8; 32] {
+    let expanded = hkdf_expand_label(secret, label, transcript_hash, 32);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&expanded);
+    out
+}
+
+fn hkdf_expand_label(secret: &[u8], label: &[u8], context: &[u8], len: usize) -> Vec<u8> {
+    let mut info = Vec::with_capacity(2 + 1 + 6 + label.len() + 1 + context.len());
+    put_u16(len as u16, &mut info);
+    info.push((6 + label.len()) as u8);
+    info.extend_from_slice(b"tls13 ");
+    info.extend_from_slice(label);
+    info.push(context.len() as u8);
+    info.extend_from_slice(context);
+    hkdf_expand(secret, &info, len)
+}
+
+fn hkdf_sha256(secret: &[u8], salt: &[u8], info: &[u8], len: usize) -> Result<Vec<u8>> {
+    let prk = hkdf_extract(salt, secret);
+    Ok(hkdf_expand(&prk, info, len))
+}
+
+fn hkdf_extract(salt: &[u8], ikm: &[u8]) -> [u8; 32] {
+    let mut h = <HmacSha256 as Mac>::new_from_slice(salt).expect("HMAC accepts any key length");
+    h.update(ikm);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&h.finalize().into_bytes());
+    out
+}
+
+fn hkdf_expand(prk: &[u8], info: &[u8], len: usize) -> Vec<u8> {
+    let mut okm = Vec::with_capacity(len);
+    let mut previous = Vec::new();
+    let mut counter = 1u8;
+    while okm.len() < len {
+        let mut h = <HmacSha256 as Mac>::new_from_slice(prk).expect("HMAC accepts any key length");
+        h.update(&previous);
+        h.update(info);
+        h.update(&[counter]);
+        previous = h.finalize().into_bytes().to_vec();
+        okm.extend_from_slice(&previous);
+        counter = counter.checked_add(1).expect("HKDF output too long");
+    }
+    okm.truncate(len);
+    okm
+}
+
+fn clamp_x25519_private(private: &mut [u8; 32]) {
+    private[0] &= 248;
+    private[31] &= 127;
+    private[31] |= 64;
+}
+
+fn x25519_public_from_private(private: &[u8; 32]) -> [u8; 32] {
+    let mut public = [0u8; 32];
+    unsafe {
+        boring_sys::X25519_public_from_private(public.as_mut_ptr(), private.as_ptr());
+    }
+    public
+}
+
+fn x25519(private: &[u8; 32], peer_public: &[u8; 32]) -> Result<[u8; 32]> {
+    let mut out = [0u8; 32];
+    let ok =
+        unsafe { boring_sys::X25519(out.as_mut_ptr(), private.as_ptr(), peer_public.as_ptr()) };
+    if ok == 1 {
+        Ok(out)
+    } else {
+        Err(TransportError::Tls("X25519 ECDH failed".into()))
+    }
+}
+
+fn take<'a>(input: &'a [u8], pos: &mut usize, len: usize) -> Result<&'a [u8]> {
+    let end = pos
+        .checked_add(len)
+        .ok_or_else(|| TransportError::Tls("TLS parser offset overflow".into()))?;
+    let out = input
+        .get(*pos..end)
+        .ok_or_else(|| TransportError::Tls("TLS parser truncated input".into()))?;
+    *pos = end;
+    Ok(out)
+}
+
+fn take_u8(input: &[u8], pos: &mut usize) -> Result<u8> {
+    Ok(take(input, pos, 1)?[0])
+}
+
+fn take_u16(input: &[u8], pos: &mut usize) -> Result<u16> {
+    let b = take(input, pos, 2)?;
+    Ok(u16::from_be_bytes([b[0], b[1]]))
+}
+
+fn take_u24(input: &[u8], pos: &mut usize) -> Result<usize> {
+    let b = take(input, pos, 3)?;
+    Ok(read_u24(b))
+}
+
+fn read_u24(b: &[u8]) -> usize {
+    ((b[0] as usize) << 16) | ((b[1] as usize) << 8) | b[2] as usize
+}
+
+fn put_u16(value: u16, out: &mut Vec<u8>) {
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+fn put_u24(value: usize, out: &mut Vec<u8>) {
+    out.push(((value >> 16) & 0xff) as u8);
+    out.push(((value >> 8) & 0xff) as u8);
+    out.push((value & 0xff) as u8);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reality_client_hello_writes_32_byte_session_id() {
+        let reality = RealityConfig {
+            public_key: [9u8; 32],
+            short_id: [1, 2, 3, 4, 5, 6, 7, 8],
+            support_x25519_mlkem768: false,
+        };
+        let random = [7u8; 32];
+        let client_public = [3u8; 32];
+        let auth_key = [5u8; 32];
+        let (hello, _) = build_reality_client_hello(
+            "example.com",
+            &[],
+            &random,
+            &client_public,
+            &auth_key,
+            &reality,
+        )
+        .expect("client hello");
+        assert_eq!(hello[0], HS_CLIENT_HELLO);
+        assert_eq!(hello[38], 32);
+        assert_ne!(&hello[39..71], &[0u8; 32]);
+    }
+
+    #[test]
+    fn hkdf_expand_label_finished_len() {
+        let secret = [1u8; 32];
+        let out = hkdf_expand_label(&secret, b"finished", &[], 32);
+        assert_eq!(out.len(), 32);
+    }
+}

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -1293,4 +1293,219 @@ mod tests {
         let out = hkdf_expand_label(&secret, b"finished", &[], 32);
         assert_eq!(out.len(), 32);
     }
+
+    // ─── AEAD record layer ───────────────────────────────────────────────────
+
+    /// Two `RecordKey`s derived from the same secret model the matched
+    /// write/read pair on the two ends of a connection. Sealing then opening
+    /// must round-trip, and the per-record nonce sequence must advance in
+    /// lockstep so the second record also decrypts.
+    #[test]
+    fn record_key_seal_open_round_trips_and_sequences() {
+        let secret = [0x2bu8; 32];
+        let mut sender = RecordKey::new(CipherSuite::Aes128GcmSha256, &secret);
+        let mut receiver = RecordKey::new(CipherSuite::Aes128GcmSha256, &secret);
+
+        for payload in [b"first record".as_slice(), b"second record".as_slice()] {
+            let record = sender
+                .seal(TLS_RECORD_APPLICATION_DATA, payload)
+                .expect("seal");
+            let header: [u8; 5] = record[..5].try_into().unwrap();
+            let (inner_type, plaintext) = receiver.open(&header, &record[5..]).expect("open");
+            assert_eq!(inner_type, TLS_RECORD_APPLICATION_DATA);
+            assert_eq!(plaintext, payload);
+        }
+        // Both counters advanced once per record.
+        assert_eq!(sender.seq, 2);
+        assert_eq!(receiver.seq, 2);
+    }
+
+    /// A flipped authentication-tag byte must make `open` fail rather than
+    /// return forged plaintext.
+    #[test]
+    fn record_key_open_rejects_tampered_ciphertext() {
+        let secret = [0x42u8; 32];
+        let mut sender = RecordKey::new(CipherSuite::Aes128GcmSha256, &secret);
+        let mut receiver = RecordKey::new(CipherSuite::Aes128GcmSha256, &secret);
+
+        let mut record = sender
+            .seal(TLS_RECORD_APPLICATION_DATA, b"authentic")
+            .expect("seal");
+        let header: [u8; 5] = record[..5].try_into().unwrap();
+        let last = record.len() - 1;
+        record[last] ^= 0xff;
+        assert!(receiver.open(&header, &record[5..]).is_err());
+    }
+
+    // ─── Reality certificate authentication (anti-MITM gate) ──────────────────
+
+    /// Minimal DER TLV writer (definite length, short or long form).
+    fn der(tag: u8, value: &[u8]) -> Vec<u8> {
+        let mut out = vec![tag];
+        let len = value.len();
+        if len < 0x80 {
+            out.push(len as u8);
+        } else {
+            let bytes = len.to_be_bytes();
+            let first = bytes.iter().position(|&b| b != 0).unwrap();
+            let trimmed = &bytes[first..];
+            out.push(0x80 | trimmed.len() as u8);
+            out.extend_from_slice(trimmed);
+        }
+        out.extend_from_slice(value);
+        out
+    }
+
+    /// Build a minimal X.509 cert carrying an Ed25519 SPKI and a signature
+    /// `BIT STRING` containing `signature`, just enough for
+    /// `extract_ed25519_cert_parts` / `verify_reality_certificate`.
+    fn build_test_ed25519_cert(pubkey: &[u8; 32], signature: &[u8]) -> Vec<u8> {
+        let oid = der(0x06, &[0x2b, 0x65, 0x70]); // 1.3.101.112 (Ed25519)
+        let alg = der(0x30, &oid);
+        let mut spki_bits = vec![0u8]; // unused-bits count
+        spki_bits.extend_from_slice(pubkey);
+        let spki_bitstring = der(0x03, &spki_bits);
+        let mut spki_body = alg;
+        spki_body.extend_from_slice(&spki_bitstring);
+        let spki = der(0x30, &spki_body);
+
+        // tbsCertificate children: version[0], serial, sigAlg, issuer, validity,
+        // subject, subjectPublicKeyInfo — SPKI at index 6 (base 1 + 5).
+        let mut tbs_body = Vec::new();
+        tbs_body.extend_from_slice(&der(0xa0, &der(0x02, &[0x00]))); // version
+        tbs_body.extend_from_slice(&der(0x02, &[0x01])); // serial
+        tbs_body.extend_from_slice(&der(0x30, &[])); // sigAlg
+        tbs_body.extend_from_slice(&der(0x30, &[])); // issuer
+        tbs_body.extend_from_slice(&der(0x30, &[])); // validity
+        tbs_body.extend_from_slice(&der(0x30, &[])); // subject
+        tbs_body.extend_from_slice(&spki);
+        let tbs = der(0x30, &tbs_body);
+
+        let mut sig_bits = vec![0u8]; // unused-bits count
+        sig_bits.extend_from_slice(signature);
+        let sig_bitstring = der(0x03, &sig_bits);
+
+        let mut cert_body = tbs;
+        cert_body.extend_from_slice(&der(0x30, &[])); // outer signatureAlgorithm
+        cert_body.extend_from_slice(&sig_bitstring);
+        der(0x30, &cert_body)
+    }
+
+    fn reality_cert_hmac(auth_key: &[u8], pubkey: &[u8; 32]) -> Vec<u8> {
+        let mut mac = <HmacSha512 as Mac>::new_from_slice(auth_key).unwrap();
+        mac.update(pubkey);
+        mac.finalize().into_bytes().to_vec()
+    }
+
+    #[test]
+    fn verify_reality_certificate_accepts_matching_hmac() {
+        let auth_key = [0x11u8; 32];
+        let pubkey = [0x22u8; 32];
+        let sig = reality_cert_hmac(&auth_key, &pubkey);
+        let cert = build_test_ed25519_cert(&pubkey, &sig);
+        verify_reality_certificate(&cert, &auth_key).expect("authentic Reality cert must verify");
+    }
+
+    #[test]
+    fn verify_reality_certificate_rejects_wrong_hmac() {
+        let auth_key = [0x11u8; 32];
+        let pubkey = [0x22u8; 32];
+
+        // Garbage signature is rejected.
+        let cert = build_test_ed25519_cert(&pubkey, &[0u8; 64]);
+        assert!(verify_reality_certificate(&cert, &auth_key).is_err());
+
+        // A correctly-formed cert verified against the wrong auth key is
+        // rejected — this is the anti-MITM property.
+        let sig = reality_cert_hmac(&auth_key, &pubkey);
+        let cert_ok = build_test_ed25519_cert(&pubkey, &sig);
+        assert!(verify_reality_certificate(&cert_ok, &[0x99u8; 32]).is_err());
+    }
+
+    #[test]
+    fn verify_reality_certificate_rejects_non_ed25519_leaf() {
+        // RSA-ish OID instead of Ed25519: parser must refuse the leaf.
+        let oid = der(
+            0x06,
+            &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01],
+        );
+        let alg = der(0x30, &oid);
+        let mut bits = vec![0u8];
+        bits.extend_from_slice(&[1u8; 32]);
+        let spki = der(0x30, &{
+            let mut b = alg;
+            b.extend_from_slice(&der(0x03, &bits));
+            b
+        });
+        assert!(extract_ed25519_spki(&spki[2..]).is_none());
+    }
+
+    // ─── Reality ClientHello session_id seal ──────────────────────────────────
+
+    /// The 32-byte session_id must decrypt, under the key/nonce/AAD a real
+    /// Reality server reconstructs, to the authentication payload
+    /// (`[1, 8, 2, 0] || timestamp || short_id`). Asserting the plaintext —
+    /// not just the length — is what proves the server could authenticate us.
+    #[test]
+    fn reality_client_hello_session_id_decrypts_to_auth_payload() {
+        let reality = RealityConfig {
+            public_key: [9u8; 32],
+            short_id: [1, 2, 3, 4, 5, 6, 7, 8],
+            support_x25519_mlkem768: false,
+        };
+        let random = [7u8; 32];
+        let client_public = [3u8; 32];
+        let auth_key = [5u8; 32];
+        let (hello, returned_key) = build_reality_client_hello(
+            "example.com",
+            &[],
+            &random,
+            &client_public,
+            &auth_key,
+            &reality,
+        )
+        .expect("client hello");
+
+        // Key the server derives: HKDF(auth_key, salt = random[0..20], "REALITY").
+        let aead_key = hkdf_sha256(&auth_key, &random[..20], b"REALITY", 32);
+        assert_eq!(returned_key.as_slice(), aead_key.as_slice());
+
+        // AAD is the ClientHello with the session_id field zeroed (its state at
+        // seal time); nonce is the trailing 12 bytes of client_random.
+        let mut aad = hello.clone();
+        for b in &mut aad[39..71] {
+            *b = 0;
+        }
+        let (ciphertext, tag) = hello[39..71].split_at(16);
+        let cipher = Aes256Gcm::new_from_slice(&aead_key).unwrap();
+        let nonce = Nonce::from_slice(&random[20..32]);
+        let mut buf = ciphertext.to_vec();
+        cipher
+            .decrypt_in_place_detached(nonce, &aad, &mut buf, Tag::from_slice(tag))
+            .expect("session_id must decrypt under the server-derived key");
+
+        assert_eq!(&buf[0..4], &[1, 8, 2, 0], "reality auth header");
+        assert_eq!(&buf[8..16], &reality.short_id, "short_id echoed");
+    }
+
+    // ─── Adversarial parser inputs ────────────────────────────────────────────
+
+    #[test]
+    fn der_read_rejects_truncated_and_overlong_length() {
+        // Claims 4 content bytes, only 1 present.
+        let mut pos = 0;
+        assert!(der_read(&[0x04, 0x04, 0xaa], &mut pos).is_none());
+        // Length-of-length > 4 is refused.
+        let mut pos = 0;
+        assert!(der_read(&[0x04, 0x85, 0, 0, 0, 0, 0], &mut pos).is_none());
+    }
+
+    #[test]
+    fn parse_server_hello_rejects_malformed_input() {
+        assert!(parse_server_hello(&[]).is_err());
+        assert!(parse_server_hello(&[HS_SERVER_HELLO; 10]).is_err()); // < 42 bytes
+        let mut buf = vec![0u8; 50];
+        buf[0] = HS_CLIENT_HELLO; // wrong handshake type
+        assert!(parse_server_hello(&buf).is_err());
+    }
 }

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -207,7 +207,7 @@ async fn reality_handshake(
     client_random.fill(0);
     client_private.fill(0);
 
-    tracing::info!("Reality TLS handshake complete");
+    tracing::debug!("Reality TLS handshake complete");
     Ok(RealityConnected {
         inner,
         read_key: app.server,

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -544,7 +544,7 @@ fn build_reality_client_hello(
     put_u24(body.len(), &mut hello);
     hello.extend_from_slice(&body);
 
-    let auth_key = hkdf_sha256(auth_key, &hello[4 + 2..4 + 2 + 20], b"REALITY", 32)?;
+    let auth_key = hkdf_sha256(auth_key, &hello[4 + 2..4 + 2 + 20], b"REALITY", 32);
     let mut aead_key = [0u8; 32];
     aead_key.copy_from_slice(&auth_key);
 
@@ -1165,9 +1165,9 @@ fn hkdf_expand_label(secret: &[u8], label: &[u8], context: &[u8], len: usize) ->
     hkdf_expand(secret, &info, len)
 }
 
-fn hkdf_sha256(secret: &[u8], salt: &[u8], info: &[u8], len: usize) -> Result<Vec<u8>> {
+fn hkdf_sha256(secret: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let prk = hkdf_extract(salt, secret);
-    Ok(hkdf_expand(&prk, info, len))
+    hkdf_expand(&prk, info, len)
 }
 
 fn hkdf_extract(salt: &[u8], ikm: &[u8]) -> [u8; 32] {

--- a/crates/meow-transport/src/tls.rs
+++ b/crates/meow-transport/src/tls.rs
@@ -105,6 +105,17 @@ pub enum EchOpts {
     Config(Vec<u8>),
 }
 
+/// REALITY client authentication parameters for TLS-based outbound proxies.
+///
+/// Built by `meow-config` from `reality-opts:`. The public key is the server's
+/// X25519 public key, and `short_id` is the decoded, zero-padded short id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealityConfig {
+    pub public_key: [u8; 32],
+    pub short_id: [u8; 8],
+    pub support_x25519_mlkem768: bool,
+}
+
 /// TLS layer configuration, built by `meow-config` from YAML and passed
 /// into [`TlsLayer::new`].  This struct never sees YAML directly.
 ///
@@ -149,6 +160,11 @@ pub struct TlsConfig {
     /// Requires `boring-tls` feature.  With `boring-tls` absent and
     /// `ech = Some(_)`, [`TlsLayer::new`] returns [`TransportError::Config`].
     pub ech: Option<EchOpts>,
+
+    /// REALITY authentication options. When present, TLS uses the dedicated
+    /// REALITY TLS 1.3 path because the ClientHello session_id must be computed
+    /// from this connection's X25519 key share before it is written.
+    pub reality: Option<RealityConfig>,
 }
 
 impl TlsConfig {
@@ -163,6 +179,7 @@ impl TlsConfig {
             fingerprint: None,
             additional_roots: Vec::new(),
             ech: None,
+            reality: None,
         }
     }
 }
@@ -180,6 +197,8 @@ pub struct ClientCert {
 
 enum TlsBackend {
     Rustls(RustlsInner),
+    #[cfg(feature = "boring-tls")]
+    Reality(crate::reality_tls::RealityTlsLayer),
     #[cfg(feature = "boring-tls")]
     Boring(Box<LazyBoringInner>),
 }
@@ -242,6 +261,22 @@ impl TlsLayer {
     /// * [`TransportError::Config`] — `client_cert` PEM is unparseable (rustls path).
     /// * [`TransportError::Tls`] — client cert + key don't match (rustls path).
     pub fn new(config: &TlsConfig) -> Result<Self> {
+        #[cfg(not(feature = "boring-tls"))]
+        if config.reality.is_some() {
+            return Err(TransportError::Config(
+                "reality-opts requires the `boring-tls` Cargo feature in this build; \
+                 recompile with `--features boring-tls`."
+                    .into(),
+            ));
+        }
+
+        #[cfg(feature = "boring-tls")]
+        if config.reality.is_some() {
+            return Ok(Self {
+                backend: TlsBackend::Reality(crate::reality_tls::RealityTlsLayer::new(config)?),
+            });
+        }
+
         // ECH without either feature is a hard error.
         #[cfg(all(not(feature = "boring-tls"), not(feature = "ech")))]
         if config.ech.is_some() {
@@ -290,6 +325,8 @@ impl Transport for TlsLayer {
     async fn connect(&self, inner: Box<dyn Stream>) -> Result<Box<dyn Stream>> {
         match &self.backend {
             TlsBackend::Rustls(r) => r.connect(inner).await,
+            #[cfg(feature = "boring-tls")]
+            TlsBackend::Reality(r) => r.connect(inner).await,
             #[cfg(feature = "boring-tls")]
             TlsBackend::Boring(lazy) => lazy.connect(inner).await,
         }

--- a/crates/meow-transport/src/tls.rs
+++ b/crates/meow-transport/src/tls.rs
@@ -1046,7 +1046,7 @@ impl BoringInner {
             Ok(tls_stream) => {
                 let ech_accepted = tls_stream.ssl().ech_accepted();
                 let version = tls_stream.ssl().version_str();
-                tracing::info!(
+                tracing::debug!(
                     sni = %self.server_name,
                     ech_requested = ech_requested,
                     ech_accepted = ech_accepted,

--- a/docs/specs/vless-reality-design-test.md
+++ b/docs/specs/vless-reality-design-test.md
@@ -1,0 +1,347 @@
+# VLESS Reality Design and Test Plan
+
+**Status:** draft for issue #225  
+**Branch:** `fix/vless-reality`  
+**Last updated:** 2026-06-16  
+
+This document records the local implementation design and validation method for
+VLESS + Reality + XTLS-Vision. The runtime test sample is
+`/tmp/meow-reality-one.yml`, but this document intentionally does not include
+real proxy server details.
+
+## Redaction Rules
+
+Do not write the following values into docs, GitHub issues, PR descriptions, or
+public logs:
+
+- Proxy `server`, `port`, `servername` / SNI, and real node names.
+- `uuid`, `reality-opts.public-key`, and `reality-opts.short-id`.
+- Full downloaded subscription configs or expanded provider node content.
+- Raw `RUST_LOG=debug` logs that include real node fields.
+
+Use placeholders in docs and shared logs:
+
+```yaml
+mixed-port: 18080
+mode: rule
+log-level: debug
+ipv6: false
+allow-lan: false
+
+proxies:
+  - name: reality-sample
+    type: vless
+    server: <redacted-host>
+    port: <redacted-port>
+    uuid: <redacted-uuid>
+    tls: true
+    client-fingerprint: chrome
+    servername: <redacted-sni>
+    flow: xtls-rprx-vision
+    reality-opts:
+      public-key: <redacted-reality-public-key>
+      short-id: <redacted-short-id>
+      support-x25519mlkem768: false
+```
+
+`/tmp/meow-reality-one.yml` is a local test sample and must not be committed.
+Downloaded subscription configs should stay under `/tmp`, for example
+`/tmp/meow-clash.yml`.
+
+## Design Constraints
+
+- Do not use a third-party Reality / XTLS / VLESS protocol implementation.
+- Do not vendor xray or mihomo code.
+- It is acceptable to reference `/Users/jiawengeng/code/mihomo` for behavior and
+  wire layout, but the implementation must live in meow-rs crates.
+- The Reality TLS state machine, ClientHello construction, TLS 1.3 key schedule,
+  TLS record encryption/decryption, Reality certificate authentication, and
+  XTLS-Vision DIRECT switching are implemented in this repository.
+- Low-level cryptography uses generic primitives or existing TLS backend
+  primitives: AES-GCM, HMAC-SHA256/SHA512, SHA256/SHA512, and BoringSSL X25519.
+  No third-party Reality protocol library is used.
+- Reality currently requires the `boring-tls` feature because config parsing
+  requires `client-fingerprint`, and X25519 primitives are available through the
+  existing BoringSSL feature path.
+
+## Support Scope
+
+Implemented scope:
+
+- VLESS outbound.
+- `tls: true` with `reality-opts`.
+- TCP path for `flow: xtls-rprx-vision`.
+- Default curl HTTPS smoke test, which should negotiate HTTP/2.
+- `curl --http1.1` HTTPS smoke test as a comparison case.
+
+Out of scope:
+
+- VLESS inbound / server mode.
+- Vision UDP splice. UDP still uses plain VLESS and logs a config warning.
+- Hybrid `support-x25519mlkem768` key share. The config field is retained, but
+  the current ClientHello only sends X25519.
+- Mux.Cool.
+- Committing the test sample or subscription nodes as repository fixtures.
+
+## Config Entry Point
+
+`meow-config` parses `reality-opts` in the VLESS parser:
+
+- `public-key`: base64 RawURL without padding. The decoded value must be a
+  32-byte X25519 public key.
+- `short-id`: hex string up to 8 bytes. The decoded value is zero-padded to
+  8 bytes.
+- `support-x25519mlkem768`: boolean. It is stored in `RealityConfig`, but does
+  not change ClientHello generation yet.
+
+Config constraints:
+
+- `reality-opts` requires `tls: true`.
+- `reality-opts` requires `client-fingerprint`, so users do not accidentally
+  get ordinary TLS semantics while expecting Reality.
+- Without `boring-tls`, `TlsLayer::new` returns a config error for Reality.
+- `reality-opts` and `ech-opts` cannot be used on the same TLS layer.
+
+Data flow:
+
+```text
+YAML VLESS proxy
+  -> meow-config::parse_vless
+  -> meow_transport::tls::TlsConfig { reality: Some(RealityConfig) }
+  -> meow_transport::tls::TlsLayer::new
+  -> RealityTlsLayer
+  -> VlessConn
+  -> VisionConn when flow = xtls-rprx-vision
+```
+
+## Reality TLS Implementation
+
+Implementation file: `crates/meow-transport/src/reality_tls.rs`.
+
+Handshake flow:
+
+1. Generate a per-connection X25519 ephemeral private/public key pair.
+2. Compute the Reality auth key from the server Reality public key.
+3. Build a TLS 1.3 ClientHello:
+   - SNI comes from `servername`, falling back to `server`.
+   - ALPN comes from YAML `alpn`.
+   - `key_share` currently sends X25519.
+   - `session_id` contains Reality auth data: version, timestamp, and short-id,
+     sealed with an AES-GCM key derived from the auth key.
+4. Send the plaintext TLS handshake record.
+5. Read ServerHello and validate:
+   - The server echoed the ClientHello `session_id`.
+   - TLS 1.3 was negotiated.
+   - `key_share` is X25519.
+   - The current supported cipher suite is `TLS_AES_128_GCM_SHA256`.
+6. Run the handwritten TLS 1.3 handshake/application key schedule.
+7. Decrypt EncryptedExtensions, Certificate, CertificateVerify, and Finished.
+8. Verify the Reality certificate signature HMAC with the Reality auth key.
+9. Send client Finished and enter application data record mode.
+
+`RealityTlsStream` is responsible for:
+
+- Application data record `poll_read` / `poll_write`.
+- Ordered draining of pending encrypted records.
+- `poll_write` semantics where, after user plaintext has been copied into an
+  internal pending record, it returns `Ok(buf.len())`; later writes first drain
+  the pending encrypted record to preserve ordering.
+- Directional raw passthrough:
+  - `enable_raw_read_passthrough`
+  - `enable_raw_write_passthrough`
+
+Directional read/write passthrough is required for Vision DIRECT. The write
+side switches only after the local DIRECT padding frame is fully drained. The
+read side switches only after the server DIRECT padding frame is fully drained.
+
+## XTLS-Vision DIRECT Implementation
+
+Implementation files:
+
+- `crates/meow-proxy/src/vless/conn.rs`
+- `crates/meow-proxy/src/vless/vision.rs`
+- `crates/meow-proxy/src/vless_adapter.rs`
+
+Key design points:
+
+- `VisionConn` owns a concrete `VlessConn`, not `Box<dyn Stream>`. DIRECT needs
+  to reach the underlying Reality stream and enable raw passthrough; downcasting
+  through an extra trait object wrapper was not reliable.
+- Client write direction:
+  - Detect inner TLS ClientHello.
+  - Write a Vision padding frame.
+  - After inner TLS application data starts, send `COMMAND_PADDING_DIRECT` or
+    `COMMAND_PADDING_END`.
+  - Enable raw write passthrough after the DIRECT frame has fully drained.
+- Server read direction:
+  - Parse server Vision padding frames.
+  - Scan the first few packets for TLS 1.3 ServerHello.
+  - Allow DIRECT only when both the cipher suite and supported_versions indicate
+    TLS 1.3.
+  - Enable raw read passthrough after server DIRECT padding has fully drained.
+- `poll_flush` and `poll_shutdown` drain pending Vision frames before forwarding
+  to the inner connection.
+
+## Why Default curl HTTP/2 Must Pass
+
+For HTTPS, default curl often negotiates HTTP/2 through ALPN. That path reaches
+inner TLS application data quickly and exercises XTLS-Vision DIRECT/raw
+passthrough.
+
+If the Reality TLS stream keeps wrapping DIRECT data in TLS records, or if
+Vision switches raw read/write passthrough at the wrong time, HTTP/2 fails.
+`curl --http1.1` may still pass, so testing HTTP/1.1 alone is not sufficient.
+
+The e2e acceptance test must include default curl with HTTP/2 allowed. The
+expected result is `http_code=204` and `http_version=2`.
+
+## Unit and Build Tests
+
+Formatting:
+
+```bash
+cargo fmt --check
+```
+
+Application build:
+
+```bash
+cargo check -p meow-app --features boring-tls
+```
+
+Reality TLS transport tests:
+
+```bash
+cargo test -p meow-transport --features boring-tls
+```
+
+VLESS Reality config parsing tests:
+
+```bash
+cargo test -p meow-config --test vless_config_test --features boring-tls
+```
+
+Vision DIRECT / ServerHello filter tests:
+
+```bash
+cargo test -p meow-proxy --features vless-vision vision --lib
+```
+
+Important coverage:
+
+- Reality ClientHello writes a 32-byte `session_id`.
+- HKDF label expansion basic length.
+- `reality-opts` without `client-fingerprint` skips that proxy.
+- `reality-opts` without `tls: true` skips that proxy.
+- Invalid Reality public key skips that proxy.
+- Invalid or overlong short-id skips that proxy.
+- Valid Reality config loads with `boring-tls`.
+- Vision padding frame layout.
+- TLS ClientHello detection.
+- TLS 1.3 ServerHello detection.
+- Fragmented TLS record header handling.
+- Non-TLS1.3 cipher rejection.
+
+## Config Sample Test
+
+`/tmp/meow-reality-one.yml` is the single-node Reality test sample. First run
+config validation:
+
+```bash
+cargo run -p meow-app --features boring-tls -- -f /tmp/meow-reality-one.yml -t
+```
+
+Expected:
+
+- Exit code is 0.
+- No real node fields are printed.
+- The Reality VLESS proxy is registered.
+
+To test a user-provided full subscription, download it to `/tmp` and do not
+commit it:
+
+```bash
+SUB_URL='<user-provided-subscription-url>'
+curl -fsSL "$SUB_URL" -o /tmp/meow-clash.yml
+cargo run -p meow-app --features boring-tls -- -f /tmp/meow-clash.yml -t
+```
+
+The full subscription may contain currently unsupported proxy types such as
+`hysteria2`, and groups may warn after referenced proxies are skipped. The
+acceptance focus is:
+
+- Config loading does not panic.
+- VLESS Reality nodes are no longer rejected just because `reality-opts` exists.
+- Warnings do not leak real node fields.
+
+## e2e Smoke Test
+
+If port 18080 already has an old process, either use a sample with another
+listener port or confirm the old process is the intended test process. Do not
+kill a process the user may be observing without confirming it first.
+
+Start meow:
+
+```bash
+RUST_LOG=meow=info,meow_config=warn,meow_proxy=debug,meow_tunnel=debug,meow_transport=debug \
+cargo run -p meow-app --features boring-tls -- -f /tmp/meow-reality-one.yml
+```
+
+Default curl, HTTP/2 acceptance:
+
+```bash
+curl -fsS --max-time 30 \
+  --proxy socks5h://127.0.0.1:18080 \
+  https://www.gstatic.com/generate_204 \
+  -o /tmp/meow-reality-generate-204.out \
+  -w 'http_code=%{http_code} http_version=%{http_version} time_total=%{time_total}\n'
+```
+
+Expected:
+
+```text
+http_code=204 http_version=2
+```
+
+HTTP/1.1 comparison:
+
+```bash
+curl -fsS --http1.1 --max-time 30 \
+  --proxy socks5h://127.0.0.1:18080 \
+  https://www.gstatic.com/generate_204 \
+  -o /tmp/meow-reality-generate-204-http11.out \
+  -w 'http_code=%{http_code} http_version=%{http_version} time_total=%{time_total}\n'
+```
+
+Expected:
+
+```text
+http_code=204 http_version=1.1
+```
+
+Acceptance interpretation:
+
+- Default curl passes but reports `http_version=1.1`: HTTP/2 was not covered;
+  check whether the local curl supports HTTP/2 and whether the target negotiated
+  h2.
+- `--http1.1` passes but default curl fails: treat this as a Vision DIRECT /
+  Reality raw passthrough regression.
+- Both fail: the e2e smoke test fails and needs code or environment
+  investigation before merge.
+
+## Current Validation Record
+
+Local validation during this branch:
+
+- `cargo fmt --check` passed.
+- `cargo check -p meow-app --features boring-tls` passed.
+- `cargo test -p meow-proxy --features vless-vision vision --lib` passed.
+- `cargo test -p meow-transport --features boring-tls` passed.
+- `cargo test -p meow-config --test vless_config_test --features boring-tls` passed.
+- `/tmp/meow-reality-one.yml` config validation passed.
+- Running `/tmp/meow-reality-one.yml`, the default curl HTTPS smoke test returned
+  `http_code=204 http_version=2`.
+- The HTTP/1.1 comparison smoke test returned `http_code=204 http_version=1.1`.
+
+Before merging, rerun the command set above, especially the default curl HTTP/2
+smoke test.


### PR DESCRIPTION
## Summary
- add an in-tree Reality TLS 1.3 transport path for VLESS `reality-opts`
- wire VLESS config parsing for Reality public key / short-id validation
- fix XTLS-Vision DIRECT handling with directional raw passthrough for Reality streams
- add a redacted design and test plan for the local Reality sample

Fixes #225.

## Tests
- `cargo fmt --check`
- `cargo check -p meow-app --features boring-tls`
- `cargo test -p meow-transport --features boring-tls`
- `cargo test -p meow-config --test vless_config_test --features boring-tls`
- `cargo test -p meow-proxy --features vless-vision vision --lib`

## Manual validation
- `/tmp/meow-reality-one.yml` config validation passed locally
- default curl HTTPS smoke test returned `http_code=204 http_version=2`
- HTTP/1.1 comparison smoke test returned `http_code=204 http_version=1.1`

Manual validation used a local redacted sample only; no proxy server details are included in this PR.