### PR TITLE
[codex] fix rule matching pressure allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,9 @@ Dockerfile.debug
 dhat-heap.json
 dhat-ad-hoc.json
 dh_out.json
+*.swp
+*.swo
+*.swn
+*.un~
 .claude/scheduled_tasks.lock
 .antigravitycli/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
  "ipnet",
  "itoa",
  "meow-common",
+ "meow-config",
  "meow-dns",
  "meow-proxy",
  "meow-rules",

--- a/crates/meow-common/src/rule.rs
+++ b/crates/meow-common/src/rule.rs
@@ -131,27 +131,27 @@ pub trait Rule: Send + Sync {
 
     /// Match against metadata and, on match, return the routing target.
     ///
-    /// Default: `Some(SmolStr::from(self.adapter()))` when `match_metadata`
+    /// Default: `Some(self.adapter())` when `match_metadata`
     /// returns true, else `None`. Override only when the resolved target
     /// must come from some other source — notably `SUB-RULE`, whose
     /// target is the matched inner rule's adapter rather than any field
     /// stored on the outer rule.
     ///
-    /// Returns `SmolStr` rather than `String` to avoid a heap allocation
-    /// per matched connection: adapter names ≤23 bytes (the common case
-    /// for `DIRECT`, `REJECT`, and most user-named proxies) inline into
-    /// the SmolStr struct. This is HP-3 in ADR-0008.
+    /// Returns a borrowed `&str` so rule matching itself never allocates on
+    /// the heap, even when adapter names are longer than SmolStr's inline
+    /// capacity. Callers that need to retain the value past the route-table
+    /// snapshot can materialize it outside the rule engine.
     ///
     /// upstream: `rules/logic/logic.go::matchSubRules` — returns
     /// `(bool, adapter)` from the inner rule, not from the SUB-RULE
     /// wrapper.
-    fn match_and_resolve(
-        &self,
+    fn match_and_resolve<'a>(
+        &'a self,
         metadata: &Metadata,
         helper: &RuleMatchHelper,
-    ) -> Option<smol_str::SmolStr> {
+    ) -> Option<&'a str> {
         if self.match_metadata(metadata, helper) {
-            Some(smol_str::SmolStr::from(self.adapter()))
+            Some(self.adapter())
         } else {
             None
         }

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -577,7 +577,14 @@ fn build_parser_context_at(
 
     let asn_trigger = lines.iter().find(|l| line_is_asn_rule(l));
     let asn = match asn_trigger {
-        Some(trigger) => Some(Arc::new(load_mmdb(asn_path, "GeoLite2-ASN", trigger)?)),
+        Some(trigger) => {
+            let reader = load_mmdb_mmap(asn_path, "GeoLite2-ASN", trigger)?;
+            let allowed = collect_asn_numbers(lines);
+            let index = meow_rules::asn_index::AsnIndex::build(&reader, &allowed)
+                .map_err(|e| anyhow::anyhow!("failed to build ASN index: {e}"))?;
+            drop(reader);
+            Some(Arc::new(index))
+        }
         None => None,
     };
 
@@ -599,33 +606,6 @@ fn build_parser_context_at(
         geosite,
         ..Default::default()
     })
-}
-
-fn load_mmdb(
-    path: &Path,
-    kind: &str,
-    trigger: &str,
-) -> Result<maxminddb::Reader<Vec<u8>>, anyhow::Error> {
-    let bytes = std::fs::read(path).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to load {} database at {}\n  required by rule: {}\n  underlying error: {}",
-            kind,
-            path.display(),
-            trigger.trim(),
-            e
-        )
-    })?;
-    let reader = maxminddb::Reader::from_source(bytes).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to parse {} database at {}\n  required by rule: {}\n  underlying error: {}",
-            kind,
-            path.display(),
-            trigger.trim(),
-            e
-        )
-    })?;
-    info!("Loaded {} database from {}", kind, path.display());
-    Ok(reader)
 }
 
 /// Memory-map an MMDB file. The OS reclaims pages immediately on drop,
@@ -699,6 +679,30 @@ fn collect_geosite_categories(lines: &[String]) -> std::collections::HashSet<Str
         }
         for cap in re.captures_iter(line) {
             out.insert(cap[1].to_ascii_lowercase());
+        }
+    }
+    out
+}
+
+/// Scan raw rule lines and return the ASN numbers referenced by `IP-ASN,` /
+/// `SRC-IP-ASN,` payloads, including occurrences inside logic rules.
+fn collect_asn_numbers(lines: &[String]) -> std::collections::HashSet<u32> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?i)\b(?:SRC-)?IP-ASN\s*,\s*(\d+)").expect("compile IP-ASN scan regex")
+    });
+    let mut out = std::collections::HashSet::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        for cap in re.captures_iter(line) {
+            if let Ok(asn) = cap[1].parse::<u32>() {
+                out.insert(asn);
+            }
         }
     }
     out

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -373,6 +373,18 @@ async fn test_empty_rules() {
 }
 
 #[tokio::test]
+async fn test_memleak_regression_config_is_direct_only() {
+    let config = load_config_from_str(include_str!("fixtures/memleak_regression_direct.yaml"))
+        .await
+        .unwrap();
+
+    assert_eq!(config.listeners.mixed_port, Some(17890));
+    assert!(config.proxies.contains_key("DIRECT"));
+    assert!(config.raw.proxies.as_ref().is_none_or(Vec::is_empty));
+    assert!(config.rules.iter().all(|rule| rule.adapter() == "DIRECT"));
+}
+
+#[tokio::test]
 async fn test_proxy_group_select() {
     let yaml = r#"
 proxies:
@@ -882,7 +894,7 @@ rules:
         ..Default::default()
     };
     let target = config.rules[0].match_and_resolve(&m, &helper);
-    assert_eq!(target.as_deref(), Some("Stream"));
+    assert_eq!(target, Some("Stream"));
 }
 
 /// A2/L — block exhaustion returns None so outer loop continues.
@@ -909,7 +921,7 @@ rules:
     assert!(config.rules[0].match_and_resolve(&m, &helper).is_none());
     // MATCH still wins.
     assert_eq!(
-        config.rules[1].match_and_resolve(&m, &helper).as_deref(),
+        config.rules[1].match_and_resolve(&m, &helper),
         Some("DIRECT")
     );
 }

--- a/crates/meow-config/tests/fixtures/memleak_regression_direct.yaml
+++ b/crates/meow-config/tests/fixtures/memleak_regression_direct.yaml
@@ -1,0 +1,20 @@
+# Direct-only regression config for rule-engine memory-footprint testing.
+# No proxy nodes or server details belong in this fixture; it exercises rule
+# matching while routing every hit to the built-in DIRECT adapter.
+
+mixed-port: 17890
+allow-lan: false
+bind-address: "127.0.0.1"
+mode: rule
+log-level: warning
+ipv6: false
+
+dns:
+  enable: false
+
+rules:
+  - DOMAIN,rule-engine-regression.test,DIRECT
+  - DOMAIN-SUFFIX,example.org,DIRECT
+  - DOMAIN-KEYWORD,telemetry,DIRECT
+  - DST-PORT,80,DIRECT
+  - MATCH,DIRECT

--- a/crates/meow-rules/src/asn_index.rs
+++ b/crates/meow-rules/src/asn_index.rs
@@ -1,0 +1,130 @@
+//! ASN-keyed IP-range index built once from a GeoLite2-ASN MMDB.
+//!
+//! `IP-ASN` / `SRC-IP-ASN` matching uses the retained range tries directly,
+//! so rule matching does not perform MMDB decoding or heap allocation.
+
+use ipnet::{Ipv4Net, Ipv6Net};
+use iprange::IpRange;
+use maxminddb::PathElement;
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+use std::sync::Arc;
+
+#[derive(Clone, Default)]
+pub struct AsnRanges {
+    pub v4: Arc<IpRange<Ipv4Net>>,
+    pub v6: Arc<IpRange<Ipv6Net>>,
+}
+
+#[derive(Default)]
+pub struct AsnIndex {
+    by_asn: HashMap<u32, AsnRanges>,
+}
+
+impl AsnIndex {
+    pub fn build<S: AsRef<[u8]>>(
+        reader: &maxminddb::Reader<S>,
+        allowed: &HashSet<u32>,
+    ) -> Result<Self, String> {
+        if allowed.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let allowed_asns: Vec<u32> = allowed.iter().copied().collect();
+        if allowed_asns.len() > u16::MAX as usize {
+            return Err(format!(
+                "ASN allowlist has {} entries, exceeds {}",
+                allowed_asns.len(),
+                u16::MAX
+            ));
+        }
+        let mut buckets: Vec<(IpRange<Ipv4Net>, IpRange<Ipv6Net>)> = (0..allowed_asns.len())
+            .map(|_| Default::default())
+            .collect();
+
+        let iter = reader
+            .networks(Default::default())
+            .map_err(|e| format!("failed to iterate ASN networks: {e}"))?;
+        let path = [PathElement::Key("autonomous_system_number")];
+        let mut offset_cache: HashMap<usize, Option<u16>> = HashMap::new();
+
+        for result in iter {
+            let Ok(lookup) = result else {
+                continue;
+            };
+            let Some(offset) = lookup.offset() else {
+                continue;
+            };
+
+            let bucket_idx = match offset_cache.get(&offset) {
+                Some(&cached) => cached,
+                None => {
+                    let resolved = match lookup.decode_path::<u32>(&path) {
+                        Ok(Some(asn)) => allowed_asns
+                            .iter()
+                            .position(|candidate| *candidate == asn)
+                            .map(|idx| idx as u16),
+                        _ => None,
+                    };
+                    offset_cache.insert(offset, resolved);
+                    resolved
+                }
+            };
+            let Some(bucket_idx) = bucket_idx else {
+                continue;
+            };
+
+            let Ok(net) = lookup.network() else {
+                continue;
+            };
+            let prefix = net.prefix();
+            let bucket = &mut buckets[bucket_idx as usize];
+            match net.network() {
+                IpAddr::V4(v4) => {
+                    if let Ok(net4) = Ipv4Net::new(v4, prefix) {
+                        bucket.0.add(net4);
+                    }
+                }
+                IpAddr::V6(v6) => {
+                    if let Ok(net6) = Ipv6Net::new(v6, prefix) {
+                        bucket.1.add(net6);
+                    }
+                }
+            }
+        }
+
+        let mut by_asn = HashMap::with_capacity(allowed_asns.len());
+        for (asn, (mut v4, mut v6)) in allowed_asns.into_iter().zip(buckets) {
+            if v4.is_empty() && v6.is_empty() {
+                continue;
+            }
+            v4.simplify();
+            v6.simplify();
+            by_asn.insert(
+                asn,
+                AsnRanges {
+                    v4: Arc::new(v4),
+                    v6: Arc::new(v6),
+                },
+            );
+        }
+
+        Ok(Self { by_asn })
+    }
+
+    pub fn ranges_for(&self, asn: u32) -> AsnRanges {
+        self.by_asn.get(&asn).cloned().unwrap_or_default()
+    }
+
+    pub fn asn_count(&self) -> usize {
+        self.by_asn.len()
+    }
+}
+
+impl std::fmt::Debug for AsnIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsnIndex")
+            .field("asns", &self.by_asn.len())
+            .finish()
+    }
+}

--- a/crates/meow-rules/src/geosite.rs
+++ b/crates/meow-rules/src/geosite.rs
@@ -35,9 +35,8 @@ pub enum GeositeError {
 pub struct GeositeDB {
     categories: HashMap<String, DomainTrie<()>>,
     counts: HashMap<String, usize>,
-    /// Raw regex patterns per category; compiled lazily on first lookup.
-    regex_patterns: HashMap<String, Vec<String>>,
-    regex_compiled: HashMap<String, std::sync::OnceLock<Vec<regex::Regex>>>,
+    /// Regex patterns are compiled at load time so matching never allocates.
+    regex_compiled: HashMap<String, Vec<regex::Regex>>,
     keywords: HashMap<String, Vec<String>>,
 }
 
@@ -55,7 +54,6 @@ impl GeositeDB {
         Self {
             categories: HashMap::new(),
             counts: HashMap::new(),
-            regex_patterns: HashMap::new(),
             regex_compiled: HashMap::new(),
             keywords: HashMap::new(),
         }
@@ -73,28 +71,12 @@ impl GeositeDB {
     /// True iff `domain` is in the named category. Category match is
     /// case-insensitive. Unknown categories return `false` (no error).
     pub fn lookup(&self, category: &str, domain: &str) -> bool {
-        let cat_key;
-        let cat = if category.bytes().any(|b| b.is_ascii_uppercase()) {
-            cat_key = category.to_ascii_lowercase();
-            &cat_key
-        } else {
-            category
-        };
-
-        // `domain` is already ASCII-lowercased at every ingestion point
-        // (rule_host(), commit 0068548), so only pay for a lowercase copy on
-        // the rare mixed-case input — mirroring the `cat` guard above instead
-        // of allocating a String on every lookup.
-        let domain_lower;
-        let domain = if domain.bytes().any(|b| b.is_ascii_uppercase()) {
-            domain_lower = domain.to_ascii_lowercase();
-            domain_lower.as_str()
-        } else {
-            domain
+        let Some(cat) = self.category_key(category) else {
+            return false;
         };
 
         if let Some(trie) = self.categories.get(cat) {
-            if trie.search_normalized(domain).is_some() {
+            if trie.search(domain).is_some() {
                 return true;
             }
         }
@@ -105,23 +87,25 @@ impl GeositeDB {
             }
         }
 
-        if let Some(lock) = self.regex_compiled.get(cat) {
-            let compiled = lock.get_or_init(|| {
-                self.regex_patterns
-                    .get(cat)
-                    .map(|pats| {
-                        pats.iter()
-                            .filter_map(|p| regex::Regex::new(p).ok())
-                            .collect()
-                    })
-                    .unwrap_or_default()
-            });
+        if let Some(compiled) = self.regex_compiled.get(cat) {
             if compiled.iter().any(|re| re.is_match(domain)) {
                 return true;
             }
         }
 
         false
+    }
+
+    fn category_key<'a>(&'a self, category: &'a str) -> Option<&'a str> {
+        if !category.bytes().any(|b| b.is_ascii_uppercase()) {
+            return Some(category);
+        }
+        self.categories
+            .keys()
+            .chain(self.keywords.keys())
+            .chain(self.regex_compiled.keys())
+            .find(|key| key.as_bytes().eq_ignore_ascii_case(category.as_bytes()))
+            .map(String::as_str)
     }
 
     /// Number of categories in the DB.
@@ -136,20 +120,27 @@ impl GeositeDB {
     }
 
     pub fn from_parts(
-        categories: HashMap<String, DomainTrie<()>>,
+        mut categories: HashMap<String, DomainTrie<()>>,
         counts: HashMap<String, usize>,
         regex_patterns: HashMap<String, Vec<String>>,
         keywords: HashMap<String, Vec<String>>,
     ) -> Self {
-        let regex_compiled: HashMap<String, std::sync::OnceLock<Vec<regex::Regex>>> =
-            regex_patterns
-                .keys()
-                .map(|k| (k.clone(), std::sync::OnceLock::new()))
-                .collect();
+        for trie in categories.values_mut() {
+            trie.seal();
+        }
+        let regex_compiled: HashMap<String, Vec<regex::Regex>> = regex_patterns
+            .into_iter()
+            .map(|(category, patterns)| {
+                let compiled = patterns
+                    .into_iter()
+                    .filter_map(|p| regex::Regex::new(&p).ok())
+                    .collect();
+                (category, compiled)
+            })
+            .collect();
         Self {
             categories,
             counts,
-            regex_patterns,
             regex_compiled,
             keywords,
         }
@@ -189,13 +180,13 @@ impl GeositeDB {
                             inserted += 1;
                         }
                     }
+                    trie.seal();
                     counts.insert(name.clone(), inserted);
                     categories.insert(name, trie);
                 }
                 Ok(Self {
                     categories,
                     counts,
-                    regex_patterns: HashMap::new(),
                     regex_compiled: HashMap::new(),
                     keywords: HashMap::new(),
                 })

--- a/crates/meow-rules/src/ip_asn.rs
+++ b/crates/meow-rules/src/ip_asn.rs
@@ -1,51 +1,42 @@
 //! IP-ASN rule — matches when the destination IP's Autonomous System Number
 //! equals the payload.
 //!
-//! Requires a GeoLite2-ASN MaxMindDB reader (separate from the Country
-//! database used by GEOIP).  If the reader is absent at parse time the rule
-//! hard-errors rather than silently skipping — Class A per ADR-0002.
+//! At parse time, matching ranges for the requested ASN are materialised from
+//! the GeoLite2-ASN MMDB into Patricia tries. Match becomes a cheap
+//! `IpRange::contains` — no MMDB lookup, no allocation.
 //!
 //! upstream: `rules/common/ipasn.go`
 
+use ipnet::{Ipv4Net, Ipv6Net};
 use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
 use std::net::IpAddr;
-use std::sync::Arc;
+
+use crate::asn_index::AsnRanges;
 
 pub struct IpAsnRule {
-    asn: u32,
     raw: String,
     adapter: String,
-    reader: Arc<maxminddb::Reader<Vec<u8>>>,
+    ranges: AsnRanges,
     src: bool,
     no_resolve: bool,
 }
 
 impl IpAsnRule {
     pub fn new(
-        payload: &str,
+        _asn: u32,
+        raw: &str,
         adapter: &str,
-        reader: Arc<maxminddb::Reader<Vec<u8>>>,
+        ranges: AsnRanges,
         src: bool,
         no_resolve: bool,
-    ) -> Result<Self, String> {
-        let asn: u32 = payload
-            .trim()
-            .parse()
-            .map_err(|e| format!("invalid IP-ASN value '{}': {}", payload.trim(), e))?;
-        Ok(Self {
-            asn,
-            raw: payload.to_string(),
+    ) -> Self {
+        Self {
+            raw: raw.to_string(),
             adapter: adapter.to_string(),
-            reader,
+            ranges,
             src,
             no_resolve,
-        })
-    }
-
-    fn lookup_asn(&self, ip: IpAddr) -> Option<u32> {
-        let result = self.reader.lookup(ip).ok()?;
-        let record: maxminddb::geoip2::Asn = result.decode().ok()??;
-        record.autonomous_system_number
+        }
     }
 }
 
@@ -61,7 +52,14 @@ impl Rule for IpAsnRule {
             metadata.dst_ip
         };
         match ip {
-            Some(ip) => self.lookup_asn(ip) == Some(self.asn),
+            Some(IpAddr::V4(v4)) => self
+                .ranges
+                .v4
+                .contains(&Ipv4Net::new(v4, 32).expect("/32 is always valid")),
+            Some(IpAddr::V6(v6)) => self
+                .ranges
+                .v6
+                .contains(&Ipv6Net::new(v6, 128).expect("/128 is always valid")),
             None => false,
         }
     }
@@ -85,21 +83,16 @@ mod tests {
 
     #[test]
     fn ip_asn_invalid_payload_errors() {
-        // We need a dummy reader to exercise the parse path.  Use an empty
-        // Vec — `Reader::from_source` accepts arbitrary bytes only in some
-        // variants, so build a zero-record DB is out of scope for this test.
-        // Skip unless a fixture reader becomes available.
-        //
-        // Minimal coverage: parse validates payload before touching the reader.
-        // This path is exercised by `parse_ip_asn_error_without_reader` in
-        // `parser.rs` (covers the missing-reader branch) and by the
-        // integration tests in `rules_test.rs` when a fixture DB is present.
+        // Minimal coverage: parse validates payload before building a rule.
+        // This path is exercised by parser tests for the missing-index branch;
+        // fixture-backed positive ASN coverage can be added when an ASN MMDB
+        // fixture is available.
     }
 
     #[test]
     fn ip_asn_rule_type_smoke() {
-        // `IpAsnRule::new` requires a reader; this smoke test just confirms
-        // the enum variant is constructible and distinct.
+        // Smoke-test the enum variant while fixture-backed construction lives
+        // in parser/config tests.
         assert_eq!(RuleType::IpAsn.to_string(), "IP-ASN");
     }
 }

--- a/crates/meow-rules/src/lib.rs
+++ b/crates/meow-rules/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod asn_index;
 pub mod country_index;
 pub mod domain;
 pub mod domain_keyword;

--- a/crates/meow-rules/src/parser.rs
+++ b/crates/meow-rules/src/parser.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use meow_common::Rule;
 
+use crate::asn_index::AsnIndex;
 use crate::country_index::CountryIndex;
 use crate::domain::DomainRule;
 use crate::domain_keyword::DomainKeywordRule;
@@ -41,10 +42,12 @@ pub struct ParserContext {
     /// MMDB Reader itself is dropped after the index is built; per-rule
     /// matching uses Patricia-trie `IpRange` lookups, not MMDB lookups.
     pub geoip: Option<Arc<CountryIndex>>,
-    /// Optional GeoLite2-ASN MaxMindDB reader for `IP-ASN` rules. `None`
-    /// triggers a parse-time hard-error on any `IP-ASN` payload — silent
-    /// skipping would misroute ASN-gated traffic (Class A per ADR-0002).
-    pub asn: Option<Arc<maxminddb::Reader<Vec<u8>>>>,
+    /// Optional GeoLite2-ASN range index for `IP-ASN` rules. `None` triggers
+    /// a parse-time hard-error on any `IP-ASN` payload — silent skipping would
+    /// misroute ASN-gated traffic (Class A per ADR-0002). The MMDB Reader
+    /// itself is dropped after the index is built; per-rule matching uses
+    /// Patricia-trie `IpRange` lookups, not MMDB lookups.
+    pub asn: Option<Arc<AsnIndex>>,
     /// Optional geosite database for `GEOSITE` rules. Unlike GEOIP/ASN,
     /// absence does NOT hard-error at parse time — per spec §Divergences
     /// #3, GEOSITE tolerates an absent DB (always-no-match) so that configs
@@ -204,28 +207,41 @@ pub fn parse_rule(line: &str, ctx: &ParserContext) -> Result<Box<dyn Rule>, Stri
                 .map(|r| Box::new(r) as Box<dyn Rule>)
         }
         "IP-ASN" => {
-            let reader = ctx.asn.clone().ok_or_else(|| {
+            let index = ctx.asn.clone().ok_or_else(|| {
                 "IP-ASN rule requires an ASN database (GeoLite2-ASN.mmdb); drop the file at \
                  $XDG_CONFIG_HOME/meow/GeoLite2-ASN.mmdb, $HOME/.config/meow/GeoLite2-ASN.mmdb, \
                  or ./meow/GeoLite2-ASN.mmdb"
                     .to_string()
             })?;
+            let asn = parse_asn_payload(payload)?;
             let no_resolve = extra.is_some_and(|e| e.eq_ignore_ascii_case("no-resolve"));
-            IpAsnRule::new(payload, adapter, reader, false, no_resolve)
-                .map(|r| Box::new(r) as Box<dyn Rule>)
+            let ranges = index.ranges_for(asn);
+            Ok(Box::new(IpAsnRule::new(
+                asn, payload, adapter, ranges, false, no_resolve,
+            )))
         }
         "SRC-IP-ASN" => {
-            let reader = ctx.asn.clone().ok_or_else(|| {
+            let index = ctx.asn.clone().ok_or_else(|| {
                 "SRC-IP-ASN rule requires an ASN database (GeoLite2-ASN.mmdb); drop the file at \
                  $XDG_CONFIG_HOME/meow/GeoLite2-ASN.mmdb, $HOME/.config/meow/GeoLite2-ASN.mmdb, \
                  or ./meow/GeoLite2-ASN.mmdb"
                     .to_string()
             })?;
-            IpAsnRule::new(payload, adapter, reader, true, true)
-                .map(|r| Box::new(r) as Box<dyn Rule>)
+            let asn = parse_asn_payload(payload)?;
+            let ranges = index.ranges_for(asn);
+            Ok(Box::new(IpAsnRule::new(
+                asn, payload, adapter, ranges, true, true,
+            )))
         }
         _ => Err(format!("unknown rule type: {rule_type}")),
     }
+}
+
+fn parse_asn_payload(payload: &str) -> Result<u32, String> {
+    payload
+        .trim()
+        .parse()
+        .map_err(|e| format!("invalid IP-ASN value '{}': {}", payload.trim(), e))
 }
 
 fn split_once_trimmed(s: &str, sep: char) -> Option<(&str, &str)> {

--- a/crates/meow-rules/src/rule_set.rs
+++ b/crates/meow-rules/src/rule_set.rs
@@ -220,6 +220,7 @@ impl DomainRuleSet {
                 warn!("rule-set (domain): skipping invalid entry '{}'", entry);
             }
         }
+        trie.seal();
         Self { trie, count }
     }
 }

--- a/crates/meow-rules/src/sub_rule.rs
+++ b/crates/meow-rules/src/sub_rule.rs
@@ -96,11 +96,11 @@ impl Rule for SubRuleRule {
         self.block.iter().any(|r| r.should_find_process())
     }
 
-    fn match_and_resolve(
-        &self,
+    fn match_and_resolve<'a>(
+        &'a self,
         metadata: &Metadata,
         helper: &RuleMatchHelper,
-    ) -> Option<smol_str::SmolStr> {
+    ) -> Option<&'a str> {
         // upstream: rules/logic/logic.go::matchSubRules lines 179–190
         for rule in self.block.iter() {
             if let Some(target) = rule.match_and_resolve(metadata, helper) {
@@ -175,7 +175,7 @@ mod tests {
     fn sub_rule_inner_match_returns_inner_target() {
         let sub = SubRuleRule::from_rules("BLOCK", vec![match_rule("DIRECT")]);
         let m = Metadata::default();
-        assert_eq!(sub.match_and_resolve(&m, &helper()), Some("DIRECT".into()));
+        assert_eq!(sub.match_and_resolve(&m, &helper()), Some("DIRECT"));
     }
 
     /// A2 — block exhaustion propagates as None.
@@ -194,7 +194,7 @@ mod tests {
             vec![no_match_rule("A"), match_rule("B"), match_rule("C")],
         );
         let m = Metadata::default();
-        assert_eq!(sub.match_and_resolve(&m, &helper()), Some("B".into()));
+        assert_eq!(sub.match_and_resolve(&m, &helper()), Some("B"));
     }
 
     /// A4 — empty block returns None.
@@ -210,10 +210,7 @@ mod tests {
     fn sub_rule_match_rule_inside_block() {
         let sub = SubRuleRule::from_rules("BLOCK", vec![match_rule("Fallback")]);
         let m = Metadata::default();
-        assert_eq!(
-            sub.match_and_resolve(&m, &helper()),
-            Some("Fallback".into())
-        );
+        assert_eq!(sub.match_and_resolve(&m, &helper()), Some("Fallback"));
     }
 
     /// A6 — target comes from inner rule, not from block_name.
@@ -223,8 +220,8 @@ mod tests {
         let a = SubRuleRule::new("BLOCK-A", Arc::clone(&block));
         let b = SubRuleRule::new("BLOCK-B", block);
         let m = Metadata::default();
-        assert_eq!(a.match_and_resolve(&m, &helper()), Some("DIRECT".into()));
-        assert_eq!(b.match_and_resolve(&m, &helper()), Some("DIRECT".into()));
+        assert_eq!(a.match_and_resolve(&m, &helper()), Some("DIRECT"));
+        assert_eq!(b.match_and_resolve(&m, &helper()), Some("DIRECT"));
     }
 
     /// B1 — nested SubRule returns leaf target.
@@ -234,10 +231,7 @@ mod tests {
         let nested = SubRuleRule::new("B", inner);
         let outer = SubRuleRule::from_rules("A", vec![Box::new(nested)]);
         let m = Metadata::default();
-        assert_eq!(
-            outer.match_and_resolve(&m, &helper()),
-            Some("DIRECT".into())
-        );
+        assert_eq!(outer.match_and_resolve(&m, &helper()), Some("DIRECT"));
     }
 
     /// B2 — inner no-match propagates as None.
@@ -259,6 +253,6 @@ mod tests {
         let top_mid = SubRuleRule::new("B", outer_mid);
         let top = SubRuleRule::from_rules("A", vec![Box::new(top_mid)]);
         let m = Metadata::default();
-        assert_eq!(top.match_and_resolve(&m, &helper()), Some("LEAF".into()));
+        assert_eq!(top.match_and_resolve(&m, &helper()), Some("LEAF"));
     }
 }

--- a/crates/meow-rules/tests/geosite_lookup_alloc_test.rs
+++ b/crates/meow-rules/tests/geosite_lookup_alloc_test.rs
@@ -1,24 +1,15 @@
-//! Regression test: `GeositeDB::lookup` must not allocate for already-lowercase
-//! input.
+//! Regression test: `GeositeDB::lookup` must not allocate while matching.
 //!
-//! The category argument is guarded — only lowercased when it actually contains
-//! an uppercase byte (geosite.rs:77-82). Before the fix the domain was
-//! lowercased UNCONDITIONALLY via `domain.to_ascii_lowercase()`, even though the
-//! sole production caller, `GeoSiteRule::match_metadata`, passes
-//! `metadata.rule_host()` — guaranteed ASCII-lowercase at every ingestion point
-//! since commit 0068548. `str::to_ascii_lowercase` always allocates a fresh
-//! `String`, so that was ≈1 wasted heap allocation per match on the rule hot
-//! path. The fix guards the domain lowercase the same way the category is
-//! guarded.
-//!
-//! This installs a counting global allocator and asserts the per-lookup
-//! allocation count for already-lowercase input is ~0. It FAILS if the guard
-//! regresses.
+//! The rule hot path can see both trie-backed domains and geosite regexes. Trie
+//! lookup must handle mixed-case host/category input without lowercasing into a
+//! new `String`, and regex patterns must already be compiled before lookup.
 
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use meow_rules::geosite::GeositeDB;
+use meow_trie::DomainTrie;
 
 struct CountingAlloc;
 static ALLOCS: AtomicUsize = AtomicUsize::new(0);
@@ -41,31 +32,36 @@ fn under_coverage() -> bool {
 }
 
 #[test]
-fn geosite_lookup_is_zero_alloc_for_normalized_input() {
-    let mut db = GeositeDB::empty();
-    // A category with a few domains so the trie path is exercised on lookup.
-    db.insert("ads", "doubleclick.net");
-    db.insert("ads", "ad.example.com");
-    db.insert("cn", "example.cn");
+fn geosite_lookup_is_zero_alloc_for_domain_and_regex_paths() {
+    let mut trie = DomainTrie::new();
+    trie.insert("+.example.com", ());
 
-    // All inputs already lowercase (the production contract) and category is
-    // lowercase too (so the category guard takes its zero-alloc branch).
-    let domain = "lookup.misses.every.category.test";
+    let db = GeositeDB::from_parts(
+        HashMap::from([("ads".to_string(), trie)]),
+        HashMap::from([("ads".to_string(), 1)]),
+        HashMap::from([(
+            "ads".to_string(),
+            vec![r"^tracker\d+\.example\.net$".to_string()],
+        )]),
+        HashMap::new(),
+    );
 
-    // Warm any lazy init (regex OnceLock etc. — none here, but be safe).
-    let _ = db.lookup("ads", domain);
+    // Warm any one-time initialization before measuring.
+    assert!(db.lookup("ADS", "Sub.Example.COM"));
+    assert!(db.lookup("ads", "tracker123.example.net"));
 
     let before = ALLOCS.load(Ordering::SeqCst);
     let n = 10_000;
     for _ in 0..n {
-        let hit = db.lookup("ads", domain);
-        std::hint::black_box(hit);
+        std::hint::black_box(db.lookup("ADS", "Sub.Example.COM"));
+        std::hint::black_box(db.lookup("ads", "tracker123.example.net"));
     }
     let allocs = ALLOCS.load(Ordering::SeqCst) - before;
-    let per_lookup = allocs as f64 / n as f64;
+    let lookups = n * 2;
+    let per_lookup = allocs as f64 / lookups as f64;
     println!(
-        "GeositeDB::lookup (already-lowercase input): {allocs} allocs / {n} lookups = \
-         {per_lookup:.3} allocs/lookup  (must be ~0 — the domain lowercase is guarded like cat)"
+        "GeositeDB::lookup: {allocs} allocs / {lookups} lookups = \
+         {per_lookup:.3} allocs/lookup"
     );
 
     if under_coverage() {
@@ -73,9 +69,7 @@ fn geosite_lookup_is_zero_alloc_for_normalized_input() {
         return;
     }
     assert!(
-        per_lookup < 0.1,
-        "GeositeDB::lookup allocates {per_lookup:.3} heap allocations per lookup for \
-         already-lowercase input — the domain lowercase must be guarded like the category arg \
-         (geosite.rs:77-82) given the rule_host() lowercase-at-ingestion contract (commit 0068548)."
+        allocs == 0,
+        "GeositeDB::lookup must not allocate during trie or regex matching; got {allocs} allocations"
     );
 }

--- a/crates/meow-trie/src/trie.rs
+++ b/crates/meow-trie/src/trie.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 pub struct DomainTrie<T: Clone + 'static> {
@@ -154,8 +155,7 @@ impl<T: Clone + 'static> DomainTrie<T> {
 
         let trimmed = domain.trim();
         if trimmed.bytes().any(|b| b.is_ascii_uppercase()) {
-            let lower = trimmed.to_ascii_lowercase();
-            self.search_inner(lower.trim_end_matches('.'))
+            self.search_ascii_case_insensitive_inner(trimmed.trim_end_matches('.'))
         } else {
             self.search_inner(trimmed.trim_end_matches('.'))
         }
@@ -179,6 +179,16 @@ impl<T: Clone + 'static> DomainTrie<T> {
         }
     }
 
+    fn search_ascii_case_insensitive_inner(&self, query: &str) -> Option<&T> {
+        if query.is_empty() {
+            return None;
+        }
+        match &self.state {
+            TrieState::Building(root) => Self::search_build_case_insensitive(root, query),
+            TrieState::Sealed(root) => Self::search_sealed_case_insensitive(root, query),
+        }
+    }
+
     fn search_build<'a>(root: &'a BuildNode<T>, query: &str) -> Option<&'a T> {
         // Count labels up front (dots + 1) so `remaining` is known while
         // iterating `rsplit` directly — no per-search SmallVec collection.
@@ -190,6 +200,40 @@ impl<T: Clone + 'static> DomainTrie<T> {
             match node.children.get(label) {
                 None => break,
                 Some(child) => {
+                    node = child;
+                    let remaining = n - d - 1;
+                    if remaining == 0 {
+                        if let Some(ref v) = node.exact_value {
+                            return Some(v);
+                        }
+                    } else if remaining == 1 {
+                        if let Some(ref v) = node.star_value {
+                            best = Some(v);
+                        } else if let Some(ref v) = node.dot_value {
+                            best = Some(v);
+                        }
+                    } else if let Some(ref v) = node.dot_value {
+                        best = Some(v);
+                    }
+                }
+            }
+        }
+        best
+    }
+
+    fn search_build_case_insensitive<'a>(root: &'a BuildNode<T>, query: &str) -> Option<&'a T> {
+        let n = query.bytes().filter(|&b| b == b'.').count() + 1;
+        let mut node = root;
+        let mut best: Option<&T> = None;
+
+        for (d, label) in query.rsplit('.').enumerate() {
+            match node
+                .children
+                .iter()
+                .find(|(k, _)| k.as_bytes().eq_ignore_ascii_case(label.as_bytes()))
+            {
+                None => break,
+                Some((_, child)) => {
                     node = child;
                     let remaining = n - d - 1;
                     if remaining == 0 {
@@ -245,9 +289,54 @@ impl<T: Clone + 'static> DomainTrie<T> {
         best
     }
 
+    fn search_sealed_case_insensitive<'a>(root: &'a SealedNode<T>, query: &str) -> Option<&'a T> {
+        let n = query.bytes().filter(|&b| b == b'.').count() + 1;
+        let mut node = root;
+        let mut best: Option<&T> = None;
+
+        for (d, label) in query.rsplit('.').enumerate() {
+            let label = label.as_bytes();
+            let found = node
+                .children
+                .binary_search_by(|(k, _)| cmp_ascii_lower_to_mixed(k.as_bytes(), label));
+            match found {
+                Err(_) => break,
+                Ok(idx) => {
+                    node = &node.children[idx].1;
+                    let remaining = n - d - 1;
+                    if remaining == 0 {
+                        if let Some(ref v) = node.exact_value {
+                            return Some(v);
+                        }
+                    } else if remaining == 1 {
+                        if let Some(ref v) = node.star_value {
+                            best = Some(v);
+                        } else if let Some(ref v) = node.dot_value {
+                            best = Some(v);
+                        }
+                    } else if let Some(ref v) = node.dot_value {
+                        best = Some(v);
+                    }
+                }
+            }
+        }
+        best
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
+}
+
+fn cmp_ascii_lower_to_mixed(lower: &[u8], mixed: &[u8]) -> Ordering {
+    for (&a, &b) in lower.iter().zip(mixed.iter()) {
+        let b = b.to_ascii_lowercase();
+        match a.cmp(&b) {
+            Ordering::Equal => {}
+            non_eq => return non_eq,
+        }
+    }
+    lower.len().cmp(&mixed.len())
 }
 
 impl<T: Clone + 'static> Default for DomainTrie<T> {

--- a/crates/meow-tunnel/Cargo.toml
+++ b/crates/meow-tunnel/Cargo.toml
@@ -36,6 +36,7 @@ meow-trie = { workspace = true }
 criterion = { workspace = true }
 dashmap = { workspace = true }
 ipnet = { workspace = true }
+meow-config = { workspace = true }
 meow-rules = { workspace = true }
 
 [lints]

--- a/crates/meow-tunnel/benches/rules_bench.rs
+++ b/crates/meow-tunnel/benches/rules_bench.rs
@@ -84,7 +84,6 @@ fn bench_rules(c: &mut Criterion) {
                     black_box(&meta_hit),
                     black_box(&rules),
                     black_box(&index),
-                    false,
                 ))
             });
         });
@@ -105,7 +104,6 @@ fn bench_rules(c: &mut Criterion) {
                     black_box(&meta_miss),
                     black_box(&rules),
                     black_box(&index),
-                    false,
                 ))
             });
         });

--- a/crates/meow-tunnel/src/match_engine.rs
+++ b/crates/meow-tunnel/src/match_engine.rs
@@ -1,31 +1,25 @@
 use meow_common::{find_process, Metadata, Rule, RuleMatchHelper, RuleType};
 use meow_trie::DomainTrie;
-use smol_str::SmolStr;
 use std::collections::HashSet;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use tracing::trace;
 
-/// One match result. Both string fields are `SmolStr` (inline ≤23 bytes,
-/// heap-backed via `Arc<str>` above that) so a connection on the rule
-/// hot path (ADR-0008 HP-3) typically incurs zero heap allocations to
-/// populate this struct — the common DIRECT / REJECT / short-named
-/// proxy / short CIDR payload cases all inline.
-pub struct MatchResult {
-    pub adapter_name: SmolStr,
+/// One borrowed match result. String fields point into the matched rule, so
+/// rule matching itself does not allocate even for long adapter names or
+/// diagnostic payloads.
+pub struct MatchResult<'a> {
+    pub adapter_name: &'a str,
     pub rule_type: RuleType,
-    pub rule_payload: SmolStr,
+    pub rule_payload: &'a str,
 }
 
 /// Index of DOMAIN and DOMAIN-SUFFIX rules keyed by the trie.
 ///
-/// Stores `(rule_index, adapter_name)` for each pattern, keeping the
-/// minimum (earliest) rule index so the match algorithm can short-circuit
-/// the linear scan at the right position. The adapter name is shared as
-/// `Arc<str>` so the trie clone-on-lookup is a refcount bump rather than
-/// a string copy.
+/// Stores only the earliest matching rule index for each pattern. The adapter
+/// and payload are borrowed from the rule slice after lookup, which keeps the
+/// index compact and avoids per-match result allocation.
 pub struct DomainIndex {
-    trie: DomainTrie<(usize, Arc<str>)>,
+    trie: DomainTrie<usize>,
 }
 
 impl DomainIndex {
@@ -39,7 +33,7 @@ impl DomainIndex {
     /// occurrence of each domain pattern.
     pub fn build(rules: &[Box<dyn Rule>]) -> Self {
         use std::borrow::Cow;
-        let mut trie: DomainTrie<(usize, Arc<str>)> = DomainTrie::new();
+        let mut trie: DomainTrie<usize> = DomainTrie::new();
         let mut seen: HashSet<String> = HashSet::new();
         for (idx, rule) in rules.iter().enumerate() {
             match rule.rule_type() {
@@ -61,26 +55,23 @@ impl DomainIndex {
                     // For DomainSuffix: use "+." prefix so trie matches subdomains.
                     if rule.rule_type() == RuleType::DomainSuffix {
                         let trie_key = format!("+.{pattern}");
-                        trie.insert(&trie_key, (idx, Arc::from(rule.adapter())));
+                        trie.insert(&trie_key, idx);
                     } else {
-                        trie.insert(&pattern, (idx, Arc::from(rule.adapter())));
+                        trie.insert(&pattern, idx);
                     }
                     seen.insert(pattern);
                 }
                 _ => {}
             }
         }
+        trie.seal();
         Self { trie }
     }
 
-    /// Probe the trie for a hostname. Returns `(rule_index, adapter_name)` of
-    /// the minimum-index matching DOMAIN/DOMAIN-SUFFIX rule, or `None`.
-    /// The returned `&Arc<str>` lives as long as `self` — the caller can
-    /// `Arc::clone` it for free if it needs to keep the name.
-    pub fn search(&self, host: &str) -> Option<(usize, &Arc<str>)> {
-        self.trie
-            .search_normalized(host)
-            .map(|(idx, adapter)| (*idx, adapter))
+    /// Probe the trie for a production-normalized hostname. Returns the
+    /// matching DOMAIN/DOMAIN-SUFFIX rule index, or `None`.
+    pub fn search(&self, host: &str) -> Option<usize> {
+        self.trie.search_normalized(host).copied()
     }
 }
 
@@ -96,22 +87,14 @@ impl DomainIndex {
 ///
 /// Pre-resolution of `metadata.dst_ip` from a hostname must happen before this
 /// function is called (see `TunnelInner::pre_resolve`).
-pub fn match_rules(
+pub fn match_rules<'rules>(
     metadata: &Metadata,
-    rules: &[Box<dyn Rule>],
+    rules: &'rules [Box<dyn Rule>],
     index: &DomainIndex,
-    needs_process_lookup: bool,
-) -> Option<MatchResult> {
+) -> Option<MatchResult<'rules>> {
     let helper = RuleMatchHelper;
 
-    let enriched = if needs_process_lookup {
-        maybe_enrich_with_process(metadata)
-    } else {
-        None
-    };
-    let meta: &Metadata = enriched.as_ref().unwrap_or(metadata);
-
-    let host = meta.rule_host();
+    let host = metadata.rule_host();
     let trie_hit = if host.is_empty() {
         None
     } else {
@@ -124,35 +107,35 @@ pub fn match_rules(
     // all patterns that match this host.  A broader rule at index < T (e.g.
     // DOMAIN-SUFFIX "example.com" at idx 0 before DOMAIN "sub.example.com" at
     // idx 1) can still match, so we cannot skip domain rules in the prefix scan.
-    let scan_end = trie_hit.map_or(rules.len(), |(t, _)| t);
+    let scan_end = trie_hit.unwrap_or(rules.len());
 
     for rule in &rules[..scan_end] {
-        if let Some(adapter_name) = rule.match_and_resolve(meta, &helper) {
+        if let Some(adapter_name) = rule.match_and_resolve(metadata, &helper) {
             return Some(MatchResult {
                 adapter_name,
                 rule_type: rule.rule_type(),
-                rule_payload: SmolStr::from(rule.payload()),
+                rule_payload: rule.payload(),
             });
         }
     }
 
     // Return trie hit if it beat the linear scan.
-    if let Some((trie_idx, adapter)) = trie_hit {
+    if let Some(trie_idx) = trie_hit {
         let rule = &rules[trie_idx];
         return Some(MatchResult {
-            adapter_name: SmolStr::from(adapter.as_ref()),
+            adapter_name: rule.adapter(),
             rule_type: rule.rule_type(),
-            rule_payload: SmolStr::from(rule.payload()),
+            rule_payload: rule.payload(),
         });
     }
 
     // No match in [0..T]; continue scanning the remainder (trie miss path).
     for rule in &rules[scan_end..] {
-        if let Some(adapter_name) = rule.match_and_resolve(meta, &helper) {
+        if let Some(adapter_name) = rule.match_and_resolve(metadata, &helper) {
             return Some(MatchResult {
                 adapter_name,
                 rule_type: rule.rule_type(),
-                rule_payload: SmolStr::from(rule.payload()),
+                rule_payload: rule.payload(),
             });
         }
     }
@@ -160,7 +143,7 @@ pub fn match_rules(
     None
 }
 
-fn maybe_enrich_with_process(metadata: &Metadata) -> Option<Metadata> {
+pub fn maybe_enrich_with_process(metadata: &Metadata) -> Option<Metadata> {
     if !metadata.process.is_empty() {
         return None;
     }
@@ -232,7 +215,8 @@ mod tests {
 
         let meta = base_metadata(local);
         let index = DomainIndex::build(&rules);
-        let result = match_rules(&meta, &rules, &index, true).expect("engine must return a match");
+        let enriched = maybe_enrich_with_process(&meta).expect("process lookup must succeed");
+        let result = match_rules(&enriched, &rules, &index).expect("engine must return a match");
         assert_eq!(result.adapter_name, "Proxy");
         assert_eq!(result.rule_type.as_str(), "PROCESS-NAME");
     }
@@ -251,7 +235,8 @@ mod tests {
 
         let meta = base_metadata(local);
         let index = DomainIndex::build(&rules);
-        let result = match_rules(&meta, &rules, &index, true).expect("final rule should match");
+        let enriched = maybe_enrich_with_process(&meta).expect("process lookup must succeed");
+        let result = match_rules(&enriched, &rules, &index).expect("final rule should match");
         assert_eq!(result.adapter_name, "DIRECT");
         assert_eq!(result.rule_type.as_str(), "MATCH");
     }
@@ -270,7 +255,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index, true).expect("final rule should match");
+        let result = match_rules(&meta, &rules, &index).expect("final rule should match");
         assert_eq!(result.adapter_name, "DIRECT");
     }
 
@@ -290,7 +275,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index, true).expect("must match");
+        let result = match_rules(&meta, &rules, &index).expect("must match");
         assert_eq!(result.adapter_name, "Proxy");
         assert_eq!(result.rule_type.as_str(), "DOMAIN-SUFFIX");
     }
@@ -313,7 +298,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index, true).expect("must match");
+        let result = match_rules(&meta, &rules, &index).expect("must match");
         assert_eq!(result.adapter_name, "Direct");
     }
 
@@ -341,7 +326,7 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         };
-        let result = match_rules(&meta, &rules, &index, true).expect("must match");
+        let result = match_rules(&meta, &rules, &index).expect("must match");
         assert_eq!(
             result.adapter_name, "Broad",
             "first-match-wins: broader rule at lower index must take precedence"

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -118,12 +118,10 @@ impl TunnelInner {
 
     /// Resolve which proxy to use for the given metadata.
     ///
-    /// The `(rule_name, rule_payload)` strings are `SmolStr` (inline ≤23 B)
-    /// rather than `String`, so the common-case fixed names (`Direct`,
-    /// `Global`, `Final`, short rule_type names like `DOMAIN`, `GEOIP`) and
-    /// short payloads (`example.com`, `192.168.1.0/24`) populate without
-    /// touching the heap. This is the HP-3 hot path (ADR-0008): every TCP
-    /// connection and every UDP NAT session creation flows through here.
+    /// Rule matching returns borrowed adapter/payload text, so the rule engine
+    /// itself stays heap-allocation-free. This method materializes the public
+    /// tracking payloads as `SmolStr` after matching, where short common names
+    /// still remain inline.
     pub fn resolve_proxy(
         &self,
         metadata: &Metadata,
@@ -156,11 +154,16 @@ impl TunnelInner {
                 // consistent snapshot. Replaces three RwLock acquisitions.
                 let route = self.route.load();
                 let needs_proc = self.needs_process_lookup.load(Ordering::Relaxed);
+                let enriched = if needs_proc {
+                    match_engine::maybe_enrich_with_process(metadata)
+                } else {
+                    None
+                };
+                let match_metadata = enriched.as_ref().unwrap_or(metadata);
                 let result = match_engine::match_rules(
-                    metadata,
+                    match_metadata,
                     route.rules.as_ref(),
                     route.domain_index.as_ref(),
-                    needs_proc,
                 );
                 match result {
                     Some(m) => {
@@ -174,23 +177,19 @@ impl TunnelInner {
                         self.stats
                             .rule_match
                             .increment(m.rule_type.as_str(), action);
-                        let proxy = route
-                            .proxies
-                            .get(m.adapter_name.as_str())
-                            .cloned()
-                            .map_or_else(
-                                || {
-                                    debug!("proxy '{}' not found, using DIRECT", m.adapter_name);
-                                    Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>
-                                },
-                                |p| p as Arc<dyn ProxyAdapter>,
-                            );
+                        let proxy = route.proxies.get(m.adapter_name).cloned().map_or_else(
+                            || {
+                                debug!("proxy '{}' not found, using DIRECT", m.adapter_name);
+                                Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>
+                            },
+                            |p| p as Arc<dyn ProxyAdapter>,
+                        );
                         // `rule_type.as_str()` is a `&'static str` — wrap it
                         // inline without heap.
                         Some((
                             proxy,
                             SmolStr::new_static(m.rule_type.as_str()),
-                            m.rule_payload,
+                            SmolStr::from(m.rule_payload),
                         ))
                     }
                     None => {

--- a/crates/meow-tunnel/tests/alloc_count_test.rs
+++ b/crates/meow-tunnel/tests/alloc_count_test.rs
@@ -1,4 +1,5 @@
 use meow_common::{ConnType, DnsMode, Metadata, Network, Rule, RuleType};
+use meow_config::load_config_from_str;
 use meow_tunnel::match_engine::{match_rules, DomainIndex};
 use meow_tunnel::Statistics;
 use smallvec::smallvec;
@@ -6,11 +7,13 @@ use smol_str::SmolStr;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::Mutex;
 
 struct CountingAlloc;
 
 static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
 static DEALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 unsafe impl GlobalAlloc for CountingAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -119,20 +122,26 @@ fn test_metadata() -> Metadata {
 
 #[test]
 fn rule_match_zero_alloc_on_hot_path() {
+    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
+    let long_adapter = "ProxyNameThatExceedsSmolStrInlineCapacity";
+    let long_domain = "very-long-subdomain-name-that-exceeds-inline-capacity.example.com";
     let rules: Vec<Box<dyn Rule>> = vec![
-        Box::new(SimpleDomainRule::new("example.com", "Proxy")),
+        Box::new(SimpleDomainRule::new(long_domain, long_adapter)),
         Box::new(FinalRule::new("DIRECT")),
     ];
     let index = DomainIndex::build(&rules);
-    let meta = test_metadata();
+    let meta = Metadata {
+        host: SmolStr::from(long_domain),
+        ..test_metadata()
+    };
 
     // Warm up
-    let _ = match_rules(&meta, &rules, &index, false);
+    let _ = match_rules(&meta, &rules, &index);
 
     reset_counts();
     let n = 1000;
     for _ in 0..n {
-        let result = match_rules(&meta, &rules, &index, false);
+        let result = match_rules(&meta, &rules, &index);
         let _ = std::hint::black_box(result);
     }
     let (allocs, _) = snapshot();
@@ -143,17 +152,126 @@ fn rule_match_zero_alloc_on_hot_path() {
         println!("skipping alloc assertion under coverage instrumentation");
         return;
     }
-    // Rule matching with short adapter names (≤23B) and no process lookup.
-    // The trie's internal SmallVec and HashMap traversal may cause minor
-    // allocator activity in debug builds. Target: ≤ 2 per match.
+    // Rule matching returns borrowed adapter/payload text and the domain index
+    // is sealed, so even long adapter names and payloads must not allocate.
     assert!(
-        per_match <= 2.0,
-        "expected ≤ 2 heap allocations per rule match, got {per_match:.3}"
+        allocs == 0,
+        "expected zero heap allocations per rule match, got {allocs} total ({per_match:.3}/match)"
+    );
+}
+
+#[tokio::test]
+async fn rule_engine_pressure_zero_alloc_free_on_critical_path() {
+    const ITERS: usize = 50_000;
+
+    let required_providers = [
+        "/Users/mlv/.config/meow/Country.mmdb",
+        "/Users/mlv/.config/meow/geosite.dat",
+    ];
+    if let Some(missing) = required_providers
+        .iter()
+        .find(|path| !std::path::Path::new(path).exists())
+    {
+        println!("skipping provider-backed pressure test; missing {missing}");
+        return;
+    }
+
+    let config = load_config_from_str(include_str!("fixtures/memleak_ech_pressure_config.yaml"))
+        .await
+        .expect("memleak ECH pressure config must load with geodata providers");
+    let rules = config.rules;
+    let index = DomainIndex::build(&rules);
+    let domain_hit = Metadata {
+        host: SmolStr::new_static("api.maxlv.net"),
+        ..test_metadata()
+    };
+    let geosite_hit = Metadata {
+        host: SmolStr::new_static("github.com"),
+        ..test_metadata()
+    };
+    let geoip_hit = Metadata {
+        dst_ip: Some("223.5.5.5".parse().expect("valid CN DNS IP")),
+        ..test_metadata()
+    };
+    let full_scan_final = Metadata {
+        host: SmolStr::new_static("no-index-hit.example.net"),
+        ..test_metadata()
+    };
+
+    // Warm up any lazy test/runtime state outside the measured critical path.
+    assert_eq!(
+        match_rules(&domain_hit, &rules, &index)
+            .expect("domain suffix rule should match")
+            .adapter_name,
+        "直连"
+    );
+    assert_eq!(
+        match_rules(&geosite_hit, &rules, &index)
+            .expect("GEOSITE github rule should match")
+            .adapter_name,
+        "Github"
+    );
+    assert_eq!(
+        match_rules(&geoip_hit, &rules, &index)
+            .expect("GEOIP CN rule should match")
+            .adapter_name,
+        "国内"
+    );
+    assert_eq!(
+        match_rules(&full_scan_final, &rules, &index)
+            .expect("final rule should match")
+            .adapter_name,
+        "其他"
+    );
+
+    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
+    reset_counts();
+    for _ in 0..ITERS {
+        let domain = match_rules(
+            std::hint::black_box(&domain_hit),
+            std::hint::black_box(&rules),
+            std::hint::black_box(&index),
+        );
+        let geosite = match_rules(
+            std::hint::black_box(&geosite_hit),
+            std::hint::black_box(&rules),
+            std::hint::black_box(&index),
+        );
+        let geoip = match_rules(
+            std::hint::black_box(&geoip_hit),
+            std::hint::black_box(&rules),
+            std::hint::black_box(&index),
+        );
+        let full_scan = match_rules(
+            std::hint::black_box(&full_scan_final),
+            std::hint::black_box(&rules),
+            std::hint::black_box(&index),
+        );
+        std::hint::black_box((domain, geosite, geoip, full_scan));
+    }
+    let (allocs, deallocs) = snapshot();
+
+    println!(
+        "rule_engine_pressure: {allocs} allocs / {deallocs} frees across {} match calls",
+        ITERS * 4
+    );
+    if under_coverage_instrumentation() {
+        println!("skipping alloc/free assertion under coverage instrumentation");
+        return;
+    }
+    assert_eq!(
+        allocs, 0,
+        "rule engine critical path allocated {allocs} times under pressure"
+    );
+    assert_eq!(
+        deallocs, 0,
+        "rule engine critical path freed heap memory {deallocs} times under pressure"
     );
 }
 
 #[test]
 fn track_connection_alloc_count() {
+    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
     let stats = Statistics::new();
     let meta = test_metadata();
 
@@ -204,6 +322,7 @@ fn track_connection_alloc_count() {
 
 #[test]
 fn metadata_remote_address_zero_alloc() {
+    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
     let meta = test_metadata();
 
     reset_counts();

--- a/crates/meow-tunnel/tests/fixtures/memleak_ech_pressure_config.yaml
+++ b/crates/meow-tunnel/tests/fixtures/memleak_ech_pressure_config.yaml
@@ -1,0 +1,240 @@
+# url 里填写自己的订阅,名称不能重复
+proxy-providers:
+  provider1:
+    url: ""
+    type: http
+    interval: 86400
+    health-check: {enable: true,url: "https://www.gstatic.com/generate_204", interval: 300}
+    override:
+      additional-prefix: "[provider1]"
+
+  provider2:
+    url: ""
+    type: http
+    interval: 86400
+    health-check: {enable: true,url: "https://www.gstatic.com/generate_204",interval: 300}
+    override:
+      additional-prefix: "[provider2]"
+
+proxies:
+  - name: "直连"
+    type: direct
+    udp: true
+
+  # SS + ech-tls-tunnel (meow-rs 内置 SIP003 client transport)
+  - name: "🇸🇬 ech-sgp"
+    type: ss
+    server: sgp.example.com
+    port: 443
+    cipher: aes-128-gcm
+    password: a6wfmS1PBTVVC7L23YDTAW2mmXgPGb2
+    udp: false
+    plugin: ech-tls-tunnel
+    plugin-opts:
+      mode: client
+      sni: example.com
+      path: /ws-e6ebfddbb858dfe8
+      ech_config: "AEn+DQBF/gAgACCQeNQYP6XhS1bAPcT1x0nWjCNDLiaAg83tJwDi3QhDDwAIAAEAAQABAAMAEnd3dy5jbG91ZGZsYXJlLmNvbQAA"
+      fingerprint: chrome
+
+  - name: "🇯🇵 ech-tyo"
+    type: ss
+    server: tyo.example.com
+    port: 443
+    cipher: aes-128-gcm
+    password: dEVKfRcyKoTqh0Gzm3jNZMwHlsXRXrvt
+    udp: false
+    plugin: ech-tls-tunnel
+    plugin-opts:
+      mode: client
+      sni: tyo.example.com
+      path: /ws-2c6af267052c82c3
+      ech_config: "AEn+DQBFugAgACCuFeWIakYIR6OK4qfni8rg9k6lVvfQTi4jxSpRAgnPTQAIAAEAAQABAAMAEnd3dy5jbG91ZGZsYXJlLmNvbQAA"
+      fingerprint: chrome
+      fast_open: true
+
+mixed-port: 17890
+ipv6: true
+allow-lan: true
+unified-delay: false
+tcp-concurrent: true
+external-controller: 127.0.0.1:19090
+external-ui: ui
+external-ui-url: "https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip"
+
+geodata-mode: true
+geox-url:
+  geoip: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip-lite.dat"
+  geosite: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+  mmdb: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country-lite.mmdb"
+  asn: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+
+geodata:
+  mmdb-path: /Users/mlv/.config/meow/Country.mmdb
+  asn-path: /Users/mlv/.config/meow/GeoLite2-ASN.mmdb
+  geosite-path: /Users/mlv/.config/meow/geosite.dat
+
+find-process-mode: strict
+global-client-fingerprint: chrome
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80, 8080]
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+  skip-domain:
+    - "Mijia Cloud"
+    - "+.push.apple.com"
+
+tun:
+  enable: false
+  stack: mixed
+  dns-hijack:
+    - "any:53"
+    - "tcp://any:53"
+  auto-route: true
+  auto-redirect: true
+  auto-detect-interface: true
+
+dns:
+  enable: true
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-filter:
+    - "*"
+    - "+.lan"
+    - "+.local"
+    - "+.market.xiaomi.com"
+  default-nameserver:
+    - udp://223.5.5.5
+    - udp://223.6.6.6
+  nameserver:
+    - https://doh.pub/dns-query
+    - https://dns.alidns.com/dns-query
+
+proxy-groups:
+
+  - name: 默认
+    type: select
+    proxies: [自动选择,直连,🇸🇬 ech-sgp,🇯🇵 ech-tyo,香港,台湾,日本,新加坡,美国,其它地区,全部节点]
+
+  - name: Google
+    type: select
+    proxies: [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: Telegram
+    type: select
+    proxies: [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: Twitter
+    type: select
+    proxies: [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: 哔哩哔哩
+    type: select
+    proxies: [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: 巴哈姆特
+    type: select
+    proxies: [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: YouTube
+    type: select
+    proxies: [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: NETFLIX
+    type: select
+    proxies: [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: Spotify
+    type: select
+    proxies:  [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: Github
+    type: select
+    proxies:  [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  - name: 国内
+    type: select
+    proxies:  [直连,默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择]
+
+  - name: 其他
+    type: select
+    proxies:  [默认,香港,台湾,日本,新加坡,美国,其它地区,全部节点,自动选择,直连]
+
+  #分隔,下面是地区分组
+  - name: 香港
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)港|hk|hongkong|hong kong"
+
+  - name: 台湾
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)台|tw|taiwan"
+
+  - name: 日本
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)日|jp|japan|tyo"
+
+  - name: 美国
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)美|us|unitedstates|united states"
+
+  - name: 新加坡
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)(新|sg|singapore|sgp)"
+
+  - name: 其它地区
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)^(?!.*(?:🇭🇰|🇯🇵|🇺🇸|🇸🇬|🇨🇳|港|hk|hongkong|台|tw|taiwan|日|jp|japan|tyo|新|sg|singapore|sgp|美|us|unitedstates)).*"
+
+  - name: 全部节点
+    type: select
+    include-all: true
+    exclude-type: [direct]
+
+  - name: 自动选择
+    type: url-test
+    include-all: true
+    exclude-type: [direct]
+    tolerance: 10
+
+rules:
+  - GEOIP,lan,直连,no-resolve
+  - DOMAIN-SUFFIX,maxlv.net,直连
+  - GEOSITE,github,Github
+  - GEOSITE,twitter,Twitter
+  - GEOSITE,youtube,YouTube
+  - GEOSITE,google,Google
+  - GEOSITE,telegram,Telegram
+  - GEOSITE,netflix,NETFLIX
+  - GEOSITE,bilibili,哔哩哔哩
+  - GEOSITE,bahamut,巴哈姆特
+  - GEOSITE,spotify,Spotify
+  - GEOSITE,CN,国内
+  - GEOSITE,geolocation-!cn,其他
+
+  - GEOIP,google,Google
+  - GEOIP,netflix,NETFLIX
+  - GEOIP,telegram,Telegram
+  - GEOIP,twitter,Twitter
+  - GEOIP,CN,国内
+  - MATCH,其他


### PR DESCRIPTION
## Summary
- make rule matching return borrowed match results to avoid hot-path allocation
- add provider-backed pressure coverage using the full ECH-style config fixture
- add geodata index helpers and fixture coverage for direct-only regression config

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib
- cargo test -p meow-tunnel --test alloc_count_test rule_engine_pressure_zero_alloc_free_on_critical_path -- --nocapture
- /usr/bin/time -l target/debug/deps/alloc_count_test-5bc6c8818bd455c1 --exact rule_engine_pressure_zero_alloc_free_on_critical_path --nocapture