### PR TITLE
fix(socks5): reverse-map fake-IP to host before rule matching on TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ name = "meow-listener"
 version = "0.14.0"
 dependencies = [
  "base64",
+ "ipnet",
  "libc",
  "meow-common",
  "meow-dns",

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -981,6 +981,15 @@ impl Resolver {
     pub fn clear_cache(&self) {
         self.cache.clear();
     }
+
+    /// Seed the positive-resolution cache directly with a known mapping.
+    ///
+    /// Production lookups populate the cache from upstream queries; this is for
+    /// preloading known answers (and for tests) without a round-trip. Mirrors
+    /// the bound used by ordinary cached entries via `ttl`.
+    pub fn preload_cache(&self, host: &str, ips: &[IpAddr], ttl: std::time::Duration) {
+        self.cache.put(host, ips, ttl);
+    }
 }
 
 #[cfg(test)]

--- a/crates/meow-listener/Cargo.toml
+++ b/crates/meow-listener/Cargo.toml
@@ -25,6 +25,7 @@ smallvec = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 meow-dns = { workspace = true }
 meow-trie = { workspace = true }
+ipnet = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/meow-listener/src/socks5.rs
+++ b/crates/meow-listener/src/socks5.rs
@@ -201,6 +201,17 @@ async fn handle_socks5_inner(
     debug!("SOCKS5 CONNECT to {}", metadata.remote_address());
 
     let inner = tunnel.inner();
+
+    // Fake-IP → host rewrite (no-op outside fake-IP mode aside from the
+    // snooping-cache hostname fill-in), then resolve host → real IP for any
+    // IP-based rules. Without this, a fake-IP TCP flow reaches `resolve_proxy`
+    // still carrying the 28.x/198.18.x placeholder, matches no DOMAIN/GEOSITE/
+    // GEOIP rule, and falls through to MATCH()/final — so domain rules are
+    // silently bypassed for TCP under fake-IP. Mirrors `handle_tcp`
+    // (meow-tunnel/src/tcp.rs) and the UDP ASSOCIATE path (socks5_udp.rs).
+    inner.pre_handle_metadata(&mut metadata);
+    inner.pre_resolve(&mut metadata).await;
+
     let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy(&metadata) else {
         return Err("no matching rule".into());
     };

--- a/crates/meow-listener/tests/common/mod.rs
+++ b/crates/meow-listener/tests/common/mod.rs
@@ -25,6 +25,38 @@ pub fn direct_tunnel() -> Tunnel {
     tunnel
 }
 
+/// Build a `Tunnel` in fake-IP mode, synthesise a fake IP for `host`, and seed
+/// the resolver cache so `host` resolves back to `real_ip` on the dial path.
+///
+/// Returns `(tunnel, fake_ip)`. A SOCKS5 client that CONNECTs to `fake_ip`
+/// should reach `real_ip` **iff** the listener reverse-maps the fake IP to
+/// `host` before dialing (see `pre_handle_metadata`). Direct mode keeps rule
+/// matching out of the picture so the test isolates the reverse-map step.
+pub async fn fakeip_tunnel(host: &str, real_ip: std::net::IpAddr) -> (Tunnel, std::net::IpAddr) {
+    use ipnet::IpNet;
+    use meow_dns::fakeip::{MemoryStore, Pool};
+    use std::time::Duration;
+
+    let mut resolver = Resolver::new(vec![], vec![], DnsMode::FakeIp, DomainTrie::new(), true);
+    let net = "198.18.0.0/16".parse::<IpNet>().unwrap();
+    resolver.set_fakeip_v4(Arc::new(
+        Pool::new(net, Arc::new(MemoryStore::new(1024))).unwrap(),
+    ));
+    let resolver = Arc::new(resolver);
+
+    // Synthesise the fake IP first (cache empty for `host`), which records the
+    // fake-IP → host reverse mapping the listener will later recover.
+    let fake = resolver.lookup_ipv4(host).await.unwrap();
+    assert!(resolver.is_fake_ip(fake), "expected a fake IP, got {fake}");
+
+    // Then seed the forward cache so the reverse-mapped host dials `real_ip`.
+    resolver.preload_cache(host, &[real_ip], Duration::from_secs(300));
+
+    let tunnel = Tunnel::new(resolver);
+    tunnel.set_mode(meow_common::TunnelMode::Direct);
+    (tunnel, fake)
+}
+
 /// Spawn a local echo server that accepts one connection, echoes all bytes
 /// back, then exits.  Returns the bound `SocketAddr`.
 pub async fn spawn_echo_server() -> std::net::SocketAddr {

--- a/crates/meow-listener/tests/socks5_fakeip.rs
+++ b/crates/meow-listener/tests/socks5_fakeip.rs
@@ -1,0 +1,105 @@
+//! Regression test: a SOCKS5 CONNECT to a fake IP must be reverse-mapped to
+//! its hostname before dialing.
+//!
+//! On iOS the tun2socks bridge forwards captured TCP flows to the local SOCKS5
+//! listener using the fake IP (28.x / 198.18.x) as the target — the only thing
+//! it knows. `handle_socks5_inner` must call `pre_handle_metadata` to recover
+//! the real hostname from the fake-IP reverse map before rule matching and
+//! dialing; otherwise the flow dials the dead fake IP (and rule matching sees
+//! the placeholder, so every fake-IP'd domain falls through to MATCH()/final).
+//!
+//! The fixture seeds the resolver cache so the recovered hostname resolves to a
+//! local echo server. The echo round-trip succeeds only when the reverse-map
+//! ran; without it the relay dials the fake IP and no bytes come back.
+#![cfg(feature = "listener-socks5")]
+
+mod common;
+
+use common::{fakeip_tunnel, spawn_echo_server};
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+async fn loopback_pair() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (accept_res, connect_res) = tokio::join!(listener.accept(), TcpStream::connect(addr));
+    (accept_res.unwrap().0, connect_res.unwrap())
+}
+
+/// SOCKS5 greeting + CONNECT to an IPv4 target (RFC 1928).
+fn socks5_connect_ipv4(target: SocketAddr) -> Vec<u8> {
+    let std::net::IpAddr::V4(ip4) = target.ip() else {
+        panic!("expected IPv4 target");
+    };
+    let mut buf = vec![0x05, 0x01, 0x00, 0x05, 0x01, 0x00, 0x01];
+    buf.extend_from_slice(&ip4.octets());
+    buf.extend_from_slice(&target.port().to_be_bytes());
+    buf
+}
+
+#[tokio::test]
+async fn socks5_connect_to_fake_ip_reverse_maps_and_dials_real_host() {
+    // Echo server is what "example.test" really resolves to.
+    let echo_addr = spawn_echo_server().await;
+
+    // Fake-IP tunnel: example.test → <fake>, and the cache maps it back to the
+    // echo server's IP for the dial. Direct mode isolates the reverse-map step.
+    let (tunnel, fake_ip) = fakeip_tunnel("example.test", echo_addr.ip()).await;
+    assert_ne!(
+        fake_ip,
+        echo_addr.ip(),
+        "fake IP must differ from the real target"
+    );
+
+    let (server_stream, mut client_stream) = loopback_pair().await;
+    let listener_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let handle = tokio::spawn(async move {
+        meow_listener::socks5::handle_socks5(
+            &tunnel,
+            server_stream,
+            listener_addr,
+            None, // no sniffer — force the reverse-map path, not SNI/Host recovery
+            None, // no auth
+            "test",
+            0,
+        )
+        .await;
+    });
+
+    // CONNECT to the FAKE IP, but the echo server's port. The listener must
+    // recover example.test and dial echo_addr.ip():port.
+    let target = SocketAddr::new(fake_ip, echo_addr.port());
+    client_stream
+        .write_all(&socks5_connect_ipv4(target))
+        .await
+        .unwrap();
+
+    let mut reply = [0u8; 12];
+    client_stream.read_exact(&mut reply).await.unwrap();
+    assert_eq!(reply[0], 0x05, "greeting reply version");
+    assert_eq!(reply[1], 0x00, "NoAuth chosen");
+    assert_eq!(reply[3], 0x00, "CONNECT must succeed (REP_SUCCESS)");
+
+    // The relay is up only if the dial reached the echo server. Without the
+    // reverse-map the relay would have dialed the dead fake IP and this
+    // round-trip would hang (and the timeout below would fire).
+    let probe = b"fakeip-revmap";
+    client_stream.write_all(probe).await.unwrap();
+    let mut echo_buf = [0u8; 13];
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        client_stream.read_exact(&mut echo_buf),
+    )
+    .await
+    .expect("echo timed out — fake IP was not reverse-mapped to the real host")
+    .expect("echo read failed");
+    assert_eq!(
+        &echo_buf, probe,
+        "relay did not forward bytes to echo server"
+    );
+
+    drop(client_stream);
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+}


### PR DESCRIPTION
## What

`handle_socks5_inner` matched rules and dialed straight off the metadata without calling `pre_handle_metadata` / `pre_resolve` — unlike the canonical TCP handler (`meow-tunnel/src/tcp.rs:59`) and the UDP ASSOCIATE path (`socks5_udp.rs:129`).

On iOS, tun2socks forwards captured TCP flows to this listener using the **fake IP** (`28.x` / `198.18.x`) as the target. So every fake-IP'd flow reached `resolve_proxy` still carrying the placeholder:
- it matched no `DOMAIN`/`GEOSITE`/`GEOIP` rule and fell through to `MATCH()` → final (domain rules silently bypassed for TCP under fake-IP);
- when SNI/Host sniffing didn't recover a host, the relay dialed the dead fake IP — surfacing as `relay error: unexpected end of file`.

## Fix
Call `pre_handle_metadata` (fake-IP → real domain, clears `dst_ip`) and `pre_resolve` (domain → real IP for IP-based rules) before `resolve_proxy`, mirroring `tcp.rs` and `socks5_udp.rs`. No-op for non-fake-IP SOCKS5 clients.

## Test
`tests/socks5_fakeip.rs` — a SOCKS5 CONNECT to a fake IP echoes back only when reverse-mapped to the real host. Verified **red without the fix** (echo times out) and **green with it**. Adds `Resolver::preload_cache` to seed the dial resolution.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p meow-listener -p meow-dns -p meow-tunnel --all-targets -- -D warnings` — clean
- `cargo test -p meow-listener -p meow-dns` — all pass (dns 101 + integration; listener 31 + new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
