### PR TITLE
fix(net): cross-platform HostResolver + system-DNS cache for upstream dials

### DIFF
--- a/crates/meow-common/src/lib.rs
+++ b/crates/meow-common/src/lib.rs
@@ -26,9 +26,11 @@ pub use process_lookup::{find_process, ProcessInfo};
 pub use rule::{Rule, RuleMatchHelper, RuleType};
 pub use sniffer::SnifferConfig;
 pub use socket_protect::{bind_udp, connect_tcp, connect_tcp_host, resolve_host, resolve_host_all};
+// Host-resolver hook is cross-platform (iOS installs it without a protector).
+pub use socket_protect::{clear_host_resolver, host_resolver, set_host_resolver, HostResolver};
+// Socket protector is Android-only (raw-fd `VpnService.protect`).
 #[cfg(target_os = "android")]
 pub use socket_protect::{
-    clear_host_resolver, clear_socket_protector, host_resolver, set_host_resolver,
-    set_socket_protector, socket_protector, HostResolver, SocketProtector,
+    clear_socket_protector, set_socket_protector, socket_protector, SocketProtector,
 };
 pub use tunnel_mode::TunnelMode;

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -22,15 +22,123 @@
 //! whose upstream sockets *are* protected) before falling back to the
 //! system resolver.
 //!
-//! The hooks are compiled only on Android in production — that's the
-//! platform whose VPN model demands this. For tests we additionally enable
-//! the module on any unix host so CI (which does not target Android) can
-//! actually exercise the hooks against real loopback sockets.
+//! The `SocketProtector` (raw-fd) hook is compiled only on Android in
+//! production — that's the platform whose VPN model demands it; for tests we
+//! also enable it on any unix host so CI can exercise it against real
+//! loopback sockets. The `HostResolver` hook carries no platform dependency
+//! and is compiled everywhere: Android installs it alongside the protector,
+//! iOS installs it on its own (the NE process needs the off-tunnel, async,
+//! coalesced resolution but not raw-fd protection).
 
 use std::io;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 
+use async_trait::async_trait;
+use parking_lot::RwLock;
 use tokio::net::{TcpStream, ToSocketAddrs, UdpSocket};
+
+// ─── Host-resolver hook (cross-platform) ──────────────────────────────────
+//
+// Unlike the `SocketProtector` (which protects raw fds and is meaningful only
+// inside Android's `VpnService` model — see the `android` module below), the
+// hostname→IP hook is useful on every VPN platform. Routing a hostname dial
+// through meow-rs's own `meow_dns::Resolver` (whose upstream sockets either
+// bypass the tunnel or are protected) instead of libc's `getaddrinfo` gives
+// us three things the system resolver can't: it never loops a lookup back
+// through our own tunnel, it runs fully async (no blocking-pool thread per
+// `getaddrinfo`, so a wake-time burst of dials can't exhaust the pool), and
+// it coalesces + caches concurrent lookups for the same host. The registry
+// itself carries no platform dependency, so it is compiled unconditionally;
+// only the *installation* is platform-specific (Android JNI bridge / iOS FFI
+// engine start).
+
+/// Hostname → IP resolution hook consulted by [`connect_tcp_host`],
+/// [`resolve_host`] and [`resolve_host_all`] whenever one is installed.
+/// Typically backed by `meow_dns::ResolverHostHook`.
+#[async_trait]
+pub trait HostResolver: Send + Sync {
+    /// Resolve `host` to one `IpAddr`. Returning `Err` aborts the dial.
+    async fn resolve(&self, host: &str) -> io::Result<IpAddr>;
+}
+
+static RESOLVER: RwLock<Option<Arc<dyn HostResolver>>> = RwLock::new(None);
+
+/// Install the global host resolver. Call once at startup, right after the
+/// meow-rs `Resolver` is built. Safe to re-install (e.g. config reload) — the
+/// new resolver takes effect on the next hostname dial.
+pub fn set_host_resolver(resolver: Arc<dyn HostResolver>) {
+    *RESOLVER.write() = Some(resolver);
+}
+
+/// Remove the currently installed host resolver, if any. Subsequent
+/// hostname dials fall back to the system resolver.
+pub fn clear_host_resolver() {
+    *RESOLVER.write() = None;
+}
+
+/// Snapshot of the currently-installed host resolver.
+pub fn host_resolver() -> Option<Arc<dyn HostResolver>> {
+    RESOLVER.read().clone()
+}
+
+// ─── System-resolver result cache (Android / iOS only) ─────────────────────
+//
+// Backstop for the path that still hits libc `getaddrinfo` (no `HostResolver`
+// installed, or one that defers to the system). A proxy upstream is dialed
+// once per outbound flow, so a wake-from-sleep burst would otherwise fire one
+// blocking `getaddrinfo` per flow against the same hostname while the network
+// path is still transitioning. Caching the resolved addresses for a short TTL
+// collapses that burst to a single lookup. Gated to the VPN platforms so
+// desktop / CI dial behaviour is byte-for-byte unchanged.
+
+/// How long a system-resolver result is reused before re-querying.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+const SYS_DNS_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn sys_dns_cache(
+) -> &'static RwLock<std::collections::HashMap<String, (Vec<IpAddr>, std::time::Instant)>> {
+    static C: std::sync::OnceLock<
+        RwLock<std::collections::HashMap<String, (Vec<IpAddr>, std::time::Instant)>>,
+    > = std::sync::OnceLock::new();
+    C.get_or_init(|| RwLock::new(std::collections::HashMap::new()))
+}
+
+/// Cached system-resolver addresses for `host`, or `None` on miss/expiry.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn sys_cache_get(host: &str, port: u16) -> Option<Vec<SocketAddr>> {
+    let guard = sys_dns_cache().read();
+    let (ips, at) = guard.get(host)?;
+    if at.elapsed() > SYS_DNS_TTL {
+        return None;
+    }
+    Some(ips.iter().map(|ip| SocketAddr::new(*ip, port)).collect())
+}
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn sys_cache_get(_host: &str, _port: u16) -> Option<Vec<SocketAddr>> {
+    None
+}
+
+/// Record a fresh system-resolver result for `host`.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn sys_cache_put(host: &str, addrs: &[SocketAddr]) {
+    let ips: Vec<IpAddr> = addrs.iter().map(SocketAddr::ip).collect();
+    sys_dns_cache()
+        .write()
+        .insert(host.to_string(), (ips, std::time::Instant::now()));
+}
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn sys_cache_put(_host: &str, _addrs: &[SocketAddr]) {}
+
+/// Drop any cached entry for `host` (called when every candidate failed to
+/// connect, so the next dial re-resolves instead of reusing a dead address).
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn sys_cache_evict(host: &str) {
+    sys_dns_cache().write().remove(host);
+}
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn sys_cache_evict(_host: &str) {}
 
 // In production we only compile the protector hook on Android — that's the
 // platform whose VPN model demands `VpnService.protect(fd)` and we don't want
@@ -40,11 +148,9 @@ use tokio::net::{TcpStream, ToSocketAddrs, UdpSocket};
 #[cfg(any(target_os = "android", all(test, unix)))]
 mod android {
     use super::*;
-    use std::net::IpAddr;
     use std::os::fd::{AsRawFd, RawFd};
     use std::sync::Arc;
 
-    use async_trait::async_trait;
     use parking_lot::RwLock;
 
     /// Hook invoked on every outbound socket fd just before `connect()` /
@@ -59,20 +165,7 @@ mod android {
         fn protect(&self, fd: RawFd) -> io::Result<()>;
     }
 
-    /// Hostname → IP resolution hook used by [`connect_tcp_host`] when a
-    /// [`SocketProtector`] is installed. Mirrors the protector registry:
-    /// the JNI bridge / app startup installs an implementation that routes
-    /// queries through meow-rs's own DNS pipeline (whose upstream sockets
-    /// are themselves protected), so the resolution itself bypasses the
-    /// VPN. Without this, `getaddrinfo` would loop DNS through the tunnel.
-    #[async_trait]
-    pub trait HostResolver: Send + Sync {
-        /// Resolve `host` to one `IpAddr`. Returning `Err` aborts the dial.
-        async fn resolve(&self, host: &str) -> io::Result<IpAddr>;
-    }
-
     static PROTECTOR: RwLock<Option<Arc<dyn SocketProtector>>> = RwLock::new(None);
-    static RESOLVER: RwLock<Option<Arc<dyn HostResolver>>> = RwLock::new(None);
 
     /// Install the global socket protector. Call once during VPN startup,
     /// before any proxy adapter dials.
@@ -93,27 +186,6 @@ mod android {
     /// can still apply protect on the fd they own.
     pub fn socket_protector() -> Option<Arc<dyn SocketProtector>> {
         PROTECTOR.read().clone()
-    }
-
-    /// Install the global host resolver used by [`connect_tcp_host`]. Call
-    /// once at startup, right after the meow-rs `Resolver` is built. Safe
-    /// to re-install (e.g. config reload) — the new resolver takes effect
-    /// on the next hostname dial.
-    pub fn set_host_resolver(resolver: Arc<dyn HostResolver>) {
-        *RESOLVER.write() = Some(resolver);
-    }
-
-    /// Remove the currently installed host resolver, if any. With the
-    /// protector still installed, subsequent [`connect_tcp_host`] calls
-    /// will fall back to the system resolver and log a warning — that
-    /// path is known-unsafe when the VPN is active.
-    pub fn clear_host_resolver() {
-        *RESOLVER.write() = None;
-    }
-
-    /// Snapshot of the currently-installed host resolver.
-    pub fn host_resolver() -> Option<Arc<dyn HostResolver>> {
-        RESOLVER.read().clone()
     }
 
     pub(super) async fn connect_tcp_protected(
@@ -170,8 +242,7 @@ mod android {
 
 #[cfg(any(target_os = "android", all(test, unix)))]
 pub use android::{
-    clear_host_resolver, clear_socket_protector, host_resolver, set_host_resolver,
-    set_socket_protector, socket_protector, HostResolver, SocketProtector,
+    clear_socket_protector, set_socket_protector, socket_protector, SocketProtector,
 };
 
 /// Dial an outbound TCP stream to an already-resolved [`SocketAddr`]. On
@@ -194,69 +265,89 @@ pub async fn connect_tcp(addr: SocketAddr) -> io::Result<TcpStream> {
     TcpStream::connect(addr).await
 }
 
-/// Dial an outbound TCP stream to `host:port`, resolving the hostname
-/// through the installed `HostResolver` when a `SocketProtector` is
-/// also installed. This routes the lookup through meow-rs's own DNS
-/// resolver (whose upstream sockets are themselves protected) instead of
-/// libc's `getaddrinfo`, which on a VPN-active device would loop DNS
-/// queries back through the tunnel.
+/// Single resolution chokepoint shared by [`connect_tcp_host`],
+/// [`resolve_host`] and [`resolve_host_all`]. Resolution order:
 ///
-/// IP literals short-circuit straight to [`connect_tcp`] — no resolver
-/// hook is needed.
+/// 1. IP literal → returned verbatim (no lookup, no hook).
+/// 2. Installed [`HostResolver`] (e.g. `meow_dns::ResolverHostHook`) → one
+///    address. Preferred on every platform when present: it runs async (no
+///    blocking-pool `getaddrinfo`), caches + coalesces concurrent lookups,
+///    and on a VPN-active device its upstream sockets don't loop the query
+///    back through our own tunnel. Consulted independently of whether a
+///    `SocketProtector` is installed — iOS uses the resolver hook without a
+///    protector.
+/// 3. Short-TTL cache of prior system-resolver results (Android / iOS only)
+///    → collapses a wake-time burst of dials to one `getaddrinfo`.
+/// 4. System resolver (`tokio::net::lookup_host`), result cached.
 ///
-/// Fallback behaviour (when no `HostResolver` is installed):
-/// * If a `SocketProtector` is installed, falls back to
-///   `tokio::net::lookup_host` and logs a warning — this path is the
-///   exact failure mode the resolver hook exists to prevent, but is kept
-///   so a protector-only configuration still functions (degraded).
-/// * If no `SocketProtector` is installed (i.e. not running inside a
-///   VPN), behaves as a plain `TcpStream::connect((host, port))`.
-pub async fn connect_tcp_host(host: &str, port: u16) -> io::Result<TcpStream> {
-    // IP literal — no DNS needed, regardless of platform.
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        return connect_tcp(SocketAddr::new(ip, port)).await;
+/// Never returns an empty `Vec`.
+async fn resolve_addrs(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+
+    if let Some(r) = host_resolver() {
+        let ip = r.resolve(host).await?;
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+
+    if let Some(cached) = sys_cache_get(host, port) {
+        return Ok(cached);
     }
 
     #[cfg(any(target_os = "android", all(test, unix)))]
     {
-        if let Some(p) = android::socket_protector() {
-            if let Some(r) = android::host_resolver() {
-                let ip = r.resolve(host).await?;
-                return android::connect_tcp_protected(SocketAddr::new(ip, port), p.as_ref()).await;
-            }
+        if android::socket_protector().is_some() {
             tracing::warn!(
                 host,
-                "connect_tcp_host: protector installed but no HostResolver — \
-                 falling back to system resolver, which may loop DNS through the VPN"
+                "resolve: protector installed but no HostResolver — falling back \
+                 to system resolver, which may loop DNS through the VPN"
             );
-            let mut last_err: Option<io::Error> = None;
-            let mut any = false;
-            for resolved in tokio::net::lookup_host((host, port)).await? {
-                any = true;
-                match android::connect_tcp_protected(resolved, p.as_ref()).await {
-                    Ok(s) => return Ok(s),
-                    Err(e) => last_err = Some(e),
-                }
-            }
-            return Err(last_err.unwrap_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    if any {
-                        "connect_tcp_host: all candidates failed"
-                    } else {
-                        "connect_tcp_host: no addresses resolved"
-                    },
-                )
-            }));
         }
     }
-    TcpStream::connect((host, port)).await
+
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port)).await?.collect();
+    if addrs.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("resolve: no address for {host}:{port}"),
+        ));
+    }
+    sys_cache_put(host, &addrs);
+    Ok(addrs)
 }
 
-/// Resolve `host` to a single [`SocketAddr`] using the same hook chain
-/// as [`connect_tcp_host`]: IP literals short-circuit, the installed
-/// `HostResolver` is preferred when a `SocketProtector` is present,
-/// and the system resolver is the (warning-logged) fallback.
+/// Dial an outbound TCP stream to `host:port`. The hostname is resolved
+/// through [`resolve_addrs`] (installed `HostResolver` → cache → system
+/// resolver), then each candidate is dialed via [`connect_tcp`] so the
+/// `SocketProtector` (Android) still applies. If every candidate fails to
+/// connect, any cached system-resolver entry is evicted so the next dial
+/// re-resolves instead of reusing a dead address.
+///
+/// IP literals short-circuit inside [`resolve_addrs`] — no resolver hook is
+/// consulted, but the protector still applies to the literal dial.
+pub async fn connect_tcp_host(host: &str, port: u16) -> io::Result<TcpStream> {
+    let addrs = resolve_addrs(host, port).await?;
+    let mut last_err: Option<io::Error> = None;
+    for addr in &addrs {
+        match connect_tcp(*addr).await {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    // Every candidate failed — drop any cached system entry so the next dial
+    // re-resolves. No-op for the literal / resolver-hook paths (not cached).
+    sys_cache_evict(host);
+    Err(last_err.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "connect_tcp_host: no addresses resolved",
+        )
+    }))
+}
+
+/// Resolve `host` to a single [`SocketAddr`] (the first candidate from
+/// [`resolve_host_all`]).
 ///
 /// Prefer [`resolve_host_all`] for call sites that can try candidates in
 /// order (e.g. a UDP `connect()` loop): taking only the first address
@@ -268,41 +359,10 @@ pub async fn resolve_host(host: &str, port: u16) -> io::Result<SocketAddr> {
 }
 
 /// Resolve `host` to every candidate [`SocketAddr`], in resolver order,
-/// using the same hook chain as [`connect_tcp_host`]: IP literals
-/// short-circuit, the installed `HostResolver` is preferred when a
-/// `SocketProtector` is present (it returns a single address), and the
-/// system resolver is the (warning-logged) fallback.
-///
-/// Never returns an empty `Vec` — no-address resolution is an `Err`, so
-/// callers may index `[0]` safely.
+/// via [`resolve_addrs`]. Never returns an empty `Vec` — no-address
+/// resolution is an `Err`, so callers may index `[0]` safely.
 pub async fn resolve_host_all(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        return Ok(vec![SocketAddr::new(ip, port)]);
-    }
-
-    #[cfg(any(target_os = "android", all(test, unix)))]
-    {
-        if android::socket_protector().is_some() {
-            if let Some(r) = android::host_resolver() {
-                let ip = r.resolve(host).await?;
-                return Ok(vec![SocketAddr::new(ip, port)]);
-            }
-            tracing::warn!(
-                host,
-                "resolve_host: protector installed but no HostResolver — \
-                 falling back to system resolver, which may loop DNS through the VPN"
-            );
-        }
-    }
-
-    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port)).await?.collect();
-    if addrs.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("resolve_host: no address for {host}:{port}"),
-        ));
-    }
-    Ok(addrs)
+    resolve_addrs(host, port).await
 }
 
 /// Bind an outbound UDP socket. On Android, applies the installed

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -318,13 +318,13 @@ async fn resolve_addrs(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
 }
 
 /// Dial an outbound TCP stream to `host:port`. The hostname is resolved
-/// through [`resolve_addrs`] (installed `HostResolver` → cache → system
+/// through `resolve_addrs` (installed `HostResolver` → cache → system
 /// resolver), then each candidate is dialed via [`connect_tcp`] so the
 /// `SocketProtector` (Android) still applies. If every candidate fails to
 /// connect, any cached system-resolver entry is evicted so the next dial
 /// re-resolves instead of reusing a dead address.
 ///
-/// IP literals short-circuit inside [`resolve_addrs`] — no resolver hook is
+/// IP literals short-circuit inside `resolve_addrs` — no resolver hook is
 /// consulted, but the protector still applies to the literal dial.
 pub async fn connect_tcp_host(host: &str, port: u16) -> io::Result<TcpStream> {
     let addrs = resolve_addrs(host, port).await?;
@@ -359,7 +359,7 @@ pub async fn resolve_host(host: &str, port: u16) -> io::Result<SocketAddr> {
 }
 
 /// Resolve `host` to every candidate [`SocketAddr`], in resolver order,
-/// via [`resolve_addrs`]. Never returns an empty `Vec` — no-address
+/// via `resolve_addrs`. Never returns an empty `Vec` — no-address
 /// resolution is an `Err`, so callers may index `[0]` safely.
 pub async fn resolve_host_all(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
     resolve_addrs(host, port).await

--- a/crates/meow-dns/src/host_resolver_hook.rs
+++ b/crates/meow-dns/src/host_resolver_hook.rs
@@ -2,17 +2,16 @@
 //! [`meow_common::HostResolver`] hook consulted by
 //! [`meow_common::connect_tcp_host`] / [`meow_common::resolve_host`].
 //!
-//! Gated identically to the trait it implements (Android in production,
-//! plus `test/unix` so CI can exercise the wiring) — outside of those
-//! cfgs the hook isn't compiled, so no impl is needed.
+//! Compiled on every platform (the `meow_common::HostResolver` trait is now
+//! cross-platform): Android installs it alongside the `SocketProtector`, iOS
+//! installs it on its own from the NE FFI engine start.
 //!
 //! See `meow-common/src/socket_protect.rs` for *why* this hook exists:
-//! `getaddrinfo` queries from libc bypass `VpnService.protect(fd)` and
-//! therefore route back through meow-rs's own tunnel, looping. Routing
-//! the lookup through `Resolver::resolve_ip` instead breaks that loop
-//! because the resolver's upstream sockets are themselves protected.
-
-#![cfg(target_os = "android")]
+//! `getaddrinfo` queries from libc bypass the per-fd protection and loop DNS
+//! back through meow-rs's own tunnel; even where they don't loop, they run on
+//! the blocking pool one thread per lookup. Routing the lookup through
+//! `Resolver::resolve_ip` instead resolves async, coalesces + caches, and
+//! keeps the query off the tunnel.
 
 use std::io;
 use std::net::IpAddr;

--- a/crates/meow-dns/src/lib.rs
+++ b/crates/meow-dns/src/lib.rs
@@ -9,7 +9,6 @@ pub mod upstream;
 pub use cache::DnsCache;
 pub use client::{set_socket_factory, ClientError, DnsClient, SocketFactory};
 pub use fakeip::{FileStore, MemoryStore, Pool, PoolError, Skipper, SkipperMode, Store};
-#[cfg(target_os = "android")]
 pub use host_resolver_hook::ResolverHostHook;
 pub use resolver::{BootstrapError, FallbackFilter, NameserverPolicy, PolicyEntry, Resolver};
 pub use server::DnsServer;


### PR DESCRIPTION
## Summary
On iOS the `HostResolver`/`SocketProtector` hooks were gated to Android, so every proxy upstream hostname re-resolved via libc `getaddrinfo` on each dial — a wake-from-sleep burst became a `getaddrinfo` stampede that could wedge the 2-worker engine runtime (data path + REST API both dead).

- Extract `HostResolver` trait + registry out of the android-only module to top-level (no socket2/libc dep); keep `SocketProtector` android-only.
- Consult the installed `HostResolver` independent of the `SocketProtector` so iOS can use meow-dns resolution (async, coalesced, cached, off-tunnel) without raw-fd protection.
- Add a short-TTL system-resolver cache (android/ios only) as a backstop for the `getaddrinfo` path; evict on total connect failure.
- Ungate meow-dns `ResolverHostHook`.

## Verification (local)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib` (712 passed)
- `cargo test -p meow-common -p meow-dns --lib` (139 passed)