### PR TITLE
Limit delay probe concurrency

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -22,7 +22,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
-use tokio::task::JoinSet;
 use tower_http::cors::CorsLayer;
 use tracing::{debug, info};
 
@@ -1096,40 +1095,32 @@ async fn get_group_delay(
         .collect();
     drop(route);
 
-    let url_shared = Arc::new(url);
-    let expected_shared = Arc::new(expected);
-    let mut set: JoinSet<(String, u16)> = JoinSet::new();
-    for (member_name, proxy) in members {
-        let url = Arc::clone(&url_shared);
-        let expected = Arc::clone(&expected_shared);
-        set.spawn(async move {
-            // Per-member errors collapse to 0 in the map — upstream uses the
-            // same sentinel for both timeout and transport-error inside the
-            // group result body.
-            let delay = probe_and_record(&proxy, &url, expected.as_deref(), timeout)
-                .await
-                .unwrap_or(0);
-            (member_name, delay)
-        });
-    }
-
-    // upstream: group probe wraps the whole JoinSet in one context.WithTimeout,
+    // upstream: group probe wraps the whole batch in one context.WithTimeout,
     // not per-member. A slow member does not get its own budget.
-    let mut result: BTreeMap<String, u16> = BTreeMap::new();
-    let collected = tokio::time::timeout(timeout, async {
-        while let Some(join) = set.join_next().await {
-            if let Ok((member_name, delay)) = join {
-                result.insert(member_name, delay);
-            }
-        }
-    })
+    let collected = tokio::time::timeout(
+        timeout,
+        meow_proxy::health::probe_many_bounded_detailed(
+            members,
+            &url,
+            expected.as_deref(),
+            timeout,
+            meow_proxy::health::GROUP_DELAY_CONCURRENCY,
+        ),
+    )
     .await;
 
-    if collected.is_err() {
+    let Ok(pairs) = collected else {
         // upstream: 504 "Timeout". Even if some members completed before the
         // deadline, upstream still returns the timeout error — we match.
-        set.abort_all();
         return msg_err(StatusCode::GATEWAY_TIMEOUT, "Timeout");
+    };
+
+    let mut result: BTreeMap<String, u16> = BTreeMap::new();
+    for pair in pairs {
+        if matches!(pair.error, Some(meow_proxy::health::UrlTestError::Timeout)) {
+            return msg_err(StatusCode::GATEWAY_TIMEOUT, "Timeout");
+        }
+        result.insert(pair.name, pair.delay);
     }
     Json(result).into_response()
 }
@@ -1589,23 +1580,22 @@ async fn provider_healthcheck(
         None => return msg_err(StatusCode::NOT_FOUND, "resource not found"),
     };
 
-    let members = provider.proxies();
-    let url_shared = Arc::new(url);
-    let expected_shared = Arc::new(expected);
-    let mut set: JoinSet<(String, u16)> = JoinSet::new();
-    for proxy in members {
-        let url = Arc::clone(&url_shared);
-        let expected = Arc::clone(&expected_shared);
-        set.spawn(async move {
-            let delay = probe_and_record(&proxy, &url, expected.as_deref(), timeout)
-                .await
-                .unwrap_or(0);
-            (proxy.name().to_string(), delay)
-        });
-    }
+    let members = provider
+        .proxies()
+        .into_iter()
+        .map(|proxy| (proxy.name().to_string(), proxy))
+        .collect();
 
     let mut results = serde_json::Map::new();
-    while let Some(Ok((pname, delay))) = set.join_next().await {
+    for (pname, delay) in meow_proxy::health::probe_many_bounded(
+        members,
+        &url,
+        expected.as_deref(),
+        timeout,
+        meow_proxy::health::PROVIDER_HEALTHCHECK_CONCURRENCY,
+    )
+    .await
+    {
         results.insert(pname, serde_json::Value::Number(delay.into()));
     }
 

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -1983,6 +1983,49 @@ async fn e1_group_delay_dials_all_members_concurrently() {
 }
 
 #[tokio::test]
+async fn e1b_group_delay_limits_large_group_inflight_probes() {
+    // 17 members with the production group limit of 16. The first 16 may
+    // start immediately, but the final member must wait for an earlier probe
+    // to finish instead of creating an unbounded burst.
+    let mut starts_vec = Vec::new();
+    let mut members: Vec<Arc<dyn meow_common::Proxy>> = Vec::new();
+    let mut named: Vec<(&str, Arc<dyn meow_common::Proxy>)> = Vec::new();
+    let names: Vec<String> = (0..17).map(|i| format!("P{i:02}")).collect();
+
+    for name in &names {
+        let adapter = TestAdapter::new(
+            name,
+            DialBehavior::SleepThenOk(std::time::Duration::from_millis(120)),
+        );
+        starts_vec.push(Arc::clone(&adapter.dial_starts));
+        let p = adapter.into_proxy();
+        members.push(Arc::clone(&p));
+        named.push((name.as_str(), p));
+    }
+
+    let group = fallback_group("G", members);
+    named.push(("G", group));
+    let state = state_with_proxies(named);
+    let app = create_router(state);
+    let resp = delay_req(app, format!("/group/G/delay?url={}&timeout=1000", url_q())).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut first_starts: Vec<std::time::Instant> = starts_vec
+        .iter()
+        .map(|s| *s.lock().unwrap().first().expect("each member dialed once"))
+        .collect();
+    first_starts.sort();
+    let spread = first_starts
+        .last()
+        .unwrap()
+        .duration_since(*first_starts.first().unwrap());
+    assert!(
+        spread >= std::time::Duration::from_millis(80),
+        "17th dial should wait behind the 16-probe group limit, spread was {spread:?}"
+    );
+}
+
+#[tokio::test]
 async fn e2_group_delay_total_walltime_bounded_by_timeout() {
     // 3 instant-ok members with a generous budget; total wall time should
     // be well under 100ms. Guards against accidental serial dispatch (which

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -64,21 +64,17 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
             .collect();
         drop(route);
 
-        let url = spec.url.clone();
-        let mut set: tokio::task::JoinSet<(String, u16)> = tokio::task::JoinSet::new();
-        for (name, proxy) in members {
-            let url = url.clone();
-            set.spawn(async move {
-                let delay = meow_proxy::health::probe_and_record(&proxy, &url, None, PROBE_TIMEOUT)
-                    .await
-                    .unwrap_or(0);
-                (name, delay)
-            });
-        }
-
         let mut alive_count = 0u32;
         let mut total_count = 0u32;
-        while let Some(Ok((name, delay))) = set.join_next().await {
+        for (name, delay) in meow_proxy::health::probe_many_bounded(
+            members,
+            &spec.url,
+            None,
+            PROBE_TIMEOUT,
+            meow_proxy::health::PROVIDER_HEALTHCHECK_CONCURRENCY,
+        )
+        .await
+        {
             total_count += 1;
             if delay > 0 {
                 alive_count += 1;

--- a/crates/meow-proxy/src/health.rs
+++ b/crates/meow-proxy/src/health.rs
@@ -1,11 +1,24 @@
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use meow_common::{Proxy, ProxyAdapter};
 use smol_str::SmolStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Semaphore;
 use tracing::{debug, trace, warn};
 
 pub use meow_common::ProxyHealth;
+
+pub const GROUP_DELAY_CONCURRENCY: usize = 16;
+pub const PROVIDER_HEALTHCHECK_CONCURRENCY: usize = 10;
+pub const GLOBAL_DELAY_PROBE_CONCURRENCY: usize = 32;
+
+#[derive(Debug)]
+pub struct NamedProbeResult {
+    pub name: String,
+    pub delay: u16,
+    pub error: Option<UrlTestError>,
+}
 
 /// Outcome of a single [`url_test`] probe. Callers distinguish transport
 /// failure from deadline expiry to pick the right HTTP status code
@@ -81,6 +94,10 @@ pub async fn probe_and_record(
     expected: Option<&str>,
     timeout: Duration,
 ) -> Result<u16, UrlTestError> {
+    let _permit = global_delay_probe_limiter()
+        .acquire()
+        .await
+        .expect("global delay probe semaphore is never closed");
     let adapter: &dyn ProxyAdapter = proxy.as_ref();
     let result = url_test(adapter, url, expected, timeout).await;
     match &result {
@@ -88,6 +105,92 @@ pub async fn probe_and_record(
         Err(_) => proxy.health().record_delay(0),
     }
     result
+}
+
+pub async fn probe_many_bounded(
+    probes: Vec<(String, Arc<dyn Proxy + 'static>)>,
+    url: &str,
+    expected: Option<&str>,
+    timeout: Duration,
+    concurrency: usize,
+) -> Vec<(String, u16)> {
+    probe_many_bounded_detailed(probes, url, expected, timeout, concurrency)
+        .await
+        .into_iter()
+        .map(|result| (result.name, result.delay))
+        .collect()
+}
+
+pub async fn probe_many_bounded_detailed(
+    probes: Vec<(String, Arc<dyn Proxy + 'static>)>,
+    url: &str,
+    expected: Option<&str>,
+    timeout: Duration,
+    concurrency: usize,
+) -> Vec<NamedProbeResult> {
+    let url = Arc::<str>::from(url.to_owned());
+    let expected = expected.map(|s| Arc::<str>::from(s.to_owned()));
+    let concurrency = concurrency.max(1);
+
+    let mut probes = probes.into_iter();
+    let mut pending = FuturesUnordered::new();
+    for _ in 0..concurrency {
+        let Some((name, proxy)) = probes.next() else {
+            break;
+        };
+        pending.push(named_probe_future(
+            name,
+            proxy,
+            Arc::clone(&url),
+            expected.clone(),
+            timeout,
+        ));
+    }
+
+    let mut results = Vec::new();
+    while let Some(result) = pending.next().await {
+        results.push(result);
+        if let Some((name, proxy)) = probes.next() {
+            pending.push(named_probe_future(
+                name,
+                proxy,
+                Arc::clone(&url),
+                expected.clone(),
+                timeout,
+            ));
+        }
+    }
+
+    results
+}
+
+fn named_probe_future(
+    name: String,
+    proxy: Arc<dyn Proxy + 'static>,
+    url: Arc<str>,
+    expected: Option<Arc<str>>,
+    timeout: Duration,
+) -> BoxFuture<'static, NamedProbeResult> {
+    async move {
+        match probe_and_record(&proxy, url.as_ref(), expected.as_deref(), timeout).await {
+            Ok(delay) => NamedProbeResult {
+                name,
+                delay,
+                error: None,
+            },
+            Err(error) => NamedProbeResult {
+                name,
+                delay: 0,
+                error: Some(error),
+            },
+        }
+    }
+    .boxed()
+}
+
+fn global_delay_probe_limiter() -> &'static Semaphore {
+    static LIMITER: std::sync::OnceLock<Semaphore> = std::sync::OnceLock::new();
+    LIMITER.get_or_init(|| Semaphore::new(GLOBAL_DELAY_PROBE_CONCURRENCY))
 }
 
 async fn probe_once(


### PR DESCRIPTION
## Summary
- add bounded batch delay probing with GROUP_DELAY_CONCURRENCY=16, PROVIDER_HEALTHCHECK_CONCURRENCY=10, and GLOBAL_DELAY_PROBE_CONCURRENCY=32
- apply bounded probing to group delay, provider healthcheck, and background health checks
- preserve group timeout semantics and add coverage for the 16-probe group limit

## Tests
- cargo check -p meow-app -p meow-api -p meow-proxy
- cargo test -p meow-api delay -- --nocapture
- cargo test -p meow-app health -- --nocapture
- cargo test -p meow-proxy health -- --nocapture