### PR TITLE
[codex] support MetaCube rules and async runtime paths

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -8,7 +8,7 @@ use axum::{
     Router,
 };
 use dashmap::DashMap;
-use meow_common::TunnelMode;
+use meow_common::{Proxy, TunnelMode};
 use meow_config::{
     proxy_provider::ProxyProvider,
     raw::{RawConfig, RawProxyGroup, RawSubscription},
@@ -24,7 +24,7 @@ use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio::task::JoinSet;
 use tower_http::cors::CorsLayer;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::log_stream::{parse_log_level, LogMessage};
 use crate::ui;
@@ -319,21 +319,22 @@ async fn update_proxy(
     Path(group_name): Path<String>,
     Json(body): Json<UpdateProxyRequest>,
 ) -> StatusCode {
-    use meow_proxy::SelectorGroup;
     let route = state.tunnel.route_snapshot();
-    if let Some(proxy) = route.proxies.get(group_name.as_str()) {
-        if let Some(selector) = proxy
-            .as_any()
-            .and_then(|a| a.downcast_ref::<SelectorGroup>())
-        {
-            if selector.select(&body.name) {
-                info!("Selector '{}' switched to '{}'", group_name, body.name);
-                return StatusCode::NO_CONTENT;
-            }
-            return StatusCode::BAD_REQUEST;
+    let Some(proxy) = route.proxies.get(group_name.as_str()).cloned() else {
+        return StatusCode::NOT_FOUND;
+    };
+    match select_proxy_member_async(proxy, body.name.clone()).await {
+        Ok(Some(true)) => {
+            info!("Selector '{}' switched to '{}'", group_name, body.name);
+            StatusCode::NO_CONTENT
+        }
+        Ok(Some(false)) => StatusCode::BAD_REQUEST,
+        Ok(None) => StatusCode::NOT_FOUND,
+        Err(e) => {
+            warn!("Selector '{}' update task failed: {}", group_name, e);
+            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
-    StatusCode::NOT_FOUND
 }
 
 #[derive(Serialize)]
@@ -524,7 +525,8 @@ async fn save_config(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let raw = state.raw_config.read().clone();
-    meow_config::save_raw_config(&state.config_path, &raw)
+    meow_config::save_raw_config_async(&state.config_path, &raw)
+        .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(Json(serde_json::json!({"message": "config saved"})))
 }
@@ -542,12 +544,38 @@ async fn apply_raw_to_tunnel(
     if let Some(ps) = raw.proxies.as_mut() {
         meow_config::ech_dns::preresolve_ech(ps).await;
     }
-    let (proxies, rules) =
-        meow_config::rebuild_from_raw_with_resolver(&raw, Some(Arc::clone(tunnel.resolver())))
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let (proxies, rules) = rebuild_from_raw_with_resolver_async(raw, Arc::clone(tunnel.resolver()))
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     tunnel.update_proxies(proxies);
     tunnel.update_rules(rules);
     Ok(())
+}
+
+async fn rebuild_from_raw_with_resolver_async(
+    raw: RawConfig,
+    resolver: Arc<meow_dns::Resolver>,
+) -> Result<meow_config::RebuildResult, String> {
+    tokio::task::spawn_blocking(move || {
+        meow_config::rebuild_from_raw_with_resolver(&raw, Some(resolver))
+    })
+    .await
+    .map_err(|e| format!("config rebuild task failed: {e}"))?
+    .map_err(|e| e.to_string())
+}
+
+async fn select_proxy_member_async(
+    proxy: Arc<dyn Proxy>,
+    member: String,
+) -> Result<Option<bool>, tokio::task::JoinError> {
+    tokio::task::spawn_blocking(move || {
+        use meow_proxy::SelectorGroup;
+        proxy
+            .as_any()
+            .and_then(|a| a.downcast_ref::<SelectorGroup>())
+            .map(|selector| selector.select(&member))
+    })
+    .await
 }
 
 // ── Subscriptions ────────────────────────────────────────────────────
@@ -636,7 +664,8 @@ async fn add_subscription(
     apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
 
     // Auto-save so subscription data is cached on disk
-    let _ = meow_config::save_raw_config(&state.config_path, &state.raw_config.read());
+    let raw = state.raw_config.read().clone();
+    let _ = meow_config::save_raw_config_async(&state.config_path, &raw).await;
 
     Ok(Json(serde_json::json!({
         "message": "subscription added",
@@ -669,7 +698,8 @@ async fn delete_subscription(
         raw.clone()
     };
     apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
-    let _ = meow_config::save_raw_config(&state.config_path, &state.raw_config.read());
+    let raw = state.raw_config.read().clone();
+    let _ = meow_config::save_raw_config_async(&state.config_path, &raw).await;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -717,7 +747,8 @@ async fn refresh_subscription(
     apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
 
     // Auto-save so subscription data is cached on disk
-    let _ = meow_config::save_raw_config(&state.config_path, &state.raw_config.read());
+    let raw = state.raw_config.read().clone();
+    let _ = meow_config::save_raw_config_async(&state.config_path, &raw).await;
 
     Ok(Json(serde_json::json!({
         "message": "subscription refreshed",
@@ -748,17 +779,15 @@ async fn get_proxy_groups(State(state): State<Arc<AppState>>) -> Json<Vec<ProxyG
     let result: Vec<ProxyGroupInfo> = groups
         .iter()
         .map(|g| {
-            use meow_proxy::SelectorGroup;
-            let now = tunnel_proxies
-                .get(g.name.as_str())
-                .and_then(|p| p.as_any())
-                .and_then(|a| a.downcast_ref::<SelectorGroup>())
-                .and_then(meow_proxy::SelectorGroup::selected_proxy)
-                .map(|p| p.name().to_string());
+            let runtime = tunnel_proxies.get(g.name.as_str());
+            let now = runtime.and_then(|p| p.current());
+            let proxies = runtime
+                .and_then(|p| p.members())
+                .unwrap_or_else(|| g.proxies.clone().unwrap_or_default());
             ProxyGroupInfo {
                 name: g.name.clone(),
                 group_type: g.group_type.clone(),
-                proxies: g.proxies.clone().unwrap_or_default(),
+                proxies,
                 now,
                 url: g.url.clone(),
                 interval: g.interval,
@@ -870,21 +899,22 @@ async fn select_proxy_in_group(
     Path(group_name): Path<String>,
     Json(body): Json<SelectProxyRequest>,
 ) -> StatusCode {
-    use meow_proxy::SelectorGroup;
     let route = state.tunnel.route_snapshot();
-    if let Some(proxy) = route.proxies.get(group_name.as_str()) {
-        if let Some(selector) = proxy
-            .as_any()
-            .and_then(|a| a.downcast_ref::<SelectorGroup>())
-        {
-            if selector.select(&body.name) {
-                info!("Selector '{}' switched to '{}'", group_name, body.name);
-                return StatusCode::NO_CONTENT;
-            }
-            return StatusCode::BAD_REQUEST;
+    let Some(proxy) = route.proxies.get(group_name.as_str()).cloned() else {
+        return StatusCode::NOT_FOUND;
+    };
+    match select_proxy_member_async(proxy, body.name.clone()).await {
+        Ok(Some(true)) => {
+            info!("Selector '{}' switched to '{}'", group_name, body.name);
+            StatusCode::NO_CONTENT
+        }
+        Ok(Some(false)) => StatusCode::BAD_REQUEST,
+        Ok(None) => StatusCode::NOT_FOUND,
+        Err(e) => {
+            warn!("Selector '{}' update task failed: {}", group_name, e);
+            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
-    StatusCode::NOT_FOUND
 }
 
 // ── Rules CRUD ───────────────────────────────────────────────────────
@@ -1213,24 +1243,23 @@ async fn put_configs(
 
     // Semantic rebuild (proxy/rule parsing)
     let resolver = Arc::clone(state.tunnel.resolver());
-    let (proxies, rules) =
-        match meow_config::rebuild_from_raw_with_resolver(&raw_config, Some(resolver)) {
-            Ok(r) => r,
-            Err(e) => {
-                if force {
-                    tracing::error!("config reload forced despite validation error: {e}");
-                    (Default::default(), Vec::new())
-                } else {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(
-                            serde_json::json!({"message": format!("config validation error: {e}")}),
-                        ),
-                    )
-                        .into_response();
-                }
+    let (proxies, rules) = match rebuild_from_raw_with_resolver_async(raw_config.clone(), resolver)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            if force {
+                tracing::error!("config reload forced despite validation error: {e}");
+                (Default::default(), Vec::new())
+            } else {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"message": format!("config validation error: {e}")})),
+                )
+                    .into_response();
             }
-        };
+        }
+    };
 
     // Cold reload: close all connections with structured log (Class A divergence from upstream)
     let stats = state.tunnel.statistics();
@@ -1342,7 +1371,7 @@ async fn get_metrics(State(state): State<Arc<AppState>>) -> Response {
 
     // meow_memory_rss_bytes — gauge
     let memory_rss = Gauge::<i64, AtomicI64>::default();
-    memory_rss.set(read_rss_bytes() as i64);
+    memory_rss.set(read_rss_bytes().await as i64);
     registry.register(
         "meow_memory_rss_bytes",
         "Current process RSS in bytes",
@@ -1443,8 +1472,8 @@ fn subscribe_memory_feed() -> broadcast::Receiver<Arc<str>> {
                     break;
                 }
             }
-            let inuse = read_rss_bytes();
-            let oslimit = read_os_memory_limit();
+            let inuse = read_rss_bytes().await;
+            let oslimit = read_os_memory_limit().await;
             let msg: Arc<str> = Arc::from(format!("{{\"inuse\":{inuse},\"oslimit\":{oslimit}}}"));
             let _ = tx.send(msg);
         }
@@ -1473,18 +1502,22 @@ async fn get_memory(State(_state): State<Arc<AppState>>, ws: WebSocketUpgrade) -
     })
 }
 
-fn read_rss_bytes() -> u64 {
-    use sysinfo::{Pid, ProcessesToUpdate, System};
-    let pid = Pid::from_u32(std::process::id());
-    let mut sys = System::new();
-    sys.refresh_processes(ProcessesToUpdate::Some(&[pid]), false);
-    sys.process(pid).map_or(0, sysinfo::Process::memory)
+async fn read_rss_bytes() -> u64 {
+    tokio::task::spawn_blocking(|| {
+        use sysinfo::{Pid, ProcessesToUpdate, System};
+        let pid = Pid::from_u32(std::process::id());
+        let mut sys = System::new();
+        sys.refresh_processes(ProcessesToUpdate::Some(&[pid]), false);
+        sys.process(pid).map_or(0, sysinfo::Process::memory)
+    })
+    .await
+    .unwrap_or(0)
 }
 
-fn read_os_memory_limit() -> u64 {
+async fn read_os_memory_limit() -> u64 {
     #[cfg(target_os = "linux")]
     {
-        read_os_memory_limit_linux()
+        read_os_memory_limit_linux().await
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -1493,9 +1526,9 @@ fn read_os_memory_limit() -> u64 {
 }
 
 #[cfg(target_os = "linux")]
-fn read_os_memory_limit_linux() -> u64 {
+async fn read_os_memory_limit_linux() -> u64 {
     // Try cgroup v2 memory limit first, fall back to rlimit.
-    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+    if let Ok(s) = tokio::fs::read_to_string("/sys/fs/cgroup/memory.max").await {
         if let Ok(n) = s.trim().parse::<u64>() {
             return n;
         }

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -2,7 +2,7 @@ use axum::http::{Request, StatusCode};
 use dashmap::DashMap;
 use http_body_util::BodyExt;
 use meow_api::routes::{create_router, AppState};
-use meow_common::DnsMode;
+use meow_common::{DnsMode, Proxy};
 use meow_config::raw::{RawConfig, RawProxyGroup, RawSubscription};
 use meow_dns::Resolver;
 use meow_trie::DomainTrie;
@@ -48,6 +48,38 @@ fn test_state(raw: RawConfig) -> Arc<AppState> {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.yaml").to_str().unwrap().to_string();
     // Leak the tempdir so it persists for the test — fine for tests
+    std::mem::forget(dir);
+
+    Arc::new(AppState {
+        tunnel,
+        secret: None,
+        config_path,
+        raw_config: Arc::new(RwLock::new(raw)),
+        log_tx: test_log_tx(),
+        proxy_providers: Arc::new(DashMap::new()),
+        rule_providers: Arc::new(RwLock::new(HashMap::new())),
+        listeners: vec![],
+    })
+}
+
+fn test_state_with_route(raw: RawConfig, named: Vec<(&str, Arc<dyn Proxy>)>) -> Arc<AppState> {
+    let resolver = Arc::new(Resolver::new(
+        vec!["8.8.8.8:53".parse().unwrap()],
+        vec![],
+        DnsMode::Normal,
+        DomainTrie::new(),
+        true,
+    ));
+    let tunnel = Tunnel::new(resolver);
+
+    let mut proxies = std::collections::HashMap::new();
+    for (name, proxy) in named {
+        proxies.insert(smol_str::SmolStr::from(name), proxy);
+    }
+    tunnel.update_proxies(proxies);
+
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.yaml").to_str().unwrap().to_string();
     std::mem::forget(dir);
 
     Arc::new(AppState {
@@ -617,6 +649,53 @@ async fn get_proxy_groups_with_data() {
     assert_eq!(groups[0]["proxies"].as_array().unwrap().len(), 2);
     // Selector should have a current selection
     assert!(groups[0]["now"].is_string());
+}
+
+#[tokio::test]
+async fn get_proxy_groups_expands_provider_backed_runtime_members() {
+    let mut raw = test_raw_config();
+    raw.proxy_groups = Some(vec![RawProxyGroup {
+        name: "AUTO".into(),
+        group_type: "url-test".into(),
+        proxies: None,
+        use_providers: Some(vec!["default".into()]),
+        ..Default::default()
+    }]);
+
+    let node_a = delay_support::TestAdapter::new("node-a", delay_support::DialBehavior::InstantOk)
+        .into_proxy();
+    let node_b = delay_support::TestAdapter::new("node-b", delay_support::DialBehavior::InstantOk)
+        .into_proxy();
+    let slot: meow_common::ProviderSlot = Arc::new(RwLock::new(vec![node_a, node_b]));
+    let auto: Arc<dyn Proxy> = Arc::new(meow_proxy::UrlTestGroup::new_with_providers(
+        "AUTO",
+        Vec::new(),
+        150,
+        vec![slot],
+    ));
+    let state = test_state_with_route(raw, vec![("AUTO", auto)]);
+    let app = create_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::get("/api/proxy-groups")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let groups = json.as_array().unwrap();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0]["name"], "AUTO");
+    assert_eq!(groups[0]["type"], "url-test");
+    assert_eq!(groups[0]["now"], "node-a");
+    let proxies = groups[0]["proxies"].as_array().unwrap();
+    assert_eq!(proxies.len(), 2);
+    assert_eq!(proxies[0], "node-a");
+    assert_eq!(proxies[1], "node-b");
 }
 
 #[tokio::test]

--- a/crates/meow-app/src/geodata_fetch.rs
+++ b/crates/meow-app/src/geodata_fetch.rs
@@ -114,13 +114,22 @@ pub async fn run_on_startup(
     }
 
     let raw = raw_config.read().clone();
-    match meow_config::rebuild_from_raw_with_resolver(&raw, Some(Arc::clone(&resolver))) {
-        Ok((_proxies, new_rules)) => {
+    let rebuild = tokio::task::spawn_blocking({
+        let resolver = Arc::clone(&resolver);
+        move || meow_config::rebuild_from_raw_with_resolver(&raw, Some(resolver))
+    })
+    .await;
+    match rebuild {
+        Ok(Ok((_proxies, new_rules))) => {
             tunnel.update_rules(new_rules);
             info!("geodata startup-fetch: rules reloaded with downloaded DBs");
         }
-        Err(e) => warn!(
+        Ok(Err(e)) => warn!(
             "geodata startup-fetch: rule rebuild failed after download: {:#}",
+            e
+        ),
+        Err(e) => warn!(
+            "geodata startup-fetch: rule rebuild task failed after download: {}",
             e
         ),
     }
@@ -188,14 +197,25 @@ pub async fn auto_update_loop(
         }
 
         let raw = raw_config.read().clone();
-        match meow_config::rebuild_from_raw_with_resolver(&raw, Some(Arc::clone(&resolver))) {
-            Ok((_proxies, new_rules)) => {
+        let rebuild = tokio::task::spawn_blocking({
+            let resolver = Arc::clone(&resolver);
+            move || meow_config::rebuild_from_raw_with_resolver(&raw, Some(resolver))
+        })
+        .await;
+        match rebuild {
+            Ok(Ok((_proxies, new_rules))) => {
                 tunnel.update_rules(new_rules);
                 info!("geodata auto-update: rules reloaded with updated DBs");
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!(
                     "geodata auto-update: rule rebuild failed after DB download: {:#}",
+                    e
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "geodata auto-update: rule rebuild task failed after DB download: {}",
                     e
                 );
             }

--- a/crates/meow-app/src/subscription_refresh.rs
+++ b/crates/meow-app/src/subscription_refresh.rs
@@ -49,29 +49,46 @@ pub async fn run_loop(raw_config: Arc<RwLock<RawConfig>>, tunnel: Tunnel, config
                     // held across `parking_lot::RwLock`.
                     meow_config::ech_dns::preresolve_ech(&mut fetched.proxies).await;
 
-                    let mut raw = raw_config.write();
+                    let snapshot = {
+                        let mut raw = raw_config.write();
 
-                    if let Some(ref mut subs) = raw.subscriptions {
-                        if let Some(sub) = subs.iter_mut().find(|s| s.name == name) {
-                            sub.last_updated = Some(now);
+                        if let Some(ref mut subs) = raw.subscriptions {
+                            if let Some(sub) = subs.iter_mut().find(|s| s.name == name) {
+                                sub.last_updated = Some(now);
+                            }
                         }
-                    }
 
-                    raw.proxies = Some(fetched.proxies);
-                    raw.proxy_groups = Some(fetched.proxy_groups);
-                    raw.rules = Some(fetched.rules);
+                        raw.proxies = Some(fetched.proxies);
+                        raw.proxy_groups = Some(fetched.proxy_groups);
+                        raw.rules = Some(fetched.rules);
 
-                    match meow_config::rebuild_from_raw_with_resolver(
-                        &raw,
-                        Some(Arc::clone(tunnel.resolver())),
-                    ) {
-                        Ok((new_proxies, new_rules)) => {
+                        raw.clone()
+                    };
+
+                    let resolver = Arc::clone(tunnel.resolver());
+                    let rebuild = tokio::task::spawn_blocking({
+                        let snapshot = snapshot.clone();
+                        move || {
+                            meow_config::rebuild_from_raw_with_resolver(&snapshot, Some(resolver))
+                        }
+                    })
+                    .await;
+
+                    match rebuild {
+                        Ok(Ok((new_proxies, new_rules))) => {
                             tunnel.update_proxies(new_proxies);
                             tunnel.update_rules(new_rules);
                             info!("Subscription '{}' refreshed successfully", name);
-                            let _ = meow_config::save_raw_config(&config_path, &raw);
+                            let _ =
+                                meow_config::save_raw_config_async(&config_path, &snapshot).await;
                         }
-                        Err(e) => error!("Failed to rebuild after refreshing '{}': {}", name, e),
+                        Ok(Err(e)) => {
+                            error!("Failed to rebuild after refreshing '{}': {}", name, e);
+                        }
+                        Err(e) => error!(
+                            "Failed to join rebuild task after refreshing '{}': {}",
+                            name, e
+                        ),
                     }
                 }
                 Err(e) => error!("Failed to refresh subscription '{}': {}", name, e),

--- a/crates/meow-config/src/dns_parser.rs
+++ b/crates/meow-config/src/dns_parser.rs
@@ -2,13 +2,14 @@ use crate::raw::{HostsValue, RawConfig};
 use crate::DnsConfig;
 use meow_common::DnsMode;
 use meow_dns::fakeip::{FileStore, MemoryStore, Pool, Skipper, SkipperMode, Store};
-use meow_dns::resolver::{FallbackFilter, NameserverPolicy, PolicyEntry};
+use meow_dns::resolver::{FallbackFilter, NameserverPolicy, NameserverPolicyMatcher, PolicyEntry};
 use meow_dns::upstream::{NameServerEntry, NameServerUrl};
-use meow_dns::{HostOrIp, Resolver};
+use meow_dns::{DnsClient, HostOrIp, Resolver};
 use meow_trie::DomainTrie;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::warn;
 
 /// Upstream Go mihomo default for v4 fake-IP CIDR. Used when
@@ -20,6 +21,7 @@ pub async fn parse_dns(
     mmdb_path: Option<&std::path::Path>,
     cache_dir: Option<&std::path::Path>,
     proxy_registry: &HashMap<smol_str::SmolStr, Arc<dyn meow_common::Proxy>>,
+    geosite: Option<Arc<meow_rules::geosite::GeositeDB>>,
 ) -> Result<DnsConfig, anyhow::Error> {
     let dns = match &raw.dns {
         Some(dns) if dns.enable.unwrap_or(false) => dns,
@@ -58,7 +60,7 @@ pub async fn parse_dns(
     let mut hosts = build_hosts_trie(raw.hosts.as_ref())?;
 
     if use_hosts && use_system_hosts {
-        merge_system_hosts(&mut hosts);
+        merge_system_hosts(&mut hosts).await;
     }
 
     // Build nameserver-policy if configured.
@@ -66,7 +68,8 @@ pub async fn parse_dns(
         if nsp_map.is_empty() {
             None
         } else {
-            Some(build_nameserver_policy(nsp_map)?)
+            let bootstrap_clients = build_policy_bootstrap_clients(&default_ns_urls, &main_urls);
+            Some(build_nameserver_policy(nsp_map, geosite.as_ref(), &bootstrap_clients).await?)
         }
     } else {
         None
@@ -76,10 +79,15 @@ pub async fn parse_dns(
     let fallback_filter = if fallback_urls.is_empty() {
         None
     } else {
-        Some(build_fallback_filter(
-            dns.fallback_filter.as_ref(),
-            mmdb_path,
-        ))
+        let raw_filter = dns.fallback_filter.clone();
+        let mmdb_path = mmdb_path.map(std::path::Path::to_path_buf);
+        Some(
+            tokio::task::spawn_blocking(move || {
+                build_fallback_filter(raw_filter.as_ref(), mmdb_path.as_deref())
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("fallback-filter build task failed: {e}"))?,
+        )
     };
 
     let mut resolver = Resolver::new_with_bootstrap_with_proxies(
@@ -101,7 +109,7 @@ pub async fn parse_dns(
     // silently fall back to the upstream resolver, which is a user-surprising
     // privacy regression.
     if mode == DnsMode::FakeIp {
-        install_fakeip(&mut resolver, dns, cache_dir)?;
+        install_fakeip(&mut resolver, dns, cache_dir).await?;
     }
 
     Ok(DnsConfig {
@@ -110,7 +118,7 @@ pub async fn parse_dns(
     })
 }
 
-fn install_fakeip(
+async fn install_fakeip(
     resolver: &mut Resolver,
     dns: &crate::raw::RawDns,
     cache_dir: Option<&std::path::Path>,
@@ -137,7 +145,7 @@ fn install_fakeip(
             ipnet::IpNet::V4(_) => "v4",
             ipnet::IpNet::V6(_) => "v6",
         });
-        let p = FileStore::open(&path).map_err(|e| {
+        let p = FileStore::open_async(path.clone()).await.map_err(|e| {
             let disp = path.display();
             anyhow::anyhow!("cannot open fakeip store {disp}: {e}")
         })?;
@@ -196,87 +204,271 @@ fn parse_nameserver_urls(servers: &[String]) -> Result<Vec<NameServerUrl>, anyho
 
 /// Build a `NameserverPolicy` from the raw YAML map.
 ///
-/// Unknown-prefix patterns (e.g. `geosite:`, `rule-set:`) → warn-once and skip.
-/// Class B per ADR-0002: NOT a hard error (too many real configs use these).
+/// `geosite:` patterns are compiled into matchers when a geosite DB is loaded.
+/// Unsupported prefixes (currently `rule-set:`) warn once and skip.
 ///
 /// An entry with no valid nameservers after skipping → hard error.
 /// Class A per ADR-0002: DNS leakage risk for internal/corporate domains.
-fn build_nameserver_policy(
+async fn build_nameserver_policy(
     map: &HashMap<String, crate::raw::RawNspValue>,
+    geosite: Option<&Arc<meow_rules::geosite::GeositeDB>>,
+    bootstrap_clients: &[Arc<DnsClient>],
 ) -> Result<NameserverPolicy, anyhow::Error> {
     let mut policy = NameserverPolicy::new();
-    let mut warned_prefix = false;
-    let empty_resolved = HashMap::new();
+    let mut warned_unsupported_prefix = false;
+    let mut warned_missing_geosite = false;
 
     for (key, value) in map {
-        // Patterns with ':' (geosite:, rule-set:) are unsupported in M1.
-        if key.contains(':') {
-            if !warned_prefix {
-                warn!(
-                    "nameserver-policy: patterns with ':' prefix (e.g. 'geosite:', 'rule-set:') \
-                    are not supported in M1 and will be skipped (Class B per ADR-0002)"
-                );
-                warned_prefix = true;
+        let mut patterns = Vec::new();
+        for expanded_key in expand_policy_keys(key) {
+            let key_lower = expanded_key.to_ascii_lowercase();
+            if let Some(category) = key_lower.strip_prefix("geosite:") {
+                let category = category.trim();
+                if category.is_empty() {
+                    continue;
+                }
+                let Some(db) = geosite else {
+                    if !warned_missing_geosite {
+                        warn!(
+                            "nameserver-policy: geosite: patterns require a loaded geosite DB; \
+                            skipping geosite policy entries"
+                        );
+                        warned_missing_geosite = true;
+                    }
+                    continue;
+                };
+                let category = category.to_string();
+                let db = Arc::clone(db);
+                patterns.push(PolicyPattern::Matcher(Arc::new(move |domain| {
+                    db.lookup(&category, domain)
+                })));
+                continue;
             }
+
+            if key_lower.starts_with("rule-set:") || key_lower.contains(':') {
+                if !warned_unsupported_prefix {
+                    warn!(
+                        "nameserver-policy: unsupported prefixed patterns such as 'rule-set:' \
+                        will be skipped"
+                    );
+                    warned_unsupported_prefix = true;
+                }
+                continue;
+            }
+
+            if key_lower.starts_with("+.") {
+                patterns.push(PolicyPattern::Wildcard(key_lower));
+            } else if !key_lower.is_empty() {
+                patterns.push(PolicyPattern::Exact(key_lower));
+            }
+        }
+
+        if patterns.is_empty() {
             continue;
         }
 
-        let url_strs = value.as_urls();
-        let mut resolvers = Vec::new();
-        for url_str in &url_strs {
-            match NameServerUrl::parse(url_str) {
-                Ok(url) => {
-                    // Warn if the URL has a hostname (needs bootstrap that we skip in M1).
-                    if let Some(host) = needs_hostname_bootstrap(&url) {
-                        warn!(
-                            "nameserver-policy entry '{}': URL '{}' uses hostname '{}' which \
-                            cannot be bootstrapped for policy entries in M1; \
-                            configure IP literals for policy entries",
-                            key, url_str, host
-                        );
-                    }
-                    let resolver = Resolver::build_single_resolver(&url, &empty_resolved);
-                    resolvers.push(resolver);
-                }
-                Err(e) => {
-                    warn!(
-                        "nameserver-policy entry '{}': skipping invalid URL '{}': {}",
-                        key, url_str, e
-                    );
-                }
-            }
-        }
-
-        if resolvers.is_empty() {
-            return Err(anyhow::anyhow!(
-                "nameserver-policy entry '{key}' has no valid nameservers after skipping \
-                unsupported entries (Class A per ADR-0002 — DNS leakage risk for \
-                internal/corporate domains)"
-            ));
-        }
+        let resolvers = build_policy_resolvers(key, value, bootstrap_clients).await?;
 
         let entry = PolicyEntry {
             nameservers: resolvers,
         };
-        if key.starts_with("+.") {
-            policy.insert_wildcard(key, entry);
-        } else {
-            policy.insert_exact(key.clone(), entry);
+        for pattern in patterns {
+            match pattern {
+                PolicyPattern::Exact(domain) => policy.insert_exact(domain, entry.clone()),
+                PolicyPattern::Wildcard(pattern) => policy.insert_wildcard(&pattern, entry.clone()),
+                PolicyPattern::Matcher(matcher) => policy.insert_matcher(matcher, entry.clone()),
+            }
         }
     }
 
     Ok(policy)
 }
 
-/// Returns the hostname that would need bootstrap resolution, if any.
-fn needs_hostname_bootstrap(url: &NameServerUrl) -> Option<&str> {
-    let (NameServerUrl::Tls { addr, .. } | NameServerUrl::Https { addr, .. }) = url else {
-        return None;
-    };
-    match addr {
-        HostOrIp::Host(h) => Some(h.as_str()),
-        HostOrIp::Ip(_) => None,
+enum PolicyPattern {
+    Exact(String),
+    Wildcard(String),
+    Matcher(NameserverPolicyMatcher),
+}
+
+fn expand_policy_keys(key: &str) -> Vec<String> {
+    let key = key.trim();
+    let lower = key.to_ascii_lowercase();
+    if lower.starts_with("geosite:") {
+        return key["geosite:".len()..]
+            .split(',')
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .map(|part| format!("geosite:{part}"))
+            .collect();
     }
+    if lower.starts_with("rule-set:") {
+        return key["rule-set:".len()..]
+            .split(',')
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .map(|part| format!("rule-set:{part}"))
+            .collect();
+    }
+    key.split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn build_policy_bootstrap_clients(
+    default_ns: &[NameServerEntry],
+    main_urls: &[NameServerEntry],
+) -> Vec<Arc<DnsClient>> {
+    let source = if default_ns.is_empty() {
+        main_urls
+    } else {
+        default_ns
+    };
+    let empty_resolved = HashMap::new();
+    source
+        .iter()
+        .filter(|entry| entry.proxy.is_none())
+        .filter(|entry| entry.url.needs_bootstrap().is_none())
+        .filter(|entry| !matches!(entry.url, NameServerUrl::RCode { .. }))
+        .map(|entry| Resolver::build_single_resolver(&entry.url, &empty_resolved))
+        .collect()
+}
+
+async fn build_policy_resolvers(
+    key: &str,
+    value: &crate::raw::RawNspValue,
+    bootstrap_clients: &[Arc<DnsClient>],
+) -> Result<Vec<Arc<meow_dns::DnsClient>>, anyhow::Error> {
+    let url_strs = value.as_urls();
+    let empty_resolved = HashMap::new();
+    let mut resolvers = Vec::new();
+    for url_str in &url_strs {
+        match NameServerUrl::parse(url_str) {
+            Ok(url) => {
+                let Some(url) =
+                    resolve_policy_hostname_url(url, key, url_str, bootstrap_clients).await
+                else {
+                    continue;
+                };
+                let resolver = Resolver::build_single_resolver(&url, &empty_resolved);
+                resolvers.push(resolver);
+            }
+            Err(e) => {
+                warn!(
+                    "nameserver-policy entry '{}': skipping invalid URL '{}': {}",
+                    key, url_str, e
+                );
+            }
+        }
+    }
+
+    if resolvers.is_empty() {
+        return Err(anyhow::anyhow!(
+            "nameserver-policy entry '{key}' has no valid nameservers after skipping \
+            unsupported entries (Class A per ADR-0002 — DNS leakage risk for \
+            internal/corporate domains)"
+        ));
+    }
+
+    Ok(resolvers)
+}
+
+async fn resolve_policy_hostname_url(
+    url: NameServerUrl,
+    key: &str,
+    url_str: &str,
+    bootstrap_clients: &[Arc<DnsClient>],
+) -> Option<NameServerUrl> {
+    match url {
+        NameServerUrl::Udp {
+            addr: HostOrIp::Host(host),
+            port,
+        } => resolve_policy_host(key, url_str, &host, bootstrap_clients)
+            .await
+            .map(|ip| NameServerUrl::Udp {
+                addr: HostOrIp::Ip(ip),
+                port,
+            }),
+        NameServerUrl::Tcp {
+            addr: HostOrIp::Host(host),
+            port,
+        } => resolve_policy_host(key, url_str, &host, bootstrap_clients)
+            .await
+            .map(|ip| NameServerUrl::Tcp {
+                addr: HostOrIp::Ip(ip),
+                port,
+            }),
+        NameServerUrl::Tls {
+            addr: HostOrIp::Host(host),
+            port,
+            sni,
+        } => resolve_policy_host(key, url_str, &host, bootstrap_clients)
+            .await
+            .map(|ip| NameServerUrl::Tls {
+                addr: HostOrIp::Ip(ip),
+                port,
+                sni,
+            }),
+        NameServerUrl::Https {
+            addr: HostOrIp::Host(host),
+            port,
+            path,
+            sni,
+        } => resolve_policy_host(key, url_str, &host, bootstrap_clients)
+            .await
+            .map(|ip| NameServerUrl::Https {
+                addr: HostOrIp::Ip(ip),
+                port,
+                path,
+                sni,
+            }),
+        other => Some(other),
+    }
+}
+
+async fn resolve_policy_host(
+    key: &str,
+    url_str: &str,
+    host: &str,
+    bootstrap_clients: &[Arc<DnsClient>],
+) -> Option<IpAddr> {
+    if bootstrap_clients.is_empty() {
+        warn!(
+            "nameserver-policy entry '{}': URL '{}' uses hostname '{}' but no IP-literal \
+            nameserver/default-nameserver is available for policy bootstrap; skipping",
+            key, url_str, host
+        );
+        return None;
+    }
+
+    for client in bootstrap_clients {
+        match tokio::time::timeout(Duration::from_secs(3), client.lookup_ip(host)).await {
+            Ok(Ok((ips, _ttl))) => {
+                if let Some(ip) = ips.into_iter().next() {
+                    return Some(ip);
+                }
+            }
+            Ok(Err(e)) => {
+                warn!(
+                    "nameserver-policy entry '{}': bootstrap lookup for '{}' via '{}' failed: {}",
+                    key, host, url_str, e
+                );
+            }
+            Err(_) => {
+                warn!(
+                    "nameserver-policy entry '{}': bootstrap lookup for '{}' timed out; \
+                    trying next bootstrap nameserver",
+                    key, host
+                );
+            }
+        }
+    }
+    warn!(
+        "nameserver-policy entry '{}': URL '{}' hostname '{}' resolved to no addresses; skipping",
+        key, url_str, host
+    );
+    None
 }
 
 /// Build a `FallbackFilter` from the raw config.
@@ -397,10 +589,10 @@ fn build_hosts_trie(
 
 /// Merge `/etc/hosts` entries into the trie at lower priority than config entries.
 /// No-op on non-Unix platforms (warn logged).
-fn merge_system_hosts(trie: &mut DomainTrie<Vec<IpAddr>>) {
+async fn merge_system_hosts(trie: &mut DomainTrie<Vec<IpAddr>>) {
     #[cfg(unix)]
     {
-        let entries = parse_system_hosts();
+        let entries = parse_system_hosts().await;
         for (domain, ips) in entries {
             if trie.search(&domain).is_none() {
                 trie.insert(&domain, ips);
@@ -417,10 +609,9 @@ fn merge_system_hosts(trie: &mut DomainTrie<Vec<IpAddr>>) {
 }
 
 /// Parse `/etc/hosts` and return (domain, ips) pairs.
-/// Startup-only sync I/O — never called from the DNS query path.
 #[cfg(unix)]
-fn parse_system_hosts() -> Vec<(String, Vec<IpAddr>)> {
-    let content = match std::fs::read_to_string("/etc/hosts") {
+async fn parse_system_hosts() -> Vec<(String, Vec<IpAddr>)> {
+    let content = match tokio::fs::read_to_string("/etc/hosts").await {
         Ok(c) => c,
         Err(e) => {
             warn!("use-system-hosts: cannot read /etc/hosts: {}", e);
@@ -578,17 +769,16 @@ mod tests {
         );
     }
 
-    // geosite: prefix → warn-once and skip (Class B per ADR-0002).
-    // Upstream: supports geosite: in nameserver-policy. NOT supported in M1 — deferred.
-    #[test]
-    fn parse_nameserver_policy_geosite_prefix_warns() {
+    // geosite: prefix without a loaded DB → warn-once and skip.
+    #[tokio::test]
+    async fn parse_nameserver_policy_geosite_prefix_without_db_skips() {
         use crate::raw::RawNspValue;
         let mut map = HashMap::new();
         map.insert(
             "geosite:cn".to_string(),
-            RawNspValue::One("8.8.8.8".to_string()),
+            RawNspValue::One("rcode://success".to_string()),
         );
-        let result = build_nameserver_policy(&map);
+        let result = build_nameserver_policy(&map, None, &[]).await;
         assert!(result.is_ok(), "geosite: prefix must not hard-error");
         let pol = result.unwrap();
         assert!(
@@ -597,10 +787,29 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn parse_nameserver_policy_geosite_prefix_matches_loaded_db() {
+        use crate::raw::RawNspValue;
+        let mut db = meow_rules::geosite::GeositeDB::empty();
+        db.insert("cn", "example.cn");
+        db.insert("private", "lan");
+        let db = Arc::new(db);
+
+        let mut map = HashMap::new();
+        map.insert(
+            "geosite:cn,private".to_string(),
+            RawNspValue::One("rcode://success".to_string()),
+        );
+        let pol = build_nameserver_policy(&map, Some(&db), &[]).await.unwrap();
+        assert!(pol.lookup("example.cn").is_some());
+        assert!(pol.lookup("lan").is_some());
+        assert!(pol.lookup("example.com").is_none());
+    }
+
     // All URLs invalid after skip → hard error (Class A per ADR-0002).
     // Upstream: panics. NOT a panic — hard parse error.
-    #[test]
-    fn parse_nameserver_policy_all_invalid_urls_errors() {
+    #[tokio::test]
+    async fn parse_nameserver_policy_all_invalid_urls_errors() {
         use crate::raw::RawNspValue;
         let mut map = HashMap::new();
         // quic:// is explicitly rejected by the URL parser (QuicNotSupported error).
@@ -608,7 +817,7 @@ mod tests {
             "corp.example".to_string(),
             RawNspValue::Many(vec!["quic://bad.example".to_string()]),
         );
-        let result = build_nameserver_policy(&map);
+        let result = build_nameserver_policy(&map, None, &[]).await;
         assert!(
             result.is_err(),
             "policy entry with no valid servers must be a hard error"
@@ -616,15 +825,15 @@ mod tests {
     }
 
     // Wildcard policy entry matches subdomain and root.
-    #[test]
-    fn parse_nameserver_policy_wildcard_inserted() {
+    #[tokio::test]
+    async fn parse_nameserver_policy_wildcard_inserted() {
         use crate::raw::RawNspValue;
         let mut map = HashMap::new();
         map.insert(
             "+.corp.internal".to_string(),
             RawNspValue::One("192.168.1.53".to_string()),
         );
-        let pol = build_nameserver_policy(&map).unwrap();
+        let pol = build_nameserver_policy(&map, None, &[]).await.unwrap();
         assert!(pol.lookup("foo.corp.internal").is_some());
         assert!(pol.lookup("corp.internal").is_some());
         assert!(pol.lookup("other.example").is_none());

--- a/crates/meow-config/src/dns_parser.rs
+++ b/crates/meow-config/src/dns_parser.rs
@@ -82,7 +82,7 @@ pub async fn parse_dns(
         let raw_filter = dns.fallback_filter.clone();
         let mmdb_path = mmdb_path.map(std::path::Path::to_path_buf);
         Some(
-            tokio::task::spawn_blocking(move || {
+            crate::spawn_blocking_with_current_dispatcher(move || {
                 build_fallback_filter(raw_filter.as_ref(), mmdb_path.as_deref())
             })
             .await

--- a/crates/meow-config/src/ech_dns.rs
+++ b/crates/meow-config/src/ech_dns.rs
@@ -99,11 +99,11 @@ const _: fn() = || {
 /// Unix: parse `/etc/resolv.conf` `nameserver` lines.  Other platforms (or a
 /// missing / unreadable resolv.conf) fall back to a short list of well-known
 /// public resolvers so ECH lookups still succeed in unconfigured environments.
-fn system_nameservers() -> Vec<SocketAddr> {
+async fn system_nameservers() -> Vec<SocketAddr> {
     let mut out = Vec::new();
     #[cfg(unix)]
     {
-        if let Ok(contents) = std::fs::read_to_string("/etc/resolv.conf") {
+        if let Ok(contents) = tokio::fs::read_to_string("/etc/resolv.conf").await {
             for line in contents.lines() {
                 let line = line.trim();
                 if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
@@ -128,7 +128,7 @@ fn system_nameservers() -> Vec<SocketAddr> {
 }
 
 pub(crate) async fn fetch_ech_from_dns(name: &str) -> Result<Vec<u8>, String> {
-    let nameservers = system_nameservers();
+    let nameservers = system_nameservers().await;
     let mut clients: Vec<Arc<DnsClient>> = nameservers
         .iter()
         .map(|addr| Arc::new(DnsClient::udp(*addr).with_timeout(Duration::from_secs(5))))

--- a/crates/meow-config/src/geodata.rs
+++ b/crates/meow-config/src/geodata.rs
@@ -133,12 +133,12 @@ pub async fn download_and_replace(
     };
 
     if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent)?;
+        tokio::fs::create_dir_all(parent).await?;
     }
-    std::fs::write(&tmp, &bytes)?;
+    tokio::fs::write(&tmp, &bytes).await?;
 
-    if let Err(e) = std::fs::rename(&tmp, dest) {
-        let _ = std::fs::remove_file(&tmp);
+    if let Err(e) = tokio::fs::rename(&tmp, dest).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
         return Err(anyhow!(
             "atomic rename {} → {}: {}",
             tmp.display(),

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -25,6 +25,17 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{info, warn};
 
+pub(crate) async fn spawn_blocking_with_current_dispatcher<F, R>(
+    f: F,
+) -> Result<R, tokio::task::JoinError>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let dispatch = tracing::dispatcher::get_default(Clone::clone);
+    tokio::task::spawn_blocking(move || tracing::dispatcher::with_default(&dispatch, f)).await
+}
+
 pub struct Config {
     pub general: GeneralConfig,
     pub dns: DnsConfig,
@@ -360,7 +371,7 @@ fn rebuild_from_raw_impl(
 async fn open_selector_store_async(
     path: PathBuf,
 ) -> Result<Arc<meow_proxy::SelectorStore>, anyhow::Error> {
-    tokio::task::spawn_blocking(move || meow_proxy::SelectorStore::open(path))
+    spawn_blocking_with_current_dispatcher(move || meow_proxy::SelectorStore::open(path))
         .await
         .map_err(|e| anyhow::anyhow!("selector store open task failed: {e}"))
 }
@@ -369,7 +380,7 @@ async fn build_parser_context_with_geo_async(
     raw: raw::RawConfig,
     geo: GeoDataConfig,
 ) -> Result<meow_rules::ParserContext, anyhow::Error> {
-    tokio::task::spawn_blocking(move || build_parser_context_with_geo(&raw, &geo))
+    spawn_blocking_with_current_dispatcher(move || build_parser_context_with_geo(&raw, &geo))
         .await
         .map_err(|e| anyhow::anyhow!("parser context build task failed: {e}"))?
 }
@@ -382,7 +393,7 @@ async fn rebuild_from_raw_impl_async(
     selector_store: Option<Arc<meow_proxy::SelectorStore>>,
     ctx: meow_rules::ParserContext,
 ) -> Result<RebuildResult, anyhow::Error> {
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking_with_current_dispatcher(move || {
         rebuild_from_raw_impl(
             &raw,
             cache_dir.as_deref(),
@@ -402,7 +413,7 @@ async fn load_rule_providers_async(
     ctx: meow_rules::ParserContext,
     download_proxy: Option<Arc<dyn Proxy>>,
 ) -> Result<HashMap<String, Arc<rule_provider::RuleProvider>>, anyhow::Error> {
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking_with_current_dispatcher(move || {
         rule_provider::load_providers(
             &raw_providers,
             cache_dir.as_deref(),

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -108,7 +108,8 @@ pub struct ApiConfig {
 }
 
 pub async fn load_config(path: &str) -> Result<Config, anyhow::Error> {
-    let bytes = std::fs::read(path)
+    let bytes = tokio::fs::read(path)
+        .await
         .map_err(|e| anyhow::anyhow!("failed to read config file {path}: {e}"))?;
     // Strip an optional UTF-8 BOM, which YAML 1.2 permits but some
     // editors (especially on Windows) leave behind.
@@ -156,6 +157,20 @@ pub fn save_raw_config(path: &str, raw: &raw::RawConfig) -> Result<(), anyhow::E
         let _ = std::fs::rename(path, &bak_path);
     }
     std::fs::rename(&tmp_path, path)?;
+    info!("Config saved to {}", path);
+    Ok(())
+}
+
+/// Async counterpart to [`save_raw_config`] for Tokio request/background paths.
+pub async fn save_raw_config_async(path: &str, raw: &raw::RawConfig) -> Result<(), anyhow::Error> {
+    let yaml = serde_yaml::to_string(raw)?;
+    let tmp_path = format!("{path}.tmp");
+    let bak_path = format!("{path}.bak");
+    tokio::fs::write(&tmp_path, yaml).await?;
+    if tokio::fs::metadata(path).await.is_ok() {
+        let _ = tokio::fs::rename(path, &bak_path).await;
+    }
+    tokio::fs::rename(&tmp_path, path).await?;
     info!("Config saved to {}", path);
     Ok(())
 }
@@ -342,6 +357,63 @@ fn rebuild_from_raw_impl(
     Ok((proxies, rules))
 }
 
+async fn open_selector_store_async(
+    path: PathBuf,
+) -> Result<Arc<meow_proxy::SelectorStore>, anyhow::Error> {
+    tokio::task::spawn_blocking(move || meow_proxy::SelectorStore::open(path))
+        .await
+        .map_err(|e| anyhow::anyhow!("selector store open task failed: {e}"))
+}
+
+async fn build_parser_context_with_geo_async(
+    raw: raw::RawConfig,
+    geo: GeoDataConfig,
+) -> Result<meow_rules::ParserContext, anyhow::Error> {
+    tokio::task::spawn_blocking(move || build_parser_context_with_geo(&raw, &geo))
+        .await
+        .map_err(|e| anyhow::anyhow!("parser context build task failed: {e}"))?
+}
+
+async fn rebuild_from_raw_impl_async(
+    raw: raw::RawConfig,
+    cache_dir: Option<PathBuf>,
+    resolver: Option<Arc<Resolver>>,
+    providers: HashMap<String, Arc<ProxyProvider>>,
+    selector_store: Option<Arc<meow_proxy::SelectorStore>>,
+    ctx: meow_rules::ParserContext,
+) -> Result<RebuildResult, anyhow::Error> {
+    tokio::task::spawn_blocking(move || {
+        rebuild_from_raw_impl(
+            &raw,
+            cache_dir.as_deref(),
+            resolver,
+            &providers,
+            selector_store.as_ref(),
+            Some(&ctx),
+        )
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("config rebuild task failed: {e}"))?
+}
+
+async fn load_rule_providers_async(
+    raw_providers: HashMap<String, raw::RawRuleProvider>,
+    cache_dir: Option<PathBuf>,
+    ctx: meow_rules::ParserContext,
+    download_proxy: Option<Arc<dyn Proxy>>,
+) -> Result<HashMap<String, Arc<rule_provider::RuleProvider>>, anyhow::Error> {
+    tokio::task::spawn_blocking(move || {
+        rule_provider::load_providers(
+            &raw_providers,
+            cache_dir.as_deref(),
+            &ctx,
+            download_proxy.as_ref(),
+        )
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("rule-provider load task failed: {e}"))
+}
+
 fn parse_sniffer_config(raw: &raw::RawConfig) -> Result<SnifferConfig, anyhow::Error> {
     // Deprecated alias: tproxy_sni (pre-spec) synthesises a minimal config.
     let has_tproxy_sni = raw.tproxy_sni.unwrap_or(false);
@@ -469,7 +541,8 @@ async fn ensure_geodata(raw: &raw::RawConfig, geo: &GeoDataConfig) {
 
     let needs_geoip = lines.iter().any(|l| line_is_geoip_rule(l));
     let needs_asn = lines.iter().any(|l| line_is_asn_rule(l));
-    let needs_geosite = lines.iter().any(|l| line_is_geosite_rule(l));
+    let needs_geosite =
+        lines.iter().any(|l| line_is_geosite_rule(l)) || dns_policy_uses_geosite(raw);
 
     if !needs_geoip && !needs_asn && !needs_geosite {
         return;
@@ -588,14 +661,24 @@ fn build_parser_context_at(
         None => None,
     };
 
-    let geosite_trigger = lines.iter().any(|l| line_is_geosite_rule(l));
+    let geosite_trigger =
+        lines.iter().any(|l| line_is_geosite_rule(l)) || dns_policy_uses_geosite(raw);
     let geosite = if geosite_trigger {
-        let allowed = collect_geosite_categories(lines);
-        meow_rules::geosite::discover_and_load_at(
+        let mut allowed = collect_geosite_categories(lines);
+        allowed.extend(collect_dns_policy_geosite_categories(raw));
+        info!(
+            "Loading geosite database for {} referenced categories",
+            allowed.len()
+        );
+        let loaded = meow_rules::geosite::discover_and_load_at(
             geosite_explicit,
             geosite_candidates,
             Some(&allowed),
-        )
+        );
+        if loaded.is_some() {
+            info!("Loaded geosite database");
+        }
+        loaded
     } else {
         None
     };
@@ -604,7 +687,6 @@ fn build_parser_context_at(
         geoip,
         asn,
         geosite,
-        ..Default::default()
     })
 }
 
@@ -669,7 +751,8 @@ fn collect_geosite_categories(lines: &[String]) -> std::collections::HashSet<Str
     use std::sync::OnceLock;
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| {
-        Regex::new(r"(?i)\bGEOSITE\s*,\s*([A-Za-z0-9_-]+)").expect("compile GEOSITE scan regex")
+        Regex::new(r"(?i)\bGEOSITE\s*,\s*([A-Za-z0-9_!\-]+)(?:@[A-Za-z0-9_!\-]+)*")
+            .expect("compile GEOSITE scan regex")
     });
     let mut out = std::collections::HashSet::new();
     for line in lines {
@@ -679,6 +762,48 @@ fn collect_geosite_categories(lines: &[String]) -> std::collections::HashSet<Str
         }
         for cap in re.captures_iter(line) {
             out.insert(cap[1].to_ascii_lowercase());
+        }
+    }
+    out
+}
+
+fn dns_policy_uses_geosite(raw: &raw::RawConfig) -> bool {
+    raw.dns
+        .as_ref()
+        .and_then(|dns| dns.nameserver_policy.as_ref())
+        .is_some_and(|policy| {
+            policy
+                .keys()
+                .any(|key| key.trim().to_ascii_lowercase().starts_with("geosite:"))
+        })
+}
+
+fn collect_dns_policy_geosite_categories(
+    raw: &raw::RawConfig,
+) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    let Some(policy) = raw
+        .dns
+        .as_ref()
+        .and_then(|dns| dns.nameserver_policy.as_ref())
+    else {
+        return out;
+    };
+    for key in policy.keys() {
+        let trimmed = key.trim();
+        if !trimmed.to_ascii_lowercase().starts_with("geosite:") {
+            continue;
+        }
+        for category in trimmed["geosite:".len()..].split(',') {
+            let category = category
+                .trim()
+                .split('@')
+                .next()
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            if !category.is_empty() {
+                out.insert(category);
+            }
         }
     }
     out
@@ -987,8 +1112,11 @@ async fn build_config(
     //      depends on the placeholder built in step 1.
     // Open the persistent selector store (one JSON file in cache_dir).
     // Missing/unreadable files yield an empty store — no fatal errors.
-    let selector_store =
-        cache_dir.map(|d| meow_proxy::SelectorStore::open(d.join("selector-cache.json")));
+    let cache_dir_buf = cache_dir.map(Path::to_path_buf);
+    let selector_store = match cache_dir_buf.as_ref() {
+        Some(d) => Some(open_selector_store_async(d.join("selector-cache.json")).await?),
+        None => None,
+    };
 
     // Ensure geodata files exist — download any that are missing and needed
     // by the config's rules. This must happen before building the parser
@@ -996,36 +1124,50 @@ async fn build_config(
     ensure_geodata(&raw, &geodata).await;
 
     // Build the parser context once and share across all passes.
-    let ctx = build_parser_context_with_geo(&raw, &geodata)?;
+    let ctx = build_parser_context_with_geo_async(raw.clone(), geodata.clone()).await?;
 
-    let (proxies, _) = rebuild_from_raw_impl(
-        &raw,
-        cache_dir,
+    let (proxies, _) = rebuild_from_raw_impl_async(
+        raw.clone(),
+        cache_dir_buf.clone(),
         None,
-        &proxy_providers,
-        selector_store.as_ref(),
-        Some(&ctx),
-    )?;
+        proxy_providers.clone(),
+        selector_store.clone(),
+        ctx.clone(),
+    )
+    .await?;
 
     // DNS — pass the explicit mmdb path so fallback-filter GeoIP uses the
     // same path as the rule engine, plus the proxy registry from step 1
     // so #PROXY-tagged nameservers can resolve their referenced adapter.
-    let dns_config =
-        dns_parser::parse_dns(&raw, geodata.mmdb_path.as_deref(), cache_dir, &proxies).await?;
-
-    let (proxies, rules) = rebuild_from_raw_impl(
+    let dns_config = dns_parser::parse_dns(
         &raw,
+        geodata.mmdb_path.as_deref(),
         cache_dir,
+        &proxies,
+        ctx.geosite.clone(),
+    )
+    .await?;
+
+    let (proxies, rules) = rebuild_from_raw_impl_async(
+        raw.clone(),
+        cache_dir_buf.clone(),
         Some(Arc::clone(&dns_config.resolver)),
-        &proxy_providers,
-        selector_store.as_ref(),
-        Some(&ctx),
-    )?;
+        proxy_providers.clone(),
+        selector_store.clone(),
+        ctx.clone(),
+    )
+    .await?;
 
     let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     let rule_providers = match raw.rule_providers.as_ref() {
         Some(map) if !map.is_empty() => {
-            rule_provider::load_providers(map, cache_dir, &ctx, download_proxy.as_ref())
+            load_rule_providers_async(
+                map.clone(),
+                cache_dir_buf.clone(),
+                ctx.clone(),
+                download_proxy,
+            )
+            .await?
         }
         _ => HashMap::new(),
     };

--- a/crates/meow-config/src/proxy_provider.rs
+++ b/crates/meow-config/src/proxy_provider.rs
@@ -109,7 +109,7 @@ impl ProxyProvider {
 
     async fn fetch_content(&self) -> Result<String, String> {
         match &self.vehicle {
-            Vehicle::File(path) => std::fs::read_to_string(path).map_err(|e| {
+            Vehicle::File(path) => tokio::fs::read_to_string(path).await.map_err(|e| {
                 format!(
                     "proxy-provider '{}': failed to read {:?}: {}",
                     self.name, path, e
@@ -136,14 +136,14 @@ impl ProxyProvider {
                             Ok(text) => {
                                 // Cache to disk for offline fallback
                                 if let Some(parent) = cache_path.parent() {
-                                    let _ = std::fs::create_dir_all(parent);
+                                    let _ = tokio::fs::create_dir_all(parent).await;
                                 }
-                                let _ = std::fs::write(cache_path, &text);
+                                let _ = tokio::fs::write(cache_path, &text).await;
                                 Ok(text)
                             }
                             Err(e) => {
                                 warn!(provider = %self.name, error = %e, "HTTP body read failed, trying cache");
-                                read_cache(cache_path, &self.name)
+                                read_cache(cache_path, &self.name).await
                             }
                         }
                     }
@@ -153,11 +153,11 @@ impl ProxyProvider {
                             status = %resp.status(),
                             "HTTP provider returned non-2xx, trying cache"
                         );
-                        read_cache(cache_path, &self.name)
+                        read_cache(cache_path, &self.name).await
                     }
                     Err(e) => {
                         warn!(provider = %self.name, error = %e, "HTTP provider fetch failed, trying cache");
-                        read_cache(cache_path, &self.name)
+                        read_cache(cache_path, &self.name).await
                     }
                 }
             }
@@ -275,8 +275,9 @@ fn compile_opt_regex(
     }
 }
 
-fn read_cache(path: &Path, name: &str) -> Result<String, String> {
-    std::fs::read_to_string(path)
+async fn read_cache(path: &Path, name: &str) -> Result<String, String> {
+    tokio::fs::read_to_string(path)
+        .await
         .map_err(|e| format!("proxy-provider '{name}': no cache at {path:?}: {e}"))
 }
 

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{anyhow, Context, Result};
 use meow_common::adapter::Proxy;
 use meow_rules::{
-    build_rule_set, build_rule_set_from_mrs, is_mrs_bytes, ParserContext, RuleSet, RuleSetBehavior,
-    RuleSetFormat,
+    build_rule_set, build_rule_set_from_mrs_with_behavior, is_mrs_bytes, ParserContext, RuleSet,
+    RuleSetBehavior, RuleSetFormat,
 };
 use parking_lot::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -258,10 +258,11 @@ fn load_http(
         .as_deref()
         .ok_or_else(|| anyhow!("http provider '{name}' requires a 'url'"))?;
     let cache_path = resolve_path(cfg, cache_dir, name);
-    let bytes = fetch_http_blocking_with_cache(url, cache_path.as_deref(), download_proxy)?;
     let explicit_format = parse_explicit_format(cfg)?;
-    let rules = parse_bytes_to_ruleset_with_format(&bytes, behavior, explicit_format, ctx)?;
     let interval = cfg.interval.unwrap_or(0);
+    let bytes =
+        fetch_http_blocking_with_cache(url, cache_path.as_deref(), download_proxy, interval > 0)?;
+    let rules = parse_bytes_to_ruleset_with_format(&bytes, behavior, explicit_format, ctx)?;
     Ok(make_provider(
         name,
         ProviderType::Http,
@@ -326,7 +327,8 @@ fn parse_bytes_to_ruleset_with_format(
 ) -> Result<Box<dyn RuleSet>> {
     let use_mrs = explicit_format == Some(RuleSetFormat::Mrs) || is_mrs_bytes(bytes);
     if use_mrs {
-        return build_rule_set_from_mrs(bytes, ctx).map_err(|e| anyhow!("mrs parse error: {e}"));
+        return build_rule_set_from_mrs_with_behavior(bytes, ctx, Some(behavior))
+            .map_err(|e| anyhow!("mrs parse error: {e}"));
     }
     let text = std::str::from_utf8(bytes).context("payload is not valid UTF-8")?;
     let entries = match explicit_format.unwrap_or(RuleSetFormat::Yaml) {
@@ -386,7 +388,18 @@ fn fetch_http_blocking_with_cache(
     url: &str,
     cache_path: Option<&Path>,
     proxy: Option<&Arc<dyn Proxy>>,
+    prefer_cache: bool,
 ) -> Result<Vec<u8>> {
+    if prefer_cache {
+        if let Some(path) = cache_path {
+            if path.exists() {
+                debug!("rule-provider cache hit: {}", path.display());
+                return std::fs::read(path)
+                    .with_context(|| format!("reading cached provider {}", path.display()));
+            }
+        }
+    }
+
     match fetch_http_blocking(url, proxy) {
         Ok(bytes) => {
             if let Some(path) = cache_path {

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -97,7 +97,7 @@ impl RuleProvider {
         let bytes = fetch_http_async(&self.vehicle, self.download_proxy.as_ref()).await?;
         let behavior = self.behavior;
         let ctx_clone = ctx.clone();
-        let boxed: Box<dyn RuleSet> = tokio::task::spawn_blocking(move || {
+        let boxed: Box<dyn RuleSet> = crate::spawn_blocking_with_current_dispatcher(move || {
             parse_bytes_to_ruleset(&bytes, behavior, &ctx_clone)
         })
         .await

--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -5,7 +5,7 @@
 //! `protect()` before the socket is used. This is the reason the project
 //! ships its own DNS client instead of relying on `hickory-resolver`.
 
-use hickory_proto::op::{Message, MessageType, OpCode, Query};
+use hickory_proto::op::{Message, MessageType, OpCode, Query, ResponseCode};
 use hickory_proto::rr::{Name, RData, Record, RecordType};
 use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
 use std::future::Future;
@@ -129,6 +129,9 @@ enum Transport {
         path: Arc<str>,
         tls: Arc<rustls::ClientConfig>,
     },
+    RCode {
+        code: ResponseCode,
+    },
 }
 
 impl DnsClient {
@@ -145,6 +148,15 @@ impl DnsClient {
     pub fn tcp(addr: SocketAddr) -> Self {
         Self {
             transport: Transport::Tcp { addr },
+            timeout: DEFAULT_QUERY_TIMEOUT,
+            proxy: None,
+        }
+    }
+
+    /// Synthetic DNS response with a fixed response code and no answers.
+    pub fn rcode(code: ResponseCode) -> Self {
+        Self {
+            transport: Transport::RCode { code },
             timeout: DEFAULT_QUERY_TIMEOUT,
             proxy: None,
         }
@@ -209,7 +221,16 @@ impl DnsClient {
         let parsed: Name = name
             .parse()
             .map_err(|_| ClientError::Protocol("invalid query name"))?;
-        msg.add_query(Query::query(parsed, record_type));
+        let query = Query::query(parsed, record_type);
+        if let Transport::RCode { code } = &self.transport {
+            let mut resp = Message::new(id, MessageType::Response, OpCode::Query);
+            resp.metadata.recursion_desired = true;
+            resp.metadata.recursion_available = true;
+            resp.metadata.response_code = *code;
+            resp.add_query(query);
+            return Ok(resp);
+        }
+        msg.add_query(query);
         let wire = msg.to_bytes()?;
         let resp_bytes = tokio::time::timeout(self.timeout, self.exchange(&wire))
             .await
@@ -256,6 +277,11 @@ impl DnsClient {
         if let Some(proxy) = self.proxy.as_ref() {
             let addr = match &self.transport {
                 Transport::Udp { addr } | Transport::Tcp { addr } => *addr,
+                Transport::RCode { .. } => {
+                    return Err(ClientError::Protocol(
+                        "rcode transport should not perform network exchange",
+                    ));
+                }
                 #[cfg(feature = "encrypted")]
                 Transport::Dot { .. } | Transport::Doh { .. } => {
                     // DoT/DoH-over-proxy needs TLS layered on a Box<dyn
@@ -276,6 +302,9 @@ impl DnsClient {
         match &self.transport {
             Transport::Udp { addr } => udp_exchange(*addr, wire).await,
             Transport::Tcp { addr } => tcp_exchange(*addr, wire).await,
+            Transport::RCode { .. } => Err(ClientError::Protocol(
+                "rcode transport should not perform network exchange",
+            )),
             #[cfg(feature = "encrypted")]
             Transport::Dot { addr, sni, tls } => {
                 dot_exchange(*addr, sni, Arc::clone(tls), wire).await
@@ -496,5 +525,14 @@ mod tests {
             .with_timeout(Duration::from_millis(200));
         let r = client.query("example.test", RecordType::A).await;
         assert!(matches!(r, Err(ClientError::Timeout(_))));
+    }
+
+    #[tokio::test]
+    async fn rcode_client_returns_noerror_empty_without_network() {
+        let client = DnsClient::rcode(ResponseCode::NoError);
+        let resp = client.query("example.test", RecordType::A).await.unwrap();
+        assert_eq!(resp.metadata.response_code, ResponseCode::NoError);
+        assert!(resp.answers.is_empty());
+        assert_eq!(resp.queries.len(), 1);
     }
 }

--- a/crates/meow-dns/src/fakeip.rs
+++ b/crates/meow-dns/src/fakeip.rs
@@ -174,30 +174,25 @@ impl FileStore {
     /// warn — we never refuse to start because of a bad snapshot.
     pub fn open(path: impl Into<PathBuf>) -> io::Result<Self> {
         let path = path.into();
-        let snapshot = if path.exists() {
-            match fs::read(&path) {
-                Ok(bytes) => {
-                    serde_json::from_slice::<PersistedSnapshot>(&bytes).unwrap_or_else(|e| {
-                        warn!(
-                            "fakeip: corrupt snapshot {} ({}); starting fresh",
-                            path.display(),
-                            e
-                        );
-                        PersistedSnapshot::default()
-                    })
-                }
-                Err(e) => {
-                    warn!(
-                        "fakeip: cannot read {} ({}); starting fresh",
-                        path.display(),
-                        e
-                    );
-                    PersistedSnapshot::default()
-                }
-            }
-        } else {
-            PersistedSnapshot::default()
-        };
+        let snapshot = load_snapshot(&path);
+        Ok(Self::from_snapshot(path, snapshot))
+    }
+
+    /// Async opener for Tokio config-load paths. Snapshot read and JSON parse
+    /// run on the blocking pool because this store keeps a sync API for tests
+    /// and non-Tokio callers.
+    pub async fn open_async(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        let snapshot = tokio::task::spawn_blocking({
+            let path = path.clone();
+            move || load_snapshot(&path)
+        })
+        .await
+        .map_err(|e| io::Error::other(format!("fakeip snapshot load task failed: {e}")))?;
+        Ok(Self::from_snapshot(path, snapshot))
+    }
+
+    fn from_snapshot(path: PathBuf, snapshot: PersistedSnapshot) -> Self {
         let reverse = snapshot
             .entries
             .iter()
@@ -215,14 +210,14 @@ impl FileStore {
             Arc::clone(&notify),
         );
 
-        Ok(Self {
+        Self {
             path,
             state,
             reverse: Mutex::new(reverse),
             dirty,
             notify,
             flush_task: Some(flush_task),
-        })
+        }
     }
 
     fn spawn_flush_task(
@@ -245,7 +240,12 @@ impl FileStore {
                         let s = state.lock();
                         serialise(&s)
                     };
-                    persist_to_file(&path, &snap);
+                    let path = path.clone();
+                    if let Err(e) =
+                        tokio::task::spawn_blocking(move || persist_to_file(&path, &snap)).await
+                    {
+                        warn!("fakeip: persist task failed: {}", e);
+                    }
                 }
             }
         })
@@ -281,6 +281,30 @@ impl Drop for FileStore {
         // torn.
         if let Some(handle) = self.flush_task.take() {
             handle.abort();
+        }
+    }
+}
+
+fn load_snapshot(path: &Path) -> PersistedSnapshot {
+    if !path.exists() {
+        return PersistedSnapshot::default();
+    }
+    match fs::read(path) {
+        Ok(bytes) => serde_json::from_slice::<PersistedSnapshot>(&bytes).unwrap_or_else(|e| {
+            warn!(
+                "fakeip: corrupt snapshot {} ({}); starting fresh",
+                path.display(),
+                e
+            );
+            PersistedSnapshot::default()
+        }),
+        Err(e) => {
+            warn!(
+                "fakeip: cannot read {} ({}); starting fresh",
+                path.display(),
+                e
+            );
+            PersistedSnapshot::default()
         }
     }
 }

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -51,10 +51,18 @@ pub struct PolicyEntry {
     pub nameservers: Vec<Arc<DnsClient>>,
 }
 
+pub type NameserverPolicyMatcher = Arc<dyn Fn(&str) -> bool + Send + Sync + 'static>;
+
+struct MatcherPolicyEntry {
+    matcher: NameserverPolicyMatcher,
+    entry: PolicyEntry,
+}
+
 /// Per-domain nameserver routing: exact matches and `+.` wildcard prefixes.
 pub struct NameserverPolicy {
     exact: HashMap<String, PolicyEntry>,
     wildcard: DomainTrie<PolicyEntry>,
+    matchers: Vec<MatcherPolicyEntry>,
 }
 
 impl Default for NameserverPolicy {
@@ -68,6 +76,7 @@ impl NameserverPolicy {
         Self {
             exact: HashMap::new(),
             wildcard: DomainTrie::new(),
+            matchers: Vec::new(),
         }
     }
 
@@ -87,11 +96,21 @@ impl NameserverPolicy {
         self.wildcard.insert(pattern, entry);
     }
 
+    pub fn insert_matcher(&mut self, matcher: NameserverPolicyMatcher, entry: PolicyEntry) {
+        self.matchers.push(MatcherPolicyEntry { matcher, entry });
+    }
+
     pub fn lookup(&self, domain: &str) -> Option<&PolicyEntry> {
         if let Some(e) = self.exact.get(domain) {
             return Some(e);
         }
-        self.wildcard.search(domain)
+        if let Some(e) = self.wildcard.search(domain) {
+            return Some(e);
+        }
+        self.matchers
+            .iter()
+            .find(|entry| (entry.matcher)(domain))
+            .map(|entry| &entry.entry)
     }
 }
 
@@ -216,6 +235,9 @@ fn url_to_plain_socketaddr(url: &NameServerUrl) -> SocketAddr {
             };
             SocketAddr::new(ip, 53)
         }
+        NameServerUrl::RCode { .. } => {
+            unreachable!("rcode default-nameserver does not have a socket address")
+        }
     }
 }
 
@@ -229,11 +251,11 @@ fn url_to_plain_socketaddr(url: &NameServerUrl) -> SocketAddr {
 /// unconfigured environment. This mirrors mihomo's behaviour and the helper of
 /// the same name in `meow-config::ech_dns`; the logic is duplicated rather than
 /// shared because `meow-config` depends on `meow-dns`, not the reverse.
-fn system_nameservers() -> Vec<SocketAddr> {
+async fn system_nameservers() -> Vec<SocketAddr> {
     let mut out = Vec::new();
     #[cfg(unix)]
     {
-        if let Ok(contents) = std::fs::read_to_string("/etc/resolv.conf") {
+        if let Ok(contents) = tokio::fs::read_to_string("/etc/resolv.conf").await {
             for line in contents.lines() {
                 let line = line.trim();
                 if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
@@ -538,7 +560,7 @@ impl Resolver {
             // is configured, use it. When absent, fall back to the system
             // resolvers (mihomo reads /etc/resolv.conf here rather than erroring).
             let bootstrap_clients: Vec<Arc<DnsClient>> = if default_ns.is_empty() {
-                let system = system_nameservers();
+                let system = system_nameservers().await;
                 tracing::warn!(
                     "default-nameserver not configured; bootstrapping '{}' via system DNS ({} server(s) from /etc/resolv.conf or hardcoded fallback)",
                     first_encrypted_with_hostname.as_deref().unwrap_or("?"),
@@ -552,10 +574,12 @@ impl Resolver {
                 default_ns
                     .iter()
                     .map(|ns| {
-                        let addr = url_to_plain_socketaddr(ns);
                         let c = match ns {
-                            NameServerUrl::Tcp { .. } => DnsClient::tcp(addr),
-                            _ => DnsClient::udp(addr),
+                            NameServerUrl::RCode { code, .. } => DnsClient::rcode(*code),
+                            NameServerUrl::Tcp { .. } => {
+                                DnsClient::tcp(url_to_plain_socketaddr(ns))
+                            }
+                            _ => DnsClient::udp(url_to_plain_socketaddr(ns)),
                         };
                         Arc::new(c.with_timeout(Duration::from_secs(3)))
                     })
@@ -642,6 +666,14 @@ impl Resolver {
             | NameServerUrl::Https { addr, port, .. } => {
                 SocketAddr::new(host_or_ip_to_addr(addr, resolved), *port)
             }
+            NameServerUrl::RCode { code, .. } => {
+                let client = DnsClient::rcode(*code);
+                let client = match proxy {
+                    Some(p) => client.with_proxy(p),
+                    None => client,
+                };
+                return Arc::new(client);
+            }
         };
         let client = match url {
             NameServerUrl::Udp { .. } => DnsClient::udp(socket_addr),
@@ -673,6 +705,9 @@ impl Resolver {
                         Cargo feature; rebuild with --features encrypted"
                     )
                 }
+            }
+            NameServerUrl::RCode { .. } => {
+                unreachable!("rcode nameservers return before socket client construction")
             }
         };
         let client = match proxy {
@@ -1406,9 +1441,9 @@ mod tests {
 
     // system_nameservers always yields at least one bootstrap address (resolv.conf
     // entries on Unix, or the hardcoded public-resolver fallback otherwise).
-    #[test]
-    fn system_nameservers_never_empty() {
-        let ns = system_nameservers();
+    #[tokio::test]
+    async fn system_nameservers_never_empty() {
+        let ns = system_nameservers().await;
         assert!(!ns.is_empty(), "system_nameservers must never be empty");
         assert!(
             ns.iter().all(|a| a.port() == 53),
@@ -1518,5 +1553,16 @@ mod tests {
             "root domain must match (+. includes root)"
         );
         assert!(pol.lookup("other.example").is_none(), "non-match must miss");
+    }
+
+    #[test]
+    fn nameserver_policy_matcher_matches_domain() {
+        let entry = PolicyEntry {
+            nameservers: vec![],
+        };
+        let mut pol = NameserverPolicy::new();
+        pol.insert_matcher(Arc::new(|domain| domain.ends_with(".cn")), entry);
+        assert!(pol.lookup("example.cn").is_some());
+        assert!(pol.lookup("example.com").is_none());
     }
 }

--- a/crates/meow-dns/src/upstream.rs
+++ b/crates/meow-dns/src/upstream.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::net::IpAddr;
 
+use hickory_proto::op::ResponseCode;
+
 /// A parsed nameserver URL in one of the supported transport forms.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -23,6 +25,10 @@ pub enum NameServerUrl {
         port: u16,
         path: String,
         sni: String,
+    },
+    RCode {
+        code: ResponseCode,
+        label: String,
     },
 }
 
@@ -56,6 +62,7 @@ impl fmt::Display for NameServerUrl {
             } => {
                 write!(f, "https://{addr}:{port}{path}#{sni}")
             }
+            NameServerUrl::RCode { label, .. } => write!(f, "rcode://{label}"),
         }
     }
 }
@@ -126,6 +133,7 @@ impl NameServerUrl {
             | NameServerUrl::Tcp { addr, .. }
             | NameServerUrl::Tls { addr, .. }
             | NameServerUrl::Https { addr, .. } => addr,
+            NameServerUrl::RCode { .. } => return None,
         };
         match addr {
             HostOrIp::Host(h) => Some(h.as_str()),
@@ -135,7 +143,10 @@ impl NameServerUrl {
 
     /// Returns true if this is a plain (non-encrypted) nameserver.
     pub fn is_plain(&self) -> bool {
-        matches!(self, NameServerUrl::Udp { .. } | NameServerUrl::Tcp { .. })
+        matches!(
+            self,
+            NameServerUrl::Udp { .. } | NameServerUrl::Tcp { .. } | NameServerUrl::RCode { .. }
+        )
     }
 
     /// Parse a nameserver string into a `NameServerUrl`.
@@ -174,6 +185,9 @@ impl NameServerUrl {
         if let Some(rest) = s_no_frag.strip_prefix("tcp://") {
             let (addr, port) = parse_host_port(rest, 53)?;
             return Ok(NameServerUrl::Tcp { addr, port });
+        }
+        if let Some(rest) = s_no_frag.strip_prefix("rcode://") {
+            return parse_rcode(rest);
         }
         if s_no_frag.starts_with("quic://") {
             return Err(NameServerParseError::QuicNotSupported);
@@ -243,6 +257,23 @@ impl NameServerUrl {
     fn parse_https(_rest: &str, _fragment: Option<&str>) -> Result<Self, NameServerParseError> {
         Err(NameServerParseError::EncryptedFeatureDisabled)
     }
+}
+
+fn parse_rcode(s: &str) -> Result<NameServerUrl, NameServerParseError> {
+    let label = s.trim();
+    let code = match label {
+        "success" => ResponseCode::NoError,
+        "format_error" => ResponseCode::FormErr,
+        "server_failure" => ResponseCode::ServFail,
+        "name_error" => ResponseCode::NXDomain,
+        "not_implemented" => ResponseCode::NotImp,
+        "refused" => ResponseCode::Refused,
+        _ => return Err(NameServerParseError::UnsupportedRCode(label.to_string())),
+    };
+    Ok(NameServerUrl::RCode {
+        code,
+        label: label.to_string(),
+    })
 }
 
 /// Parse `host:port` or `[ipv6]:port` or bare `host`, returning `(HostOrIp, port)`.
@@ -328,6 +359,8 @@ pub enum NameServerParseError {
         "encrypted DNS (tls:// / https://) requires the 'encrypted' Cargo feature to be enabled"
     )]
     EncryptedFeatureDisabled,
+    #[error("unsupported rcode nameserver type '{0}'")]
+    UnsupportedRCode(String),
 }
 
 #[cfg(test)]
@@ -583,6 +616,26 @@ mod tests {
         assert!(matches!(err, NameServerParseError::UnsupportedScheme(ref s) if s == "sdns"));
     }
 
+    #[test]
+    fn parse_rcode_success() {
+        let url = NameServerUrl::parse("rcode://success").unwrap();
+        assert_eq!(
+            url,
+            NameServerUrl::RCode {
+                code: ResponseCode::NoError,
+                label: "success".to_string(),
+            }
+        );
+        assert_eq!(url.to_string(), "rcode://success");
+        assert_eq!(url.needs_bootstrap(), None);
+    }
+
+    #[test]
+    fn parse_rcode_unknown_errors() {
+        let err = NameServerUrl::parse("rcode://unknown").unwrap_err();
+        assert!(matches!(err, NameServerParseError::UnsupportedRCode(ref s) if s == "unknown"));
+    }
+
     // A19
     #[test]
     fn parse_empty_string_errors() {
@@ -663,6 +716,7 @@ mod tests {
             NameServerParseError::UnsupportedScheme(_) => "unsupported",
             NameServerParseError::InvalidHost(_) => "invalid host",
             NameServerParseError::InvalidPort(_) => "invalid port",
+            NameServerParseError::UnsupportedRCode(_) => "rcode",
             _ => "other",
         };
     }

--- a/crates/meow-rules/src/geosite.rs
+++ b/crates/meow-rules/src/geosite.rs
@@ -71,6 +71,17 @@ impl GeositeDB {
     /// True iff `domain` is in the named category. Category match is
     /// case-insensitive. Unknown categories return `false` (no error).
     pub fn lookup(&self, category: &str, domain: &str) -> bool {
+        let (base, attrs) = split_category_attrs(category);
+        if !attrs.is_empty() {
+            return attrs.iter().all(|attr| {
+                let attr_category = format!("{base}@{attr}");
+                self.lookup_one(&attr_category, domain)
+            });
+        }
+        self.lookup_one(base, domain)
+    }
+
+    fn lookup_one(&self, category: &str, domain: &str) -> bool {
         let Some(cat) = self.category_key(category) else {
             return false;
         };
@@ -210,6 +221,17 @@ impl GeositeDB {
         let bytes = std::fs::read(path)?;
         Self::from_bytes(&bytes, allowed)
     }
+}
+
+fn split_category_attrs(category: &str) -> (&str, Vec<String>) {
+    let mut parts = category.trim().split('@');
+    let base = parts.next().unwrap_or("").trim();
+    let attrs = parts
+        .map(str::trim)
+        .filter(|attr| !attr.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect();
+    (base, attrs)
 }
 
 /// Meow home directory for geosite discovery.
@@ -380,6 +402,18 @@ mod tests {
         db.insert("CN", "Example.COM");
         assert!(db.lookup("cn", "example.com"));
         assert!(db.lookup("CN", "EXAMPLE.COM"));
+    }
+
+    #[test]
+    fn lookup_attribute_category_requires_attribute_bucket() {
+        let mut db = GeositeDB::empty();
+        db.insert("microsoft", "global.example");
+        db.insert("microsoft@cn", "cn.example");
+        db.insert("microsoft@ms", "cn.example");
+        assert!(db.lookup("microsoft", "global.example"));
+        assert!(db.lookup("microsoft@cn", "cn.example"));
+        assert!(db.lookup("microsoft@cn@ms", "cn.example"));
+        assert!(!db.lookup("microsoft@cn", "global.example"));
     }
 
     #[test]

--- a/crates/meow-rules/src/geosite_dat.rs
+++ b/crates/meow-rules/src/geosite_dat.rs
@@ -8,8 +8,7 @@
 //!   enum Type { Plain = 0; Regex = 1; Domain = 2; Full = 3; }
 //!   Type type = 1;
 //!   string value = 2;
-//!   // Attribute (field 3) is parsed and discarded — attribute filtering
-//!   // is not implemented (Class B per ADR-0002 §GEOSITE @-suffix).
+//!   repeated Attribute attribute = 3;
 //! }
 //! message GeoSite { string country_code = 1; repeated Domain domain = 2; }
 //! message GeoSiteList { repeated GeoSite entry = 1; }
@@ -40,6 +39,8 @@ const FIELD_GEOSITE_COUNTRY_CODE: u32 = 1;
 const FIELD_GEOSITE_DOMAIN: u32 = 2;
 const FIELD_DOMAIN_TYPE: u32 = 1;
 const FIELD_DOMAIN_VALUE: u32 = 2;
+const FIELD_DOMAIN_ATTRIBUTE: u32 = 3;
+const FIELD_ATTRIBUTE_KEY: u32 = 1;
 
 /// `Domain.Type` enum values.
 const DOMAIN_TYPE_PLAIN: u64 = 0;
@@ -265,29 +266,49 @@ fn parse_geosite_entry<'a>(
         }
     }
 
-    let trie = categories.entry(country.clone()).or_default();
-    let regexes = regex_patterns.entry(country.clone()).or_default();
-    let keywords = keyword_patterns.entry(country.clone()).or_default();
-    let mut count = counts.get(&country).copied().unwrap_or(0);
     for domain_bytes in deferred_domains {
-        if let Some(()) = apply_domain_entry(domain_bytes, trie, regexes, keywords, skipped)? {
-            count += 1;
+        let Some(entry) = parse_domain_entry(domain_bytes, skipped)? else {
+            continue;
+        };
+        if insert_domain_entry(
+            &entry,
+            categories.entry(country.clone()).or_default(),
+            regex_patterns.entry(country.clone()).or_default(),
+            keyword_patterns.entry(country.clone()).or_default(),
+            skipped,
+        ) {
+            *counts.entry(country.clone()).or_insert(0) += 1;
+        }
+        for attr in &entry.attrs {
+            let attr_country = format!("{country}@{attr}");
+            if insert_domain_entry(
+                &entry,
+                categories.entry(attr_country.clone()).or_default(),
+                regex_patterns.entry(attr_country.clone()).or_default(),
+                keyword_patterns.entry(attr_country.clone()).or_default(),
+                skipped,
+            ) {
+                *counts.entry(attr_country).or_insert(0) += 1;
+            }
         }
     }
-    counts.insert(country, count);
     Ok(())
 }
 
-fn apply_domain_entry(
+struct ParsedDomainEntry {
+    dom_type: u64,
+    value: String,
+    attrs: Vec<String>,
+}
+
+fn parse_domain_entry(
     data: &[u8],
-    trie: &mut DomainTrie<()>,
-    regexes: &mut Vec<String>,
-    keywords: &mut Vec<String>,
     skipped: &mut SkipStats,
-) -> Result<Option<()>, DatError> {
+) -> Result<Option<ParsedDomainEntry>, DatError> {
     let mut r = PbReader::new(data);
     let mut dom_type: u64 = DOMAIN_TYPE_DOMAIN;
     let mut value: Option<String> = None;
+    let mut attrs = Vec::new();
     let mut saw_type = false;
 
     while !r.is_at_end() {
@@ -303,6 +324,12 @@ fn apply_domain_entry(
                     .map_err(|_| DatError::InvalidUtf8(r.pos))?
                     .to_ascii_lowercase();
                 value = Some(s);
+            }
+            (FIELD_DOMAIN_ATTRIBUTE, WIRE_LEN_DELIM) => {
+                let bytes = r.read_length_delimited()?;
+                if let Some(key) = parse_attribute_key(bytes)? {
+                    attrs.push(key);
+                }
             }
             (_, w) => r.skip_field(w)?,
         }
@@ -321,37 +348,64 @@ fn apply_domain_entry(
         return Ok(None);
     }
 
-    match dom_type {
+    Ok(Some(ParsedDomainEntry {
+        dom_type,
+        value,
+        attrs,
+    }))
+}
+
+fn parse_attribute_key(data: &[u8]) -> Result<Option<String>, DatError> {
+    let mut r = PbReader::new(data);
+    let mut key = None;
+    while !r.is_at_end() {
+        let (field, wire) = r.read_tag()?;
+        match (field, wire) {
+            (FIELD_ATTRIBUTE_KEY, WIRE_LEN_DELIM) => {
+                let bytes = r.read_length_delimited()?;
+                let s = std::str::from_utf8(bytes)
+                    .map_err(|_| DatError::InvalidUtf8(r.pos))?
+                    .trim()
+                    .to_ascii_lowercase();
+                if !s.is_empty() {
+                    key = Some(s);
+                }
+            }
+            (_, w) => r.skip_field(w)?,
+        }
+    }
+    Ok(key)
+}
+
+fn insert_domain_entry(
+    entry: &ParsedDomainEntry,
+    trie: &mut DomainTrie<()>,
+    regexes: &mut Vec<String>,
+    keywords: &mut Vec<String>,
+    skipped: &mut SkipStats,
+) -> bool {
+    let value = entry.value.clone();
+    match entry.dom_type {
         DOMAIN_TYPE_PLAIN => {
             keywords.push(value);
-            Ok(Some(()))
+            true
         }
         DOMAIN_TYPE_REGEX => {
             if regex::Regex::new(&value).is_ok() {
                 regexes.push(value);
-                Ok(Some(()))
+                true
             } else {
                 skipped.bad_regex += 1;
-                Ok(None)
+                false
             }
         }
         DOMAIN_TYPE_DOMAIN => {
             let pat = format!("+.{value}");
             let _ = trie.insert(&value, ());
-            if trie.insert(&pat, ()) {
-                Ok(Some(()))
-            } else {
-                Ok(None)
-            }
+            trie.insert(&pat, ())
         }
-        DOMAIN_TYPE_FULL => {
-            if trie.insert(&value, ()) {
-                Ok(Some(()))
-            } else {
-                Ok(None)
-            }
-        }
-        _ => Ok(None),
+        DOMAIN_TYPE_FULL => trie.insert(&value, ()),
+        _ => false,
     }
 }
 
@@ -383,6 +437,17 @@ mod tests {
 
     /// Build a minimal Domain submessage.
     fn build_domain(ty: u64, value: &str) -> Vec<u8> {
+        build_domain_with_attrs(ty, value, &[])
+    }
+
+    fn build_attribute(key: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        write_tag(&mut out, FIELD_ATTRIBUTE_KEY, WIRE_LEN_DELIM);
+        write_len_delim(&mut out, key.as_bytes());
+        out
+    }
+
+    fn build_domain_with_attrs(ty: u64, value: &str, attrs: &[&str]) -> Vec<u8> {
         let mut out = Vec::new();
         if ty != DOMAIN_TYPE_PLAIN {
             write_tag(&mut out, FIELD_DOMAIN_TYPE, WIRE_VARINT);
@@ -390,6 +455,11 @@ mod tests {
         }
         write_tag(&mut out, FIELD_DOMAIN_VALUE, WIRE_LEN_DELIM);
         write_len_delim(&mut out, value.as_bytes());
+        for attr in attrs {
+            let attr = build_attribute(attr);
+            write_tag(&mut out, FIELD_DOMAIN_ATTRIBUTE, WIRE_LEN_DELIM);
+            write_len_delim(&mut out, &attr);
+        }
         out
     }
 
@@ -450,6 +520,31 @@ mod tests {
         assert!(db.lookup("mixed", "has-keyword-in-it.com"));
         assert!(db.lookup("mixed", "drop-something-regex"));
         assert!(!db.lookup("mixed", "nomatch.org"));
+    }
+
+    #[test]
+    fn parse_attribute_filtered_entries() {
+        let tagged = build_domain_with_attrs(DOMAIN_TYPE_DOMAIN, "cn.example", &["cn", "ms"]);
+        let untagged = build_domain(DOMAIN_TYPE_DOMAIN, "global.example");
+        let mut site = Vec::new();
+        write_tag(&mut site, FIELD_GEOSITE_COUNTRY_CODE, WIRE_LEN_DELIM);
+        write_len_delim(&mut site, b"microsoft");
+        for dom in [tagged, untagged] {
+            write_tag(&mut site, FIELD_GEOSITE_DOMAIN, WIRE_LEN_DELIM);
+            write_len_delim(&mut site, &dom);
+        }
+
+        let mut bytes = Vec::new();
+        write_tag(&mut bytes, FIELD_GEOSITELIST_ENTRY, WIRE_LEN_DELIM);
+        write_len_delim(&mut bytes, &site);
+
+        let db = from_dat_bytes(&bytes, None).expect("ok");
+        assert!(db.lookup("microsoft", "cn.example"));
+        assert!(db.lookup("microsoft", "global.example"));
+        assert!(db.lookup("microsoft@cn", "cn.example"));
+        assert!(db.lookup("microsoft@cn@ms", "cn.example"));
+        assert!(!db.lookup("microsoft@cn", "global.example"));
+        assert!(!db.lookup("microsoft@jp", "cn.example"));
     }
 
     #[test]

--- a/crates/meow-rules/src/geosite_rule.rs
+++ b/crates/meow-rules/src/geosite_rule.rs
@@ -10,11 +10,9 @@ use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
 use crate::geosite::GeositeDB;
 
 pub struct GeoSiteRule {
-    /// Lower-cased category name (any `@suffix` stripped at parse time).
+    /// Lower-cased category name, including any `@attribute` suffix.
     category: String,
     /// Raw payload preserved for diagnostics / API introspection.
-    /// This may still contain the `@suffix` even though the suffix is
-    /// ignored for matching — matches upstream `Payload()` behavior.
     payload_raw: String,
     adapter: String,
     /// Shared DB loaded once at startup. `None` when the DB file was not
@@ -25,16 +23,10 @@ pub struct GeoSiteRule {
 
 impl GeoSiteRule {
     /// Construct a rule. `payload` may contain an `@suffix` (e.g.
-    /// `"cn@!cn"`); the suffix is stripped for matching but warn-once is
-    /// expected to have been emitted by the parser (not by this function —
-    /// constructing a rule directly from code is a test-only path).
+    /// `"microsoft@cn"`); the suffix is preserved and interpreted by
+    /// [`GeositeDB::lookup`].
     pub fn new(payload: &str, adapter: &str, db: Option<Arc<GeositeDB>>, no_resolve: bool) -> Self {
-        let category = payload
-            .split('@')
-            .next()
-            .unwrap_or("")
-            .trim()
-            .to_ascii_lowercase();
+        let category = payload.trim().to_ascii_lowercase();
         Self {
             category,
             payload_raw: payload.to_string(),
@@ -180,15 +172,18 @@ mod tests {
         assert!(!r_no_resolve.should_resolve_ip());
     }
 
-    /// @suffix is stripped from the stored category for matching, but
-    /// preserved in the `payload()` output (matches upstream Payload()).
+    /// @suffix is preserved for matching and payload output.
     #[test]
-    fn at_suffix_stripped_for_matching() {
-        let db = db_with(&[("cn", &["baidu.com"])]);
-        let r = GeoSiteRule::new("cn@!cn", "DIRECT", Some(db), false);
-        assert_eq!(r.category(), "cn");
-        assert_eq!(r.payload(), "cn@!cn");
-        assert!(r.match_metadata(&meta_host("baidu.com"), &helper()));
+    fn at_suffix_preserved_for_matching() {
+        let db = db_with(&[
+            ("microsoft", &["global.example"]),
+            ("microsoft@cn", &["cn.example"]),
+        ]);
+        let r = GeoSiteRule::new("microsoft@cn", "DIRECT", Some(db), false);
+        assert_eq!(r.category(), "microsoft@cn");
+        assert_eq!(r.payload(), "microsoft@cn");
+        assert!(r.match_metadata(&meta_host("cn.example"), &helper()));
+        assert!(!r.match_metadata(&meta_host("global.example"), &helper()));
     }
 
     /// Uses sniff_host when set, same as other domain rules.

--- a/crates/meow-rules/src/in_port.rs
+++ b/crates/meow-rules/src/in_port.rs
@@ -1,51 +1,71 @@
 //! IN-PORT rule — matches on the inbound listener port (`Metadata.in_port`).
 //!
-//! Payload: a single port number or a `lo-hi` range.
+//! Payload: a port number, a `lo-hi` range, or a comma/slash-separated list.
 //!
 //! upstream: `rules/common/inport.go`
 
 use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
 
 pub struct InPortRule {
-    lo: u16,
-    hi: u16,
+    ranges: Vec<InPortRange>,
     raw: String,
     adapter: String,
 }
 
+enum InPortRange {
+    Single(u16),
+    Range(u16, u16),
+}
+
 impl InPortRule {
-    /// Parse `ports` as `"8080"` or `"1000-2000"`.
+    /// Parse `ports` as `"8080"`, `"1000-2000"`, or a comma/slash list.
     ///
     /// upstream: `rules/common/inport.go::NewInPort`
     pub fn new(ports: &str, adapter: &str) -> Result<Self, String> {
-        let (lo, hi) = if let Some((l, r)) = ports.split_once('-') {
-            let lo = l
-                .trim()
-                .parse::<u16>()
-                .map_err(|e| format!("invalid IN-PORT range start '{}': {}", l.trim(), e))?;
-            let hi = r
-                .trim()
-                .parse::<u16>()
-                .map_err(|e| format!("invalid IN-PORT range end '{}': {}", r.trim(), e))?;
-            if lo > hi {
-                return Err(format!(
-                    "invalid IN-PORT range {lo}-{hi}: start must be ≤ end"
-                ));
+        let mut ranges = Vec::new();
+        for part in ports.split([',', '/']) {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
             }
-            (lo, hi)
-        } else {
-            let p = ports
-                .trim()
-                .parse::<u16>()
-                .map_err(|e| format!("invalid IN-PORT '{}': {}", ports.trim(), e))?;
-            (p, p)
-        };
+            if let Some((l, r)) = part.split_once('-') {
+                let lo = l
+                    .trim()
+                    .parse::<u16>()
+                    .map_err(|e| format!("invalid IN-PORT range start '{}': {}", l.trim(), e))?;
+                let hi = r
+                    .trim()
+                    .parse::<u16>()
+                    .map_err(|e| format!("invalid IN-PORT range end '{}': {}", r.trim(), e))?;
+                if lo > hi {
+                    return Err(format!(
+                        "invalid IN-PORT range {lo}-{hi}: start must be <= end"
+                    ));
+                }
+                ranges.push(InPortRange::Range(lo, hi));
+            } else {
+                let p = part
+                    .parse::<u16>()
+                    .map_err(|e| format!("invalid IN-PORT '{part}': {e}"))?;
+                ranges.push(InPortRange::Single(p));
+            }
+        }
+
+        if ranges.is_empty() {
+            return Err("invalid IN-PORT: empty range list".to_string());
+        }
 
         Ok(Self {
-            lo,
-            hi,
+            ranges,
             raw: ports.to_string(),
             adapter: adapter.to_string(),
+        })
+    }
+
+    fn matches_port(&self, port: u16) -> bool {
+        self.ranges.iter().any(|range| match range {
+            InPortRange::Single(value) => port == *value,
+            InPortRange::Range(lo, hi) => port >= *lo && port <= *hi,
         })
     }
 }
@@ -61,7 +81,7 @@ impl Rule for InPortRule {
         if metadata.in_port == 0 {
             return false;
         }
-        metadata.in_port >= self.lo && metadata.in_port <= self.hi
+        self.matches_port(metadata.in_port)
     }
 
     fn adapter(&self) -> &str {
@@ -136,5 +156,13 @@ mod tests {
     #[test]
     fn in_port_inverted_range_errors() {
         assert!(InPortRule::new("2000-1000", "DIRECT").is_err());
+    }
+
+    #[test]
+    fn in_port_slash_list_matches() {
+        let r = InPortRule::new("80/8080/443/8443", "PROXY").unwrap();
+        assert!(r.match_metadata(&meta_with_port(8080), &helper()));
+        assert!(r.match_metadata(&meta_with_port(8443), &helper()));
+        assert!(!r.match_metadata(&meta_with_port(53), &helper()));
     }
 }

--- a/crates/meow-rules/src/lib.rs
+++ b/crates/meow-rules/src/lib.rs
@@ -33,7 +33,7 @@ pub mod uid;
 
 pub use parser::{parse_rule, ParserContext};
 pub use rule_set::{
-    build_rule_set, build_rule_set_from_mrs, is_mrs_bytes, ClassicalRuleSet, DomainRuleSet,
-    IpCidrRuleSet, RuleSet, RuleSetBehavior, RuleSetFormat,
+    build_rule_set, build_rule_set_from_mrs, build_rule_set_from_mrs_with_behavior, is_mrs_bytes,
+    ClassicalRuleSet, DomainRuleSet, IpCidrRuleSet, RuleSet, RuleSetBehavior, RuleSetFormat,
 };
 pub use rule_set_rule::RuleSetRule;

--- a/crates/meow-rules/src/mrs_parser.rs
+++ b/crates/meow-rules/src/mrs_parser.rs
@@ -43,9 +43,12 @@
 //! confirm the parser reverses its own encoder.
 
 use std::io::{Cursor, Read};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 pub const MRS_MAGIC: [u8; 4] = *b"MRS!";
 pub const MRS_VERSION: u8 = 1;
+pub const UPSTREAM_MRS_MAGIC: [u8; 4] = *b"MRS\x01";
+pub const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 
 pub const TYPE_DOMAIN: u8 = 0;
 pub const TYPE_IPCIDR: u8 = 1;
@@ -59,6 +62,10 @@ pub enum MrsError {
     UnsupportedVersion(u8),
     #[error("mrs: unsupported type {0}")]
     UnsupportedType(u8),
+    #[error("mrs: invalid behavior {0}")]
+    InvalidBehavior(u8),
+    #[error("mrs: invalid reserved length {0}")]
+    InvalidReservedLength(i64),
     #[error("mrs: truncated {what} at offset {offset}: need {need} bytes, have {have}")]
     Truncated {
         what: &'static str,
@@ -70,6 +77,12 @@ pub enum MrsError {
     Zstd(#[from] std::io::Error),
     #[error("mrs: invalid UTF-8 in {0}: {1}")]
     Utf8(&'static str, std::string::FromUtf8Error),
+    #[error("mrs: invalid domain-set version {0}")]
+    InvalidDomainSetVersion(u8),
+    #[error("mrs: invalid ip-cidr-set version {0}")]
+    InvalidIpCidrSetVersion(u8),
+    #[error("mrs: invalid length for {0}: {1}")]
+    InvalidLength(&'static str, i64),
 }
 
 /// Parsed mrs header.
@@ -121,6 +134,275 @@ pub fn decompress_payload(compressed: &[u8]) -> Result<Vec<u8>, MrsError> {
     let mut decoder = zstd::stream::Decoder::new(Cursor::new(compressed))?;
     decoder.read_to_end(&mut out)?;
     Ok(out)
+}
+
+/// Parsed current upstream mihomo rule-provider `.mrs` payload.
+///
+/// Upstream stores the whole file as one zstd frame. The decompressed stream is:
+///
+/// ```text
+/// magic    [4]byte = "MRS\x01"
+/// behavior u8      = 0 domain, 1 ipcidr
+/// count    i64-be
+/// extraLen i64-be  = reserved bytes to skip
+/// body     behavior-specific binary set
+/// ```
+pub struct UpstreamRuleSetPayload {
+    pub behavior: u8,
+    pub count: usize,
+    pub entries: Vec<String>,
+}
+
+pub fn parse_upstream_ruleset_mrs(bytes: &[u8]) -> Result<UpstreamRuleSetPayload, MrsError> {
+    let decompressed = decompress_payload(bytes)?;
+    let mut r = ByteReader::new(&decompressed);
+    let magic = r.read_array::<4>("upstream_magic")?;
+    if magic != UPSTREAM_MRS_MAGIC {
+        return Err(MrsError::WrongFormat);
+    }
+
+    let behavior = r.read_u8("behavior")?;
+    let count = r.read_i64_be("count")?;
+    if count < 0 {
+        return Err(MrsError::InvalidLength("count", count));
+    }
+
+    let extra_len = r.read_i64_be("extra_len")?;
+    if extra_len < 0 {
+        return Err(MrsError::InvalidReservedLength(extra_len));
+    }
+    let _ = r.read_slice("extra", extra_len as usize)?;
+
+    let body = r.remaining_slice();
+    let entries = match behavior {
+        TYPE_DOMAIN => parse_upstream_domain_set(body)?,
+        TYPE_IPCIDR => parse_upstream_ipcidr_set(body)?,
+        other => return Err(MrsError::InvalidBehavior(other)),
+    };
+
+    Ok(UpstreamRuleSetPayload {
+        behavior,
+        count: count as usize,
+        entries,
+    })
+}
+
+fn parse_upstream_domain_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
+    let mut r = ByteReader::new(data);
+    let version = r.read_u8("domain_set_version")?;
+    if version != 1 {
+        return Err(MrsError::InvalidDomainSetVersion(version));
+    }
+    let leaves = read_u64_vec(&mut r, "domain_set_leaves")?;
+    let label_bitmap = read_u64_vec(&mut r, "domain_set_label_bitmap")?;
+    let labels_len = r.read_i64_be("domain_set_labels_len")?;
+    if labels_len < 1 {
+        return Err(MrsError::InvalidLength("domain_set_labels_len", labels_len));
+    }
+    let labels = r.read_slice("domain_set_labels", labels_len as usize)?;
+
+    let traversal = DomainSetTraversal {
+        leaves: &leaves,
+        label_bitmap: &label_bitmap,
+        label_index: DomainSetIndex::new(&label_bitmap),
+        labels,
+    };
+    let mut reversed = Vec::new();
+    let mut current = Vec::new();
+    traversal.traverse(0, 0, &mut current, &mut reversed);
+
+    Ok(reversed
+        .into_iter()
+        .filter_map(|bytes| String::from_utf8(bytes.into_iter().rev().collect()).ok())
+        .collect())
+}
+
+fn read_u64_vec(r: &mut ByteReader<'_>, what: &'static str) -> Result<Vec<u64>, MrsError> {
+    let len = r.read_i64_be(what)?;
+    if len < 1 {
+        return Err(MrsError::InvalidLength(what, len));
+    }
+    let mut out = Vec::with_capacity(len as usize);
+    for _ in 0..len {
+        out.push(r.read_u64_be(what)?);
+    }
+    Ok(out)
+}
+
+struct DomainSetTraversal<'a> {
+    leaves: &'a [u64],
+    label_bitmap: &'a [u64],
+    label_index: DomainSetIndex,
+    labels: &'a [u8],
+}
+
+impl DomainSetTraversal<'_> {
+    fn traverse(
+        &self,
+        node_id: usize,
+        bm_idx: usize,
+        current: &mut Vec<u8>,
+        out: &mut Vec<Vec<u8>>,
+    ) {
+        if get_bit(self.leaves, node_id) {
+            out.push(current.clone());
+        }
+
+        let mut idx = bm_idx;
+        loop {
+            if get_bit(self.label_bitmap, idx) {
+                return;
+            }
+
+            let label_idx = idx.saturating_sub(node_id);
+            let Some(&label) = self.labels.get(label_idx) else {
+                return;
+            };
+            let next_node_id = self.label_index.count_zeros(self.label_bitmap, idx + 1);
+            let Some(prev_terminator) = self.label_index.select_one(next_node_id.saturating_sub(1))
+            else {
+                return;
+            };
+            let next_bm_idx = prev_terminator + 1;
+
+            current.push(label);
+            self.traverse(next_node_id, next_bm_idx, current, out);
+            current.pop();
+            idx += 1;
+        }
+    }
+}
+
+struct DomainSetIndex {
+    rank_ones_by_word: Vec<usize>,
+    select_ones: Vec<usize>,
+}
+
+impl DomainSetIndex {
+    fn new(bits: &[u64]) -> Self {
+        let mut rank_ones_by_word = Vec::with_capacity(bits.len() + 1);
+        let mut select_ones = Vec::new();
+        let mut seen_ones = 0usize;
+        for (word_idx, word) in bits.iter().copied().enumerate() {
+            rank_ones_by_word.push(seen_ones);
+            let mut remaining = word;
+            while remaining != 0 {
+                let bit = remaining.trailing_zeros() as usize;
+                select_ones.push(word_idx * 64 + bit);
+                remaining &= remaining - 1;
+            }
+            seen_ones += word.count_ones() as usize;
+        }
+        rank_ones_by_word.push(seen_ones);
+        Self {
+            rank_ones_by_word,
+            select_ones,
+        }
+    }
+
+    fn count_zeros(&self, bits: &[u64], upto: usize) -> usize {
+        let total_bits = bits.len().saturating_mul(64);
+        let upto = upto.min(total_bits);
+        let word = upto / 64;
+        let bit = upto % 64;
+        let mut ones = self.rank_ones_by_word.get(word).copied().unwrap_or(0);
+        if bit > 0 {
+            if let Some(value) = bits.get(word) {
+                let mask = (1u64 << bit) - 1;
+                ones += (value & mask).count_ones() as usize;
+            }
+        }
+        upto - ones
+    }
+
+    fn select_one(&self, nth: usize) -> Option<usize> {
+        self.select_ones.get(nth).copied()
+    }
+}
+
+fn get_bit(bits: &[u64], idx: usize) -> bool {
+    bits.get(idx / 64)
+        .is_some_and(|word| (word & (1u64 << (idx % 64))) != 0)
+}
+
+fn parse_upstream_ipcidr_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
+    let mut r = ByteReader::new(data);
+    let version = r.read_u8("ipcidr_set_version")?;
+    if version != 1 {
+        return Err(MrsError::InvalidIpCidrSetVersion(version));
+    }
+    let len = r.read_i64_be("ipcidr_set_ranges_len")?;
+    if len < 1 {
+        return Err(MrsError::InvalidLength("ipcidr_set_ranges_len", len));
+    }
+    let mut out = Vec::new();
+    for _ in 0..len {
+        let from = r.read_array::<16>("ipcidr_from")?;
+        let to = r.read_array::<16>("ipcidr_to")?;
+        let from = IpAddr::from(Ipv6Addr::from(from));
+        let to = IpAddr::from(Ipv6Addr::from(to));
+        push_range_prefixes(from, to, &mut out);
+    }
+    Ok(out)
+}
+
+fn push_range_prefixes(from: IpAddr, to: IpAddr, out: &mut Vec<String>) {
+    match (from, to) {
+        (IpAddr::V4(a), IpAddr::V4(b)) => push_v4_range(a, b, out),
+        (IpAddr::V6(a), IpAddr::V6(b))
+            if a.to_ipv4_mapped().is_some() && b.to_ipv4_mapped().is_some() =>
+        {
+            push_v4_range(
+                a.to_ipv4_mapped().unwrap(),
+                b.to_ipv4_mapped().unwrap(),
+                out,
+            );
+        }
+        (IpAddr::V6(a), IpAddr::V6(b)) => push_v6_range(a, b, out),
+        _ => {}
+    }
+}
+
+fn push_v4_range(from: Ipv4Addr, to: Ipv4Addr, out: &mut Vec<String>) {
+    let mut start = u32::from(from);
+    let end = u32::from(to);
+    if start == 0 && end == u32::MAX {
+        out.push("0.0.0.0/0".to_string());
+        return;
+    }
+    while start <= end {
+        let max_size = start.trailing_zeros();
+        let remaining = u64::from(end) - u64::from(start) + 1;
+        let block_bits = max_size.min(63 - remaining.leading_zeros());
+        let prefix = 32 - block_bits;
+        out.push(format!("{}/{}", Ipv4Addr::from(start), prefix));
+        let step = 1u32 << block_bits;
+        if remaining == u64::from(step) {
+            break;
+        }
+        start = start.saturating_add(step);
+    }
+}
+
+fn push_v6_range(from: Ipv6Addr, to: Ipv6Addr, out: &mut Vec<String>) {
+    let mut start = u128::from(from);
+    let end = u128::from(to);
+    if start == 0 && end == u128::MAX {
+        out.push("::/0".to_string());
+        return;
+    }
+    while start <= end {
+        let max_size = start.trailing_zeros();
+        let remaining = end - start + 1;
+        let block_bits = max_size.min(127 - remaining.leading_zeros());
+        let prefix = 128 - block_bits;
+        out.push(format!("{}/{}", Ipv6Addr::from(start), prefix));
+        let step = 1u128 << block_bits;
+        if end - start + 1 == step {
+            break;
+        }
+        start = start.saturating_add(step);
+    }
 }
 
 /// A parsed geosite DB: category name → list of domains.
@@ -240,6 +522,10 @@ impl<'a> ByteReader<'a> {
         Self { data, pos: 0 }
     }
 
+    fn remaining_slice(&self) -> &'a [u8] {
+        &self.data[self.pos..]
+    }
+
     fn need(&self, what: &'static str, n: usize) -> Result<(), MrsError> {
         if self.pos + n > self.data.len() {
             return Err(MrsError::Truncated {
@@ -259,6 +545,13 @@ impl<'a> ByteReader<'a> {
         Ok(v)
     }
 
+    fn read_u8(&mut self, what: &'static str) -> Result<u8, MrsError> {
+        self.need(what, 1)?;
+        let v = self.data[self.pos];
+        self.pos += 1;
+        Ok(v)
+    }
+
     fn read_u32_be(&mut self, what: &'static str) -> Result<u32, MrsError> {
         self.need(what, 4)?;
         let v = u32::from_be_bytes([
@@ -269,6 +562,46 @@ impl<'a> ByteReader<'a> {
         ]);
         self.pos += 4;
         Ok(v)
+    }
+
+    fn read_u64_be(&mut self, what: &'static str) -> Result<u64, MrsError> {
+        self.need(what, 8)?;
+        let v = u64::from_be_bytes([
+            self.data[self.pos],
+            self.data[self.pos + 1],
+            self.data[self.pos + 2],
+            self.data[self.pos + 3],
+            self.data[self.pos + 4],
+            self.data[self.pos + 5],
+            self.data[self.pos + 6],
+            self.data[self.pos + 7],
+        ]);
+        self.pos += 8;
+        Ok(v)
+    }
+
+    fn read_i64_be(&mut self, what: &'static str) -> Result<i64, MrsError> {
+        self.need(what, 8)?;
+        let v = i64::from_be_bytes([
+            self.data[self.pos],
+            self.data[self.pos + 1],
+            self.data[self.pos + 2],
+            self.data[self.pos + 3],
+            self.data[self.pos + 4],
+            self.data[self.pos + 5],
+            self.data[self.pos + 6],
+            self.data[self.pos + 7],
+        ]);
+        self.pos += 8;
+        Ok(v)
+    }
+
+    fn read_array<const N: usize>(&mut self, what: &'static str) -> Result<[u8; N], MrsError> {
+        self.need(what, N)?;
+        let mut out = [0u8; N];
+        out.copy_from_slice(&self.data[self.pos..self.pos + N]);
+        self.pos += N;
+        Ok(out)
     }
 
     fn read_slice(&mut self, what: &'static str, n: usize) -> Result<&'a [u8], MrsError> {
@@ -282,6 +615,7 @@ impl<'a> ByteReader<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     fn sample() -> GeositePayload {
         GeositePayload {
@@ -293,6 +627,85 @@ mod tests {
                 ("ads".to_string(), vec!["ad.example.com".to_string()]),
             ],
         }
+    }
+
+    fn set_bit(bits: &mut Vec<u64>, idx: usize, value: bool) {
+        let word = idx / 64;
+        if bits.len() <= word {
+            bits.resize(word + 1, 0);
+        }
+        if value {
+            bits[word] |= 1u64 << (idx % 64);
+        }
+    }
+
+    fn write_i64(out: &mut Vec<u8>, value: i64) {
+        out.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn write_u64(out: &mut Vec<u8>, value: u64) {
+        out.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn encode_domain_set(entries: &[&str]) -> Vec<u8> {
+        let mut keys: Vec<Vec<u8>> = entries
+            .iter()
+            .map(|entry| entry.as_bytes().iter().rev().copied().collect())
+            .collect();
+        keys.sort();
+
+        let mut leaves = Vec::new();
+        let mut label_bitmap = Vec::new();
+        let mut labels = Vec::new();
+        let mut label_idx = 0usize;
+        let mut queue = vec![(0usize, keys.len(), 0usize)];
+
+        let mut idx = 0usize;
+        while idx < queue.len() {
+            let (mut start, end, col) = queue[idx];
+            if col == keys[start].len() {
+                start += 1;
+                set_bit(&mut leaves, idx, true);
+            }
+            let mut j = start;
+            while j < end {
+                let from = j;
+                while j < end && keys[j][col] == keys[from][col] {
+                    j += 1;
+                }
+                queue.push((from, j, col + 1));
+                labels.push(keys[from][col]);
+                set_bit(&mut label_bitmap, label_idx, false);
+                label_idx += 1;
+            }
+            set_bit(&mut label_bitmap, label_idx, true);
+            label_idx += 1;
+            idx += 1;
+        }
+
+        let mut out = Vec::new();
+        out.push(1);
+        write_i64(&mut out, leaves.len() as i64);
+        for word in leaves {
+            write_u64(&mut out, word);
+        }
+        write_i64(&mut out, label_bitmap.len() as i64);
+        for word in label_bitmap {
+            write_u64(&mut out, word);
+        }
+        write_i64(&mut out, labels.len() as i64);
+        out.extend_from_slice(&labels);
+        out
+    }
+
+    fn encode_upstream_mrs(behavior: u8, count: usize, body: &[u8]) -> Vec<u8> {
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&UPSTREAM_MRS_MAGIC);
+        inner.push(behavior);
+        write_i64(&mut inner, count as i64);
+        write_i64(&mut inner, 0);
+        inner.extend_from_slice(body);
+        zstd::encode_all(Cursor::new(inner), 0).unwrap()
     }
 
     #[test]
@@ -360,5 +773,29 @@ mod tests {
         let decompressed = decompress_payload(compressed).unwrap();
         let parsed = parse_geosite_payload(&decompressed, None).unwrap();
         assert!(parsed.categories.is_empty());
+    }
+
+    #[test]
+    fn upstream_ruleset_mrs_domain_parses() {
+        let body = encode_domain_set(&["example.com", "+.foo.com"]);
+        let bytes = encode_upstream_mrs(TYPE_DOMAIN, 2, &body);
+        let parsed = parse_upstream_ruleset_mrs(&bytes).unwrap();
+        assert_eq!(parsed.behavior, TYPE_DOMAIN);
+        assert_eq!(parsed.count, 2);
+        assert!(parsed.entries.iter().any(|e| e == "example.com"));
+        assert!(parsed.entries.iter().any(|e| e == "+.foo.com"));
+    }
+
+    #[test]
+    fn upstream_ruleset_mrs_ipcidr_parses() {
+        let mut body = Vec::new();
+        body.push(1);
+        write_i64(&mut body, 1);
+        body.extend_from_slice(&Ipv4Addr::new(192, 168, 0, 0).to_ipv6_mapped().octets());
+        body.extend_from_slice(&Ipv4Addr::new(192, 168, 0, 255).to_ipv6_mapped().octets());
+        let bytes = encode_upstream_mrs(TYPE_IPCIDR, 1, &body);
+        let parsed = parse_upstream_ruleset_mrs(&bytes).unwrap();
+        assert_eq!(parsed.behavior, TYPE_IPCIDR);
+        assert_eq!(parsed.entries, vec!["192.168.0.0/24"]);
     }
 }

--- a/crates/meow-rules/src/parser.rs
+++ b/crates/meow-rules/src/parser.rs
@@ -54,18 +54,6 @@ pub struct ParserContext {
     /// which conditionally load the DB still parse cleanly. A warn is
     /// emitted by the loader's discovery path, not here.
     pub geosite: Option<Arc<GeositeDB>>,
-    /// Internal state for warn-once on `GEOSITE,<category>@<suffix>` —
-    /// tracks whether the `@`-suffix deprecation warn has fired for this
-    /// parse context.
-    ///
-    /// Shared via `Arc<AtomicBool>` so that `ParserContext` remains `Clone`
-    /// and can be passed to rule-provider inner parsers without resetting.
-    /// Marked `#[doc(hidden)]` because it is an implementation detail of
-    /// `warn_once_at_suffix`; callers should construct `ParserContext` via
-    /// `..Default::default()` or struct update syntax and should not set
-    /// this field directly.
-    #[doc(hidden)]
-    pub geosite_at_suffix_warned: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl std::fmt::Debug for ParserContext {
@@ -81,18 +69,6 @@ impl std::fmt::Debug for ParserContext {
 impl ParserContext {
     pub fn empty() -> Self {
         Self::default()
-    }
-
-    fn warn_once_at_suffix(&self, category_raw: &str) {
-        use std::sync::atomic::Ordering;
-        if self.geosite_at_suffix_warned.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        tracing::warn!(
-            rule = %category_raw,
-            "GEOSITE '@' attribute suffix parsed but filtering is not implemented; \
-             the suffix is stripped and the full category is used (Class B per ADR-0002)"
-        );
     }
 }
 
@@ -169,9 +145,6 @@ pub fn parse_rule(line: &str, ctx: &ParserContext) -> Result<Box<dyn Rule>, Stri
             Ok(Box::new(SrcGeoIpRule::new(payload, adapter, ranges)))
         }
         "GEOSITE" => {
-            if payload.contains('@') {
-                ctx.warn_once_at_suffix(payload);
-            }
             let category = payload.split('@').next().unwrap_or("").trim();
             if category.is_empty() {
                 return Err("GEOSITE rule requires a category name".to_string());

--- a/crates/meow-rules/src/port.rs
+++ b/crates/meow-rules/src/port.rs
@@ -15,8 +15,11 @@ enum PortRange {
 impl PortRule {
     pub fn new(ports: &str, adapter: &str, is_src: bool) -> Result<Self, String> {
         let mut ranges = Vec::new();
-        for part in ports.split(',') {
+        for part in ports.split([',', '/']) {
             let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
             if let Some((start, end)) = part.split_once('-') {
                 let start: u16 = start
                     .trim()
@@ -26,11 +29,19 @@ impl PortRule {
                     .trim()
                     .parse()
                     .map_err(|e| format!("invalid port: {e}"))?;
+                if start > end {
+                    return Err(format!(
+                        "invalid port range {start}-{end}: start must be <= end"
+                    ));
+                }
                 ranges.push(PortRange::Range(start, end));
             } else {
                 let port: u16 = part.parse().map_err(|e| format!("invalid port: {e}"))?;
                 ranges.push(PortRange::Single(port));
             }
+        }
+        if ranges.is_empty() {
+            return Err("invalid port: empty range list".to_string());
         }
         Ok(Self {
             ranges,

--- a/crates/meow-rules/src/rule_set.rs
+++ b/crates/meow-rules/src/rule_set.rs
@@ -97,7 +97,9 @@ pub fn build_rule_set(
 
 /// Return `true` if `bytes` starts with the MRS magic `"MRS!"`.
 pub fn is_mrs_bytes(bytes: &[u8]) -> bool {
-    bytes.len() >= 4 && bytes[..4] == crate::mrs_parser::MRS_MAGIC
+    bytes.len() >= 4
+        && (bytes[..4] == crate::mrs_parser::MRS_MAGIC
+            || bytes[..4] == crate::mrs_parser::ZSTD_MAGIC)
 }
 
 /// Parse an MRS binary payload and return the appropriate `RuleSet`.
@@ -106,10 +108,48 @@ pub fn build_rule_set_from_mrs(
     bytes: &[u8],
     ctx: &ParserContext,
 ) -> Result<Box<dyn RuleSet>, String> {
+    build_rule_set_from_mrs_with_behavior(bytes, ctx, None)
+}
+
+/// Parse an MRS binary payload and optionally validate it against the
+/// configured provider behavior.
+pub fn build_rule_set_from_mrs_with_behavior(
+    bytes: &[u8],
+    ctx: &ParserContext,
+    expected: Option<RuleSetBehavior>,
+) -> Result<Box<dyn RuleSet>, String> {
     use crate::mrs_parser::{
-        decompress_payload, parse_header, TYPE_CLASSICAL, TYPE_DOMAIN, TYPE_IPCIDR,
+        decompress_payload, parse_header, parse_upstream_ruleset_mrs, TYPE_CLASSICAL, TYPE_DOMAIN,
+        TYPE_IPCIDR, ZSTD_MAGIC,
     };
+    if bytes.len() >= 4 && bytes[..4] == ZSTD_MAGIC {
+        let payload = parse_upstream_ruleset_mrs(bytes).map_err(|e| e.to_string())?;
+        let actual = behavior_from_type_tag(payload.behavior)?;
+        if let Some(expected) = expected {
+            if expected != actual {
+                return Err(format!(
+                    "mrs: behavior mismatch: config says {expected}, file says {actual}"
+                ));
+            }
+        }
+        return match actual {
+            RuleSetBehavior::Domain => Ok(Box::new(DomainRuleSet::from_entries(&payload.entries))),
+            RuleSetBehavior::IpCidr => Ok(Box::new(IpCidrRuleSet::from_entries(&payload.entries))),
+            RuleSetBehavior::Classical => {
+                Err("mrs: upstream format does not support classical behavior".to_string())
+            }
+        };
+    }
+
     let (hdr, compressed) = parse_header(bytes).map_err(|e| e.to_string())?;
+    let actual = behavior_from_type_tag(hdr.type_tag)?;
+    if let Some(expected) = expected {
+        if expected != actual {
+            return Err(format!(
+                "mrs: behavior mismatch: config says {expected}, file says {actual}"
+            ));
+        }
+    }
     let payload = decompress_payload(compressed).map_err(|e| e.to_string())?;
     match hdr.type_tag {
         TYPE_DOMAIN => {
@@ -124,6 +164,16 @@ pub fn build_rule_set_from_mrs(
             let entries = parse_string_list_payload(&payload)?;
             Ok(Box::new(ClassicalRuleSet::from_entries(&entries, ctx)))
         }
+        other => Err(format!("mrs: unsupported type tag {other}")),
+    }
+}
+
+fn behavior_from_type_tag(type_tag: u8) -> Result<RuleSetBehavior, String> {
+    use crate::mrs_parser::{TYPE_CLASSICAL, TYPE_DOMAIN, TYPE_IPCIDR};
+    match type_tag {
+        TYPE_DOMAIN => Ok(RuleSetBehavior::Domain),
+        TYPE_IPCIDR => Ok(RuleSetBehavior::IpCidr),
+        TYPE_CLASSICAL => Ok(RuleSetBehavior::Classical),
         other => Err(format!("mrs: unsupported type tag {other}")),
     }
 }

--- a/crates/meow-rules/tests/rules_test.rs
+++ b/crates/meow-rules/tests/rules_test.rs
@@ -282,6 +282,16 @@ fn port_multiple() {
 }
 
 #[test]
+fn port_slash_multiple() {
+    let r = PortRule::new("80/8080/443/8443", "Proxy", false).unwrap();
+    assert!(r.match_metadata(&meta("", 80), &helper()));
+    assert!(r.match_metadata(&meta("", 8080), &helper()));
+    assert!(r.match_metadata(&meta("", 443), &helper()));
+    assert!(r.match_metadata(&meta("", 8443), &helper()));
+    assert!(!r.match_metadata(&meta("", 22), &helper()));
+}
+
+#[test]
 fn port_mixed_single_and_range() {
     let r = PortRule::new("22,80,8000-9000", "Proxy", false).unwrap();
     assert!(r.match_metadata(&meta("", 22), &helper()));
@@ -585,6 +595,15 @@ fn parse_dst_port() {
     assert_eq!(r.rule_type(), RuleType::DstPort);
     assert!(r.match_metadata(&meta("", 443), &helper()));
     assert!(!r.match_metadata(&meta("", 80), &helper()));
+}
+
+#[test]
+fn parse_dst_port_slash_list() {
+    let r = parse_rule("DST-PORT,80/8080/443/8443,Proxy").unwrap();
+    assert_eq!(r.rule_type(), RuleType::DstPort);
+    assert!(r.match_metadata(&meta("", 8080), &helper()));
+    assert!(r.match_metadata(&meta("", 8443), &helper()));
+    assert!(!r.match_metadata(&meta("", 53), &helper()));
 }
 
 #[test]
@@ -937,9 +956,7 @@ fn parse_geosite_with_fixture_db_matches() {
 }
 
 #[test]
-fn parse_geosite_at_suffix_stripped_and_rule_still_matches() {
-    // Class B divergence (spec §Divergences #2) — @-attribute filtering
-    // deferred; suffix stripped and full category used.
+fn parse_geosite_at_suffix_filters_attribute_category() {
     // upstream: rules/geosite.go — @-attribute filters the category.
     use meow_rules::geosite::GeositeDB;
     use meow_rules::parse_rule as parse_rule_raw;
@@ -947,14 +964,15 @@ fn parse_geosite_at_suffix_stripped_and_rule_still_matches() {
     use std::sync::Arc;
 
     let mut db = GeositeDB::empty();
-    db.insert("cn", "baidu.com");
+    db.insert("microsoft", "global.example");
+    db.insert("microsoft@cn", "cn.example");
     let ctx = ParserContext {
         geosite: Some(Arc::new(db)),
         ..Default::default()
     };
-    let r = parse_rule_raw("GEOSITE,cn@!cn,DIRECT", &ctx).unwrap();
-    // Full category used after suffix strip.
-    assert!(r.match_metadata(&meta("baidu.com", 443), &helper()));
+    let r = parse_rule_raw("GEOSITE,microsoft@cn,DIRECT", &ctx).unwrap();
+    assert!(r.match_metadata(&meta("cn.example", 443), &helper()));
+    assert!(!r.match_metadata(&meta("global.example", 443), &helper()));
 }
 
 #[test]

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -709,13 +709,18 @@ impl PortRange {
 
 fn compile_port_matcher(payload: &str) -> Option<PortMatcher> {
     let mut ranges = Vec::new();
-    for part in payload.split(',') {
+    for part in payload.split([',', '/']) {
         let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
         if let Some((start, end)) = part.split_once('-') {
-            ranges.push(PortRange::Range(
-                start.trim().parse().ok()?,
-                end.trim().parse().ok()?,
-            ));
+            let start = start.trim().parse().ok()?;
+            let end = end.trim().parse().ok()?;
+            if start > end {
+                return None;
+            }
+            ranges.push(PortRange::Range(start, end));
         } else {
             ranges.push(PortRange::Single(part.parse().ok()?));
         }
@@ -723,22 +728,13 @@ fn compile_port_matcher(payload: &str) -> Option<PortMatcher> {
     match ranges.as_slice() {
         [PortRange::Single(value)] => Some(PortMatcher::Single(*value)),
         [PortRange::Range(lo, hi)] => Some(PortMatcher::Range(*lo, *hi)),
+        [] => None,
         _ => Some(PortMatcher::Multiple(ranges)),
     }
 }
 
 fn compile_in_port(payload: &str) -> Option<RuleOp> {
-    let matcher = if let Some((lo, hi)) = payload.split_once('-') {
-        let lo: u16 = lo.trim().parse().ok()?;
-        let hi: u16 = hi.trim().parse().ok()?;
-        if lo > hi {
-            return None;
-        }
-        PortMatcher::Range(lo, hi)
-    } else {
-        PortMatcher::Single(payload.trim().parse().ok()?)
-    };
-    Some(RuleOp::InPort(matcher))
+    compile_port_matcher(payload).map(RuleOp::InPort)
 }
 
 fn compile_network(payload: &str) -> Option<RuleOp> {
@@ -839,10 +835,22 @@ mod tests {
     use crate::match_engine::{self, DomainIndex as LegacyDomainIndex};
     use meow_common::{Metadata, Rule};
     use meow_rules::{
-        domain::DomainRule, domain_keyword::DomainKeywordRule, domain_regex::DomainRegexRule,
-        domain_suffix::DomainSuffixRule, domain_wildcard::DomainWildcardRule,
-        final_rule::FinalRule, ipcidr::IpCidrRule, logic::OrRule, port::PortRule,
+        domain::DomainRule,
+        domain_keyword::DomainKeywordRule,
+        domain_regex::DomainRegexRule,
+        domain_suffix::DomainSuffixRule,
+        domain_wildcard::DomainWildcardRule,
+        final_rule::FinalRule,
+        geosite::GeositeDB,
+        geosite_rule::GeoSiteRule,
+        in_port::InPortRule,
+        ipcidr::IpCidrRule,
+        logic::OrRule,
+        port::PortRule,
+        rule_set::{build_rule_set, RuleSet, RuleSetBehavior},
+        rule_set_rule::RuleSetRule,
         sub_rule::SubRuleRule,
+        ParserContext,
     };
     use std::net::IpAddr;
     use std::sync::{
@@ -929,6 +937,127 @@ mod tests {
             .expect("earlier port rule must match");
         assert_eq!(result.adapter_name, "Direct");
         assert_eq!(result.rule_type, RuleType::DstPort);
+    }
+
+    #[test]
+    fn lowered_dst_port_slash_list_matches() {
+        let rules: Vec<Box<dyn Rule>> = vec![Box::new(
+            PortRule::new("80/8080/443/8443", "PortProxy", false).unwrap(),
+        )];
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(set.slots()[0].is_lowered());
+
+        let meta = Metadata {
+            host: "example.com".into(),
+            dst_port: 8080,
+            ..Default::default()
+        };
+        let result = set
+            .match_rules(&meta, &rules)
+            .expect("port list must match");
+        assert_eq!(result.adapter_name, "PortProxy");
+        assert_eq!(result.rule_type, RuleType::DstPort);
+    }
+
+    #[test]
+    fn lowered_in_port_slash_list_matches() {
+        let rules: Vec<Box<dyn Rule>> = vec![Box::new(
+            InPortRule::new("80/8080/443/8443", "InboundProxy").unwrap(),
+        )];
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(set.slots()[0].is_lowered());
+
+        let meta = Metadata {
+            host: "example.com".into(),
+            in_port: 8443,
+            ..Default::default()
+        };
+        let result = set
+            .match_rules(&meta, &rules)
+            .expect("in-port list must match");
+        assert_eq!(result.adapter_name, "InboundProxy");
+        assert_eq!(result.rule_type, RuleType::InPort);
+    }
+
+    #[test]
+    fn geosite_attribute_rule_fallback_matches_under_ir() {
+        let mut db = GeositeDB::empty();
+        db.insert("microsoft", "global.example");
+        db.insert("microsoft@cn", "cn.example");
+        let rules: Vec<Box<dyn Rule>> = vec![Box::new(GeoSiteRule::new(
+            "microsoft@cn",
+            "Direct",
+            Some(Arc::new(db)),
+            false,
+        ))];
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.slots()[0].is_lowered());
+
+        let meta = Metadata {
+            host: "cn.example".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set
+            .match_rules(&meta, &rules)
+            .expect("geosite attr fallback must match");
+        assert_eq!(result.adapter_name, "Direct");
+        assert_eq!(result.rule_type, RuleType::GeoSite);
+    }
+
+    #[test]
+    fn geoip_rule_fallback_matches_under_ir() {
+        let match_count = Arc::new(AtomicUsize::new(0));
+        let counts = Arc::new(CallCounts::default());
+        let rules: Vec<Box<dyn Rule>> = vec![Box::new(CountingRule::new(
+            RuleType::GeoIp,
+            "GeoProxy",
+            "CN",
+            true,
+            Arc::clone(&match_count),
+            counts,
+        ))];
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.slots()[0].is_lowered());
+
+        let meta = Metadata {
+            dst_ip: Some("203.0.113.9".parse::<IpAddr>().unwrap()),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set
+            .match_rules(&meta, &rules)
+            .expect("geoip fallback must match");
+        assert_eq!(result.adapter_name, "GeoProxy");
+        assert_eq!(result.rule_type, RuleType::GeoIp);
+        assert_eq!(match_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn rule_set_rule_fallback_matches_under_ir() {
+        let entries = vec!["example.com".to_string()];
+        let set_box = build_rule_set(RuleSetBehavior::Domain, &entries, &ParserContext::default());
+        let rule_set: Arc<dyn RuleSet> = Arc::from(set_box);
+        let rules: Vec<Box<dyn Rule>> =
+            vec![Box::new(RuleSetRule::new("cn", rule_set, "Direct", false))];
+
+        let compiled = CompiledRuleSet::build(&rules);
+        assert!(!compiled.slots()[0].is_lowered());
+
+        let meta = Metadata {
+            host: "example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = compiled
+            .match_rules(&meta, &rules)
+            .expect("rule-set fallback must match");
+        assert_eq!(result.adapter_name, "Direct");
+        assert_eq!(result.rule_type, RuleType::RuleSet);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Support upstream MetaCube rule-provider and GEOSITE compatibility used by the reported config: zstd-backed `.mrs` payloads, `geosite:` DNS policy keys, `rcode://success`, GEOSITE attributes such as `microsoft@cn`, and slash-separated port lists.
- Keep the rule IR correct for the newly added rule behavior by falling back for GEOSITE attributes, GEOIP, RULE-SET, and slash-list port cases where needed.
- Move runtime Tokio paths away from blocking work: async config/provider/geodata file I/O where possible, `spawn_blocking` for sync rebuild/parser/provider work, async resolver/hosts reads, async fake-IP snapshot open, and offloaded selector/metrics persistence paths.
- Expose proxy-group runtime members/current selection through the API so auto proxy groups show correctly, not just individual nodes.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `RUST_LOG=meow_config=debug,meow=info cargo run -p meow-app -- -f /tmp/meow-rule-provider-geosite-check.yaml -t`
  - loaded cached provider `/tmp/./provider/rule-set/geosite-cn.mrs`
  - `Loaded rule-provider 'cn' (http/Domain): 224836 entries`
  - `Config loaded: mode=rule, proxies=4, rules=22`
  - `Configuration test passed`

## Rule Engine Perf Regression

Command:

```bash
cargo bench -p meow-tunnel --bench rules_bench -- --noplot --sample-size 10 --measurement-time 2 --warm-up-time 1
```

Criterion output used plotters because gnuplot is not installed. Change percentages below are Criterion's comparison against the previous local baseline.

| Benchmark | Linear | Indexed | IR |
| --- | ---: | ---: | ---: |
| `fixture_domain_suffix_maxlv` | 22.883 ns, improved -4.92% | 68.775 ns, improved -11.99% | 18.776 ns, improved -6.61% |
| `fixture_geosite_github` | 184.19 ns, regressed +14.70% | 214.74 ns, regressed +8.85% | 178.94 ns, regressed +13.29% |
| `fixture_geoip_cn` | 134.98 ns, regressed +8.55% | 138.91 ns, regressed +7.49% | 109.08 ns, regressed +6.05% |
| `fixture_match_fallthrough` | 6.4230 us, regressed +225.35% | 6.4679 us, regressed +217.06% | 6.4519 us, regressed +228.63% |
| `synthetic_10k_domain_suffix_hit` | 58.675 us, improved -3.46% | 57.629 us, improved -8.92% | 26.629 us, no significant change (-1.36%) |
| `synthetic_10k_match_fallthrough` | 64.919 us, no significant change (+0.89%) | 65.257 us, noise threshold (+1.18%) | 31.843 us, improved -5.44% |
| `synthetic_10k_wildcard_miss` | 78.102 us, improved -3.03% | 78.280 us, improved -3.82% | 21.646 us, improved -31.07% |

The large synthetic cases still favor the IR path materially: about 2.2x faster for 10k domain suffix hits, about 2.0x faster for 10k fallthrough, and about 3.6x faster for 10k wildcard misses versus the indexed path in this run.