### PR TITLE
Release v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64",
  "ipnet",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"


### PR DESCRIPTION
Bump workspace version 0.14.0 → 0.15.0.

Touches `Cargo.toml` (`[workspace.package].version`) and `Cargo.lock` (12 workspace crates). No source changes.

Regression bar passed locally: fmt, clippy (default / no-default-features / all-features, `-D warnings`), `cargo doc -D warnings`, `cargo test --lib`.

Tagging `v0.15.0` after merge triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)