### PR TITLE
Improve direct hostname fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,7 @@ dependencies = [
  "meow-common",
  "meow-dns",
  "meow-transport",
+ "meow-trie",
  "parking_lot",
  "quinn",
  "rand 0.9.4",

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -60,6 +60,15 @@ use tokio::net::{TcpStream, ToSocketAddrs, UdpSocket};
 pub trait HostResolver: Send + Sync {
     /// Resolve `host` to one `IpAddr`. Returning `Err` aborts the dial.
     async fn resolve(&self, host: &str) -> io::Result<IpAddr>;
+
+    /// Resolve `host` to all candidate addresses, in resolver order.
+    ///
+    /// Implementations that only support single-address lookup may rely on
+    /// this default. Multi-address resolvers should override it so callers can
+    /// fall back across families or stale endpoints before failing the dial.
+    async fn resolve_all(&self, host: &str) -> io::Result<Vec<IpAddr>> {
+        self.resolve(host).await.map(|ip| vec![ip])
+    }
 }
 
 static RESOLVER: RwLock<Option<Arc<dyn HostResolver>>> = RwLock::new(None);
@@ -269,13 +278,13 @@ pub async fn connect_tcp(addr: SocketAddr) -> io::Result<TcpStream> {
 /// [`resolve_host`] and [`resolve_host_all`]. Resolution order:
 ///
 /// 1. IP literal → returned verbatim (no lookup, no hook).
-/// 2. Installed [`HostResolver`] (e.g. `meow_dns::ResolverHostHook`) → one
-///    address. Preferred on every platform when present: it runs async (no
-///    blocking-pool `getaddrinfo`), caches + coalesces concurrent lookups,
-///    and on a VPN-active device its upstream sockets don't loop the query
-///    back through our own tunnel. Consulted independently of whether a
-///    `SocketProtector` is installed — iOS uses the resolver hook without a
-///    protector.
+/// 2. Installed [`HostResolver`] (e.g. `meow_dns::ResolverHostHook`) → all
+///    addresses it knows about. Preferred on every platform when present: it
+///    runs async (no blocking-pool `getaddrinfo`), caches + coalesces
+///    concurrent lookups, and on a VPN-active device its upstream sockets
+///    don't loop the query back through our own tunnel. Consulted
+///    independently of whether a `SocketProtector` is installed — iOS uses
+///    the resolver hook without a protector.
 /// 3. Short-TTL cache of prior system-resolver results (Android / iOS only)
 ///    → collapses a wake-time burst of dials to one `getaddrinfo`.
 /// 4. System resolver (`tokio::net::lookup_host`), result cached.
@@ -287,8 +296,17 @@ async fn resolve_addrs(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
     }
 
     if let Some(r) = host_resolver() {
-        let ip = r.resolve(host).await?;
-        return Ok(vec![SocketAddr::new(ip, port)]);
+        let ips = r.resolve_all(host).await?;
+        if ips.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("resolve: no address for {host}:{port}"),
+            ));
+        }
+        return Ok(ips
+            .into_iter()
+            .map(|ip| SocketAddr::new(ip, port))
+            .collect());
     }
 
     if let Some(cached) = sys_cache_get(host, port) {
@@ -387,7 +405,7 @@ pub async fn bind_udp<A: ToSocketAddrs>(local: A) -> io::Result<UdpSocket> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use std::net::{IpAddr, SocketAddr};
+    use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     use std::os::fd::RawFd;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -426,16 +444,20 @@ mod tests {
         }
     }
 
-    /// Counts every `resolve` and always returns a fixed `IpAddr`.
+    /// Counts every resolver call and returns fixed `IpAddr` candidates.
     struct FixedResolver {
-        ip: IpAddr,
+        ips: Vec<IpAddr>,
         count: AtomicUsize,
         last_host: parking_lot::Mutex<Option<String>>,
     }
     impl FixedResolver {
         fn new(ip: IpAddr) -> Arc<Self> {
+            Self::new_all(vec![ip])
+        }
+
+        fn new_all(ips: Vec<IpAddr>) -> Arc<Self> {
             Arc::new(Self {
-                ip,
+                ips,
                 count: AtomicUsize::new(0),
                 last_host: parking_lot::Mutex::new(None),
             })
@@ -452,7 +474,16 @@ mod tests {
         async fn resolve(&self, host: &str) -> io::Result<IpAddr> {
             self.count.fetch_add(1, Ordering::SeqCst);
             *self.last_host.lock() = Some(host.to_string());
-            Ok(self.ip)
+            self.ips
+                .first()
+                .copied()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no fixed address"))
+        }
+
+        async fn resolve_all(&self, host: &str) -> io::Result<Vec<IpAddr>> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            *self.last_host.lock() = Some(host.to_string());
+            Ok(self.ips.clone())
         }
     }
 
@@ -461,6 +492,10 @@ mod tests {
     #[async_trait]
     impl HostResolver for FailingResolver {
         async fn resolve(&self, _host: &str) -> io::Result<IpAddr> {
+            Err(io::Error::other("resolve denied"))
+        }
+
+        async fn resolve_all(&self, _host: &str) -> io::Result<Vec<IpAddr>> {
             Err(io::Error::other("resolve denied"))
         }
     }
@@ -599,7 +634,10 @@ mod tests {
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        let resolver = FixedResolver::new(IpAddr::from([127, 0, 0, 1]));
+        let resolver = FixedResolver::new_all(vec![
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::from([127, 0, 0, 1]),
+        ]);
         set_host_resolver(Arc::clone(&resolver) as Arc<dyn HostResolver>);
 
         let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
@@ -610,7 +648,11 @@ mod tests {
 
         assert_eq!(resolver.count(), 1, "resolver must be consulted once");
         assert_eq!(resolver.last_host().as_deref(), Some("example.invalid"));
-        assert_eq!(counter.count(), 1, "protector still applies");
+        assert_eq!(
+            counter.count(),
+            2,
+            "protector must apply to each resolved connect candidate"
+        );
 
         clear_host_resolver();
         clear_socket_protector();
@@ -701,13 +743,22 @@ mod tests {
     async fn resolve_host_all_uses_installed_resolver_when_protected() {
         let _g = LOCK.lock().await;
         set_socket_protector(Counting::new() as Arc<dyn SocketProtector>);
-        let resolver = FixedResolver::new(IpAddr::from([127, 0, 0, 1]));
+        let resolver = FixedResolver::new_all(vec![
+            IpAddr::from([127, 0, 0, 1]),
+            IpAddr::from([127, 0, 0, 2]),
+        ]);
         set_host_resolver(Arc::clone(&resolver) as Arc<dyn HostResolver>);
 
         let addrs = resolve_host_all("example.invalid", 8388)
             .await
             .expect("resolve");
-        assert_eq!(addrs, vec!["127.0.0.1:8388".parse().unwrap()]);
+        assert_eq!(
+            addrs,
+            vec![
+                "127.0.0.1:8388".parse().unwrap(),
+                "127.0.0.2:8388".parse().unwrap()
+            ]
+        );
         assert_eq!(resolver.count(), 1, "resolver must be consulted once");
 
         clear_host_resolver();

--- a/crates/meow-dns/src/host_resolver_hook.rs
+++ b/crates/meow-dns/src/host_resolver_hook.rs
@@ -10,7 +10,7 @@
 //! `getaddrinfo` queries from libc bypass the per-fd protection and loop DNS
 //! back through meow-rs's own tunnel; even where they don't loop, they run on
 //! the blocking pool one thread per lookup. Routing the lookup through
-//! `Resolver::resolve_ip` instead resolves async, coalesces + caches, and
+//! `Resolver::resolve_ips` instead resolves async, coalesces + caches, and
 //! keeps the query off the tunnel.
 
 use std::io;
@@ -23,7 +23,7 @@ use meow_common::HostResolver;
 use crate::Resolver;
 
 /// Adapter that implements `meow_common::HostResolver` by delegating to
-/// `Resolver::resolve_ip` — i.e. the same path `DirectAdapter` uses, so
+/// `Resolver::resolve_ips` — i.e. the same path `DirectAdapter` uses, so
 /// hosts file entries and fake-IP rules behave consistently between the
 /// direct outbound and the socket-protect dial path.
 pub struct ResolverHostHook {
@@ -40,6 +40,15 @@ impl ResolverHostHook {
 impl HostResolver for ResolverHostHook {
     async fn resolve(&self, host: &str) -> io::Result<IpAddr> {
         self.resolver.resolve_ip(host).await.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("meow-dns resolver: no address for {host}"),
+            )
+        })
+    }
+
+    async fn resolve_all(&self, host: &str) -> io::Result<Vec<IpAddr>> {
+        self.resolver.resolve_ips(host).await.ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("meow-dns resolver: no address for {host}"),

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -682,16 +682,24 @@ impl Resolver {
         Arc::new(client)
     }
 
-    pub async fn resolve_ip(&self, host: &str) -> Option<IpAddr> {
+    pub async fn resolve_ips(&self, host: &str) -> Option<Vec<IpAddr>> {
         if self.use_hosts {
             if let Some(ips) = self.hosts.search(host) {
-                return ips.first().copied();
+                if !ips.is_empty() {
+                    return Some(ips.clone());
+                }
             }
         }
         if let Some(ips) = self.cache.get(host) {
-            return ips.first().copied();
+            if !ips.is_empty() {
+                return Some(ips.to_vec());
+            }
         }
-        self.lookup_actual(host).await
+        self.lookup_actual_all(host).await
+    }
+
+    pub async fn resolve_ip(&self, host: &str) -> Option<IpAddr> {
+        self.resolve_ips(host).await?.into_iter().next()
     }
 
     pub async fn resolve_ip_real(&self, host: &str) -> Option<IpAddr> {
@@ -765,11 +773,6 @@ impl Resolver {
             return None;
         }
         self.hosts.search(host)
-    }
-
-    async fn lookup_actual(&self, host: &str) -> Option<IpAddr> {
-        let ips = self.lookup_actual_all(host).await?;
-        ips.into_iter().next()
     }
 
     async fn lookup_actual_all(&self, host: &str) -> Option<Vec<IpAddr>> {
@@ -983,7 +986,7 @@ impl Resolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     #[tokio::test]
     async fn resolve_ip_uses_hosts_file() {
@@ -996,6 +999,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_ips_preserves_all_hosts_file_addresses() {
+        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let ips = vec![
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        ];
+        hosts.insert("example.test", ips.clone());
+        let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
+
+        assert_eq!(resolver.resolve_ips("example.test").await, Some(ips));
+        assert_eq!(
+            resolver.resolve_ip("example.test").await,
+            Some(IpAddr::V6(Ipv6Addr::LOCALHOST))
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_ip_returns_cached_entry() {
         let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
         let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
@@ -1004,6 +1024,21 @@ mod tests {
             .cache
             .put("cached.test", &[real], Duration::from_secs(60));
         assert_eq!(resolver.resolve_ip("cached.test").await, Some(real));
+    }
+
+    #[tokio::test]
+    async fn resolve_ips_preserves_all_cached_addresses() {
+        let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
+        let ips = vec![
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        resolver
+            .cache
+            .put("cached.test", &ips, Duration::from_secs(60));
+
+        assert_eq!(resolver.resolve_ips("cached.test").await, Some(ips));
     }
 
     #[test]

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -67,6 +67,7 @@ crc32fast = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+meow-trie = { workspace = true }
 rcgen = "0.13"
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }

--- a/crates/meow-proxy/src/direct.rs
+++ b/crates/meow-proxy/src/direct.rs
@@ -58,18 +58,18 @@ impl DirectAdapter {
         self
     }
 
-    /// Determine the concrete `SocketAddr` to dial for `metadata`, avoiding
-    /// the OS resolver whenever possible.
-    async fn resolve_target(&self, metadata: &Metadata) -> Result<SocketAddr> {
+    /// Determine the concrete `SocketAddr` candidates to dial for `metadata`,
+    /// avoiding the OS resolver whenever possible.
+    async fn resolve_targets(&self, metadata: &Metadata) -> Result<Vec<SocketAddr>> {
         // 1. Destination already resolved (e.g. by rule-matching pre_resolve,
         //    or when the client supplied an IP literal).
         if let Some(ip) = metadata.dst_ip {
-            return Ok(SocketAddr::new(ip, metadata.dst_port));
+            return Ok(vec![SocketAddr::new(ip, metadata.dst_port)]);
         }
 
         // 2. `host` is an IP literal — no DNS needed.
         if let Ok(ip) = metadata.host.parse::<IpAddr>() {
-            return Ok(SocketAddr::new(ip, metadata.dst_port));
+            return Ok(vec![SocketAddr::new(ip, metadata.dst_port)]);
         }
 
         // 3. Resolve via meow-rs's internal resolver if available. Falls back
@@ -77,10 +77,17 @@ impl DirectAdapter {
         //    standalone usage).
         if !metadata.host.is_empty() {
             if let Some(resolver) = &self.resolver {
-                return match resolver.resolve_ip(&metadata.host).await {
-                    Some(ip) => Ok(SocketAddr::new(ip, metadata.dst_port)),
+                return match resolver.resolve_ips(&metadata.host).await {
+                    Some(ips) if !ips.is_empty() => Ok(ips
+                        .into_iter()
+                        .map(|ip| SocketAddr::new(ip, metadata.dst_port))
+                        .collect()),
                     None => Err(MeowError::Dns(format!(
                         "direct: failed to resolve {}",
+                        metadata.host
+                    ))),
+                    Some(_) => Err(MeowError::Dns(format!(
+                        "direct: no address for {}",
                         metadata.host
                     ))),
                 };
@@ -88,12 +95,18 @@ impl DirectAdapter {
 
             // Legacy fallback: let tokio use getaddrinfo. Only reachable when
             // no resolver was injected — production code paths always inject.
-            let addr = format!("{}:{}", metadata.host, metadata.dst_port);
-            return tokio::net::lookup_host(&addr)
-                .await
-                .map_err(MeowError::Io)?
-                .next()
-                .ok_or_else(|| MeowError::Dns(format!("direct: no address for {addr}")));
+            let addrs: Vec<SocketAddr> =
+                tokio::net::lookup_host((&*metadata.host, metadata.dst_port))
+                    .await
+                    .map_err(MeowError::Io)?
+                    .collect();
+            if addrs.is_empty() {
+                return Err(MeowError::Dns(format!(
+                    "direct: no address for {}:{}",
+                    metadata.host, metadata.dst_port
+                )));
+            }
+            return Ok(addrs);
         }
 
         Err(MeowError::Proxy(
@@ -256,14 +269,23 @@ impl ProxyAdapter for DirectAdapter {
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
-        let dest = self.resolve_target(metadata).await?;
-        let stream = apply_connect_timeout(
-            connect_with_mark(dest, self.routing_mark),
-            self.connect_timeout,
-            dest,
-        )
-        .await?;
-        Ok(Box::new(DirectConn(stream)))
+        let dests = self.resolve_targets(metadata).await?;
+        let mut last_err = None;
+
+        for dest in dests {
+            match apply_connect_timeout(
+                connect_with_mark(dest, self.routing_mark),
+                self.connect_timeout,
+                dest,
+            )
+            .await
+            {
+                Ok(stream) => return Ok(Box::new(DirectConn(stream))),
+                Err(err) => last_err = Some(err),
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| MeowError::Proxy("direct: no reachable address".into())))
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
@@ -315,6 +337,8 @@ impl ProxyAdapter for DirectAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use meow_common::DnsMode;
+    use meow_trie::DomainTrie;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     fn fake_dest() -> SocketAddr {
@@ -327,6 +351,41 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         }
+    }
+
+    fn tcp_metadata(host: &str, port: u16) -> Metadata {
+        Metadata {
+            host: host.into(),
+            dst_port: port,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn dial_tcp_tries_next_resolved_address_after_first_fails() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        hosts.insert(
+            "multi.test",
+            vec![
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+            ],
+        );
+        let resolver = Arc::new(Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true));
+        let adapter = DirectAdapter::new()
+            .with_resolver(resolver)
+            .with_connect_timeout(Duration::from_secs(2));
+
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
+        let conn = adapter
+            .dial_tcp(&tcp_metadata("multi.test", port))
+            .await
+            .expect("second resolved address should connect");
+        let _ = accept.await.unwrap();
+        drop(conn);
     }
 
     /// Regression for QUIC/HTTP3 direct: `dial_udp` must bind the reply socket


### PR DESCRIPTION
## Summary
- return all DNS resolver candidates through the direct and protected hostname paths
- make direct TCP try each resolved address in order before failing
- add regression coverage for multi-address hosts/cache resolution and direct fallback

## Root cause
Direct hostname dialing collapsed resolver results to the first IP address. When that candidate was stale or unreachable, the direct connection failed even if later resolver candidates would work.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`