### PR TITLE
Fix Snell UDP response frame parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,11 @@ jobs:
           MEOW_REQUIRE_DOCKER: "1"
         run: cargo test -p meow-proxy --features hysteria2 --test hysteria2_integration -- --nocapture
 
+      - name: Snell v3 Docker integration tests
+        env:
+          MEOW_REQUIRE_DOCKER: "1"
+        run: cargo test -p meow-proxy --features snell --test snell_server_docker_integration -- --nocapture
+
       - name: v2ray-plugin integration tests
         run: cargo test --test v2ray_plugin_integration -- --nocapture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ cargo test --lib
 cargo test --test rules_test           # 78 rule matching tests
 cargo test --test trojan_integration   # embedded mock server, no external deps
 cargo test --test shadowsocks_integration  # requires ssserver (see below)
+cargo test -p meow-proxy --features snell --test snell_server_docker_integration  # requires Docker; real Snell v3 server
 bash tests/test_tproxy_qemu.sh             # Docker-based tproxy e2e tests
 
 # Install ssserver for SS integration tests
@@ -36,6 +37,93 @@ cargo test -p meow-dns --lib
 # Lint
 cargo clippy --all-targets
 ```
+
+## Manual Real-Node Smoke Tests
+
+Real-node tests are opt-in and must never run in CI. Use this flow to test any
+single outbound proxy type end-to-end through the real app path: config parser
+→ tunnel routing → listener → adapter → remote server. It applies to Snell,
+VLESS, VMess, Trojan, Hysteria2, AnyTLS, or any future outbound with a Clash
+Meta-style `proxies:` entry.
+
+Keep node secrets in environment variables or temporary files under `/tmp`; do
+not commit PSKs, UUIDs, passwords, private subscription files, or expanded
+provider nodes.
+
+### Generic single-proxy curl smoke
+
+Create a temporary one-node config under `/tmp`. Replace only the proxy block
+with the outbound being tested and keep `rules: [MATCH,<name>]` so every curl
+request must use that proxy.
+
+```bash
+cat >/tmp/meow-one-proxy.yml <<'EOF'
+mixed-port: 18080
+mode: rule
+log-level: debug
+ipv6: false
+allow-lan: false
+
+dns:
+  enable: true
+  listen: 127.0.0.1:18053
+  nameserver:
+    - 1.1.1.1
+
+proxies:
+  - name: sample
+    type: <proxy-type>
+    server: <server>
+    port: <port>
+    # Add the fields required by this proxy type, such as:
+    # password, uuid, psk, cipher, tls, servername, reality-opts,
+    # transport options, obfs options, udp, alpn, client-fingerprint.
+
+rules:
+  - MATCH,sample
+EOF
+```
+
+If the proxy type needs Cargo features, add them to both `cargo run` commands
+below.
+
+Config validation:
+
+```bash
+cargo run -p meow-app -- -f /tmp/meow-one-proxy.yml -t
+```
+
+Start meow:
+
+```bash
+RUST_LOG=meow=debug,meow_config=debug,meow_proxy=debug,meow_tunnel=debug \
+cargo run -p meow-app -- -f /tmp/meow-one-proxy.yml
+```
+
+Default HTTPS curl:
+
+```bash
+curl -fsS --max-time 30 \
+  --proxy socks5h://127.0.0.1:18080 \
+  https://www.gstatic.com/generate_204 \
+  -o /tmp/meow-generate-204.out \
+  -w 'http_code=%{http_code} http_version=%{http_version} time_total=%{time_total}\n'
+```
+
+HTTP/1.1 comparison:
+
+```bash
+curl -fsS --http1.1 --max-time 30 \
+  --proxy socks5h://127.0.0.1:18080 \
+  https://www.gstatic.com/generate_204 \
+  -o /tmp/meow-generate-204-http11.out \
+  -w 'http_code=%{http_code} http_version=%{http_version} time_total=%{time_total}\n'
+```
+
+Expected result: both curl commands return `http_code=204`. Default curl may
+report `http_version=2` when local curl and the target negotiate HTTP/2; keep
+the `--http1.1` comparison because some transport bugs only show up on one of
+the two HTTPS paths.
 
 ## Architecture
 

--- a/crates/meow-proxy/src/snell/udp.rs
+++ b/crates/meow-proxy/src/snell/udp.rs
@@ -53,22 +53,47 @@ async fn read_response_frame<R: AsyncRead + Unpin>(
     reader: &mut R,
     out: &mut [u8],
 ) -> io::Result<(usize, SocketAddr)> {
-    let mut family = [0u8; 1];
-    reader.read_exact(&mut family).await?;
-    let addr = match family[0] {
+    let mut frame = vec![0u8; super::v4::MAX_PAYLOAD_LENGTH];
+    let n = reader.read(&mut frame).await?;
+    if n < 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "snell udp: empty response frame",
+        ));
+    }
+    frame.truncate(n);
+
+    let (addr, payload_start) = match frame[0] {
         0x04 => {
-            let mut ip = [0u8; 4];
-            reader.read_exact(&mut ip).await?;
-            let mut port = [0u8; 2];
-            reader.read_exact(&mut port).await?;
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::from(ip)), u16::from_be_bytes(port))
+            const HEAD_LEN: usize = 1 + 4 + 2;
+            if frame.len() < HEAD_LEN {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "snell udp: short IPv4 response frame",
+                ));
+            }
+            let ip = [frame[1], frame[2], frame[3], frame[4]];
+            let port = [frame[5], frame[6]];
+            (
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::from(ip)), u16::from_be_bytes(port)),
+                HEAD_LEN,
+            )
         }
         0x06 => {
+            const HEAD_LEN: usize = 1 + 16 + 2;
+            if frame.len() < HEAD_LEN {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "snell udp: short IPv6 response frame",
+                ));
+            }
             let mut ip = [0u8; 16];
-            reader.read_exact(&mut ip).await?;
-            let mut port = [0u8; 2];
-            reader.read_exact(&mut port).await?;
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::from(ip)), u16::from_be_bytes(port))
+            ip.copy_from_slice(&frame[1..17]);
+            let port = [frame[17], frame[18]];
+            (
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::from(ip)), u16::from_be_bytes(port)),
+                HEAD_LEN,
+            )
         }
         other => {
             return Err(io::Error::new(
@@ -77,20 +102,11 @@ async fn read_response_frame<R: AsyncRead + Unpin>(
             ));
         }
     };
-    // The remainder of the snell frame is the payload. The v4 codec already
-    // re-assembles a frame's payload into a contiguous read, but the snell
-    // AEAD frame is sized to hold exactly one datagram, so a single
-    // `read` returns the entire payload. Pull until we observe the end.
-    //
-    // We can't know the payload length from the snell frame header alone
-    // (it's been consumed by the v4 codec). Instead we keep reading into
-    // `out` until the next read would block — but we have no zero-frame
-    // sentinel here. opensnell's PacketConn.ReadFrom does a single Read
-    // call and relies on the snell frame == one datagram invariant. We do
-    // the same: one `read` gives us the payload up to `out.len()`, and any
-    // extra is dropped (datagram-truncation semantics matching net.UDPConn).
-    let n = reader.read(out).await?;
-    Ok((n, addr))
+
+    let payload = &frame[payload_start..];
+    let copied = payload.len().min(out.len());
+    out[..copied].copy_from_slice(&payload[..copied]);
+    Ok((copied, addr))
 }
 
 /// Per-connection snell UDP relay. Multiplexes datagrams over a single AEAD

--- a/crates/meow-proxy/tests/snell_server_docker_integration.rs
+++ b/crates/meow-proxy/tests/snell_server_docker_integration.rs
@@ -1,0 +1,310 @@
+#![cfg(feature = "snell")]
+
+use meow_common::{Metadata, Network, ProxyAdapter, ProxyPacketConn};
+use meow_proxy::{SnellAdapter, SnellObfs, SnellVersion};
+use std::fs::File;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, UdpSocket};
+use tokio::time::{sleep, timeout, Duration, Instant};
+
+const IMAGE_SNELL_V3: &str = "geekdada/snell-server:3.0.1";
+const PSK: &str = "meow-snell-docker-psk";
+const T: Duration = Duration::from_secs(30);
+
+fn docker_required() -> bool {
+    std::env::var_os("MEOW_REQUIRE_DOCKER").is_some()
+        || std::env::var_os("MIHOMO_REQUIRE_INTEGRATION_BINS").is_some()
+}
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("info")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+fn skip_or_panic(reason: impl AsRef<str>) -> bool {
+    let reason = reason.as_ref();
+    if docker_required() {
+        panic!("{reason}");
+    }
+    eprintln!("skipping snell docker integration test: {reason}");
+    false
+}
+
+fn free_tcp_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+struct SnellServer {
+    _dir: TempDir,
+    child: std::process::Child,
+    log_path: PathBuf,
+}
+
+impl SnellServer {
+    fn logs(&self) -> String {
+        std::fs::read_to_string(&self.log_path).unwrap_or_default()
+    }
+}
+
+impl Drop for SnellServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn ensure_snell_binary(dir: &Path) -> Option<PathBuf> {
+    let bin = dir.join("snell-server");
+    if bin.exists() {
+        return Some(bin);
+    }
+
+    let pull = Command::new("docker")
+        .args(["pull", IMAGE_SNELL_V3])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    if pull.is_err() || !pull.unwrap_or_default().success() {
+        return None;
+    }
+
+    let extract_name = format!("meow-snell-v3-extract-{}", std::process::id());
+    let _ = Command::new("docker")
+        .args(["rm", "-f", &extract_name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    let create = Command::new("docker")
+        .args(["create", "--name", &extract_name, IMAGE_SNELL_V3])
+        .output()
+        .ok()?;
+    if !create.status.success() {
+        return None;
+    }
+
+    let copy = Command::new("docker")
+        .args([
+            "cp",
+            &format!("{extract_name}:/usr/bin/snell-server"),
+            &bin.to_string_lossy(),
+        ])
+        .output()
+        .ok()?;
+    let _ = Command::new("docker")
+        .args(["rm", "-f", &extract_name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    if !copy.status.success() {
+        return None;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(&bin) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o755);
+            let _ = std::fs::set_permissions(&bin, perms);
+        }
+    }
+    Some(bin)
+}
+
+fn write_server_config(dir: &Path, port: u16) -> PathBuf {
+    let config_path = dir.join("snell-server.conf");
+    let config = format!(
+        concat!(
+            "[snell-server]\n",
+            "listen = 127.0.0.1:{port}\n",
+            "psk = {psk}\n",
+            "obfs = off\n",
+        ),
+        port = port,
+        psk = PSK,
+    );
+    std::fs::write(&config_path, config).unwrap();
+    config_path
+}
+
+fn start_snell_server(port: u16) -> Option<SnellServer> {
+    if !cfg!(target_os = "linux") {
+        skip_or_panic("test requires Linux snell-server binary from Docker image");
+        return None;
+    }
+    if !docker_available() {
+        skip_or_panic("docker daemon is not available");
+        return None;
+    }
+
+    let dir = TempDir::new().unwrap();
+    let Some(snell_bin) = ensure_snell_binary(dir.path()) else {
+        skip_or_panic(format!(
+            "failed to extract snell-server from {IMAGE_SNELL_V3}"
+        ));
+        return None;
+    };
+    let config_path = write_server_config(dir.path(), port);
+    let log_path = dir.path().join("server.log");
+    let log_file = match File::create(&log_path) {
+        Ok(file) => file,
+        Err(e) => {
+            skip_or_panic(format!("failed to create snell-server log file: {e}"));
+            return None;
+        }
+    };
+    let stdout = log_file.try_clone().map_or(Stdio::null(), Stdio::from);
+    let child = match Command::new(&snell_bin)
+        .args(["-c", &config_path.to_string_lossy()])
+        .stdout(stdout)
+        .stderr(Stdio::from(log_file))
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => {
+            skip_or_panic(format!("failed to start snell-server process: {e}"));
+            return None;
+        }
+    };
+
+    Some(SnellServer {
+        _dir: dir,
+        child,
+        log_path,
+    })
+}
+
+async fn start_tcp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    let n = match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => n,
+                    };
+                    if stream.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    (addr, handle)
+}
+
+async fn start_udp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = socket.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let mut buf = [0u8; 4096];
+        while let Ok((n, peer)) = socket.recv_from(&mut buf).await {
+            let _ = socket.send_to(&buf[..n], peer).await;
+        }
+    });
+    (addr, handle)
+}
+
+fn adapter(port: u16) -> SnellAdapter {
+    SnellAdapter::new(
+        "docker-snell-v3",
+        "127.0.0.1",
+        port,
+        PSK,
+        SnellObfs::None,
+        SnellVersion::V3,
+        true,
+        false,
+    )
+    .expect("snell adapter must build")
+}
+
+fn metadata_for(addr: SocketAddr, network: Network) -> Metadata {
+    Metadata {
+        network,
+        host: addr.ip().to_string().into(),
+        dst_port: addr.port(),
+        ..Default::default()
+    }
+}
+
+async fn dial_tcp_with_retry(
+    adapter: &SnellAdapter,
+    metadata: &Metadata,
+) -> meow_common::Result<Box<dyn meow_common::ProxyConn>> {
+    let deadline = Instant::now() + T;
+    loop {
+        match adapter.dial_tcp(metadata).await {
+            Ok(conn) => return Ok(conn),
+            Err(e) if Instant::now() >= deadline => return Err(e),
+            Err(_) => {}
+        }
+        sleep(Duration::from_millis(250)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snell_v3_docker_tcp_and_udp_round_trip() {
+    let server_port = free_tcp_port();
+    let Some(server) = start_snell_server(server_port) else {
+        return;
+    };
+    sleep(Duration::from_millis(500)).await;
+    let (tcp_echo, _tcp_h) = start_tcp_echo_server().await;
+    let (udp_echo, _udp_h) = start_udp_echo_server().await;
+    let adapter = adapter(server_port);
+
+    let tcp_metadata = metadata_for(tcp_echo, Network::Tcp);
+    let mut conn = match timeout(T, dial_tcp_with_retry(&adapter, &tcp_metadata)).await {
+        Ok(Ok(conn)) => conn,
+        Ok(Err(e)) => panic!("snell v3 TCP dial failed: {e}\n{}", server.logs()),
+        Err(_) => panic!("snell v3 TCP dial timed out\n{}", server.logs()),
+    };
+    let tcp_payload = b"meow snell docker tcp";
+    timeout(T, conn.write_all(tcp_payload))
+        .await
+        .expect("tcp write timed out")
+        .expect("tcp write failed");
+    timeout(T, conn.flush())
+        .await
+        .expect("tcp flush timed out")
+        .expect("tcp flush failed");
+    let mut tcp_buf = vec![0u8; tcp_payload.len()];
+    timeout(T, conn.read_exact(&mut tcp_buf))
+        .await
+        .expect("tcp read timed out")
+        .expect("tcp read failed");
+    assert_eq!(&tcp_buf, tcp_payload);
+
+    let udp_metadata = metadata_for(udp_echo, Network::Udp);
+    let packet_conn: Box<dyn ProxyPacketConn> = timeout(T, adapter.dial_udp(&udp_metadata))
+        .await
+        .expect("udp associate timed out")
+        .unwrap_or_else(|e| panic!("udp associate failed: {e}\n{}", server.logs()));
+    let udp_payload = b"meow snell docker udp";
+    timeout(T, packet_conn.write_packet(udp_payload, &udp_echo))
+        .await
+        .expect("udp write timed out")
+        .expect("udp write failed");
+    let mut udp_buf = [0u8; 1500];
+    let (n, src) = timeout(T, packet_conn.read_packet(&mut udp_buf))
+        .await
+        .unwrap_or_else(|_| panic!("udp read timed out\n{}", server.logs()))
+        .expect("udp read failed");
+    assert_eq!(src, udp_echo);
+    assert_eq!(&udp_buf[..n], udp_payload);
+}


### PR DESCRIPTION
## Summary

- Fix Snell UDP response parsing by reading one complete decrypted datagram frame before splitting address header and payload.
- Preserve datagram truncation semantics by copying at most the caller-provided output buffer length.
- Document the generic `/tmp` single-proxy config + app-level curl smoke flow, with Snell v3 as an example proxy block.

## Why

The previous parser read the address family/header and payload through separate `read` calls. Real Snell servers return each UDP response as one Snell frame whose decrypted body contains both the source address and payload, matching mihomo/opensnell behavior. Splitting it across reads can leave the payload unavailable to the caller and cause UDP DNS timeouts on real nodes.

## Tests

- `cargo fmt --check`
- `cargo test -p meow-proxy --features snell snell::udp --lib`
- `cargo test -p meow-proxy --features snell --test snell_integration`
- Manual real-node smoke:
  - Snell v3 TCP HTTPS curl returned `http_code=204` for default curl and `--http1.1`.
  - Snell v3 UDP DNS returned a response from `1.1.1.1:53`.
  - Snell v4 TCP HTTPS curl returned `http_code=204` for default curl and `--http1.1`.
  - Snell v4 UDP DNS returned a response from `1.1.1.1:53`.
