### PR TITLE
[codex] refresh docs status and diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ A high-performance Rust implementation of the [mihomo](https://github.com/MetaCu
 - **Trojan** -- TLS 1.2/1.3 via rustls, SNI, optional skip-cert-verify
 - **Hysteria2** -- QUIC-based TCP and UDP relay, Salamander obfs, port hopping, down bandwidth auth hint, SNI, skip-cert-verify, and certificate pinning
 - **VLESS** -- Plain VLESS and XTLS-Vision splice; TLS, WebSocket, gRPC, H2, HTTPUpgrade transports
+- **VMess** -- AEAD VMess outbound with TCP/WebSocket transports
 - **HTTP** -- HTTP CONNECT outbound proxy with optional TLS and basic auth
 - **SOCKS5** -- SOCKS5 outbound proxy with optional TLS and auth
 - **Snell** -- v3/v4/v5 TCP, UDP-over-TCP, optional HTTP/TLS obfs; v4/v5 connection reuse
+- **AnyTLS** -- Optional AnyTLS outbound (`anytls` feature)
 - **Direct** -- Direct connection to destination
 - **Reject** -- Drop connections (with configurable behavior)
 
@@ -34,18 +36,27 @@ A high-performance Rust implementation of the [mihomo](https://github.com/MetaCu
 | DOMAIN-SUFFIX | `DOMAIN-SUFFIX,google.com,Proxy` | Domain and subdomains |
 | DOMAIN-KEYWORD | `DOMAIN-KEYWORD,google,Proxy` | Substring match |
 | DOMAIN-REGEX | `DOMAIN-REGEX,^ads?\.,Proxy` | Regex pattern |
+| DOMAIN-WILDCARD | `DOMAIN-WILDCARD,*.example.com,Proxy` | Wildcard domain pattern |
 | IP-CIDR | `IP-CIDR,10.0.0.0/8,DIRECT,no-resolve` | Destination IP range |
+| IP-SUFFIX | `IP-SUFFIX,0.0.0.1/8,Proxy` | Destination IP suffix bits |
 | SRC-IP-CIDR | `SRC-IP-CIDR,192.168.0.0/16,DIRECT` | Source IP range |
+| SRC-GEOIP | `SRC-GEOIP,CN,DIRECT` | Source GeoIP lookup |
+| IP-ASN | `IP-ASN,15169,Proxy` | Destination ASN lookup |
 | DST-PORT | `DST-PORT,80,443,8080,Proxy` | Destination port(s) |
 | SRC-PORT | `SRC-PORT,1234,DIRECT` | Source port(s) |
 | NETWORK | `NETWORK,udp,Proxy` | TCP or UDP |
 | PROCESS-NAME | `PROCESS-NAME,curl,DIRECT` | Process name |
 | PROCESS-PATH | `PROCESS-PATH,/usr/bin/curl,DIRECT` | Process path |
 | GEOIP | `GEOIP,CN,DIRECT,no-resolve` | MaxMind GeoIP lookup |
-| SRC-GEOIP | `SRC-GEOIP,CN,DIRECT` | Source GeoIP lookup |
+| GEOSITE | `GEOSITE,cn,DIRECT` | MetaCubeX `.mrs` geosite database |
+| RULE-SET | `RULE-SET,ads,REJECT` | Rule provider lookup |
 | DSCP | `DSCP,46,Proxy` | IP DSCP field |
 | IN-PORT | `IN-PORT,7890,Proxy` | Inbound listener port |
+| IN-NAME | `IN-NAME,mixed,Proxy` | Inbound listener name |
+| IN-TYPE | `IN-TYPE,SOCKS5,Proxy` | Inbound listener protocol |
+| IN-USER | `IN-USER,alice,Proxy` | Authenticated inbound user |
 | UID | `UID,1000,DIRECT` | Process UID (Linux) |
+| SUB-RULE | `SUB-RULE,LOCAL-BYPASS` | Named rule subset |
 | MATCH | `MATCH,Proxy` | Catch-all fallback |
 
 Logic composition rules (AND, OR, NOT) are also supported for combining conditions.
@@ -94,14 +105,28 @@ Built-in web UI served at `http://<api-addr>/ui` with:
 | `/version` | GET | Version info |
 | `/proxies` | GET | List all proxies |
 | `/proxies/{name}` | GET/PUT | Get or switch proxy |
+| `/proxies/{name}/delay` | GET | Run an on-demand delay probe |
+| `/group/{name}/delay` | GET | Run a group delay probe |
 | `/rules` | GET/POST/PUT | List, replace, or update rules |
 | `/rules/{index}` | DELETE | Delete rule at index |
 | `/rules/reorder` | POST | Reorder rules |
 | `/connections` | GET | Active connections with traffic stats |
+| `/connections` | DELETE | Close all active connections |
 | `/connections/{id}` | DELETE | Close a connection |
-| `/configs` | GET/PATCH | Get config (incl. ports) or update mode |
+| `/configs` | GET/PATCH/PUT | Get config, patch mode, or reload config |
 | `/traffic` | GET | Upload/download statistics |
-| `/dns/query` | POST | Direct DNS query |
+| `/logs` | GET (WS) | Runtime log stream |
+| `/memory` | GET (WS) | Runtime memory stream |
+| `/metrics` | GET | Prometheus metrics |
+| `/dns/query` | GET/POST | Direct DNS query |
+| `/cache/dns/flush` | POST | Flush DNS cache |
+| `/cache/fakeip/flush` | POST | Flush fake-IP mappings |
+| `/listeners` | GET | List configured named listeners |
+| `/providers/proxies` | GET | List proxy providers |
+| `/providers/proxies/{name}` | GET/PUT | Get or refresh a proxy provider |
+| `/providers/proxies/{name}/healthcheck` | GET | Run provider health check |
+| `/providers/rules` | GET | List rule providers |
+| `/providers/rules/{name}` | GET/PUT | Get or refresh a rule provider |
 | `/api/config/save` | POST | Save running config to disk |
 | `/api/subscriptions` | GET/POST | List or add subscriptions |
 | `/api/subscriptions/{name}` | DELETE | Delete subscription |
@@ -136,18 +161,16 @@ Single-run results from `bash bench.sh`; numbers will vary with host load. For t
 
 ## Architecture
 
-```
-Listeners (HTTP/SOCKS5/Mixed/TProxy)
-        |
-        v
-    Tunnel (routing engine)  <-->  DNS Resolver (Normal/Snooping)
-        |
-    Rule Matching Engine
-        |
-        v
-  Proxy Adapters / Groups  --->  Remote Server
-
-  REST API Server (Axum)   --->  Runtime control + Web UI
+```mermaid
+flowchart TD
+    inbound["Inbound listeners<br/>Mixed / HTTP / SOCKS5 / TProxy"] --> tunnel["Tunnel<br/>routing, relay, connection stats"]
+    api["REST API + Web UI<br/>Axum"] --> tunnel
+    api --> runtime["Runtime state<br/>config, subscriptions, proxy groups, rules"]
+    runtime --> tunnel
+    tunnel <--> dns["DNS resolver<br/>cache, fake-IP, policy, snooping"]
+    tunnel --> rules["Rule engine<br/>linear / indexed / IR matchers"]
+    rules --> outbounds["Proxy adapters and groups<br/>SS, Trojan, VLESS, VMess, Snell, Hysteria2, Direct, Reject"]
+    outbounds --> remote["Remote server / DIRECT"]
 ```
 
 11 workspace crates with clear separation of concerns:

--- a/docs/ci-status.md
+++ b/docs/ci-status.md
@@ -1,118 +1,117 @@
 # CI Status Report
 
-Last updated: 2026-04-11 (owner: qa)
+Last updated: 2026-06-19 (owner: qa)
 
 ## Current CI Pipelines
 
-Four GitHub Actions workflows live under `.github/workflows/`:
+Seven GitHub Actions workflows live under `.github/workflows/`:
 
-### `test.yml`
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `test.yml` | `push` / `pull_request` touching code, Cargo files, tests, or workflows | Required build, lint, test, feature, MSRV, macOS, and TProxy gates |
+| `audit.yml` | Weekly cron, lockfile/workflow changes, manual dispatch | RustSec advisory audit |
+| `coverage.yml` | Scheduled/manual coverage run | Workspace coverage signal |
+| `bench.yml` | Manual benchmark dispatch | Ad hoc benchmark artifact generation |
+| `bench-daily.yml` | Scheduled benchmark run | Daily benchmark trend artifact |
+| `release.yml` | `v*` tags and manual dispatch | Static Linux release artifacts via `cargo-zigbuild` |
+| `pages.yml` | Pushes to `main` affecting `docs/` | GitHub Pages deployment for docs |
 
-Trigger: `push` / `pull_request` touching `crates/**`, `tests/**`, `Cargo.toml`, `Cargo.lock`, or workflow files.
+## `test.yml`
 
-Jobs:
+`test.yml` is the PR gate. It is path-filtered to code, test, Cargo, and
+workflow changes; docs-only PRs do not run it unless workflow files are touched.
 
-1. **lint** (`ubuntu-latest`, runs first)
-   - `cargo fmt --all -- --check`
-   - `cargo clippy --all-targets --all-features -- -D warnings`
-   - Toolchain: `dtolnay/rust-toolchain@stable`
-   - Cache: `Swatinem/rust-cache@v2`
+### `lint`
 
-2. **test** (`ubuntu-latest`, `needs: lint`)
-   - Installs `ssserver` (cached by `Cargo.lock` hash) and `simple-obfs` (apt) so SS + obfs tests do not silently SKIP (`MIHOMO_REQUIRE_INTEGRATION_BINS=1`).
-   - `cargo build --tests`
-   - `cargo test --lib` (all unit tests)
-   - Explicit per-suite invocations for integration tests:
-     - `common_test`, `dns_cache_test`, `config_test`, `statistics_test`,
-       `rules_test`, `shadowsocks_integration`, `api_test`,
-       `config_persistence_test`, `systemd_config_test` (via `-p meow-app`),
-       `trojan_integration`, `v2ray_plugin_integration`, `pre_resolve_test`.
+Runs first on Ubuntu:
 
-3. **tproxy** (`ubuntu-latest`, `needs: lint`)
-   - Runs `bash tests/test_tproxy_qemu.sh` which uses Docker (GitHub runner has Docker preinstalled) to exercise the transparent-proxy listener end-to-end.
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo clippy --all-targets --no-default-features -- -D warnings`
+- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
 
-4. **msrv** (`ubuntu-latest`, `needs: lint`)
-   - Reads `rust-version` from the workspace `Cargo.toml` (currently `1.88`), installs that exact toolchain, runs `cargo check --workspace --all-targets`. Keeps the stated MSRV honest.
+### `test`
 
-5. **macos** (`macos-latest`, `needs: lint`)
-   - Runs `cargo test --lib` plus the cross-platform integration suites: `common_test`, `dns_cache_test`, `config_test`, `config_persistence_test`, `statistics_test`, `rules_test`, `api_test`, `trojan_integration`, `v2ray_plugin_integration`, `pre_resolve_test`.
-   - Deliberately skips `shadowsocks_integration` (ssserver + simple-obfs not available), `systemd_config_test` (Linux-only), and the `tproxy` suite (nftables-only).
+Runs on Ubuntu after `lint`:
 
-### `audit.yml`
-Weekly cron (Mon 03:17 UTC) plus triggers on `Cargo.lock` and its own changes, plus `workflow_dispatch`. Runs `rustsec/audit-check@v2.0.0` against the lockfile.
+- Installs/caches `ssserver` and installs `simple-obfs`; missing integration
+  binaries are treated as failures, not silent skips.
+- Builds all tests with `cargo build --tests`.
+- Runs workspace unit tests plus integration suites for common types, DNS cache
+  and upstream parsing, config parsing/persistence, statistics, rules,
+  Shadowsocks, API, systemd config, Trojan, Hysteria2 Docker, Snell Docker,
+  v2ray-plugin, pre-resolve DNS, transport TLS/WS/gRPC/H2/HTTPUpgrade,
+  transport crate invariants, VLESS config/integration, VLESS feature matrix,
+  and DNS encrypted feature matrix.
 
-### `release.yml`
-Triggers on `v*` tag pushes (plus `workflow_dispatch` for dry runs). Matrix-builds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` via `cargo-zigbuild` + zig 0.13, packages tarballs with sha256 sidecars, uploads as artifacts, then a `release` job (tag-only) publishes via `softprops/action-gh-release@v2` with generated notes.
+### `features`
 
-### `pages.yml`
-Deploys `docs/` to GitHub Pages on pushes to `main`. Not test-gating.
+Runs on Ubuntu after `lint`:
+
+- Installs `cargo-hack`.
+- Runs feature-powerset checks for `meow-transport`, `meow-proxy`, and
+  `meow-listener`.
+- Excludes `boring-tls` from the `meow-transport` powerset because that backend
+  needs a C++/BoringSSL toolchain; the broader transport matrix still covers
+  the normal feature combinations.
+
+### `msrv`
+
+Runs on Ubuntu after `lint`:
+
+- Reads the workspace `rust-version` from `Cargo.toml`.
+- Installs that exact toolchain.
+- Runs `cargo check --workspace --all-targets`.
+
+### `macos`
+
+Runs on `macos-latest` after `lint`:
+
+- `cargo build --tests`
+- `cargo test --lib`
+- Cross-platform integration smoke tests: common types, config, rules, API,
+  DNS cache, config persistence, statistics, Trojan, v2ray-plugin, and
+  pre-resolve DNS.
+
+### `tproxy`
+
+Runs on Ubuntu after `lint`:
+
+- `bash tests/test_tproxy_qemu.sh`
+- Builds a Docker test image and exercises the transparent-proxy listener
+  end-to-end with nftables.
 
 ## What Is Tested Today
 
 | Area | Location | In CI? |
 |------|----------|--------|
-| Unit tests (all crates) | `cargo test --lib` | Yes (ubuntu + macos) |
-| Rule matching | `crates/meow-rules/tests/rules_test.rs` | Yes (ubuntu + macos) |
-| Trojan protocol (embedded mock) | `crates/meow-proxy/tests/trojan_integration.rs` | Yes (ubuntu + macos) |
-| Shadowsocks + simple-obfs | `crates/meow-proxy/tests/shadowsocks_integration.rs` | Yes (ubuntu only) |
-| v2ray-plugin (WS+TLS) integration | `crates/meow-proxy/tests/v2ray_plugin_integration.rs` | Yes (ubuntu + macos) |
-| Pre-resolve / DNS-before-dial | `crates/meow-tunnel/tests/pre_resolve_test.rs` | Yes (ubuntu + macos) |
-| REST API | `crates/meow-api/tests/api_test.rs` | Yes (ubuntu + macos) |
-| Config parsing | `crates/meow-config/tests/config_test.rs` | Yes (ubuntu + macos) |
-| Config persistence | `crates/meow-config/tests/config_persistence_test.rs` | Yes (ubuntu + macos) |
-| DNS cache | `crates/meow-dns/tests/dns_cache_test.rs` | Yes (ubuntu + macos) |
-| Tunnel statistics | `crates/meow-tunnel/tests/statistics_test.rs` | Yes (ubuntu + macos) |
-| Common types | `crates/meow-common/tests/common_test.rs` | Yes (ubuntu + macos) |
-| Systemd config | `crates/meow-app/tests/systemd_config_test.rs` | Yes (ubuntu only) |
-| TProxy e2e (nftables, Docker) | `tests/test_tproxy_qemu.sh` | Yes (ubuntu only) |
-| MSRV check | `cargo check` on pinned `rust-version` | Yes |
-| Dependency advisories | `rustsec/audit-check` | Yes (weekly + lockfile changes) |
-| Release artifacts | `release.yml` musl matrix | Yes (on `v*` tags) |
-| ~~24h soak (M1 exit gate)~~ | `docs/soak-test-plan.md` — **abandoned 2026-04-11**; replaced with manual real-subscription smoke test at M1 exit | Out of scope for M1 |
+| Formatting | `cargo fmt --all -- --check` | Yes |
+| Clippy default/all/no-default features | `cargo clippy --all-targets ...` | Yes |
+| Rustdoc links/warnings | `cargo doc --workspace --no-deps` with `-D warnings` | Yes |
+| Workspace unit tests | `cargo test --lib` | Yes (Ubuntu + macOS) |
+| Rule matching | `crates/meow-rules/tests/rules_test.rs` | Yes (Ubuntu + macOS) |
+| REST API | `crates/meow-api/tests/api_test.rs` | Yes (Ubuntu + macOS) |
+| Config parsing/persistence | `crates/meow-config/tests/` | Yes |
+| DNS cache/upstream parser | `crates/meow-dns` tests | Yes |
+| Shadowsocks + simple-obfs | `crates/meow-proxy/tests/shadowsocks_integration.rs` | Yes (Ubuntu) |
+| Trojan protocol | `crates/meow-proxy/tests/trojan_integration.rs` | Yes (Ubuntu + macOS) |
+| Hysteria2 Docker integration | `crates/meow-proxy/tests/hysteria2_integration.rs` | Yes (Ubuntu) |
+| Snell Docker integration | `crates/meow-proxy/tests/snell_server_docker_integration.rs` | Yes (Ubuntu) |
+| v2ray-plugin integration | `crates/meow-proxy/tests/v2ray_plugin_integration.rs` | Yes (Ubuntu + macOS) |
+| VLESS parser/integration | `crates/meow-config/tests/vless_config_test.rs`, `vless_integration` | Yes |
+| Transport layers | `meow-transport` TLS/WS/gRPC/H2/HTTPUpgrade tests | Yes |
+| Feature powersets | `cargo hack check` for transport/proxy/listener crates | Yes |
+| TProxy e2e | `tests/test_tproxy_qemu.sh` | Yes (Ubuntu Docker) |
+| MSRV | Workspace `rust-version` | Yes |
+| Dependency advisories | `audit.yml` | Yes |
+| Coverage | `coverage.yml` | Scheduled/manual |
+| Benchmarks | `bench.yml`, `bench-daily.yml` | Manual/scheduled |
+| Release artifacts | `release.yml` | Tags/manual |
 
-## Baseline
+## Known Gaps
 
-`cargo test --lib` on 2026-04-11 (updated): **100 passed, 0 failed, 0 ignored** across 10 crates (meow-proxy 37, meow-rules 18, meow-config 18, meow-dns 8, meow-trie 6, meow-tunnel 3, meow-common 3; api/app/listener crates have no lib tests). `api_test` integration suite: **82 passed, 0 failed**.
-
-## Gaps
-
-### P0 — wiring (tests exist but are not gated)
-
-1. ~~`v2ray_plugin_integration` not invoked~~ — **Resolved 2026-04-11** (task #1, engineer). Wired into `test.yml` after the Trojan step and into the new `macos` job.
-
-2. ~~`pre_resolve_test` not invoked~~ — **Resolved 2026-04-11** (task #2, engineer). Wired into `test.yml` and `macos`.
-
-### P1 — platform / toolchain coverage
-
-3. ~~No MSRV pin~~ — **Resolved 2026-04-11** (task #3, engineer). `rust-version = "1.88"` pinned in workspace `Cargo.toml` (all 10 crates inherit via `workspace = true`). New `msrv` job in `test.yml` reads the pin and runs `cargo check --workspace --all-targets` on that toolchain. Note: the original README/CLAUDE.md "1.70+" claim was wrong — transitive deps (shadowsocks 1.24, time 0.3.47, constant_time_eq 0.4.2 edition2024) require 1.88. Docs were updated to match.
-
-4. ~~Single platform only~~ — **Resolved 2026-04-11** (task #4, engineer). New `macos` job on `macos-latest` runs all cross-platform suites. Linux-specific suites (`shadowsocks_integration`, `systemd_config_test`, `tproxy`) remain ubuntu-only by design.
-
-5. ~~No cross-compile / release artifact build~~ — **Resolved 2026-04-11** (task #6, engineer). `release.yml` builds static musl binaries for `x86_64` and `aarch64` via `cargo-zigbuild`, tarballs + sha256, publishes on `v*` tags.
-
-### P2 — quality signal
-
-6. **No code coverage**
-   - No `cargo-llvm-cov`, no Codecov upload. We have no visibility into which adapters/rules are actually covered.
-   - **Fix:** add a nightly (scheduled) `coverage` job running `cargo llvm-cov --workspace --lcov --output-path lcov.info` and upload to Codecov or artifact.
-
-7. ~~No dependency audit~~ — **Resolved 2026-04-11** (task #5, engineer). `audit.yml` weekly cron + on-change trigger using `rustsec/audit-check@v2.0.0`.
-
-8. **No `cargo doc` check**
-   - Broken doc-links go unnoticed. Cheap to add: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`.
-
-9. **`--all-features` only in clippy, not in test**
-   - `cargo test --lib` uses default features. If a crate gates code behind a feature, that code is never exercised. Worth a `cargo hack --feature-powerset check` pass (at least for `meow-proxy` and `meow-config`).
-
-10. **No flakiness protection**
-    - Integration tests that start real servers (ssserver, embedded mock Trojan, Docker tproxy) are prime flake candidates. No retry, no `--test-threads=1` gating, no timing metrics. Recommend: add `--test-threads=1` for integration suites that bind ports, and consider `nextest` with retries for the `test` job.
-
-### P3 — hygiene
-
-11. **`pages.yml` deploys `docs/` unconditionally** including any intermediate doc we drop there. Currently `docs/` has `index.html`, `superpowers/`, `ci-status.md`, `roadmap.md`, `vision.md`, `soak-test-plan.md`, `gap-analysis.md`, and `adr/`. Confirm with PM whether internal CI notes belong on the public Pages build.
-
-12. **Workflow `paths` filter excludes `.github/workflows/**` for `pages.yml`** — fine, but `test.yml`'s path filter will skip re-runs on `CLAUDE.md` or `docs/**` edits that touch real behavior. Low risk today; note for future.
-
-### Outstanding (non-CI testing work)
-
-- ~~**24h soak harness**~~ — **out of scope for M1** (decision 2026-04-11). `docs/soak-test-plan.md` retained as a record. Tasks #26 (panic-abort), #27 (`/debug/state`), #28 (conn-table drain) remain as independent hygiene items.
+- Docs-only PRs do not trigger `test.yml`; run local doc sanity checks for
+  Markdown and links before publishing docs-only changes.
+- `pages.yml` deploys the whole `docs/` tree. Keep internal planning notes
+  clearly labeled as archived or planning-only when they remain in `docs/`.

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -4,9 +4,16 @@ Authored by: architect
 Date: 2026-04-11
 Upstream reference: https://github.com/MetaCubeX/mihomo (Alpha branch)
 
+> **Archived planning snapshot.** This document captures the 2026-04-11 M1
+> planning baseline. Many rows below have since landed or changed. Use
+> [README.md](../README.md), [docs/migration-from-go-mihomo.md](migration-from-go-mihomo.md),
+> [docs/roadmap.md](roadmap.md), and [docs/ci-status.md](ci-status.md) for
+> current operator-facing status. Do not treat the "Gap" labels below as a
+> current feature matrix without re-checking the code.
+
 ## Scope
 
-This document compares the current `meow-rs` implementation against the upstream Go `mihomo` (Clash Meta) kernel, enumerating features that exist upstream but are missing, partial, or divergent in this port.
+This document compared the 2026-04-11 `meow-rs` implementation against the upstream Go `mihomo` (Clash Meta) kernel, enumerating features that existed upstream but were missing, partial, or divergent in this port at that time.
 
 ### Explicitly excluded (non-goals)
 

--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -1,22 +1,22 @@
 # Migration guide: Go mihomo → meow-rs
 
-Last updated: 2026-04-18. Tracks M1 feature state.
+Last updated: 2026-06-19. Tracks the current default app feature set.
 Owner: pm. Tracks roadmap item: **M1.H-3**.
 Review cadence: updated at each milestone exit.
 
 This document is for operators migrating a working Go mihomo (Clash Meta)
 deployment to meow-rs. It covers:
 
-- What config surface is supported, partially supported, or not yet supported in M1.
+- What config surface is supported, partially supported, or not yet supported.
 - Behavioral divergences and what to do about them.
 - Migration steps for common subscription types.
 - Feature flags equivalent to Go mihomo build tags.
 
 If you are starting fresh (not migrating), read the main README instead.
 
-**Scope note:** Features marked *M1.x*, *M2*, or *M3* are planned but not yet
-shipped. This guide is a snapshot of M1 at release, not a promise about future
-milestones.
+**Scope note:** This guide describes the default `meow-app` build unless a
+feature flag is called out explicitly. Features marked *M2* or later are planned
+but not yet shipped.
 
 ---
 
@@ -39,7 +39,7 @@ loads. If `-t` exits 0, the config will load.
 Before migrating, scan your config for the following. Items marked ✗ will
 cause problems; items marked ~ work with caveats; items marked ✓ work.
 
-| Config section / feature | M1 status | Notes |
+| Config section / feature | Status | Notes |
 |--------------------------|:---------:|-------|
 | `port`, `socks-port`, `mixed-port` | ✓ | Fully supported. |
 | `allow-lan`, `bind-address` | ✓ | Fully supported. |
@@ -52,38 +52,41 @@ cause problems; items marked ~ work with caveats; items marked ✓ work.
 | `proxies:` — Shadowsocks | ✓ | Including AEAD 2022 ciphers. |
 | `proxies:` — Trojan | ✓ | TLS + WebSocket transport. |
 | `proxies:` — Direct, Reject | ✓ | Fully supported. |
-| `proxies:` — VMess | ✗ | Not implemented — use VLESS instead. |
-| `proxies:` — VLESS | ~ | M1.B-2 — see §Protocols. |
+| `proxies:` — VMess | ✓ | AEAD VMess outbound with TCP/WebSocket transports. |
+| `proxies:` — VLESS | ✓ | Plain VLESS, XTLS-Vision, and Reality/uTLS paths in the default app build. |
 | `proxies:` — HTTP CONNECT outbound | ✓ | Full parity (M1.B-3). |
 | `proxies:` — SOCKS5 outbound | ✓ | Full parity (M1.B-4). |
-| `proxies:` — Hysteria2 / TUIC / WireGuard | ✗ | Deferred to M1.5/M2. |
+| `proxies:` — Snell | ✓ | v3/v4/v5, UDP-over-TCP, optional HTTP/TLS obfs. |
+| `proxies:` — Hysteria2 | ✓ | QUIC TCP/UDP, Salamander obfs, port hopping, bandwidth hints. |
+| `proxies:` — AnyTLS | ~ | Implemented behind the opt-in `anytls` feature, not in the default app bundle. |
+| `proxies:` — TUIC / WireGuard / SSH | ✗ | Not implemented. |
 | `proxy-groups:` — selector, url-test, fallback | ✓ | Fully supported. |
 | `proxy-groups:` — load-balance | ✓ | round-robin + consistent-hashing (M1.C-1). |
 | `proxy-groups:` — relay | ✓ | Chain multiple outbounds (M1.C-2). |
 | `rules:` — DOMAIN, DOMAIN-SUFFIX, DOMAIN-KEYWORD | ✓ | Fully supported. |
 | `rules:` — IP-CIDR, IP-CIDR6 | ✓ | Fully supported. |
 | `rules:` — GEOIP | ✓ | MaxMind MMDB. |
-| `rules:` — GEOSITE | ~ | M1.D-2, mrs format only — see §Rules. |
+| `rules:` — GEOSITE | ✓ | mrs format only — see §Rules. |
 | `rules:` — RULE-SET | ✓ | M1.D-5, mrs + yaml formats. |
-| `rules:` — PROCESS-NAME | ~ | M1.D-1, platform lookup wired. |
-| `rules:` — IN-NAME, IN-TYPE, IN-PORT, IN-USER | ~ | M1.D-4/F-1/F-3. |
-| `rules:` — SUB-RULE | ~ | M1.D-7 — blocked on upstream verification. |
+| `rules:` — PROCESS-NAME | ✓ | Platform lookup wired. |
+| `rules:` — IN-NAME, IN-TYPE, IN-PORT, IN-USER | ✓ | Named listeners and auth metadata are wired. |
+| `rules:` — SUB-RULE | ✓ | Named rule subsets with cycle detection. |
 | `rules:` — AND, OR, NOT | ✓ | Logic composition supported. |
 | `rules:` — MATCH | ✓ | Fully supported. |
 | `rule-providers:` — http, file | ✓ | With interval refresh (M1.D-5). |
 | `rule-providers:` — inline | ✓ | M1.D-5. |
 | `dns:` — udp, tcp nameservers | ✓ | Fully supported. |
-| `dns:` — DoH (`https://`) | ~ | M1.E-1 — see §DNS. |
-| `dns:` — DoT (`tls://`) | ~ | M1.E-1 — see §DNS. |
+| `dns:` — DoH (`https://`) | ✓ | See §DNS. |
+| `dns:` — DoT (`tls://`) | ✓ | See §DNS. |
 | `dns:` — DoQ (`quic://`) | ✗ | Deferred to M1.E-6/M2. Hard error (not silent). |
-| `dns:` — `default-nameserver` | ~ | M1.E-2, bundled with M1.E-1. |
-| `dns:` — `nameserver-policy` | ~ | M1.E-3 — see §DNS. |
-| `dns:` — `fallback-filter` | ~ | M1.E-4, bundled with M1.E-3. |
+| `dns:` — `default-nameserver` | ✓ | Bootstrap resolver for encrypted upstream hostnames. |
+| `dns:` — `nameserver-policy` | ✓ | Exact, wildcard, and `geosite:` policy keys. |
+| `dns:` — `fallback-filter` | ✓ | GeoIP/IP-CIDR/domain gates. |
 | `dns:` — `hosts` + `use-system-hosts` | ✓ | M1.E-5, wildcards supported. |
 | `dns:` — `fake-ip` mode | ✓ | v4/v6 pools, `fake-ip-filter`, `fake-ip-filter-mode`, `store-fake-ip` JSON persistence. See §fake-ip mode. |
 | `tproxy-port` | ✓ | Linux nftables / macOS pf. |
-| `proxy-providers:` | ~ | M1.H-1 — see §Providers. |
-| `geodata:` / `geox-url` | ✗ | M2+ (auto-update, path overrides). M1 uses XDG discovery. |
+| `proxy-providers:` | ✓ | http/file sources, provider filters, health checks, and group `use:`. |
+| `geodata:` | ✓ | Path overrides, auto-update, interval, and download URL overrides. |
 | `/metrics` Prometheus endpoint | ✓ | meow-rs enhancement (no Go upstream equiv). |
 
 ---
@@ -142,9 +145,8 @@ security gaps and typo-likely mistakes become hard errors (Class A).
 
 ## Protocols
 
-Protocol sections are populated from approved specs as M1.B/C code lands.
-Sections marked "Supported in M1.B-x" describe the spec-approved behaviour;
-"Known-broken" bullets are filled in after integration and soak testing.
+Protocol sections summarize the current default app build unless a feature flag
+is called out explicitly.
 
 ### Shadowsocks
 
@@ -155,13 +157,15 @@ WebSocket transport is included. External plugin binaries are not supported
 ### Trojan
 
 Fully supported. TLS via rustls (not OpenSSL). WebSocket transport via the
-built-in transport layer. gRPC transport: M1.A-3.
+built-in transport layer. gRPC transport is available through the shared
+transport layer.
 
 ### VLESS
 
-Supported in M1.B-2. Plain VLESS — UUID auth header, no body cipher. Security
-comes entirely from the outer transport (`tls: true`). XTLS-Vision flow
-(`flow: xtls-rprx-vision`) supported; Reality transport deferred.
+Supported. Plain VLESS uses the UUID auth header and has no body cipher.
+Security comes from the outer transport (`tls: true`). XTLS-Vision flow
+(`flow: xtls-rprx-vision`) and Reality/uTLS paths are supported in the default
+app build.
 
 ```yaml
 proxies:
@@ -191,14 +195,12 @@ proxies:
 | `mux: {enabled: true}` | Multiplexes | Warn-once, ignored. |
 | `tls: false` with no outer encryption | Accepted silently | Warn-once at load — traffic is plaintext. |
 
-**Deferred:** Reality transport (`reality-opts:`), VLESS inbound, Mux.Cool.
-
-**Known-broken:** *(fill in after M1 smoke test).*
+**Deferred:** VLESS inbound and Mux.Cool.
 
 ### HTTP CONNECT outbound
 
-Supported in M1.B-3. HTTP/1.1 CONNECT tunnel with optional Basic auth and
-custom headers. Optional TLS wrapping of the proxy connection.
+Supported. HTTP/1.1 CONNECT tunnel with optional Basic auth and custom headers.
+Optional TLS wrapping of the proxy connection.
 
 ```yaml
 proxies:
@@ -222,12 +224,10 @@ proxies:
 | Proxy auth schemes other than Basic (Digest, NTLM) | Supported | M1 supports Basic only. Unknown auth challenge → `Err(ProxyAuthFailed)`. |
 | Proxy returns 407 | `ProxyAuthFailed` | Same, clearly named in logs: "http proxy auth failed". |
 
-**Known-broken:** *(fill in after M1 smoke test).*
-
 ### SOCKS5 outbound
 
-Supported in M1.B-4. SOCKS5 TCP tunnel (CMD `0x01` CONNECT) with optional
-username/password auth. Optional TLS-over-SOCKS5.
+Supported. SOCKS5 TCP tunnel (CMD `0x01` CONNECT) with optional username/password
+auth. Optional TLS-over-SOCKS5.
 
 ```yaml
 proxies:
@@ -254,21 +254,17 @@ proxies:
 an `atyp 0x03` (domain) request. IP-only dial is used only when no hostname is
 available. This preserves domain for SNI and logging on the destination server.
 
-**Known-broken:** *(fill in after M1 smoke test).*
+### Not supported in the default app build
 
-### Not supported in M1
+The following protocols are not available in the default app build. Using them
+in `proxies:` will produce a hard parse error unless a feature note says
+otherwise:
 
-The following protocols are not available in M1. Using them in `proxies:` will
-produce a hard parse error:
-
-- **VMess** — intentionally not implemented; use VLESS instead. Protocol
-  complexity (AEAD KDF, auth-id replay cache, legacy cipher quirks) for
-  diminishing returns as most deployments have migrated to VLESS. Hard parse
-  error with a message directing users to the VLESS equivalent.
-- **Hysteria2** — QUIC dep tree; deferred to M1.5/M2.
-- **TUIC** — same reason.
+- **TUIC** — not implemented.
 - **WireGuard** — niche; deferred.
-- **Snell, SSH** — niche; deferred.
+- **SSH** — niche; deferred.
+- **AnyTLS** — implemented behind the opt-in `anytls` feature, not compiled
+  into the default `meow-app` bundle.
 
 ---
 
@@ -499,10 +495,9 @@ using them will produce a clear error at startup.
 
 | Feature | Reason | Alternative |
 |---------|--------|-------------|
-| `geodata:` YAML subsection | M2+ only | M1 uses XDG file discovery |
 | External plugin subprocess (v2ray-plugin bin) | No subprocess exec in M1 | Built-in transport layer (WS + TLS) |
-| Hysteria2, TUIC, WireGuard protocols | QUIC dep tree + size budget | Revisit in M1.5/M2 |
-| VMess protocol | Protocol complexity for diminishing returns (decision 2026-04-11) | Use VLESS — same ecosystem, simpler wire format |
+| TUIC, WireGuard, SSH protocols | Protocol scope and dependency budget | Revisit in M2+ if users need them |
+| TUN inbound | Out of scope for this kernel | Use `tproxy-port` with nftables/pf |
 
 ---
 
@@ -530,10 +525,10 @@ meow-rs uses Cargo feature flags where Go mihomo uses build tags:
 | Go mihomo build tag / upstream | meow-rs Cargo feature | Default |
 |-------------------------------|--------------------------|:-------:|
 | Encrypted DNS (DoH, DoT) | `meow-dns/encrypted` | on |
-| *(M2: minimal build)* | `--no-default-features` | — |
-
-Note: the `vmess-legacy` feature flag is defined in the dropped VMess spec —
-it does not exist in the codebase since VMess was not implemented.
+| BoringSSL-backed uTLS/ECH paths | `meow-app/boring-tls` | on for `meow-app` |
+| Full app bundle | `meow-app/full` | on |
+| Minimal app bundle | `meow-app/minimal` | off |
+| AnyTLS outbound | non-default build enabling `meow-config/anytls` and `meow-proxy/anytls` | off |
 
 To build without encrypted DNS (smaller binary):
 
@@ -549,8 +544,10 @@ cargo build --release --no-default-features -p meow-dns
 
 Most common format from public providers. Typical issues:
 
-1. **VMess proxies** — replace with VLESS alternatives from your provider, or
-   remove them. meow-rs hard-errors on `type: vmess`.
+1. **Unsupported proxy types** — TUIC, WireGuard, SSH, ShadowsocksR, and other
+   niche upstream protocols still need replacement or removal. AnyTLS requires
+   a non-default build enabling the `meow-config/anytls` and `meow-proxy/anytls`
+   features.
 2. **`enhanced-mode: fake-ip`** — supported. Migration from a prior
    meow-rs release that warned-and-fell-back to `normal` is automatic;
    no config change required.
@@ -571,8 +568,8 @@ Most common format from public providers. Typical issues:
    array (M1.F-1). Shorthand ports (`mixed-port`, `socks-port`) get auto-names
    (`"mixed"`, `"socks"`) — `IN-NAME,mixed,...` works without changes.
 2. **`nameserver-policy` with `geosite:` keys** — entries like
-   `"geosite:cn": [...]` are skipped with a warn-once until geosite-in-policy
-   integration lands post-M1. Use exact domain or `+.` wildcard patterns instead.
+   `"geosite:cn": [...]` work when a geosite `.mrs` database is loaded. If no
+   geosite DB is available, those policy entries are skipped with a warn-once.
 3. **`authentication:`** — ensure each entry has a colon separating username and
    password. Entries without a colon are a hard parse error.
 4. **`skip-auth-prefixes:`** — loopback (`127.0.0.1/32`, `::1/128`) is always
@@ -591,8 +588,8 @@ Most common format from public providers. Typical issues:
 1. **`proxy-providers:`** — supported in M1.H-1 (http + file sources, health-check,
    `include-all` shorthand).
 2. **`interval:` refresh** — supported in M1.D-5. No config change needed.
-3. **`use:` in proxy groups** — wired in M1.H-1. Until that PR merges, list
-   proxies explicitly in the group's `proxies:` array.
+3. **`use:` in proxy groups** — wired for proxy providers. Provider filters and
+   `include-all` shorthands are applied when groups are resolved.
 
 ---
 
@@ -603,23 +600,31 @@ These have been tested against a real subscription and confirmed working:
 - Rule-based routing with DOMAIN, DOMAIN-SUFFIX, IP-CIDR, GEOIP rules
 - Shadowsocks AEAD proxies with selector group + url-test health check
 - Trojan with TLS + WebSocket transport
+- VLESS with TLS/WebSocket/gRPC/H2/HTTPUpgrade transports
+- VMess AEAD TCP/WebSocket outbound
+- Snell v3/v4/v5 outbound with UDP-over-TCP
+- Hysteria2 TCP/UDP with Docker integration coverage
+- Proxy providers with group `use:`
 - Mixed listener on a single port with SOCKS5 + HTTP clients
 - TProxy on Linux (nftables mark-based routing)
 - DNS with plain UDP nameservers + fallback
+- DoH/DoT upstreams, nameserver policy, fallback filter, and fake-IP mode
 
 ---
 
 ## Known-broken patterns
 
-The following produce hard errors at load time (not silent failures):
+The following are unsupported or intentionally rejected:
 
 - **`quic://` nameservers** — hard error; replace with `tls://` or `https://`.
-- **Hysteria2 / TUIC proxies** — hard error (`type: hysteria2` / `type: tuic`); no alternative in M1.
-- **`fake-ip` DNS mode** — supported in full; see §fake-ip mode.
-- **VMess proxies** — hard error; use `type: vless` instead.
+- **TUIC / WireGuard / SSH / ShadowsocksR proxies** — hard error; no default-build adapter.
+- **AnyTLS proxies in the default app build** — hard error unless the binary is
+  built with the opt-in `anytls` feature wiring.
+- **Snell v1/v2** — hard error; use Snell v3/v4/v5.
 - **`vless` with `flow: xtls-rprx-direct`** — hard error; use `xtls-rprx-vision`.
-
-*(Additional patterns filled in after M1 soak testing against real subscriptions.)*
+- **External dashboard mounting** (`external-ui`, `external-ui-name`,
+  `external-ui-url`) — not implemented yet; the built-in `/ui` dashboard is
+  served from the binary.
 
 ---
 
@@ -627,5 +632,5 @@ The following produce hard errors at load time (not silent failures):
 
 - File issues at the project issue tracker.
 - Check `docs/roadmap.md` for the status of features you need.
-- For features not in M1, note the milestone (M1.x, M2) and subscribe to the
+- For features not yet shipped, note the milestone and subscribe to the
   tracking issue.


### PR DESCRIPTION
## Summary
- refresh README feature/API tables and replace the architecture ASCII art with a Mermaid diagram
- update the CI status document to match the current GitHub Actions workflows
- label the older gap analysis as an archived planning snapshot and update the migration guide for the current default app feature set

## Validation
- `git diff --check`
- Markdown fenced-block balance check for edited files
- `npx --yes @mermaid-js/mermaid-cli -i /tmp/meow-readme-architecture.mmd -o /tmp/meow-readme-architecture.svg`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib`