### PR TITLE
[codex] Compile rule matching hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "parking_lot",
  "regex",
  "serde",
+ "serde_yaml",
  "smallvec",
  "smol_str",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,7 @@ dependencies = [
  "meow-rules",
  "meow-trie",
  "parking_lot",
+ "regex",
  "serde",
  "smallvec",
  "smol_str",

--- a/crates/meow-tunnel/Cargo.toml
+++ b/crates/meow-tunnel/Cargo.toml
@@ -40,6 +40,7 @@ dashmap = { workspace = true }
 ipnet = { workspace = true }
 meow-config = { workspace = true }
 meow-rules = { workspace = true }
+serde_yaml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/meow-tunnel/Cargo.toml
+++ b/crates/meow-tunnel/Cargo.toml
@@ -10,6 +10,8 @@ meow-dns = { workspace = true, default-features = false }
 meow-rules = { workspace = true }
 meow-proxy = { workspace = true, default-features = false }
 meow-trie = { workspace = true }
+ipnet = { workspace = true }
+regex = { workspace = true }
 tokio = { workspace = true }
 dashmap = { workspace = true }
 tracing = { workspace = true }

--- a/crates/meow-tunnel/benches/rules_bench.rs
+++ b/crates/meow-tunnel/benches/rules_bench.rs
@@ -6,7 +6,10 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
 use meow_config::raw::RawConfig;
-use meow_rules::{domain_suffix::DomainSuffixRule, final_rule::FinalRule, ipcidr::IpCidrRule};
+use meow_rules::{
+    domain_suffix::DomainSuffixRule, domain_wildcard::DomainWildcardRule, final_rule::FinalRule,
+    ipcidr::IpCidrRule,
+};
 use meow_tunnel::match_engine::{match_rules, DomainIndex};
 use meow_tunnel::rule_ir::CompiledRuleSet;
 use std::net::IpAddr;
@@ -139,6 +142,31 @@ fn synthetic_10k_cases() -> Vec<BenchCase> {
     ]
 }
 
+fn build_synthetic_wildcard_rules(n: usize) -> Vec<Box<dyn Rule>> {
+    let mut rules: Vec<Box<dyn Rule>> = Vec::with_capacity(n + 1);
+    for i in 0..n {
+        rules.push(Box::new(
+            DomainWildcardRule::new(&format!("*.blocked{i}.example.com"), "Proxy")
+                .expect("synthetic wildcard rule must compile"),
+        ));
+    }
+    rules.push(Box::new(FinalRule::new("DIRECT")));
+    rules
+}
+
+fn synthetic_10k_wildcard_cases() -> Vec<BenchCase> {
+    vec![BenchCase {
+        name: "synthetic_10k_wildcard_miss",
+        metadata: Metadata {
+            host: "nomatch.unknown.invalid".into(),
+            dst_port: 443,
+            ..Default::default()
+        },
+        expected_rule_type: RuleType::Match,
+        expected_payload: "",
+    }]
+}
+
 fn scan_linear<'a>(
     rules: &'a [Box<dyn Rule>],
     metadata: &Metadata,
@@ -237,5 +265,21 @@ fn bench_synthetic_10k_rules(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_fixture_rules, bench_synthetic_10k_rules);
+fn bench_synthetic_10k_wildcard_rules(c: &mut Criterion) {
+    let rules = build_synthetic_wildcard_rules(10_000);
+    let index = DomainIndex::build(&rules);
+    let compiled = CompiledRuleSet::build(&rules);
+    let cases = synthetic_10k_wildcard_cases();
+
+    for case in &cases {
+        bench_case_group(c, &rules, &index, &compiled, case);
+    }
+}
+
+criterion_group!(
+    benches,
+    bench_fixture_rules,
+    bench_synthetic_10k_rules,
+    bench_synthetic_10k_wildcard_rules
+);
 criterion_main!(benches);

--- a/crates/meow-tunnel/benches/rules_bench.rs
+++ b/crates/meow-tunnel/benches/rules_bench.rs
@@ -1,124 +1,150 @@
 /// Rule-engine match benchmark — linear scan vs domain-index early-exit vs
 /// compiled native IR (ADR-0008 §7 sub-area 0).
 ///
-/// BEFORE: `scan_linear` — iterate all rules in order until a match.
-/// INDEXED: `match_engine::match_rules` with `DomainIndex` — trie probe + partial scan.
-/// IR: `rule_ir::CompiledRuleSet` — native opcodes for simple predicates,
-/// fallback slots for rules with private embedded state.
-///
-/// The domain-suffix hit at the last indexed rule (worst-case for the trie) still
-/// wins because it scans rules[0..trie_idx] instead of the full list.
+/// Fixture: `tests/fixtures/memleak_ech_pressure_config.yaml`, which exercises
+/// a realistic GEOSITE/GEOIP-heavy Clash config rather than synthetic rules.
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use meow_common::{Metadata, Rule, RuleMatchHelper};
-use meow_rules::{domain_suffix::DomainSuffixRule, final_rule::FinalRule, ipcidr::IpCidrRule};
+use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
+use meow_config::raw::RawConfig;
 use meow_tunnel::match_engine::{match_rules, DomainIndex};
 use meow_tunnel::rule_ir::CompiledRuleSet;
 use std::net::IpAddr;
 
-fn build_rules(n: usize) -> Vec<Box<dyn Rule>> {
-    let mut rules: Vec<Box<dyn Rule>> = Vec::with_capacity(n + 1);
-    for i in 0..n {
-        match i % 3 {
-            0 => rules.push(Box::new(DomainSuffixRule::new(
-                &format!("suffix{i}.example.com"),
-                "DIRECT",
-            ))),
-            1 => rules.push(Box::new(DomainSuffixRule::new(
-                &format!("other{i}.net"),
-                "Proxy",
-            ))),
-            _ => {
-                let cidr = format!("10.{}.0.0/16", i % 256);
-                if let Ok(r) = IpCidrRule::new(&cidr, "DIRECT", false, true) {
-                    rules.push(Box::new(r));
-                }
-            }
-        }
-    }
-    rules.push(Box::new(FinalRule::new("DIRECT")));
+const ECH_PRESSURE_CONFIG: &str =
+    include_str!("../tests/fixtures/memleak_ech_pressure_config.yaml");
+
+struct FixtureCase {
+    name: &'static str,
+    metadata: Metadata,
+    expected_rule_type: RuleType,
+    expected_payload: &'static str,
+}
+
+fn load_fixture_rules() -> Vec<Box<dyn Rule>> {
+    let mut value: serde_yaml::Value =
+        serde_yaml::from_str(ECH_PRESSURE_CONFIG).expect("fixture config must be valid YAML");
+    value
+        .apply_merge()
+        .expect("fixture config merge keys must expand");
+    let raw: RawConfig =
+        serde_yaml::from_value(value).expect("fixture config must deserialize as RawConfig");
+    let (_, rules) =
+        meow_config::rebuild_from_raw(&raw).expect("fixture config rules must rebuild");
+    assert_eq!(rules.len(), 19, "fixture rule count changed");
     rules
 }
 
-fn make_metadata_hit(n: usize) -> Metadata {
-    let last_suffix_i = (0..n).rev().find(|&i| i % 3 == 0).unwrap_or(0);
-    Metadata {
-        host: format!("host.suffix{last_suffix_i}.example.com").into(),
-        dst_port: 443,
-        ..Default::default()
-    }
+fn fixture_cases() -> Vec<FixtureCase> {
+    vec![
+        FixtureCase {
+            name: "fixture_domain_suffix_maxlv",
+            metadata: Metadata {
+                host: "www.maxlv.net".into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+            expected_rule_type: RuleType::DomainSuffix,
+            expected_payload: "maxlv.net",
+        },
+        FixtureCase {
+            name: "fixture_geosite_github",
+            metadata: Metadata {
+                host: "github.com".into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+            expected_rule_type: RuleType::GeoSite,
+            expected_payload: "github",
+        },
+        FixtureCase {
+            name: "fixture_geoip_cn",
+            metadata: Metadata {
+                dst_port: 443,
+                dst_ip: Some("223.5.5.5".parse::<IpAddr>().unwrap()),
+                ..Default::default()
+            },
+            expected_rule_type: RuleType::GeoIp,
+            expected_payload: "CN",
+        },
+        FixtureCase {
+            name: "fixture_match_fallthrough",
+            metadata: Metadata {
+                host: "unmatched.invalid".into(),
+                dst_port: 443,
+                dst_ip: Some("203.0.113.1".parse::<IpAddr>().unwrap()),
+                ..Default::default()
+            },
+            expected_rule_type: RuleType::Match,
+            expected_payload: "",
+        },
+    ]
 }
 
-fn make_metadata_miss() -> Metadata {
-    Metadata {
-        host: "nomatch.unknown.invalid".into(),
-        dst_port: 80,
-        dst_ip: Some("203.0.113.1".parse::<IpAddr>().unwrap()),
-        ..Default::default()
-    }
-}
-
-fn scan_linear<'a>(rules: &'a [Box<dyn Rule>], metadata: &Metadata) -> Option<&'a str> {
+fn scan_linear<'a>(
+    rules: &'a [Box<dyn Rule>],
+    metadata: &Metadata,
+) -> Option<(&'a str, RuleType, &'a str)> {
     let helper = RuleMatchHelper;
     for rule in rules {
         if let Some(adapter) = rule.match_and_resolve(metadata, &helper) {
-            return Some(adapter);
+            return Some((adapter, rule.rule_type(), rule.payload()));
         }
     }
     None
 }
 
+fn assert_matchers_agree(
+    rules: &[Box<dyn Rule>],
+    index: &DomainIndex,
+    compiled: &CompiledRuleSet,
+    case: &FixtureCase,
+) {
+    let linear = scan_linear(rules, &case.metadata);
+    let indexed = match_rules(&case.metadata, rules, index)
+        .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+    let ir = compiled
+        .match_rules(&case.metadata, rules)
+        .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+
+    assert_eq!(indexed, linear, "indexed diverged for {}", case.name);
+    assert_eq!(ir, linear, "IR diverged for {}", case.name);
+
+    let Some((_, rule_type, payload)) = ir else {
+        panic!("fixture case {} did not match", case.name);
+    };
+    assert_eq!(rule_type, case.expected_rule_type, "{}", case.name);
+    assert_eq!(payload, case.expected_payload, "{}", case.name);
+}
+
 fn bench_rules(c: &mut Criterion) {
-    for n in [50usize, 200, 500, 10_000] {
-        let rules = build_rules(n);
-        let index = DomainIndex::build(&rules);
-        let compiled = CompiledRuleSet::build(&rules);
-        let meta_hit = make_metadata_hit(n);
-        let meta_miss = make_metadata_miss();
+    let rules = load_fixture_rules();
+    let index = DomainIndex::build(&rules);
+    let compiled = CompiledRuleSet::build(&rules);
+    let cases = fixture_cases();
 
-        // ── Hit: last DOMAIN-SUFFIX rule ─────────────────────────────────────
+    for case in &cases {
+        assert_matchers_agree(&rules, &index, &compiled, case);
 
-        let mut group = c.benchmark_group(format!("rules_hit_last/n={n}"));
+        let mut group = c.benchmark_group(case.name);
 
-        group.bench_with_input(BenchmarkId::new("before_linear", n), &n, |b, _| {
-            b.iter(|| black_box(scan_linear(black_box(&rules), black_box(&meta_hit))));
+        group.bench_function(BenchmarkId::new("before_linear", case.name), |b| {
+            b.iter(|| black_box(scan_linear(black_box(&rules), black_box(&case.metadata))));
         });
 
-        group.bench_with_input(BenchmarkId::new("after_indexed", n), &n, |b, _| {
+        group.bench_function(BenchmarkId::new("after_indexed", case.name), |b| {
             b.iter(|| {
                 black_box(match_rules(
-                    black_box(&meta_hit),
+                    black_box(&case.metadata),
                     black_box(&rules),
                     black_box(&index),
                 ))
             });
         });
 
-        group.bench_with_input(BenchmarkId::new("after_ir", n), &n, |b, _| {
-            b.iter(|| black_box(compiled.match_rules(black_box(&meta_hit), black_box(&rules))));
-        });
-
-        group.finish();
-
-        // ── Miss: FINAL rule (full scan — index can't help) ──────────────────
-
-        let mut group = c.benchmark_group(format!("rules_miss_final/n={n}"));
-
-        group.bench_with_input(BenchmarkId::new("before_linear", n), &n, |b, _| {
-            b.iter(|| black_box(scan_linear(black_box(&rules), black_box(&meta_miss))));
-        });
-
-        group.bench_with_input(BenchmarkId::new("after_indexed", n), &n, |b, _| {
+        group.bench_function(BenchmarkId::new("after_ir", case.name), |b| {
             b.iter(|| {
-                black_box(match_rules(
-                    black_box(&meta_miss),
-                    black_box(&rules),
-                    black_box(&index),
-                ))
+                black_box(compiled.match_rules(black_box(&case.metadata), black_box(&rules)))
             });
-        });
-
-        group.bench_with_input(BenchmarkId::new("after_ir", n), &n, |b, _| {
-            b.iter(|| black_box(compiled.match_rules(black_box(&meta_miss), black_box(&rules))));
         });
 
         group.finish();

--- a/crates/meow-tunnel/benches/rules_bench.rs
+++ b/crates/meow-tunnel/benches/rules_bench.rs
@@ -1,7 +1,10 @@
-/// Rule-engine match benchmark — linear scan vs domain-index early-exit (ADR-0008 §7 sub-area 0).
+/// Rule-engine match benchmark — linear scan vs domain-index early-exit vs
+/// compiled native IR (ADR-0008 §7 sub-area 0).
 ///
 /// BEFORE: `scan_linear` — iterate all rules in order until a match.
-/// AFTER:  `match_engine::match_rules` with `DomainIndex` — trie probe + partial scan.
+/// INDEXED: `match_engine::match_rules` with `DomainIndex` — trie probe + partial scan.
+/// IR: `rule_ir::CompiledRuleSet` — native opcodes for simple predicates,
+/// fallback slots for rules with private embedded state.
 ///
 /// The domain-suffix hit at the last indexed rule (worst-case for the trie) still
 /// wins because it scans rules[0..trie_idx] instead of the full list.
@@ -9,6 +12,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use meow_common::{Metadata, Rule, RuleMatchHelper};
 use meow_rules::{domain_suffix::DomainSuffixRule, final_rule::FinalRule, ipcidr::IpCidrRule};
 use meow_tunnel::match_engine::{match_rules, DomainIndex};
+use meow_tunnel::rule_ir::CompiledRuleSet;
 use std::net::IpAddr;
 
 fn build_rules(n: usize) -> Vec<Box<dyn Rule>> {
@@ -53,11 +57,11 @@ fn make_metadata_miss() -> Metadata {
     }
 }
 
-fn scan_linear(rules: &[Box<dyn Rule>], metadata: &Metadata) -> Option<String> {
+fn scan_linear<'a>(rules: &'a [Box<dyn Rule>], metadata: &Metadata) -> Option<&'a str> {
     let helper = RuleMatchHelper;
     for rule in rules {
         if let Some(adapter) = rule.match_and_resolve(metadata, &helper) {
-            return Some(adapter.into());
+            return Some(adapter);
         }
     }
     None
@@ -67,6 +71,7 @@ fn bench_rules(c: &mut Criterion) {
     for n in [50usize, 200, 500, 10_000] {
         let rules = build_rules(n);
         let index = DomainIndex::build(&rules);
+        let compiled = CompiledRuleSet::build(&rules);
         let meta_hit = make_metadata_hit(n);
         let meta_miss = make_metadata_miss();
 
@@ -88,6 +93,10 @@ fn bench_rules(c: &mut Criterion) {
             });
         });
 
+        group.bench_with_input(BenchmarkId::new("after_ir", n), &n, |b, _| {
+            b.iter(|| black_box(compiled.match_rules(black_box(&meta_hit), black_box(&rules))));
+        });
+
         group.finish();
 
         // ── Miss: FINAL rule (full scan — index can't help) ──────────────────
@@ -106,6 +115,10 @@ fn bench_rules(c: &mut Criterion) {
                     black_box(&index),
                 ))
             });
+        });
+
+        group.bench_with_input(BenchmarkId::new("after_ir", n), &n, |b, _| {
+            b.iter(|| black_box(compiled.match_rules(black_box(&meta_miss), black_box(&rules))));
         });
 
         group.finish();

--- a/crates/meow-tunnel/benches/rules_bench.rs
+++ b/crates/meow-tunnel/benches/rules_bench.rs
@@ -6,6 +6,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
 use meow_config::raw::RawConfig;
+use meow_rules::{domain_suffix::DomainSuffixRule, final_rule::FinalRule, ipcidr::IpCidrRule};
 use meow_tunnel::match_engine::{match_rules, DomainIndex};
 use meow_tunnel::rule_ir::CompiledRuleSet;
 use std::net::IpAddr;
@@ -14,6 +15,13 @@ const ECH_PRESSURE_CONFIG: &str =
     include_str!("../tests/fixtures/memleak_ech_pressure_config.yaml");
 
 struct FixtureCase {
+    name: &'static str,
+    metadata: Metadata,
+    expected_rule_type: RuleType,
+    expected_payload: &'static str,
+}
+
+struct BenchCase {
     name: &'static str,
     metadata: Metadata,
     expected_rule_type: RuleType,
@@ -80,6 +88,57 @@ fn fixture_cases() -> Vec<FixtureCase> {
     ]
 }
 
+fn build_synthetic_rules(n: usize) -> Vec<Box<dyn Rule>> {
+    let mut rules: Vec<Box<dyn Rule>> = Vec::with_capacity(n + 1);
+    for i in 0..n {
+        match i % 3 {
+            0 => rules.push(Box::new(DomainSuffixRule::new(
+                &format!("suffix{i}.example.com"),
+                "DIRECT",
+            ))),
+            1 => rules.push(Box::new(DomainSuffixRule::new(
+                &format!("other{i}.net"),
+                "Proxy",
+            ))),
+            _ => {
+                let cidr = format!("10.{}.0.0/16", i % 256);
+                if let Ok(rule) = IpCidrRule::new(&cidr, "DIRECT", false, true) {
+                    rules.push(Box::new(rule));
+                }
+            }
+        }
+    }
+    rules.push(Box::new(FinalRule::new("DIRECT")));
+    rules
+}
+
+fn synthetic_10k_cases() -> Vec<BenchCase> {
+    let last_suffix_i = (0..10_000).rev().find(|&i| i % 3 == 0).unwrap_or(0);
+    vec![
+        BenchCase {
+            name: "synthetic_10k_domain_suffix_hit",
+            metadata: Metadata {
+                host: format!("host.suffix{last_suffix_i}.example.com").into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+            expected_rule_type: RuleType::DomainSuffix,
+            expected_payload: "suffix9999.example.com",
+        },
+        BenchCase {
+            name: "synthetic_10k_match_fallthrough",
+            metadata: Metadata {
+                host: "nomatch.unknown.invalid".into(),
+                dst_port: 80,
+                dst_ip: Some("203.0.113.1".parse::<IpAddr>().unwrap()),
+                ..Default::default()
+            },
+            expected_rule_type: RuleType::Match,
+            expected_payload: "",
+        },
+    ]
+}
+
 fn scan_linear<'a>(
     rules: &'a [Box<dyn Rule>],
     metadata: &Metadata,
@@ -97,7 +156,7 @@ fn assert_matchers_agree(
     rules: &[Box<dyn Rule>],
     index: &DomainIndex,
     compiled: &CompiledRuleSet,
-    case: &FixtureCase,
+    case: &BenchCase,
 ) {
     let linear = scan_linear(rules, &case.metadata);
     let indexed = match_rules(&case.metadata, rules, index)
@@ -110,46 +169,73 @@ fn assert_matchers_agree(
     assert_eq!(ir, linear, "IR diverged for {}", case.name);
 
     let Some((_, rule_type, payload)) = ir else {
-        panic!("fixture case {} did not match", case.name);
+        panic!("benchmark case {} did not match", case.name);
     };
     assert_eq!(rule_type, case.expected_rule_type, "{}", case.name);
     assert_eq!(payload, case.expected_payload, "{}", case.name);
 }
 
-fn bench_rules(c: &mut Criterion) {
+fn bench_case_group(
+    c: &mut Criterion,
+    rules: &[Box<dyn Rule>],
+    index: &DomainIndex,
+    compiled: &CompiledRuleSet,
+    case: &BenchCase,
+) {
+    assert_matchers_agree(rules, index, compiled, case);
+
+    let mut group = c.benchmark_group(case.name);
+
+    group.bench_function(BenchmarkId::new("before_linear", case.name), |b| {
+        b.iter(|| black_box(scan_linear(black_box(rules), black_box(&case.metadata))));
+    });
+
+    group.bench_function(BenchmarkId::new("after_indexed", case.name), |b| {
+        b.iter(|| {
+            black_box(match_rules(
+                black_box(&case.metadata),
+                black_box(rules),
+                black_box(index),
+            ))
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("after_ir", case.name), |b| {
+        b.iter(|| black_box(compiled.match_rules(black_box(&case.metadata), black_box(rules))));
+    });
+
+    group.finish();
+}
+
+fn bench_fixture_rules(c: &mut Criterion) {
     let rules = load_fixture_rules();
     let index = DomainIndex::build(&rules);
     let compiled = CompiledRuleSet::build(&rules);
-    let cases = fixture_cases();
+    let cases = fixture_cases()
+        .into_iter()
+        .map(|case| BenchCase {
+            name: case.name,
+            metadata: case.metadata,
+            expected_rule_type: case.expected_rule_type,
+            expected_payload: case.expected_payload,
+        })
+        .collect::<Vec<_>>();
 
     for case in &cases {
-        assert_matchers_agree(&rules, &index, &compiled, case);
-
-        let mut group = c.benchmark_group(case.name);
-
-        group.bench_function(BenchmarkId::new("before_linear", case.name), |b| {
-            b.iter(|| black_box(scan_linear(black_box(&rules), black_box(&case.metadata))));
-        });
-
-        group.bench_function(BenchmarkId::new("after_indexed", case.name), |b| {
-            b.iter(|| {
-                black_box(match_rules(
-                    black_box(&case.metadata),
-                    black_box(&rules),
-                    black_box(&index),
-                ))
-            });
-        });
-
-        group.bench_function(BenchmarkId::new("after_ir", case.name), |b| {
-            b.iter(|| {
-                black_box(compiled.match_rules(black_box(&case.metadata), black_box(&rules)))
-            });
-        });
-
-        group.finish();
+        bench_case_group(c, &rules, &index, &compiled, case);
     }
 }
 
-criterion_group!(benches, bench_rules);
+fn bench_synthetic_10k_rules(c: &mut Criterion) {
+    let rules = build_synthetic_rules(10_000);
+    let index = DomainIndex::build(&rules);
+    let compiled = CompiledRuleSet::build(&rules);
+    let cases = synthetic_10k_cases();
+
+    for case in &cases {
+        bench_case_group(c, &rules, &index, &compiled, case);
+    }
+}
+
+criterion_group!(benches, bench_fixture_rules, bench_synthetic_10k_rules);
 criterion_main!(benches);

--- a/crates/meow-tunnel/src/lib.rs
+++ b/crates/meow-tunnel/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod match_engine;
 pub mod relay;
+pub mod rule_ir;
 pub mod statistics;
 pub mod tcp;
 pub mod tunnel;

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -1,0 +1,836 @@
+use crate::match_engine::DomainIndex;
+use ipnet::IpNet;
+use meow_common::{ConnType, Metadata, Network, Rule, RuleMatchHelper, RuleType};
+use regex::Regex;
+use smol_str::SmolStr;
+use std::collections::HashMap;
+use std::ops::Range;
+use std::path::Path;
+
+/// Native compiled rule metadata plus indexes for hot-path matching.
+///
+/// This IR is intentionally hybrid: common parser-produced predicates lower to
+/// native opcodes, while rules with private embedded state fall back to the
+/// public `Rule` trait. Stable result metadata is captured once at build time
+/// so successful matches avoid repeat `rule_type` / `payload` / top-level
+/// `adapter` virtual calls.
+pub struct CompiledRuleSet {
+    slots: Vec<CompiledRuleSlot>,
+    adapter_names: Vec<SmolStr>,
+    adapter_lookup: HashMap<SmolStr, usize>,
+    domain_index: DomainIndex,
+    needs_ip_resolution: bool,
+    needs_process_lookup: bool,
+}
+
+pub type RuleIr = CompiledRuleSet;
+
+#[derive(Debug, Clone)]
+pub struct CompiledRuleSlot {
+    rule_index: usize,
+    rule_type: RuleType,
+    adapter_index: usize,
+    payload: SmolStr,
+    target_plan: TargetPlan,
+    op: RuleOp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetPlan {
+    /// The target adapter is the top-level rule adapter captured in the IR.
+    StaticAdapter,
+    /// The target adapter can be returned by nested rule evaluation.
+    DynamicAdapter,
+}
+
+#[derive(Debug, Clone)]
+enum RuleOp {
+    Domain(String),
+    DomainSuffix(String),
+    DomainKeyword(String),
+    DomainRegex(Regex),
+    DomainWildcard(Regex),
+    IpCidr { net: IpNet, src: bool },
+    Port { ranges: Vec<PortRange>, src: bool },
+    InPort { lo: u16, hi: u16 },
+    Dscp(u8),
+    ProcessName(String),
+    ProcessPath(ProcessPathOp),
+    Network(Network),
+    Uid(u32),
+    InName(String),
+    InType(InTypeMask),
+    InUser(String),
+    Match,
+    Fallback,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PortRange {
+    Single(u16),
+    Range(u16, u16),
+}
+
+#[derive(Debug, Clone)]
+enum ProcessPathOp {
+    Glob(Regex),
+    Prefix(String),
+    Exact(String),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct InTypeMask {
+    http: bool,
+    https: bool,
+    socks5: bool,
+    tproxy: bool,
+    inner: bool,
+}
+
+/// One borrowed result from a compiled rule-set match.
+pub struct CompiledMatchResult<'a> {
+    pub adapter_name: &'a str,
+    pub adapter_index: Option<usize>,
+    pub rule_type: RuleType,
+    pub rule_payload: &'a str,
+    pub rule_index: usize,
+}
+
+impl CompiledRuleSet {
+    pub fn empty() -> Self {
+        Self {
+            slots: Vec::new(),
+            adapter_names: Vec::new(),
+            adapter_lookup: HashMap::new(),
+            domain_index: DomainIndex::empty(),
+            needs_ip_resolution: false,
+            needs_process_lookup: false,
+        }
+    }
+
+    pub fn build(rules: &[Box<dyn Rule>]) -> Self {
+        let mut slots = Vec::with_capacity(rules.len());
+        let mut adapter_names = Vec::new();
+        let mut adapter_lookup = HashMap::new();
+        let mut needs_ip_resolution = false;
+        let mut needs_process_lookup = false;
+
+        for (rule_index, rule) in rules.iter().enumerate() {
+            let rule_type = rule.rule_type();
+            let adapter_name = SmolStr::from(rule.adapter());
+            let adapter_index =
+                intern_adapter(&mut adapter_names, &mut adapter_lookup, adapter_name);
+
+            needs_ip_resolution |= rule.should_resolve_ip();
+            needs_process_lookup |= rule.should_find_process();
+
+            slots.push(CompiledRuleSlot {
+                rule_index,
+                rule_type,
+                adapter_index,
+                payload: SmolStr::from(rule.payload()),
+                target_plan: target_plan(rule_type),
+                op: compile_op(rule_type, rule.payload()).unwrap_or(RuleOp::Fallback),
+            });
+        }
+
+        Self {
+            slots,
+            adapter_names,
+            adapter_lookup,
+            domain_index: DomainIndex::build(rules),
+            needs_ip_resolution,
+            needs_process_lookup,
+        }
+    }
+
+    /// Match metadata against the compiled plan with the same first-match
+    /// semantics as `match_engine::match_rules`.
+    ///
+    /// `rules` must be the same rule slice this plan was built from. The plan
+    /// stores rule indices rather than references so it can live beside an
+    /// owned `Vec<Box<dyn Rule>>` in a route-table snapshot.
+    pub fn match_rules<'a>(
+        &'a self,
+        metadata: &Metadata,
+        rules: &'a [Box<dyn Rule>],
+    ) -> Option<CompiledMatchResult<'a>> {
+        debug_assert_eq!(
+            self.slots.len(),
+            rules.len(),
+            "CompiledRuleSet must be evaluated with the rule slice it was built from",
+        );
+
+        let helper = RuleMatchHelper;
+        let host = metadata.rule_host();
+        let trie_hit = if host.is_empty() {
+            None
+        } else {
+            self.domain_index.search(host)
+        };
+
+        // Preserve DomainIndex early-exit behavior:
+        // if a trie hit occurs at T, scan only [0..T] for an earlier match,
+        // then return T. On trie miss, scan the full rule list.
+        let scan_end = trie_hit.unwrap_or(self.slots.len());
+        if let Some(matched) = self.scan_range(0..scan_end, metadata, rules, &helper) {
+            return Some(matched);
+        }
+
+        if let Some(trie_idx) = trie_hit {
+            return self.slots.get(trie_idx).map(|slot| self.static_match(slot));
+        }
+
+        self.scan_range(scan_end..self.slots.len(), metadata, rules, &helper)
+    }
+
+    pub fn domain_index(&self) -> &DomainIndex {
+        &self.domain_index
+    }
+
+    pub fn slots(&self) -> &[CompiledRuleSlot] {
+        &self.slots
+    }
+
+    pub fn adapter_names(&self) -> &[SmolStr] {
+        &self.adapter_names
+    }
+
+    pub fn needs_ip_resolution(&self) -> bool {
+        self.needs_ip_resolution
+    }
+
+    pub fn needs_process_lookup(&self) -> bool {
+        self.needs_process_lookup
+    }
+
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    pub fn is_compatible_with(&self, rules: &[Box<dyn Rule>]) -> bool {
+        self.slots.len() == rules.len()
+    }
+
+    fn scan_range<'a>(
+        &'a self,
+        range: Range<usize>,
+        metadata: &Metadata,
+        rules: &'a [Box<dyn Rule>],
+        helper: &RuleMatchHelper,
+    ) -> Option<CompiledMatchResult<'a>> {
+        for slot in &self.slots[range] {
+            let rule = rules.get(slot.rule_index)?.as_ref();
+            match &slot.op {
+                RuleOp::Fallback => match slot.target_plan {
+                    TargetPlan::StaticAdapter => {
+                        if rule.match_metadata(metadata, helper) {
+                            return Some(self.static_match(slot));
+                        }
+                    }
+                    TargetPlan::DynamicAdapter => {
+                        if let Some(adapter_name) = rule.match_and_resolve(metadata, helper) {
+                            let adapter_index = self.adapter_lookup.get(adapter_name).copied();
+                            return Some(self.make_match(slot, adapter_name, adapter_index));
+                        }
+                    }
+                },
+                op => {
+                    if matches_op(op, metadata) {
+                        return Some(self.static_match(slot));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn static_match<'a>(&'a self, slot: &'a CompiledRuleSlot) -> CompiledMatchResult<'a> {
+        self.make_match(
+            slot,
+            self.adapter_names[slot.adapter_index].as_str(),
+            Some(slot.adapter_index),
+        )
+    }
+
+    fn make_match<'a>(
+        &'a self,
+        slot: &'a CompiledRuleSlot,
+        adapter_name: &'a str,
+        adapter_index: Option<usize>,
+    ) -> CompiledMatchResult<'a> {
+        CompiledMatchResult {
+            adapter_name,
+            adapter_index,
+            rule_type: slot.rule_type,
+            rule_payload: slot.payload.as_str(),
+            rule_index: slot.rule_index,
+        }
+    }
+}
+
+impl CompiledRuleSlot {
+    pub fn rule_index(&self) -> usize {
+        self.rule_index
+    }
+
+    pub fn rule_type(&self) -> RuleType {
+        self.rule_type
+    }
+
+    pub fn adapter_index(&self) -> usize {
+        self.adapter_index
+    }
+
+    pub fn payload(&self) -> &str {
+        &self.payload
+    }
+
+    pub fn has_dynamic_adapter(&self) -> bool {
+        self.target_plan == TargetPlan::DynamicAdapter
+    }
+
+    pub fn is_lowered(&self) -> bool {
+        !matches!(self.op, RuleOp::Fallback)
+    }
+}
+
+fn intern_adapter(
+    adapter_names: &mut Vec<SmolStr>,
+    adapter_lookup: &mut HashMap<SmolStr, usize>,
+    adapter_name: SmolStr,
+) -> usize {
+    if let Some(index) = adapter_lookup.get(&adapter_name) {
+        return *index;
+    }
+
+    let index = adapter_names.len();
+    adapter_names.push(adapter_name.clone());
+    adapter_lookup.insert(adapter_name, index);
+    index
+}
+
+fn target_plan(rule_type: RuleType) -> TargetPlan {
+    match rule_type {
+        // SUB-RULE returns the matched inner rule's adapter, not the outer
+        // rule's adapter/block name.
+        RuleType::SubRule => TargetPlan::DynamicAdapter,
+        _ => TargetPlan::StaticAdapter,
+    }
+}
+
+fn compile_op(rule_type: RuleType, payload: &str) -> Option<RuleOp> {
+    match rule_type {
+        RuleType::Domain => Some(RuleOp::Domain(payload.to_ascii_lowercase())),
+        RuleType::DomainSuffix => Some(RuleOp::DomainSuffix(payload.to_ascii_lowercase())),
+        RuleType::DomainKeyword => Some(RuleOp::DomainKeyword(payload.to_ascii_lowercase())),
+        RuleType::DomainRegex => Regex::new(payload).ok().map(RuleOp::DomainRegex),
+        RuleType::DomainWildcard => compile_domain_wildcard(payload).map(RuleOp::DomainWildcard),
+        RuleType::IpCidr => payload
+            .parse()
+            .ok()
+            .map(|net| RuleOp::IpCidr { net, src: false }),
+        RuleType::SrcIpCidr => payload
+            .parse()
+            .ok()
+            .map(|net| RuleOp::IpCidr { net, src: true }),
+        RuleType::SrcPort => {
+            compile_ports(payload).map(|ranges| RuleOp::Port { ranges, src: true })
+        }
+        RuleType::DstPort => {
+            compile_ports(payload).map(|ranges| RuleOp::Port { ranges, src: false })
+        }
+        RuleType::InPort => compile_in_port(payload),
+        RuleType::Dscp => payload
+            .trim()
+            .parse::<u8>()
+            .ok()
+            .filter(|v| *v <= 63)
+            .map(RuleOp::Dscp),
+        RuleType::ProcessName => Some(RuleOp::ProcessName(payload.to_string())),
+        RuleType::ProcessPath => compile_process_path(payload).map(RuleOp::ProcessPath),
+        RuleType::Network => compile_network(payload),
+        RuleType::Uid => payload.trim().parse::<u32>().ok().map(RuleOp::Uid),
+        RuleType::InName => Some(RuleOp::InName(payload.to_string())),
+        RuleType::InType => compile_in_type(payload).map(RuleOp::InType),
+        RuleType::InUser => Some(RuleOp::InUser(payload.to_string())),
+        RuleType::Match => Some(RuleOp::Match),
+        RuleType::GeoSite
+        | RuleType::GeoIp
+        | RuleType::SrcGeoIp
+        | RuleType::RuleSet
+        | RuleType::And
+        | RuleType::Or
+        | RuleType::Not
+        | RuleType::IpSuffix
+        | RuleType::IpAsn
+        | RuleType::SubRule => None,
+    }
+}
+
+fn matches_op(op: &RuleOp, metadata: &Metadata) -> bool {
+    match op {
+        RuleOp::Domain(domain) => metadata.rule_host().eq_ignore_ascii_case(domain),
+        RuleOp::DomainSuffix(suffix) => domain_suffix_matches(metadata.rule_host(), suffix),
+        RuleOp::DomainKeyword(keyword) => domain_keyword_matches(metadata.rule_host(), keyword),
+        RuleOp::DomainRegex(regex) | RuleOp::DomainWildcard(regex) => {
+            regex.is_match(metadata.rule_host())
+        }
+        RuleOp::IpCidr { net, src } => {
+            let ip = if *src {
+                metadata.src_ip
+            } else {
+                metadata.dst_ip
+            };
+            ip.is_some_and(|addr| net.contains(&addr))
+        }
+        RuleOp::Port { ranges, src } => {
+            let port = if *src {
+                metadata.src_port
+            } else {
+                metadata.dst_port
+            };
+            ranges.iter().any(|range| match range {
+                PortRange::Single(p) => port == *p,
+                PortRange::Range(lo, hi) => port >= *lo && port <= *hi,
+            })
+        }
+        RuleOp::InPort { lo, hi } => {
+            metadata.in_port != 0 && metadata.in_port >= *lo && metadata.in_port <= *hi
+        }
+        RuleOp::Dscp(value) => metadata.dscp == Some(*value),
+        RuleOp::ProcessName(name) => metadata.process.eq_ignore_ascii_case(name),
+        RuleOp::ProcessPath(op) => process_path_matches(op, &metadata.process_path),
+        RuleOp::Network(network) => metadata.network == *network,
+        RuleOp::Uid(uid) => uid_matches(metadata, *uid),
+        RuleOp::InName(name) => !metadata.in_name.is_empty() && metadata.in_name.as_str() == name,
+        RuleOp::InType(mask) => in_type_matches(*mask, metadata.conn_type),
+        RuleOp::InUser(user) => metadata.in_user.as_deref() == Some(user.as_str()),
+        RuleOp::Match => true,
+        RuleOp::Fallback => false,
+    }
+}
+
+fn domain_suffix_matches(host: &str, suffix: &str) -> bool {
+    let host = host.as_bytes();
+    let suffix = suffix.as_bytes();
+    if host.len() == suffix.len() {
+        return host.eq_ignore_ascii_case(suffix);
+    }
+    if host.len() > suffix.len() {
+        let dot_pos = host.len() - suffix.len() - 1;
+        return host[dot_pos] == b'.' && host[dot_pos + 1..].eq_ignore_ascii_case(suffix);
+    }
+    false
+}
+
+fn domain_keyword_matches(host: &str, keyword: &str) -> bool {
+    let host = host.as_bytes();
+    let needle = keyword.as_bytes();
+    if needle.is_empty() {
+        return true;
+    }
+    if host.len() < needle.len() {
+        return false;
+    }
+    host.windows(needle.len())
+        .any(|window| window.eq_ignore_ascii_case(needle))
+}
+
+fn compile_domain_wildcard(pattern: &str) -> Option<Regex> {
+    let escaped = regex::escape(pattern);
+    let expanded = escaped.replace(r"\*", r"[^.]+");
+    Regex::new(&format!("^(?i){expanded}$")).ok()
+}
+
+fn compile_ports(payload: &str) -> Option<Vec<PortRange>> {
+    let mut ranges = Vec::new();
+    for part in payload.split(',') {
+        let part = part.trim();
+        if let Some((start, end)) = part.split_once('-') {
+            ranges.push(PortRange::Range(
+                start.trim().parse().ok()?,
+                end.trim().parse().ok()?,
+            ));
+        } else {
+            ranges.push(PortRange::Single(part.parse().ok()?));
+        }
+    }
+    Some(ranges)
+}
+
+fn compile_in_port(payload: &str) -> Option<RuleOp> {
+    let (lo, hi) = if let Some((lo, hi)) = payload.split_once('-') {
+        let lo: u16 = lo.trim().parse().ok()?;
+        let hi: u16 = hi.trim().parse().ok()?;
+        if lo > hi {
+            return None;
+        }
+        (lo, hi)
+    } else {
+        let p = payload.trim().parse().ok()?;
+        (p, p)
+    };
+    Some(RuleOp::InPort { lo, hi })
+}
+
+fn compile_network(payload: &str) -> Option<RuleOp> {
+    match payload.to_ascii_lowercase().as_str() {
+        "tcp" => Some(RuleOp::Network(Network::Tcp)),
+        "udp" => Some(RuleOp::Network(Network::Udp)),
+        _ => None,
+    }
+}
+
+fn compile_in_type(payload: &str) -> Option<InTypeMask> {
+    let mut mask = InTypeMask {
+        http: false,
+        https: false,
+        socks5: false,
+        tproxy: false,
+        inner: false,
+    };
+    match payload.to_ascii_uppercase().as_str() {
+        "HTTP" => {
+            mask.http = true;
+            mask.https = true;
+        }
+        "HTTPS" => mask.https = true,
+        "SOCKS5" => mask.socks5 = true,
+        "TPROXY" => mask.tproxy = true,
+        "INNER" => mask.inner = true,
+        _ => return None,
+    }
+    Some(mask)
+}
+
+fn in_type_matches(mask: InTypeMask, conn_type: ConnType) -> bool {
+    match conn_type {
+        ConnType::Http => mask.http,
+        ConnType::Https => mask.https,
+        ConnType::Socks5 => mask.socks5,
+        ConnType::TProxy => mask.tproxy,
+        ConnType::Inner => mask.inner,
+        _ => false,
+    }
+}
+
+fn compile_process_path(payload: &str) -> Option<ProcessPathOp> {
+    if payload.contains('*') {
+        let escaped = regex::escape(payload);
+        let pattern = escaped.replace(r"\*", r"[^/\\]*");
+        Regex::new(&format!("^(?i){pattern}$"))
+            .ok()
+            .map(ProcessPathOp::Glob)
+    } else if payload.starts_with('/') || payload.starts_with('\\') {
+        Some(ProcessPathOp::Prefix(payload.to_string()))
+    } else {
+        Some(ProcessPathOp::Exact(payload.to_string()))
+    }
+}
+
+fn process_path_matches(op: &ProcessPathOp, process_path: &str) -> bool {
+    if process_path.is_empty() {
+        return false;
+    }
+    match op {
+        ProcessPathOp::Glob(regex) => regex.is_match(process_path),
+        ProcessPathOp::Prefix(prefix) => {
+            if process_path == prefix {
+                return true;
+            }
+            process_path
+                .strip_prefix(prefix)
+                .is_some_and(|rest| rest.starts_with('/') || rest.starts_with('\\'))
+        }
+        ProcessPathOp::Exact(exact) => {
+            let filename = Path::new(process_path)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(process_path);
+            filename == exact
+        }
+    }
+}
+
+fn uid_matches(metadata: &Metadata, uid: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        metadata.uid == Some(uid)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (metadata, uid);
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::match_engine::{self, DomainIndex as LegacyDomainIndex};
+    use meow_common::{Metadata, Rule};
+    use meow_rules::{
+        domain::DomainRule, domain_keyword::DomainKeywordRule, domain_suffix::DomainSuffixRule,
+        domain_wildcard::DomainWildcardRule, final_rule::FinalRule, ipcidr::IpCidrRule,
+        logic::OrRule, port::PortRule, sub_rule::SubRuleRule,
+    };
+    use std::net::IpAddr;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[test]
+    fn domain_index_early_exit_skips_later_rules() {
+        let later_match_count = Arc::new(AtomicUsize::new(0));
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainSuffixRule::new("example.com", "Proxy")),
+            Box::new(CountingRule::new(
+                RuleType::Match,
+                "DIRECT",
+                "",
+                true,
+                Arc::clone(&later_match_count),
+                Arc::new(CallCounts::default()),
+            )),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+        let meta = Metadata {
+            host: "sub.example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+
+        let result = set
+            .match_rules(&meta, &rules)
+            .expect("domain rule must match");
+        assert_eq!(result.adapter_name, "Proxy");
+        assert_eq!(result.rule_type, RuleType::DomainSuffix);
+        assert_eq!(result.rule_payload, "example.com");
+        assert_eq!(later_match_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn earlier_rule_beats_domain_trie_hit() {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(PortRule::new("443", "Direct", false).unwrap()),
+            Box::new(DomainSuffixRule::new("example.com", "Proxy")),
+            Box::new(FinalRule::new("FINAL")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+        let meta = Metadata {
+            host: "sub.example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+
+        let result = set
+            .match_rules(&meta, &rules)
+            .expect("earlier port rule must match");
+        assert_eq!(result.adapter_name, "Direct");
+        assert_eq!(result.rule_type, RuleType::DstPort);
+    }
+
+    #[test]
+    fn broader_domain_rule_before_specific_wins_first_match() {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainSuffixRule::new("example.com", "Broad")),
+            Box::new(DomainRule::new("sub.example.com", "Specific")),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+        let meta = Metadata {
+            host: "sub.example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+
+        let result = set
+            .match_rules(&meta, &rules)
+            .expect("domain rule must match");
+        assert_eq!(result.adapter_name, "Broad");
+        assert_eq!(result.rule_type, RuleType::DomainSuffix);
+    }
+
+    #[test]
+    fn lowered_match_rule_skips_virtual_match_and_metadata_calls() {
+        let match_count = Arc::new(AtomicUsize::new(0));
+        let counts = Arc::new(CallCounts::default());
+        let rules: Vec<Box<dyn Rule>> = vec![Box::new(CountingRule::new(
+            RuleType::Match,
+            "DIRECT",
+            "payload",
+            true,
+            Arc::clone(&match_count),
+            Arc::clone(&counts),
+        ))];
+
+        let set = CompiledRuleSet::build(&rules);
+        counts.reset();
+
+        let result = set
+            .match_rules(&Metadata::default(), &rules)
+            .expect("counting rule must match");
+
+        assert_eq!(result.adapter_name, "DIRECT");
+        assert_eq!(result.rule_payload, "payload");
+        assert_eq!(match_count.load(Ordering::Relaxed), 0);
+        assert_eq!(counts.rule_type.load(Ordering::Relaxed), 0);
+        assert_eq!(counts.adapter.load(Ordering::Relaxed), 0);
+        assert_eq!(counts.payload.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn sub_rule_dynamic_adapter_is_preserved() {
+        let block: Arc<Vec<Box<dyn Rule>>> = Arc::new(vec![Box::new(FinalRule::new("InnerProxy"))]);
+        let rules: Vec<Box<dyn Rule>> = vec![Box::new(SubRuleRule::new("block-a", block))];
+
+        let set = CompiledRuleSet::build(&rules);
+        let result = set
+            .match_rules(&Metadata::default(), &rules)
+            .expect("sub-rule inner final must match");
+
+        assert_eq!(result.adapter_name, "InnerProxy");
+        assert_eq!(result.adapter_index, None);
+        assert_eq!(result.rule_type, RuleType::SubRule);
+        assert_eq!(result.rule_payload, "block-a");
+    }
+
+    #[test]
+    fn compiled_rules_match_legacy_engine_for_lowered_and_fallback_rules() {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(PortRule::new("8443", "PortProxy", false).unwrap()),
+            Box::new(DomainKeywordRule::new("video", "KeywordProxy")),
+            Box::new(IpCidrRule::new("203.0.113.0/24", "CidrProxy", false, true).unwrap()),
+            Box::new(DomainWildcardRule::new("*.wild.example", "WildcardProxy").unwrap()),
+            Box::new(OrRule::new(
+                vec![
+                    Box::new(PortRule::new("9000", "unused", false).unwrap()),
+                    Box::new(DomainRule::new("fallback.example", "unused")),
+                ],
+                "FallbackProxy",
+            )),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+        let index = LegacyDomainIndex::build(&rules);
+        let compiled = CompiledRuleSet::build(&rules);
+
+        let cases = [
+            Metadata {
+                host: "plain.example".into(),
+                dst_port: 8443,
+                ..Default::default()
+            },
+            Metadata {
+                host: "api.video.example".into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+            Metadata {
+                host: "cidr.example".into(),
+                dst_ip: Some("203.0.113.9".parse::<IpAddr>().unwrap()),
+                dst_port: 443,
+                ..Default::default()
+            },
+            Metadata {
+                host: "one.wild.example".into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+            Metadata {
+                host: "fallback.example".into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+            Metadata {
+                host: "nomatch.example".into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+        ];
+
+        for metadata in cases {
+            let legacy = match_engine::match_rules(&metadata, &rules, &index)
+                .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+            let compiled = compiled
+                .match_rules(&metadata, &rules)
+                .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+
+            assert_eq!(compiled, legacy, "metadata host={}", metadata.host);
+        }
+    }
+
+    #[derive(Default)]
+    struct CallCounts {
+        rule_type: AtomicUsize,
+        adapter: AtomicUsize,
+        payload: AtomicUsize,
+    }
+
+    impl CallCounts {
+        fn reset(&self) {
+            self.rule_type.store(0, Ordering::Relaxed);
+            self.adapter.store(0, Ordering::Relaxed);
+            self.payload.store(0, Ordering::Relaxed);
+        }
+    }
+
+    struct CountingRule {
+        rule_type: RuleType,
+        adapter: &'static str,
+        payload: &'static str,
+        matches: bool,
+        match_count: Arc<AtomicUsize>,
+        counts: Arc<CallCounts>,
+    }
+
+    impl CountingRule {
+        fn new(
+            rule_type: RuleType,
+            adapter: &'static str,
+            payload: &'static str,
+            matches: bool,
+            match_count: Arc<AtomicUsize>,
+            counts: Arc<CallCounts>,
+        ) -> Self {
+            Self {
+                rule_type,
+                adapter,
+                payload,
+                matches,
+                match_count,
+                counts,
+            }
+        }
+    }
+
+    impl Rule for CountingRule {
+        fn rule_type(&self) -> RuleType {
+            self.counts.rule_type.fetch_add(1, Ordering::Relaxed);
+            self.rule_type
+        }
+
+        fn match_metadata(&self, _metadata: &Metadata, _helper: &RuleMatchHelper) -> bool {
+            self.match_count.fetch_add(1, Ordering::Relaxed);
+            self.matches
+        }
+
+        fn adapter(&self) -> &str {
+            self.counts.adapter.fetch_add(1, Ordering::Relaxed);
+            self.adapter
+        }
+
+        fn payload(&self) -> &str {
+            self.counts.payload.fetch_add(1, Ordering::Relaxed);
+            self.payload
+        }
+    }
+}

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -63,8 +63,8 @@ enum RuleOp {
     Domain(String),
     DomainSuffix(String),
     DomainKeyword(String),
-    DomainRegex(Regex),
-    DomainWildcard(Regex),
+    DomainRegex(Box<RegexMatcher>),
+    DomainWildcard(Box<RegexMatcher>),
     IpCidr { net: IpNet, src: bool },
     SrcPort(PortMatcher),
     DstPort(PortMatcher),
@@ -95,8 +95,14 @@ enum PortMatcher {
 }
 
 #[derive(Debug, Clone)]
+struct RegexMatcher {
+    regex: Regex,
+    required_literal: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 enum ProcessPathOp {
-    Glob(Regex),
+    Glob(Box<Regex>),
     Prefix(String),
     Exact(String),
 }
@@ -393,7 +399,7 @@ fn compile_op(rule_type: RuleType, payload: &str) -> Option<RuleOp> {
         RuleType::Domain => Some(RuleOp::Domain(payload.to_ascii_lowercase())),
         RuleType::DomainSuffix => Some(RuleOp::DomainSuffix(payload.to_ascii_lowercase())),
         RuleType::DomainKeyword => Some(RuleOp::DomainKeyword(payload.to_ascii_lowercase())),
-        RuleType::DomainRegex => Regex::new(payload).ok().map(RuleOp::DomainRegex),
+        RuleType::DomainRegex => compile_domain_regex(payload).map(RuleOp::DomainRegex),
         RuleType::DomainWildcard => compile_domain_wildcard(payload).map(RuleOp::DomainWildcard),
         RuleType::IpCidr => payload
             .parse()
@@ -438,7 +444,7 @@ fn matches_op(op: &RuleOp, input: &MatchInput<'_>) -> bool {
         RuleOp::Domain(domain) => input.host.eq_ignore_ascii_case(domain),
         RuleOp::DomainSuffix(suffix) => domain_suffix_matches(input.host, suffix),
         RuleOp::DomainKeyword(keyword) => domain_keyword_matches(input.host, keyword),
-        RuleOp::DomainRegex(regex) | RuleOp::DomainWildcard(regex) => regex.is_match(input.host),
+        RuleOp::DomainRegex(regex) | RuleOp::DomainWildcard(regex) => regex.matches(input.host),
         RuleOp::IpCidr { net, src } => {
             let ip = if *src {
                 input.metadata.src_ip
@@ -493,10 +499,66 @@ fn domain_keyword_matches(host: &str, keyword: &str) -> bool {
         .any(|window| window.eq_ignore_ascii_case(needle))
 }
 
-fn compile_domain_wildcard(pattern: &str) -> Option<Regex> {
+impl RegexMatcher {
+    fn matches(&self, host: &str) -> bool {
+        if let Some(required_literal) = &self.required_literal {
+            if !domain_keyword_matches(host, required_literal) {
+                return false;
+            }
+        }
+        self.regex.is_match(host)
+    }
+}
+
+fn compile_domain_regex(pattern: &str) -> Option<Box<RegexMatcher>> {
+    Some(Box::new(RegexMatcher {
+        regex: Regex::new(pattern).ok()?,
+        required_literal: required_literal_from_plain_regex(pattern),
+    }))
+}
+
+fn compile_domain_wildcard(pattern: &str) -> Option<Box<RegexMatcher>> {
     let escaped = regex::escape(pattern);
     let expanded = escaped.replace(r"\*", r"[^.]+");
-    Regex::new(&format!("^(?i){expanded}$")).ok()
+    Some(Box::new(RegexMatcher {
+        regex: Regex::new(&format!("^(?i){expanded}$")).ok()?,
+        required_literal: required_literal_from_wildcard(pattern),
+    }))
+}
+
+fn required_literal_from_plain_regex(pattern: &str) -> Option<String> {
+    if pattern.is_empty() || pattern.bytes().any(is_regex_meta_byte) {
+        return None;
+    }
+    Some(pattern.to_ascii_lowercase())
+}
+
+fn required_literal_from_wildcard(pattern: &str) -> Option<String> {
+    pattern
+        .split('*')
+        .filter(|part| !part.is_empty())
+        .max_by_key(|part| part.len())
+        .map(str::to_ascii_lowercase)
+}
+
+fn is_regex_meta_byte(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'\\'
+            | b'.'
+            | b'+'
+            | b'*'
+            | b'?'
+            | b'('
+            | b')'
+            | b'|'
+            | b'['
+            | b']'
+            | b'{'
+            | b'}'
+            | b'^'
+            | b'$'
+    )
 }
 
 impl PortMatcher {
@@ -599,6 +661,7 @@ fn compile_process_path(payload: &str) -> Option<ProcessPathOp> {
         let pattern = escaped.replace(r"\*", r"[^/\\]*");
         Regex::new(&format!("^(?i){pattern}$"))
             .ok()
+            .map(Box::new)
             .map(ProcessPathOp::Glob)
     } else if payload.starts_with('/') || payload.starts_with('\\') {
         Some(ProcessPathOp::Prefix(payload.to_string()))
@@ -649,9 +712,10 @@ mod tests {
     use crate::match_engine::{self, DomainIndex as LegacyDomainIndex};
     use meow_common::{Metadata, Rule};
     use meow_rules::{
-        domain::DomainRule, domain_keyword::DomainKeywordRule, domain_suffix::DomainSuffixRule,
-        domain_wildcard::DomainWildcardRule, final_rule::FinalRule, ipcidr::IpCidrRule,
-        logic::OrRule, port::PortRule, sub_rule::SubRuleRule,
+        domain::DomainRule, domain_keyword::DomainKeywordRule, domain_regex::DomainRegexRule,
+        domain_suffix::DomainSuffixRule, domain_wildcard::DomainWildcardRule,
+        final_rule::FinalRule, ipcidr::IpCidrRule, logic::OrRule, port::PortRule,
+        sub_rule::SubRuleRule,
     };
     use std::net::IpAddr;
     use std::sync::{
@@ -804,6 +868,62 @@ mod tests {
         assert_eq!(result.adapter_index, None);
         assert_eq!(result.rule_type, RuleType::SubRule);
         assert_eq!(result.rule_payload, "block-a");
+    }
+
+    #[test]
+    fn domain_wildcard_regex_prefilter_preserves_matches() {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainWildcardRule::new("*.wild.example", "WildcardProxy").unwrap()),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+        let index = LegacyDomainIndex::build(&rules);
+        let compiled = CompiledRuleSet::build(&rules);
+
+        for host in ["one.wild.example", "two.notwild.example"] {
+            let metadata = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let legacy = match_engine::match_rules(&metadata, &rules, &index)
+                .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+            let compiled = compiled
+                .match_rules(&metadata, &rules)
+                .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+
+            assert_eq!(compiled, legacy, "metadata host={host}");
+        }
+    }
+
+    #[test]
+    fn plain_domain_regex_gets_literal_prefilter_only_when_safe() {
+        assert_eq!(
+            required_literal_from_plain_regex("github"),
+            Some("github".to_string())
+        );
+        assert_eq!(required_literal_from_plain_regex(r"^github\.com$"), None);
+
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainRegexRule::new("github", "RegexProxy").unwrap()),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+        let index = LegacyDomainIndex::build(&rules);
+        let compiled = CompiledRuleSet::build(&rules);
+
+        for host in ["api.github.com", "gitlab.com"] {
+            let metadata = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let legacy = match_engine::match_rules(&metadata, &rules, &index)
+                .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+            let compiled = compiled
+                .match_rules(&metadata, &rules)
+                .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+
+            assert_eq!(compiled, legacy, "metadata host={host}");
+        }
     }
 
     #[test]

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -66,8 +66,9 @@ enum RuleOp {
     DomainRegex(Regex),
     DomainWildcard(Regex),
     IpCidr { net: IpNet, src: bool },
-    Port { ranges: Vec<PortRange>, src: bool },
-    InPort { lo: u16, hi: u16 },
+    SrcPort(PortMatcher),
+    DstPort(PortMatcher),
+    InPort(PortMatcher),
     Dscp(u8),
     ProcessName(String),
     ProcessPath(ProcessPathOp),
@@ -87,6 +88,13 @@ enum PortRange {
 }
 
 #[derive(Debug, Clone)]
+enum PortMatcher {
+    Single(u16),
+    Range(u16, u16),
+    Multiple(Vec<PortRange>),
+}
+
+#[derive(Debug, Clone)]
 enum ProcessPathOp {
     Glob(Regex),
     Prefix(String),
@@ -100,6 +108,11 @@ struct InTypeMask {
     socks5: bool,
     tproxy: bool,
     inner: bool,
+}
+
+struct MatchInput<'a> {
+    metadata: &'a Metadata,
+    host: &'a str,
 }
 
 /// One borrowed result from a compiled rule-set match.
@@ -185,22 +198,22 @@ impl CompiledRuleSet {
         );
 
         let helper = RuleMatchHelper;
+        let input = MatchInput::new(metadata);
         if self.execution_plan == ExecutionPlan::LinearScan {
-            return self.scan_range(0..self.slots.len(), metadata, rules, &helper);
+            return self.scan_range(0..self.slots.len(), &input, rules, &helper);
         }
 
-        let host = metadata.rule_host();
-        let trie_hit = if host.is_empty() {
+        let trie_hit = if input.host.is_empty() {
             None
         } else {
-            self.domain_index.search(host)
+            self.domain_index.search(input.host)
         };
 
         // Preserve DomainIndex early-exit behavior:
         // if a trie hit occurs at T, scan only [0..T] for an earlier match,
         // then return T. On trie miss, scan the full rule list.
         let scan_end = trie_hit.unwrap_or(self.slots.len());
-        if let Some(matched) = self.scan_range(0..scan_end, metadata, rules, &helper) {
+        if let Some(matched) = self.scan_range(0..scan_end, &input, rules, &helper) {
             return Some(matched);
         }
 
@@ -208,7 +221,7 @@ impl CompiledRuleSet {
             return self.slots.get(trie_idx).map(|slot| self.static_match(slot));
         }
 
-        self.scan_range(scan_end..self.slots.len(), metadata, rules, &helper)
+        self.scan_range(scan_end..self.slots.len(), &input, rules, &helper)
     }
 
     pub fn domain_index(&self) -> &DomainIndex {
@@ -250,28 +263,32 @@ impl CompiledRuleSet {
     fn scan_range<'a>(
         &'a self,
         range: Range<usize>,
-        metadata: &Metadata,
+        input: &MatchInput<'_>,
         rules: &'a [Box<dyn Rule>],
         helper: &RuleMatchHelper,
     ) -> Option<CompiledMatchResult<'a>> {
         for slot in &self.slots[range] {
-            let rule = rules.get(slot.rule_index)?.as_ref();
             match &slot.op {
-                RuleOp::Fallback => match slot.target_plan {
-                    TargetPlan::StaticAdapter => {
-                        if rule.match_metadata(metadata, helper) {
-                            return Some(self.static_match(slot));
+                RuleOp::Fallback => {
+                    let rule = rules.get(slot.rule_index)?.as_ref();
+                    match slot.target_plan {
+                        TargetPlan::StaticAdapter => {
+                            if rule.match_metadata(input.metadata, helper) {
+                                return Some(self.static_match(slot));
+                            }
+                        }
+                        TargetPlan::DynamicAdapter => {
+                            if let Some(adapter_name) =
+                                rule.match_and_resolve(input.metadata, helper)
+                            {
+                                let adapter_index = self.adapter_lookup.get(adapter_name).copied();
+                                return Some(self.make_match(slot, adapter_name, adapter_index));
+                            }
                         }
                     }
-                    TargetPlan::DynamicAdapter => {
-                        if let Some(adapter_name) = rule.match_and_resolve(metadata, helper) {
-                            let adapter_index = self.adapter_lookup.get(adapter_name).copied();
-                            return Some(self.make_match(slot, adapter_name, adapter_index));
-                        }
-                    }
-                },
+                }
                 op => {
-                    if matches_op(op, metadata) {
+                    if matches_op(op, input) {
                         return Some(self.static_match(slot));
                     }
                 }
@@ -300,6 +317,15 @@ impl CompiledRuleSet {
             rule_type: slot.rule_type,
             rule_payload: slot.payload.as_str(),
             rule_index: slot.rule_index,
+        }
+    }
+}
+
+impl<'a> MatchInput<'a> {
+    fn new(metadata: &'a Metadata) -> Self {
+        Self {
+            metadata,
+            host: metadata.rule_host(),
         }
     }
 }
@@ -377,12 +403,8 @@ fn compile_op(rule_type: RuleType, payload: &str) -> Option<RuleOp> {
             .parse()
             .ok()
             .map(|net| RuleOp::IpCidr { net, src: true }),
-        RuleType::SrcPort => {
-            compile_ports(payload).map(|ranges| RuleOp::Port { ranges, src: true })
-        }
-        RuleType::DstPort => {
-            compile_ports(payload).map(|ranges| RuleOp::Port { ranges, src: false })
-        }
+        RuleType::SrcPort => compile_port_matcher(payload).map(RuleOp::SrcPort),
+        RuleType::DstPort => compile_port_matcher(payload).map(RuleOp::DstPort),
         RuleType::InPort => compile_in_port(payload),
         RuleType::Dscp => payload
             .trim()
@@ -411,44 +433,35 @@ fn compile_op(rule_type: RuleType, payload: &str) -> Option<RuleOp> {
     }
 }
 
-fn matches_op(op: &RuleOp, metadata: &Metadata) -> bool {
+fn matches_op(op: &RuleOp, input: &MatchInput<'_>) -> bool {
     match op {
-        RuleOp::Domain(domain) => metadata.rule_host().eq_ignore_ascii_case(domain),
-        RuleOp::DomainSuffix(suffix) => domain_suffix_matches(metadata.rule_host(), suffix),
-        RuleOp::DomainKeyword(keyword) => domain_keyword_matches(metadata.rule_host(), keyword),
-        RuleOp::DomainRegex(regex) | RuleOp::DomainWildcard(regex) => {
-            regex.is_match(metadata.rule_host())
-        }
+        RuleOp::Domain(domain) => input.host.eq_ignore_ascii_case(domain),
+        RuleOp::DomainSuffix(suffix) => domain_suffix_matches(input.host, suffix),
+        RuleOp::DomainKeyword(keyword) => domain_keyword_matches(input.host, keyword),
+        RuleOp::DomainRegex(regex) | RuleOp::DomainWildcard(regex) => regex.is_match(input.host),
         RuleOp::IpCidr { net, src } => {
             let ip = if *src {
-                metadata.src_ip
+                input.metadata.src_ip
             } else {
-                metadata.dst_ip
+                input.metadata.dst_ip
             };
             ip.is_some_and(|addr| net.contains(&addr))
         }
-        RuleOp::Port { ranges, src } => {
-            let port = if *src {
-                metadata.src_port
-            } else {
-                metadata.dst_port
-            };
-            ranges.iter().any(|range| match range {
-                PortRange::Single(p) => port == *p,
-                PortRange::Range(lo, hi) => port >= *lo && port <= *hi,
-            })
+        RuleOp::SrcPort(matcher) => matcher.matches(input.metadata.src_port),
+        RuleOp::DstPort(matcher) => matcher.matches(input.metadata.dst_port),
+        RuleOp::InPort(matcher) => {
+            input.metadata.in_port != 0 && matcher.matches(input.metadata.in_port)
         }
-        RuleOp::InPort { lo, hi } => {
-            metadata.in_port != 0 && metadata.in_port >= *lo && metadata.in_port <= *hi
+        RuleOp::Dscp(value) => input.metadata.dscp == Some(*value),
+        RuleOp::ProcessName(name) => input.metadata.process.eq_ignore_ascii_case(name),
+        RuleOp::ProcessPath(op) => process_path_matches(op, &input.metadata.process_path),
+        RuleOp::Network(network) => input.metadata.network == *network,
+        RuleOp::Uid(uid) => uid_matches(input.metadata, *uid),
+        RuleOp::InName(name) => {
+            !input.metadata.in_name.is_empty() && input.metadata.in_name.as_str() == name
         }
-        RuleOp::Dscp(value) => metadata.dscp == Some(*value),
-        RuleOp::ProcessName(name) => metadata.process.eq_ignore_ascii_case(name),
-        RuleOp::ProcessPath(op) => process_path_matches(op, &metadata.process_path),
-        RuleOp::Network(network) => metadata.network == *network,
-        RuleOp::Uid(uid) => uid_matches(metadata, *uid),
-        RuleOp::InName(name) => !metadata.in_name.is_empty() && metadata.in_name.as_str() == name,
-        RuleOp::InType(mask) => in_type_matches(*mask, metadata.conn_type),
-        RuleOp::InUser(user) => metadata.in_user.as_deref() == Some(user.as_str()),
+        RuleOp::InType(mask) => in_type_matches(*mask, input.metadata.conn_type),
+        RuleOp::InUser(user) => input.metadata.in_user.as_deref() == Some(user.as_str()),
         RuleOp::Match => true,
         RuleOp::Fallback => false,
     }
@@ -486,7 +499,26 @@ fn compile_domain_wildcard(pattern: &str) -> Option<Regex> {
     Regex::new(&format!("^(?i){expanded}$")).ok()
 }
 
-fn compile_ports(payload: &str) -> Option<Vec<PortRange>> {
+impl PortMatcher {
+    fn matches(&self, port: u16) -> bool {
+        match self {
+            Self::Single(value) => port == *value,
+            Self::Range(lo, hi) => port >= *lo && port <= *hi,
+            Self::Multiple(ranges) => ranges.iter().any(|range| range.matches(port)),
+        }
+    }
+}
+
+impl PortRange {
+    fn matches(&self, port: u16) -> bool {
+        match self {
+            Self::Single(value) => port == *value,
+            Self::Range(lo, hi) => port >= *lo && port <= *hi,
+        }
+    }
+}
+
+fn compile_port_matcher(payload: &str) -> Option<PortMatcher> {
     let mut ranges = Vec::new();
     for part in payload.split(',') {
         let part = part.trim();
@@ -499,22 +531,25 @@ fn compile_ports(payload: &str) -> Option<Vec<PortRange>> {
             ranges.push(PortRange::Single(part.parse().ok()?));
         }
     }
-    Some(ranges)
+    match ranges.as_slice() {
+        [PortRange::Single(value)] => Some(PortMatcher::Single(*value)),
+        [PortRange::Range(lo, hi)] => Some(PortMatcher::Range(*lo, *hi)),
+        _ => Some(PortMatcher::Multiple(ranges)),
+    }
 }
 
 fn compile_in_port(payload: &str) -> Option<RuleOp> {
-    let (lo, hi) = if let Some((lo, hi)) = payload.split_once('-') {
+    let matcher = if let Some((lo, hi)) = payload.split_once('-') {
         let lo: u16 = lo.trim().parse().ok()?;
         let hi: u16 = hi.trim().parse().ok()?;
         if lo > hi {
             return None;
         }
-        (lo, hi)
+        PortMatcher::Range(lo, hi)
     } else {
-        let p = payload.trim().parse().ok()?;
-        (p, p)
+        PortMatcher::Single(payload.trim().parse().ok()?)
     };
-    Some(RuleOp::InPort { lo, hi })
+    Some(RuleOp::InPort(matcher))
 }
 
 fn compile_network(payload: &str) -> Option<RuleOp> {

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -7,6 +7,10 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::path::Path;
 
+/// Below this size, trie probing costs more than it saves for common configs
+/// with early matches. Compile small configs to straight-line ordered IR scan.
+const LINEAR_SCAN_RULE_LIMIT: usize = 64;
+
 /// Native compiled rule metadata plus indexes for hot-path matching.
 ///
 /// This IR is intentionally hybrid: common parser-produced predicates lower to
@@ -19,6 +23,7 @@ pub struct CompiledRuleSet {
     adapter_names: Vec<SmolStr>,
     adapter_lookup: HashMap<SmolStr, usize>,
     domain_index: DomainIndex,
+    execution_plan: ExecutionPlan,
     needs_ip_resolution: bool,
     needs_process_lookup: bool,
 }
@@ -41,6 +46,16 @@ enum TargetPlan {
     StaticAdapter,
     /// The target adapter can be returned by nested rule evaluation.
     DynamicAdapter,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExecutionPlan {
+    /// Straight ordered slot scan. Best for small configs where trie overhead
+    /// dominates and first-match order usually exits early.
+    LinearScan,
+    /// Domain trie early-exit plus ordered prefix scan. Best for large configs
+    /// where avoiding long scans matters.
+    DomainIndexed,
 }
 
 #[derive(Debug, Clone)]
@@ -103,6 +118,7 @@ impl CompiledRuleSet {
             adapter_names: Vec::new(),
             adapter_lookup: HashMap::new(),
             domain_index: DomainIndex::empty(),
+            execution_plan: ExecutionPlan::LinearScan,
             needs_ip_resolution: false,
             needs_process_lookup: false,
         }
@@ -134,11 +150,18 @@ impl CompiledRuleSet {
             });
         }
 
+        let execution_plan = select_execution_plan(rules.len());
+        let domain_index = match execution_plan {
+            ExecutionPlan::LinearScan => DomainIndex::empty(),
+            ExecutionPlan::DomainIndexed => DomainIndex::build(rules),
+        };
+
         Self {
             slots,
             adapter_names,
             adapter_lookup,
-            domain_index: DomainIndex::build(rules),
+            domain_index,
+            execution_plan,
             needs_ip_resolution,
             needs_process_lookup,
         }
@@ -162,6 +185,10 @@ impl CompiledRuleSet {
         );
 
         let helper = RuleMatchHelper;
+        if self.execution_plan == ExecutionPlan::LinearScan {
+            return self.scan_range(0..self.slots.len(), metadata, rules, &helper);
+        }
+
         let host = metadata.rule_host();
         let trie_hit = if host.is_empty() {
             None
@@ -214,6 +241,10 @@ impl CompiledRuleSet {
 
     pub fn is_compatible_with(&self, rules: &[Box<dyn Rule>]) -> bool {
         self.slots.len() == rules.len()
+    }
+
+    pub fn uses_linear_scan_plan(&self) -> bool {
+        self.execution_plan == ExecutionPlan::LinearScan
     }
 
     fn scan_range<'a>(
@@ -320,6 +351,14 @@ fn target_plan(rule_type: RuleType) -> TargetPlan {
         // rule's adapter/block name.
         RuleType::SubRule => TargetPlan::DynamicAdapter,
         _ => TargetPlan::StaticAdapter,
+    }
+}
+
+fn select_execution_plan(rule_count: usize) -> ExecutionPlan {
+    if rule_count <= LINEAR_SCAN_RULE_LIMIT {
+        ExecutionPlan::LinearScan
+    } else {
+        ExecutionPlan::DomainIndexed
     }
 }
 
@@ -584,6 +623,34 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+
+    #[test]
+    fn small_rule_sets_use_linear_scan_plan() {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainSuffixRule::new("example.com", "Proxy")),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+
+        assert!(set.uses_linear_scan_plan());
+    }
+
+    #[test]
+    fn large_rule_sets_use_domain_indexed_plan() {
+        let mut rules: Vec<Box<dyn Rule>> = Vec::new();
+        for i in 0..=LINEAR_SCAN_RULE_LIMIT {
+            rules.push(Box::new(DomainSuffixRule::new(
+                &format!("suffix{i}.example.com"),
+                "Proxy",
+            )));
+        }
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+
+        assert!(!set.uses_linear_scan_plan());
+    }
 
     #[test]
     fn domain_index_early_exit_skips_later_rules() {

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -1,4 +1,5 @@
 use crate::match_engine::{self, DomainIndex};
+use crate::rule_ir::CompiledRuleSet;
 use crate::statistics::Statistics;
 use crate::udp::{self, NatTable};
 use arc_swap::ArcSwap;
@@ -25,6 +26,7 @@ use tracing::{debug, info};
 pub struct RouteTable {
     pub rules: Arc<Vec<Box<dyn Rule>>>,
     pub domain_index: Arc<DomainIndex>,
+    pub compiled_rules: Arc<CompiledRuleSet>,
     pub proxies: HashMap<SmolStr, Arc<dyn Proxy>>,
 }
 
@@ -33,6 +35,7 @@ impl RouteTable {
         Self {
             rules: Arc::new(Vec::new()),
             domain_index: Arc::new(DomainIndex::empty()),
+            compiled_rules: Arc::new(CompiledRuleSet::empty()),
             proxies: HashMap::new(),
         }
     }
@@ -160,11 +163,9 @@ impl TunnelInner {
                     None
                 };
                 let match_metadata = enriched.as_ref().unwrap_or(metadata);
-                let result = match_engine::match_rules(
-                    match_metadata,
-                    route.rules.as_ref(),
-                    route.domain_index.as_ref(),
-                );
+                let result = route
+                    .compiled_rules
+                    .match_rules(match_metadata, route.rules.as_ref());
                 match result {
                     Some(m) => {
                         let action = if m.adapter_name == "DIRECT" {
@@ -244,6 +245,7 @@ impl Tunnel {
         let needs_ip = rules.iter().any(|r| r.should_resolve_ip());
         let needs_proc = rules.iter().any(|r| r.should_find_process());
         let new_index = DomainIndex::build(&rules);
+        let compiled_rules = CompiledRuleSet::build(&rules);
         // Build a new route table on top of the current proxies map. The
         // current proxies are cloned (Arc bumps for adapter handles, one
         // HashMap clone) — paid only on config-reload, not the hot path.
@@ -251,6 +253,7 @@ impl Tunnel {
         let new_route = RouteTable {
             rules: Arc::new(rules),
             domain_index: Arc::new(new_index),
+            compiled_rules: Arc::new(compiled_rules),
             proxies: current.proxies.clone(),
         };
         self.inner.route.store(Arc::new(new_route));
@@ -272,6 +275,7 @@ impl Tunnel {
         let new_route = RouteTable {
             rules: Arc::clone(&current.rules),
             domain_index: Arc::clone(&current.domain_index),
+            compiled_rules: Arc::clone(&current.compiled_rules),
             proxies,
         };
         self.inner.route.store(Arc::new(new_route));

--- a/crates/meow-tunnel/tests/rule_ir_footprint.rs
+++ b/crates/meow-tunnel/tests/rule_ir_footprint.rs
@@ -1,0 +1,273 @@
+//! Opt-in memory-footprint measurement for the rule IR.
+//!
+//! Run:
+//!
+//! ```text
+//! cargo test -p meow-tunnel --test rule_ir_footprint --release -- --ignored --nocapture
+//! ```
+
+use meow_common::{Metadata, Rule, RuleMatchHelper};
+use meow_config::raw::RawConfig;
+use meow_tunnel::match_engine::{match_rules, DomainIndex};
+use meow_tunnel::rule_ir::CompiledRuleSet;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::net::IpAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const ECH_PRESSURE_CONFIG: &str = include_str!("fixtures/memleak_ech_pressure_config.yaml");
+const HOT_LOOP_ITERS: usize = 100_000;
+
+struct CountingAlloc;
+
+static ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static DEALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static DEALLOCS: AtomicU64 = AtomicU64::new(0);
+
+#[global_allocator]
+static ALLOC: CountingAlloc = CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        DEALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, old_layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        DEALLOC_BYTES.fetch_add(old_layout.size() as u64, Ordering::Relaxed);
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        DEALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, old_layout, new_size) }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AllocSnapshot {
+    allocated_bytes: u64,
+    deallocated_bytes: u64,
+    live_bytes: i64,
+    allocations: u64,
+    deallocations: u64,
+    live_allocations: i64,
+}
+
+fn reset_allocs() {
+    ALLOC_BYTES.store(0, Ordering::Relaxed);
+    DEALLOC_BYTES.store(0, Ordering::Relaxed);
+    ALLOCS.store(0, Ordering::Relaxed);
+    DEALLOCS.store(0, Ordering::Relaxed);
+}
+
+fn alloc_snapshot() -> AllocSnapshot {
+    let allocated_bytes = ALLOC_BYTES.load(Ordering::Relaxed);
+    let deallocated_bytes = DEALLOC_BYTES.load(Ordering::Relaxed);
+    let allocations = ALLOCS.load(Ordering::Relaxed);
+    let deallocations = DEALLOCS.load(Ordering::Relaxed);
+    AllocSnapshot {
+        allocated_bytes,
+        deallocated_bytes,
+        live_bytes: allocated_bytes as i64 - deallocated_bytes as i64,
+        allocations,
+        deallocations,
+        live_allocations: allocations as i64 - deallocations as i64,
+    }
+}
+
+fn measure<T>(f: impl FnOnce() -> T) -> (T, AllocSnapshot) {
+    reset_allocs();
+    let value = f();
+    let snapshot = alloc_snapshot();
+    (value, snapshot)
+}
+
+fn load_raw_fixture() -> RawConfig {
+    let mut value: serde_yaml::Value =
+        serde_yaml::from_str(ECH_PRESSURE_CONFIG).expect("fixture config must be valid YAML");
+    value
+        .apply_merge()
+        .expect("fixture config merge keys must expand");
+    serde_yaml::from_value(value).expect("fixture config must deserialize as RawConfig")
+}
+
+fn fixture_cases() -> Vec<Metadata> {
+    vec![
+        Metadata {
+            host: "www.maxlv.net".into(),
+            dst_port: 443,
+            ..Default::default()
+        },
+        Metadata {
+            host: "github.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        },
+        Metadata {
+            dst_port: 443,
+            dst_ip: Some("223.5.5.5".parse::<IpAddr>().unwrap()),
+            ..Default::default()
+        },
+        Metadata {
+            host: "unmatched.invalid".into(),
+            dst_port: 443,
+            dst_ip: Some("203.0.113.1".parse::<IpAddr>().unwrap()),
+            ..Default::default()
+        },
+    ]
+}
+
+fn scan_linear<'a>(rules: &'a [Box<dyn Rule>], metadata: &Metadata) -> Option<&'a str> {
+    let helper = RuleMatchHelper;
+    for rule in rules {
+        if let Some(adapter) = rule.match_and_resolve(metadata, &helper) {
+            return Some(adapter);
+        }
+    }
+    None
+}
+
+fn measure_hot_loop(
+    rules: &[Box<dyn Rule>],
+    index: &DomainIndex,
+    compiled: &CompiledRuleSet,
+    cases: &[Metadata],
+    matcher: Matcher,
+) -> AllocSnapshot {
+    reset_allocs();
+    for _ in 0..HOT_LOOP_ITERS {
+        for metadata in cases {
+            match matcher {
+                Matcher::Linear => {
+                    std::hint::black_box(scan_linear(
+                        std::hint::black_box(rules),
+                        std::hint::black_box(metadata),
+                    ));
+                }
+                Matcher::Indexed => {
+                    std::hint::black_box(match_rules(
+                        std::hint::black_box(metadata),
+                        std::hint::black_box(rules),
+                        std::hint::black_box(index),
+                    ));
+                }
+                Matcher::Ir => {
+                    std::hint::black_box(
+                        compiled.match_rules(
+                            std::hint::black_box(metadata),
+                            std::hint::black_box(rules),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+    alloc_snapshot()
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Matcher {
+    Linear,
+    Indexed,
+    Ir,
+}
+
+fn rss_kb() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        for line in status.lines() {
+            if let Some(rest) = line.strip_prefix("VmRSS:") {
+                return rest
+                    .split_whitespace()
+                    .next()
+                    .and_then(|kb| kb.parse().ok());
+            }
+        }
+        None
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let pid = std::process::id().to_string();
+        let output = std::process::Command::new("ps")
+            .args(["-o", "rss=", "-p", &pid])
+            .output()
+            .ok()?;
+        String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+    }
+}
+
+fn print_alloc_row(label: &str, snapshot: AllocSnapshot) {
+    println!(
+        "{label:<28} alloc={:>10} B dealloc={:>10} B live={:>10} B allocs={:>7} deallocs={:>7} live_allocs={:>6}",
+        snapshot.allocated_bytes,
+        snapshot.deallocated_bytes,
+        snapshot.live_bytes,
+        snapshot.allocations,
+        snapshot.deallocations,
+        snapshot.live_allocations
+    );
+}
+
+#[test]
+#[ignore = "memory-footprint measurement; opt in with --ignored --nocapture"]
+fn rule_ir_fixture_memory_footprint() {
+    let rss_start = rss_kb();
+
+    let raw = load_raw_fixture();
+    let (rules, rules_alloc) = measure(|| {
+        meow_config::rebuild_from_raw(&raw)
+            .expect("fixture rules must rebuild")
+            .1
+    });
+    assert_eq!(rules.len(), 19, "fixture rule count changed");
+    let rss_after_rules = rss_kb();
+
+    let (index, index_alloc) = measure(|| DomainIndex::build(&rules));
+    let rss_after_index = rss_kb();
+
+    let (compiled, ir_alloc) = measure(|| CompiledRuleSet::build(&rules));
+    let rss_after_ir = rss_kb();
+
+    let cases = fixture_cases();
+
+    let linear_hot = measure_hot_loop(&rules, &index, &compiled, &cases, Matcher::Linear);
+    let indexed_hot = measure_hot_loop(&rules, &index, &compiled, &cases, Matcher::Indexed);
+    let ir_hot = measure_hot_loop(&rules, &index, &compiled, &cases, Matcher::Ir);
+
+    println!("\n=== rule IR fixture memory footprint ===");
+    println!("fixture rules: {}", rules.len());
+    println!(
+        "hot loop: {HOT_LOOP_ITERS} iterations x {} cases",
+        cases.len()
+    );
+    if let Some(kb) = rss_start {
+        println!("rss start:        {kb:>8} KiB");
+    }
+    if let Some(kb) = rss_after_rules {
+        println!("rss after rules:  {kb:>8} KiB");
+    }
+    if let Some(kb) = rss_after_index {
+        println!("rss after index:  {kb:>8} KiB");
+    }
+    if let Some(kb) = rss_after_ir {
+        println!("rss after IR:     {kb:>8} KiB");
+    }
+    println!();
+    print_alloc_row("parse rules", rules_alloc);
+    print_alloc_row("legacy DomainIndex", index_alloc);
+    print_alloc_row("CompiledRuleSet", ir_alloc);
+    println!();
+    print_alloc_row("hot loop linear", linear_hot);
+    print_alloc_row("hot loop indexed", indexed_hot);
+    print_alloc_row("hot loop IR", ir_hot);
+
+    std::hint::black_box((rules, index, compiled));
+}

--- a/docs/specs/rule-ir.md
+++ b/docs/specs/rule-ir.md
@@ -195,3 +195,26 @@ cargo bench -p meow-tunnel --bench rules_bench -- --noplot --sample-size 10 --me
 The fixture is intentionally smaller than synthetic 10k-rule stress tests. It
 measures real rule mix overhead and fallback behavior, while synthetic large-rule
 benches remain useful for worst-case scan pressure.
+
+## Memory Footprint Coverage
+
+`crates/meow-tunnel/tests/rule_ir_footprint.rs` is an opt-in measurement test for
+the same fixture. It installs a counting allocator for that integration-test
+binary, resets counters around each measured phase, and prints:
+
+- retained heap delta for fixture rule parsing
+- retained heap delta for the legacy `DomainIndex`
+- retained heap delta for `CompiledRuleSet`
+- allocation counts for linear, indexed, and IR hot loops
+- coarse RSS snapshots before/after each build phase
+
+Use:
+
+```bash
+cargo test -p meow-tunnel --test rule_ir_footprint --release -- --ignored --nocapture
+```
+
+RSS is page-granular and includes loaded geodata, runtime state, and allocator
+behavior. The counting allocator rows are the authoritative per-component signal
+for the rule IR itself. The hot-loop allocation rows should remain zero for all
+matchers.

--- a/docs/specs/rule-ir.md
+++ b/docs/specs/rule-ir.md
@@ -407,6 +407,96 @@ This is the main compiler-style optimization in the current IR: pick a cheap
 straight-line plan for small rule programs, and pay indexing overhead only when
 the rule set is large enough to amortize it.
 
+## How IR Optimization Works
+
+The rule matcher optimization has two phases: compile time and match time.
+
+### Compile Time
+
+`CompiledRuleSet::build(rules)` walks the source rule list once and produces a
+compact ordered slot sequence.
+
+For each source rule, the compiler:
+
+1. Copies stable result metadata into the slot: rule index, rule type, payload,
+   and top-level adapter index.
+2. Interns static adapter names in `adapter_names`.
+3. Chooses `TargetPlan::StaticAdapter` for normal rules or
+   `TargetPlan::DynamicAdapter` for rules such as `SUB-RULE`.
+4. Attempts to lower the rule into a native `RuleOp`.
+5. Uses `RuleOp::Fallback` when lowering would be incomplete or unsafe.
+
+Then the compiler selects the top-level execution plan:
+
+```text
+if rules.len() <= 64:
+    execution_plan = LinearScan
+    domain_index = empty
+else:
+    execution_plan = DomainIndexed
+    domain_index = DomainIndex::build(rules)
+```
+
+The threshold is deliberately simple. The fixture benchmark showed that small
+configs can lose more time to domain-trie probing than they save. The 10k-rule
+benchmark showed that large configs still need an index-backed plan to avoid
+unbounded ordered scans.
+
+### Match Time
+
+At runtime, `CompiledRuleSet::match_rules(metadata, rules)` executes the
+compiled plan without rebuilding or mutating anything.
+
+For `LinearScan`, the hot path is:
+
+```text
+for slot in slots:
+    if slot.op is lowered:
+        evaluate RuleOp directly against Metadata
+    else if slot.target_plan is StaticAdapter:
+        call rules[slot.rule_index].match_metadata(...)
+    else:
+        call rules[slot.rule_index].match_and_resolve(...)
+
+    if matched:
+        return cached or dynamic CompiledMatchResult
+```
+
+For `DomainIndexed`, the hot path is:
+
+```text
+host = metadata.rule_host()
+T = domain_index.search(host)
+
+if T exists:
+    scan slots [0, T)
+    if prefix matched:
+        return prefix match
+    return cached static result for slots[T]
+
+scan full slot range
+```
+
+### What Gets Faster
+
+The IR removes repeated hot-path work that was previously paid through dynamic
+`Rule` trait calls:
+
+- Lowered predicates avoid virtual `match_metadata()` dispatch.
+- Static matches return interned adapter names instead of calling
+  `rule.adapter()`.
+- Rule type and payload are copied once at compile time instead of fetched for
+  every successful match.
+- Small rule sets avoid domain-trie probe overhead entirely.
+- Large rule sets can still use domain-index early exit before falling back to
+  ordered slot scans.
+
+### What Does Not Change
+
+The optimizer cannot reorder rules, pre-resolve DNS, inspect proxies, or skip
+fallback rules whose private state may affect the result. Every optimization is
+constrained by source-order first-match semantics.
+
 ## Adapter Resolution
 
 Most rules have a static top-level adapter. For those, a successful match returns

--- a/docs/specs/rule-ir.md
+++ b/docs/specs/rule-ir.md
@@ -1,0 +1,197 @@
+# Spec: Rule matching IR
+
+Status: Draft (2026-06-18)
+Owner: core
+Related: `docs/specs/rule-engine-micro-opt.md`, ADR-0008 rule matching work
+
+## Purpose
+
+`meow-tunnel` routes each connection by matching `Metadata` against the ordered
+`rules:` list from the active config. The public rule representation is
+`Vec<Box<dyn Rule>>`, which is flexible but expensive on the hot path: a match
+can require repeated virtual calls for the predicate, adapter name, rule type,
+and payload.
+
+The rule IR is a compiled, immutable view of that same rule list. It keeps the
+original `Box<dyn Rule>` slice as the semantic source of truth, but lowers common
+parser-produced predicates into native opcodes and captures stable result
+metadata once at config-load time.
+
+The IR is not a new rule language. It is an execution plan for the existing
+rule list.
+
+## Runtime Ownership
+
+`Tunnel::update_rules()` receives the parsed `Vec<Box<dyn Rule>>` from
+`meow-config`. It builds three rule artifacts for one route snapshot:
+
+1. `rules: Arc<Vec<Box<dyn Rule>>>` is the original ordered rule list.
+2. `domain_index: Arc<DomainIndex>` is retained for compatibility and tests.
+3. `compiled_rules: Arc<CompiledRuleSet>` is the hot-path execution plan.
+
+Those fields live together in `RouteTable`, which is published through
+`ArcSwap`. A routing lookup takes one `ArcSwap` snapshot, so rules, compiled IR,
+and proxies are all read from the same route-table generation.
+
+`Tunnel::update_proxies()` does not rebuild rules. It clones the current
+`rules`, `domain_index`, and `compiled_rules` arcs into the new route table and
+replaces only the proxy map. Rule compilation is therefore paid on config/rule
+reload, not proxy refresh.
+
+## IR Shape
+
+`CompiledRuleSet` contains:
+
+- `slots`: one `CompiledRuleSlot` per source rule, in source order.
+- `adapter_names`: interned static adapter targets captured from top-level
+  rules.
+- `adapter_lookup`: reverse lookup for dynamic adapter results.
+- `domain_index`: the existing DOMAIN/DOMAIN-SUFFIX trie, scoped to the same
+  rule list.
+- `needs_ip_resolution` and `needs_process_lookup`: aggregate rule flags
+  captured at build time.
+
+Each slot stores:
+
+- `rule_index`: index into the original `rules` slice.
+- `rule_type`: copied `RuleType`.
+- `adapter_index`: interned top-level adapter.
+- `payload`: copied diagnostic payload.
+- `target_plan`: whether the rule returns a static adapter or can return a
+  nested dynamic adapter.
+- `op`: lowered native predicate or `Fallback`.
+
+## Lowered Predicates
+
+The IR currently lowers rule types whose full matching behavior is represented
+by public payload plus `Metadata`:
+
+- `DOMAIN`
+- `DOMAIN-SUFFIX`
+- `DOMAIN-KEYWORD`
+- `DOMAIN-REGEX`
+- `DOMAIN-WILDCARD`
+- `IP-CIDR`
+- `SRC-IP-CIDR`
+- `SRC-PORT`
+- `DST-PORT`
+- `IN-PORT`
+- `DSCP`
+- `PROCESS-NAME`
+- `PROCESS-PATH`
+- `NETWORK`
+- `UID`
+- `IN-NAME`
+- `IN-TYPE`
+- `IN-USER`
+- `MATCH`
+
+Rules with private embedded state or composition stay as `Fallback` and call the
+public `Rule` trait:
+
+- `GEOSITE`
+- `GEOIP`
+- `SRC-GEOIP`
+- `RULE-SET`
+- `AND`
+- `OR`
+- `NOT`
+- `IP-SUFFIX`
+- `IP-ASN`
+- `SUB-RULE`
+
+This keeps the IR conservative. A rule type is lowered only when the compiled
+opcode can preserve existing behavior without duplicating hidden state.
+
+## Adapter Resolution
+
+Most rules have a static top-level adapter. For those, a successful match returns
+the interned adapter name without calling `rule.adapter()` on the hot path.
+
+`SUB-RULE` is dynamic: the adapter comes from the matched inner rule, not the
+outer block name. Dynamic slots therefore call `match_and_resolve()` and return
+the adapter string from the fallback rule evaluation. If that adapter was not a
+top-level adapter captured in the current IR, `adapter_index` is `None`; the
+runtime still resolves it by name in the route snapshot's proxy map.
+
+## Execution Algorithm
+
+`CompiledRuleSet::match_rules(metadata, rules)` preserves the ordered
+first-match semantics of `match_engine::match_rules`.
+
+1. Read `metadata.rule_host()`.
+2. If the host is non-empty, probe the embedded `DomainIndex`.
+3. If the trie returns a domain hit at index `T`, scan slots `[0, T)` in order.
+   This is required because an earlier non-domain rule, or a broader domain
+   rule before a more-specific trie hit, must still win.
+4. If the prefix scan matched, return that result.
+5. If the trie had hit `T` and the prefix did not match, return the static
+   result for slot `T`.
+6. If the trie missed, scan the full slot range in source order.
+
+For each scanned slot:
+
+- If `op` is lowered, evaluate the native predicate against `Metadata`.
+- If `op` is `Fallback` and the adapter target is static, call
+  `rule.match_metadata()` and return the captured static result on success.
+- If `op` is `Fallback` and the adapter target is dynamic, call
+  `rule.match_and_resolve()` and return the dynamic adapter result on success.
+
+The returned `CompiledMatchResult` borrows adapter and payload strings from the
+compiled rule set or source rule. It does not allocate for successful matches.
+
+## Tunnel Hot Path
+
+In `TunnelInner::match_adapter()`:
+
+1. `Direct` mode bypasses the rule engine.
+2. `Global` mode resolves the `GLOBAL` proxy or falls back to DIRECT.
+3. `Rule` mode loads the current `RouteTable` snapshot.
+4. If any active rule needs process lookup, the metadata is enriched before
+   matching.
+5. The tunnel calls `route.compiled_rules.match_rules(metadata, route.rules)`.
+6. On match, statistics are incremented from the returned `RuleType`, the proxy
+   is resolved by returned adapter name, and missing proxies fall back to DIRECT.
+7. On no match, the tunnel uses DIRECT.
+
+DNS/IP pre-resolution remains outside the IR. The IR consumes the `Metadata`
+prepared by the tunnel and rule helpers; it does not perform DNS or process
+lookups itself.
+
+## Correctness Invariants
+
+- `CompiledRuleSet` must be evaluated with the same `rules` slice it was built
+  from. Runtime snapshots store both together.
+- Slot order must match source rule order exactly.
+- Trie early-exit must scan the prefix before returning a trie hit.
+- Fallback rules must remain fallback until their semantics can be represented
+  only from public rule payload and `Metadata`.
+- Dynamic adapter rules must not be rewritten to the outer rule adapter.
+- Proxy reload must preserve the compiled rule set for the current rule
+  generation.
+
+## Benchmark Coverage
+
+`crates/meow-tunnel/benches/rules_bench.rs` uses the complex fixture
+`crates/meow-tunnel/tests/fixtures/memleak_ech_pressure_config.yaml`.
+
+The bench parses that fixture through `meow-config`'s raw config rebuild path,
+builds `DomainIndex` and `CompiledRuleSet`, and asserts that linear, indexed,
+and IR execution return the same match for each measured case before timing.
+
+The fixture cases cover:
+
+- early `DOMAIN-SUFFIX` hit
+- early `GEOSITE` hit
+- IP-only `GEOIP` hit
+- full fallthrough to `MATCH`
+
+Use:
+
+```bash
+cargo bench -p meow-tunnel --bench rules_bench -- --noplot --sample-size 10 --measurement-time 2 --warm-up-time 1
+```
+
+The fixture is intentionally smaller than synthetic 10k-rule stress tests. It
+measures real rule mix overhead and fallback behavior, while synthetic large-rule
+benches remain useful for worst-case scan pressure.

--- a/docs/specs/rule-ir.md
+++ b/docs/specs/rule-ir.md
@@ -213,7 +213,7 @@ slots:
     payload       = "443"
     adapter_index = 1  # "DIRECT"
     target_plan   = StaticAdapter
-    op            = RuleOp::Port { ranges: [Single(443)], src: false }
+    op            = RuleOp::DstPort(PortMatcher::Single(443))
 
   2:
     rule_index    = 2
@@ -235,7 +235,7 @@ Execution for `host = "other.test", dst_port = 443`:
 
 ```text
 scan slot 0 -> no match
-scan slot 1 -> RuleOp::Port matches
+scan slot 1 -> RuleOp::DstPort matches
 return adapter_names[1], DST-PORT, "443", rule_index 1
 ```
 
@@ -260,7 +260,7 @@ Compiled rule set:
 execution_plan = DomainIndexed
 domain_index   = { "example.com" => 75, ... }
 
-slots[0].op   = RuleOp::Port { ranges: [Single(443)], src: false }
+slots[0].op   = RuleOp::DstPort(PortMatcher::Single(443))
 slots[1].op   = RuleOp::Fallback  # GEOSITE owns private geosite state
 slots[75].op  = RuleOp::DomainSuffix("example.com")
 slots[100].op = RuleOp::Match
@@ -424,7 +424,10 @@ For each source rule, the compiler:
 3. Chooses `TargetPlan::StaticAdapter` for normal rules or
    `TargetPlan::DynamicAdapter` for rules such as `SUB-RULE`.
 4. Attempts to lower the rule into a native `RuleOp`.
-5. Uses `RuleOp::Fallback` when lowering would be incomplete or unsafe.
+5. Specializes lowered opcodes when a narrower form is available. For example,
+   `DST-PORT,443` becomes `RuleOp::DstPort(PortMatcher::Single(443))` instead
+   of a generic port-range loop.
+6. Uses `RuleOp::Fallback` when lowering would be incomplete or unsafe.
 
 Then the compiler selects the top-level execution plan:
 
@@ -444,8 +447,14 @@ unbounded ordered scans.
 
 ### Match Time
 
-At runtime, `CompiledRuleSet::match_rules(metadata, rules)` executes the
-compiled plan without rebuilding or mutating anything.
+At runtime, `CompiledRuleSet::match_rules(metadata, rules)` creates one
+`MatchInput` view for the request and executes the compiled plan without
+rebuilding or mutating anything.
+
+`MatchInput` caches request fields that many opcodes need, starting with
+`metadata.rule_host()`. Lowered domain opcodes and the domain-index probe share
+that borrowed host view instead of repeatedly asking `Metadata` for the rule
+host.
 
 For `LinearScan`, the hot path is:
 
@@ -454,8 +463,10 @@ for slot in slots:
     if slot.op is lowered:
         evaluate RuleOp directly against Metadata
     else if slot.target_plan is StaticAdapter:
+        load rules[slot.rule_index]
         call rules[slot.rule_index].match_metadata(...)
     else:
+        load rules[slot.rule_index]
         call rules[slot.rule_index].match_and_resolve(...)
 
     if matched:
@@ -465,7 +476,7 @@ for slot in slots:
 For `DomainIndexed`, the hot path is:
 
 ```text
-host = metadata.rule_host()
+host = input.host
 T = domain_index.search(host)
 
 if T exists:
@@ -487,6 +498,11 @@ The IR removes repeated hot-path work that was previously paid through dynamic
   `rule.adapter()`.
 - Rule type and payload are copied once at compile time instead of fetched for
   every successful match.
+- `MatchInput` computes common request views once per match call.
+- Lowered slots do not load from the source `rules` slice at all; source-rule
+  lookup is deferred until a fallback slot needs it.
+- Specialized port matchers avoid a range loop for single-port and single-range
+  rules.
 - Small rule sets avoid domain-trie probe overhead entirely.
 - Large rule sets can still use domain-index early exit before falling back to
   ordered slot scans.
@@ -522,7 +538,7 @@ For `LinearScan`, execution is:
 
 For `DomainIndexed`, execution is:
 
-1. Read `metadata.rule_host()`.
+1. Read the request host from `MatchInput`.
 2. If the host is non-empty, probe the embedded `DomainIndex`.
 3. If the trie returns a domain hit at index `T`, scan slots `[0, T)` in order.
    This is required because an earlier non-domain rule, or a broader domain

--- a/docs/specs/rule-ir.md
+++ b/docs/specs/rule-ir.md
@@ -12,13 +12,43 @@ Related: `docs/specs/rule-engine-micro-opt.md`, ADR-0008 rule matching work
 can require repeated virtual calls for the predicate, adapter name, rule type,
 and payload.
 
-The rule IR is a compiled, immutable view of that same rule list. It keeps the
-original `Box<dyn Rule>` slice as the semantic source of truth, but lowers common
-parser-produced predicates into native opcodes and captures stable result
-metadata once at config-load time.
+## IR Definition
 
-The IR is not a new rule language. It is an execution plan for the existing
-rule list.
+The rule IR is the immutable execution plan produced from one parsed `rules:`
+list. It is represented by `CompiledRuleSet`.
+
+The IR has three responsibilities:
+
+1. Preserve the source rule list's first-match semantics.
+2. Lower rule predicates that can be represented from public rule payload plus
+   `Metadata` into native opcodes.
+3. Cache stable match-result metadata so the hot path does not repeatedly call
+   virtual `Rule` methods for rule type, payload, and static adapter names.
+
+The IR does not replace the source rules. The original `Vec<Box<dyn Rule>>`
+remains the semantic source of truth and is stored beside the IR in the same
+route-table snapshot.
+
+The IR is not:
+
+- a new config format
+- a new rule language
+- a lossy rewrite of rule ordering
+- a replacement for rules with private embedded state
+- responsible for DNS resolution, process lookup, or proxy selection
+
+### IR Terms
+
+| term | definition |
+| --- | --- |
+| source rule | One parsed `Box<dyn Rule>` from the ordered config rule list. |
+| compiled rule set | `CompiledRuleSet`, the immutable IR built from the full source rule list. |
+| slot | `CompiledRuleSlot`, one IR entry corresponding one-to-one with a source rule. Slot order is source order. |
+| opcode | `RuleOp`, a native predicate compiled from a source rule's public type and payload. |
+| fallback slot | A slot whose source rule cannot be fully represented as an opcode and must call the public `Rule` trait. |
+| target plan | Whether a successful slot returns the source rule's static adapter or a dynamic adapter from nested rule evaluation. |
+| execution plan | The top-level strategy used by `CompiledRuleSet::match_rules`: straight ordered scan or domain-indexed scan. |
+| match result | `CompiledMatchResult`, a borrowed adapter/rule-type/payload result returned to the tunnel. |
 
 ## Runtime Ownership
 
@@ -38,7 +68,7 @@ and proxies are all read from the same route-table generation.
 replaces only the proxy map. Rule compilation is therefore paid on config/rule
 reload, not proxy refresh.
 
-## IR Shape
+## IR Data Model
 
 `CompiledRuleSet` contains:
 
@@ -47,7 +77,8 @@ reload, not proxy refresh.
   rules.
 - `adapter_lookup`: reverse lookup for dynamic adapter results.
 - `domain_index`: the existing DOMAIN/DOMAIN-SUFFIX trie, scoped to the same
-  rule list.
+  rule list when the selected plan uses trie probing.
+- `execution_plan`: the compiler-selected plan for the rule-set shape.
 - `needs_ip_resolution` and `needs_process_lookup`: aggregate rule flags
   captured at build time.
 
@@ -60,6 +91,90 @@ Each slot stores:
 - `target_plan`: whether the rule returns a static adapter or can return a
   nested dynamic adapter.
 - `op`: lowered native predicate or `Fallback`.
+
+## IR Coding Spec
+
+This section is normative for `crates/meow-tunnel/src/rule_ir.rs`.
+
+### Construction
+
+- `CompiledRuleSet::build(rules)` must create exactly one slot for every source
+  rule.
+- `slot.rule_index` must equal the source rule's position in `rules`.
+- Slot order must remain identical to source rule order. The IR may add indexes
+  or choose a different scan plan, but it must not reorder slots.
+- Build-time extraction may call `Rule` methods for stable metadata:
+  `rule_type()`, `adapter()`, `payload()`, `should_resolve_ip()`, and
+  `should_find_process()`.
+- Build-time extraction must not evaluate a rule against request metadata.
+- Static adapter names should be interned in `adapter_names` and referenced by
+  slot index so successful static matches do not allocate.
+- A malformed or unsupported payload must compile to `Fallback`, not to a
+  partial opcode.
+
+### Opcode Rules
+
+Add a `RuleOp` only when all of these are true:
+
+- The rule behavior can be implemented from public rule type, public payload,
+  and `Metadata`.
+- The opcode preserves case sensitivity, boundary checks, platform behavior,
+  and empty-field behavior of the source rule.
+- The opcode does not require hidden parser state, external datasets, async I/O,
+  DNS lookup, process lookup, or proxy-map access.
+- Existing source-order first-match semantics are unchanged.
+
+Keep a rule as `Fallback` when any of these are true:
+
+- The rule owns private compiled state that is not visible through public
+  payload.
+- The rule delegates to nested rules and can return a nested adapter.
+- The rule depends on geodata, rule-set providers, or other state outside
+  `Metadata`.
+- The source behavior is uncertain or cannot be covered by parity tests.
+
+Every new lowered opcode must have unit coverage for:
+
+- positive match
+- negative match
+- case and boundary behavior when relevant
+- parity with the source `Rule` implementation
+
+### Fallback Rules
+
+Fallback slots preserve correctness for rule types that are not safe to lower.
+
+- Static fallback slots call `rule.match_metadata()` and return the slot's
+  captured adapter, rule type, and payload.
+- Dynamic fallback slots call `rule.match_and_resolve()` and return the adapter
+  produced by nested rule evaluation.
+- `SUB-RULE` must remain dynamic unless its nested adapter semantics are
+  represented explicitly in a future IR.
+- Fallback is a correctness boundary, not an error path.
+
+### Execution Plans
+
+Execution-plan selection is a compiler optimization over the same slots.
+
+- `LinearScan` scans every slot in source order and must not build or probe
+  `DomainIndex`.
+- `DomainIndexed` may use `DomainIndex` only as an early-exit hint. It must scan
+  all slots before a trie hit before returning the trie result.
+- A plan may skip work only when the skipped slots cannot affect first-match
+  semantics.
+- Changing a plan threshold requires benchmark evidence for both fixture-backed
+  rules and synthetic large-rule cases.
+
+### Runtime Contract
+
+- `CompiledRuleSet::match_rules(metadata, rules)` must be called with the same
+  source rule list used to build the compiled rule set.
+- Returned `CompiledMatchResult` should borrow from the compiled rule set or the
+  source rule; the successful hot path should not allocate.
+- The IR must not mutate runtime state.
+- The IR must not resolve DNS, perform process lookup, or inspect proxies.
+- `needs_ip_resolution()` and `needs_process_lookup()` are aggregate hints
+  copied from source rules. The tunnel owns the actual enrichment work.
 
 ## Lowered Predicates
 
@@ -103,6 +218,19 @@ public `Rule` trait:
 This keeps the IR conservative. A rule type is lowered only when the compiled
 opcode can preserve existing behavior without duplicating hidden state.
 
+## Execution Plan Selection
+
+The IR compiler selects one of two plans at build time:
+
+| plan | selected when | behavior |
+| --- | --- | --- |
+| `LinearScan` | `rules.len() <= 64` | Scan compiled slots in source order. This avoids domain-trie probe overhead for small configs where early matches are common and straight-line execution is cheaper. |
+| `DomainIndexed` | `rules.len() > 64` | Build and probe `DomainIndex`, then use the ordered prefix-scan algorithm. This avoids long scans in large rule sets. |
+
+This is the main compiler-style optimization in the current IR: pick a cheap
+straight-line plan for small rule programs, and pay indexing overhead only when
+the rule set is large enough to amortize it.
+
 ## Adapter Resolution
 
 Most rules have a static top-level adapter. For those, a successful match returns
@@ -118,6 +246,15 @@ runtime still resolves it by name in the route snapshot's proxy map.
 
 `CompiledRuleSet::match_rules(metadata, rules)` preserves the ordered
 first-match semantics of `match_engine::match_rules`.
+
+For `LinearScan`, execution is:
+
+1. Scan slots `[0, len)` in source order.
+2. Evaluate lowered opcodes directly.
+3. Use fallback `Rule` calls only for non-lowered slots.
+4. Return the first match.
+
+For `DomainIndexed`, execution is:
 
 1. Read `metadata.rule_host()`.
 2. If the host is non-empty, probe the embedded `DomainIndex`.
@@ -163,7 +300,8 @@ lookups itself.
 - `CompiledRuleSet` must be evaluated with the same `rules` slice it was built
   from. Runtime snapshots store both together.
 - Slot order must match source rule order exactly.
-- Trie early-exit must scan the prefix before returning a trie hit.
+- `LinearScan` must not build or probe the domain trie.
+- `DomainIndexed` early-exit must scan the prefix before returning a trie hit.
 - Fallback rules must remain fallback until their semantics can be represented
   only from public rule payload and `Metadata`.
 - Dynamic adapter rules must not be rewritten to the outer rule adapter.
@@ -174,6 +312,7 @@ lookups itself.
 
 `crates/meow-tunnel/benches/rules_bench.rs` uses the complex fixture
 `crates/meow-tunnel/tests/fixtures/memleak_ech_pressure_config.yaml`.
+It also includes synthetic 10k-rule groups for large-rule scaling.
 
 The bench parses that fixture through `meow-config`'s raw config rebuild path,
 builds `DomainIndex` and `CompiledRuleSet`, and asserts that linear, indexed,
@@ -185,6 +324,11 @@ The fixture cases cover:
 - early `GEOSITE` hit
 - IP-only `GEOIP` hit
 - full fallthrough to `MATCH`
+
+The synthetic cases cover:
+
+- 10k-rule late `DOMAIN-SUFFIX` hit
+- 10k-rule full fallthrough to `MATCH`
 
 Use:
 

--- a/docs/specs/rule-ir.md
+++ b/docs/specs/rule-ir.md
@@ -427,7 +427,10 @@ For each source rule, the compiler:
 5. Specializes lowered opcodes when a narrower form is available. For example,
    `DST-PORT,443` becomes `RuleOp::DstPort(PortMatcher::Single(443))` instead
    of a generic port-range loop.
-6. Uses `RuleOp::Fallback` when lowering would be incomplete or unsafe.
+6. Adds conservative regex prefilters when a required literal is known. For
+   example, `DOMAIN-WILDCARD,*.example.com` stores `.example.com` as a
+   case-insensitive prefilter before running the full regex.
+7. Uses `RuleOp::Fallback` when lowering would be incomplete or unsafe.
 
 Then the compiler selects the top-level execution plan:
 
@@ -503,6 +506,8 @@ The IR removes repeated hot-path work that was previously paid through dynamic
   lookup is deferred until a fallback slot needs it.
 - Specialized port matchers avoid a range loop for single-port and single-range
   rules.
+- Regex-heavy domain wildcard misses can skip `regex.is_match()` when the host
+  does not contain the required literal.
 - Small rule sets avoid domain-trie probe overhead entirely.
 - Large rule sets can still use domain-index early exit before falling back to
   ordered slot scans.
@@ -611,6 +616,7 @@ The synthetic cases cover:
 
 - 10k-rule late `DOMAIN-SUFFIX` hit
 - 10k-rule full fallthrough to `MATCH`
+- 10k-rule `DOMAIN-WILDCARD` miss for regex-prefilter coverage
 
 Use:
 

--- a/docs/specs/rule-ir.md
+++ b/docs/specs/rule-ir.md
@@ -176,6 +176,182 @@ Execution-plan selection is a compiler optimization over the same slots.
 - `needs_ip_resolution()` and `needs_process_lookup()` are aggregate hints
   copied from source rules. The tunnel owns the actual enrichment work.
 
+## Example IR Sequences
+
+The IR is not a bytecode VM. An "IR sequence" is the ordered `slots` array plus
+the selected execution plan and any side indexes needed by that plan.
+
+### Example 1: Small Lowered Rule List
+
+Source rules:
+
+| index | source rule |
+| ---: | --- |
+| 0 | `DOMAIN-SUFFIX,example.com,Proxy` |
+| 1 | `DST-PORT,443,DIRECT` |
+| 2 | `MATCH,DIRECT` |
+
+Compiled rule set:
+
+```text
+execution_plan = LinearScan
+adapter_names  = ["Proxy", "DIRECT"]
+domain_index   = empty
+
+slots:
+  0:
+    rule_index    = 0
+    rule_type     = DOMAIN-SUFFIX
+    payload       = "example.com"
+    adapter_index = 0  # "Proxy"
+    target_plan   = StaticAdapter
+    op            = RuleOp::DomainSuffix("example.com")
+
+  1:
+    rule_index    = 1
+    rule_type     = DST-PORT
+    payload       = "443"
+    adapter_index = 1  # "DIRECT"
+    target_plan   = StaticAdapter
+    op            = RuleOp::Port { ranges: [Single(443)], src: false }
+
+  2:
+    rule_index    = 2
+    rule_type     = MATCH
+    payload       = ""
+    adapter_index = 1  # "DIRECT"
+    target_plan   = StaticAdapter
+    op            = RuleOp::Match
+```
+
+Execution for `host = "www.example.com", dst_port = 80`:
+
+```text
+scan slot 0 -> RuleOp::DomainSuffix matches
+return adapter_names[0], DOMAIN-SUFFIX, "example.com", rule_index 0
+```
+
+Execution for `host = "other.test", dst_port = 443`:
+
+```text
+scan slot 0 -> no match
+scan slot 1 -> RuleOp::Port matches
+return adapter_names[1], DST-PORT, "443", rule_index 1
+```
+
+No source `Rule` method is called on the match hot path for these three slots.
+
+### Example 2: Large Domain-Indexed Rule List
+
+Source rules, reduced to the relevant prefix:
+
+| index | source rule |
+| ---: | --- |
+| 0 | `DST-PORT,443,DIRECT` |
+| 1 | `GEOSITE,github,Proxy` |
+| ... | non-domain rules and other domain rules |
+| 75 | `DOMAIN-SUFFIX,example.com,Proxy` |
+| ... | remaining rules |
+| 100 | `MATCH,DIRECT` |
+
+Compiled rule set:
+
+```text
+execution_plan = DomainIndexed
+domain_index   = { "example.com" => 75, ... }
+
+slots[0].op   = RuleOp::Port { ranges: [Single(443)], src: false }
+slots[1].op   = RuleOp::Fallback  # GEOSITE owns private geosite state
+slots[75].op  = RuleOp::DomainSuffix("example.com")
+slots[100].op = RuleOp::Match
+```
+
+Execution for `host = "www.example.com", dst_port = 80`:
+
+```text
+trie probe host "www.example.com" -> hit T = 75
+scan slots [0, 75):
+  slot 0 -> port does not match
+  slot 1 -> fallback GEOSITE does not match
+  ...
+prefix scan has no match
+return static result for slot 75
+```
+
+Execution for `host = "www.example.com", dst_port = 443`:
+
+```text
+trie probe host "www.example.com" -> hit T = 75
+scan slots [0, 75):
+  slot 0 -> port matches
+return slot 0
+```
+
+The prefix scan before returning trie hit `75` is mandatory. Without it, the
+domain index would incorrectly skip the earlier `DST-PORT` rule.
+
+### Example 3: Fallback and Dynamic Adapter
+
+Source rules:
+
+| index | source rule |
+| ---: | --- |
+| 0 | `OR,((DOMAIN-SUFFIX,corp.example),(DST-PORT,8443)),Proxy` |
+| 1 | `SUB-RULE,private-block,PrivateBlock` |
+| 2 | `MATCH,DIRECT` |
+
+Compiled rule set:
+
+```text
+execution_plan = LinearScan
+adapter_names  = ["Proxy", "PrivateBlock", "DIRECT"]
+
+slots:
+  0:
+    rule_index    = 0
+    rule_type     = OR
+    payload       = "..."
+    adapter_index = 0  # "Proxy"
+    target_plan   = StaticAdapter
+    op            = RuleOp::Fallback
+
+  1:
+    rule_index    = 1
+    rule_type     = SUB-RULE
+    payload       = "private-block"
+    adapter_index = 1  # outer block name, not necessarily returned
+    target_plan   = DynamicAdapter
+    op            = RuleOp::Fallback
+
+  2:
+    rule_index    = 2
+    rule_type     = MATCH
+    payload       = ""
+    adapter_index = 2  # "DIRECT"
+    target_plan   = StaticAdapter
+    op            = RuleOp::Match
+```
+
+Execution:
+
+```text
+slot 0 is static fallback:
+  call rules[0].match_metadata(metadata, helper)
+  if true, return captured adapter "Proxy"
+
+slot 1 is dynamic fallback:
+  call rules[1].match_and_resolve(metadata, helper)
+  if it returns "Proxy-A", return adapter "Proxy-A"
+  adapter_index is Some(i) only when "Proxy-A" exists in adapter_lookup
+
+slot 2 is lowered:
+  RuleOp::Match returns captured adapter "DIRECT"
+```
+
+The `SUB-RULE` slot must not return `PrivateBlock` just because that is the
+outer rule adapter. Its runtime adapter is the matched nested rule's adapter, so
+it stays dynamic fallback.
+
 ## Lowered Predicates
 
 The IR currently lowers rule types whose full matching behavior is represented


### PR DESCRIPTION
## Summary

Adds a compiled rule-set IR for `meow-tunnel` so the route hot path can evaluate common rule predicates without repeated virtual metadata calls. The compiled matcher keeps first-match semantics, falls back to the public `Rule` trait for rules with private embedded state such as logic/rule-set/geodata/sub-rule cases, and selects an execution plan at compile time.

The compiler currently chooses:

- `LinearScan` for small rule sets (`rules.len() <= 64`), where a straight ordered scan is cheaper than probing a trie.
- `DomainIndexed` for larger rule sets, where the existing DOMAIN/DOMAIN-SUFFIX trie avoids long scans.

The IR optimizer also:

- builds one borrowed `MatchInput` per match call so lowered domain ops and trie probing share the same host view
- avoids loading from the source `rules` slice for lowered slots
- specializes port opcodes into `SrcPort`, `DstPort`, and `InPort` with single-port/single-range fast paths
- adds conservative required-literal prefilters before regex-backed domain wildcard/regex checks

This keeps the best behavior from linear matching on small configs while retaining the indexed approach for large configs. The 10k-rule benchmark is the reason indexed execution still matters: a pure linear strategy scales directly with rule count, while the indexed plan gives the IR a way to skip work when domain structure is useful.

The tunnel builds the compiled rule set when rules are loaded and uses it for `match_adapter`; proxy-table reloads retain the already-built matcher snapshot. The `rules_bench` Criterion benchmark now loads the complex ECH pressure fixture and also includes synthetic 10k-rule stress cases, including wildcard-heavy regex-prefilter coverage. Each case asserts linear/indexed/IR matcher equivalence before timing.

Also adds `docs/specs/rule-ir.md`, which now defines the IR precisely, shows example IR sequences, explains how the IR optimizer works, documents the runtime ownership model, lowered vs fallback predicates, execution algorithm, and an IR coding spec for adding future opcodes or execution-plan optimizations. The opt-in `rule_ir_footprint` test benchmarks retained heap/RSS footprint and verifies hot-loop allocation counts for the same fixture.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `cargo bench -p meow-tunnel --bench rules_bench -- --noplot --sample-size 10 --measurement-time 2 --warm-up-time 1`
- `cargo test -p meow-tunnel --test rule_ir_footprint --release -- --ignored --nocapture`

## Runtime Benchmark Results

Benchmark command:

```bash
cargo bench -p meow-tunnel --bench rules_bench -- --noplot --sample-size 10 --measurement-time 2 --warm-up-time 1
```

Column definitions:

| column | meaning |
| --- | --- |
| linear | Baseline ordered scan over `Vec<Box<dyn Rule>>`; every scanned rule is evaluated through the public `Rule` trait until first match. This can be fastest for small configs because it has no index-probe overhead. |
| indexed | Current domain-index matcher: probes `DomainIndex` for DOMAIN/DOMAIN-SUFFIX early exit, then scans the required prefix or full rule list through `Rule` trait calls. This is retained for large rule sets where pure linear scan cost grows with rule count. |
| IR | New `CompiledRuleSet` matcher: chooses `LinearScan` for small rule sets and `DomainIndexed` for large rule sets, evaluates lowered predicates with native opcodes, avoids source-rule loads for lowered slots, prefilters regex-backed wildcard misses, and falls back to `Rule` only for rules with private state. |

Fixture: `crates/meow-tunnel/tests/fixtures/memleak_ech_pressure_config.yaml` parsed through `meow_config::rebuild_from_raw` into 19 rules, with local GEOSITE/GEOIP data loaded from the fixture's configured geodata paths.

Fixture median-ish results:

| case | linear | indexed | IR | IR vs best baseline |
| --- | ---: | ---: | ---: | ---: |
| domain suffix `www.maxlv.net` | 23.894 ns | 78.935 ns | 20.110 ns | 1.19x |
| GEOSITE `github.com` | 161.82 ns | 197.93 ns | 158.62 ns | 1.02x |
| GEOIP CN `223.5.5.5` | 123.61 ns | 128.62 ns | 102.94 ns | 1.20x |
| fallthrough to MATCH | 1.9623 us | 2.0350 us | 1.9508 us | 1.01x |

Synthetic 10k-rule median-ish results:

| case | linear | indexed | IR | IR vs best baseline |
| --- | ---: | ---: | ---: | ---: |
| late DOMAIN-SUFFIX hit | 60.184 us | 63.514 us | 27.410 us | 2.20x |
| full fallthrough to MATCH | 64.378 us | 64.435 us | 33.717 us | 1.91x |
| DOMAIN-WILDCARD miss | 79.093 us | 77.837 us | 30.952 us | 2.51x |

The fixture shows why pure linear can look best before IR optimization: it is only 19 rules, so trie probing is mostly overhead. The compiled IR now uses the linear plan for that shape, but still avoids repeated virtual calls and cached metadata lookups. The synthetic 10k cases show why the indexed approach remains useful for scale, and the wildcard case shows the regex-prefilter pass on the rule shape it targets.

## IR Optimization Comparison

The first table compares the earlier IR implementation, which always paid the domain-index execution path, against the current plan-selected and specialized IR. The fixture has only 19 rules, so the optimizer selects `LinearScan` and removes the trie probe from these cases.

| fixture case | always-indexed IR | current IR | speedup |
| --- | ---: | ---: | ---: |
| domain suffix `www.maxlv.net` | 72.436 ns | 20.110 ns | 3.60x |
| GEOSITE `github.com` | 186.05 ns | 158.62 ns | 1.17x |
| GEOIP CN `223.5.5.5` | 103.28 ns | 102.94 ns | 1.00x |
| fallthrough to MATCH | 2.0755 us | 1.9508 us | 1.06x |

This table compares the latest regex-prefilter build against the prior plan-selected and opcode-specialized IR numbers:

| case | previous IR | current IR | change |
| --- | ---: | ---: | ---: |
| fixture domain suffix | 18.517 ns | 20.110 ns | 0.92x |
| fixture GEOSITE | 154.42 ns | 158.62 ns | 0.97x |
| fixture GEOIP | 99.421 ns | 102.94 ns | 0.97x |
| fixture MATCH fallthrough | 1.9725 us | 1.9508 us | 1.01x |
| 10k late DOMAIN-SUFFIX hit | 27.031 us | 27.410 us | 0.99x |
| 10k full fallthrough | 31.038 us | 33.717 us | 0.92x |
| 10k DOMAIN-WILDCARD miss | n/a | 30.952 us | 2.51x vs best baseline |

The regex-prefilter pass is targeted at regex-heavy wildcard misses. It adds a clear win on that shape while keeping the broader 10k suffix/fallthrough cases materially faster than both baselines.

## Memory Footprint Results

Footprint command:

```bash
cargo test -p meow-tunnel --test rule_ir_footprint --release -- --ignored --nocapture
```

RSS snapshots from the fixture run:

| phase | RSS |
| --- | ---: |
| start | 2,432 KiB |
| after rules | 38,944 KiB |
| after legacy DomainIndex | 38,960 KiB |
| after CompiledRuleSet | 38,976 KiB |

Counting-allocator component deltas:

| component | allocated | deallocated | retained live | allocs | live allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| parse rules | 75,597,723 B | 68,545,516 B | 7,052,207 B | 1,381,147 | 170,358 |
| legacy DomainIndex | 1,879 B | 1,711 B | 168 B | 15 | 4 |
| CompiledRuleSet | 3,149 B | 700 B | 2,449 B | 8 | 4 |

Hot-loop allocation counts over `100000` iterations x 4 fixture cases:

| matcher | allocated | deallocated | retained live | allocs | live allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| linear | 0 B | 0 B | 0 B | 0 | 0 |
| indexed | 0 B | 0 B | 0 B | 0 | 0 |
| IR | 0 B | 0 B | 0 B | 0 | 0 |

The IR adds about 2.4 KiB retained heap for this 19-rule fixture, while preserving zero heap allocations on the match hot path.
