### PR TITLE
fix(tunnel): reap half-closed-then-stuck relays to stop CLOSE-WAIT leak

### DIFF
--- a/crates/meow-tunnel/src/relay.rs
+++ b/crates/meow-tunnel/src/relay.rs
@@ -13,10 +13,11 @@
 //   Public API: `copy_bidirectional_buf` and `RELAY_BUF_SIZE`.
 //   No new public types exposed — no M2 API break.
 
-use std::future::poll_fn;
+use std::future::{poll_fn, Future};
 use std::io;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 /// Buffer size used for each relay direction.
@@ -24,6 +25,20 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 /// cost of more syscalls; acceptable for proxy workloads where connections
 /// are long-lived and latency matters less than memory at 5k+ conns.
 pub const RELAY_BUF_SIZE: usize = 4 * 1024;
+
+/// Grace window granted to the surviving relay direction after the *other*
+/// direction has reached EOF.
+///
+/// Without a bound, a peer that closes one half of the connection and then
+/// holds its read side open forever pins this future — and with it both
+/// underlying sockets. That surfaces as leaked CLOSE-WAIT sockets on the
+/// inbound (client) side (the client sent FIN but meow never `close()`s its
+/// socket) and FIN-WAIT-2 on the outbound side. The reference mihomo kernel
+/// avoids this by tearing the whole relay down once *either* direction
+/// completes; this linger is the equivalent, but lenient: a normal
+/// simultaneous close drains in microseconds — far inside the window — so only
+/// genuinely half-stuck connections are reaped.
+pub const RELAY_HALF_CLOSE_LINGER: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
 // Internal copy-one-direction state (no heap allocation)
@@ -132,11 +147,19 @@ where
     let mut a_done = false;
     let mut b_done = false;
 
-    poll_fn(move |cx| {
-        let a_pin = Pin::new(&mut *a);
-        let b_pin = Pin::new(&mut *b);
+    // Linger timer reaping a half-closed-then-stuck connection. Created up front
+    // so it can be pinned on the stack (no per-relay heap allocation), but not
+    // polled — and therefore not registered with the timer driver — until one
+    // direction has finished and the other is still running. See
+    // `RELAY_HALF_CLOSE_LINGER`.
+    let linger = tokio::time::sleep(RELAY_HALF_CLOSE_LINGER);
+    tokio::pin!(linger);
+    let mut linger_armed = false;
 
+    poll_fn(move |cx| {
         if !a_done {
+            let a_pin = Pin::new(&mut *a);
+            let b_pin = Pin::new(&mut *b);
             match a_to_b.poll_copy(cx, a_pin, b_pin) {
                 Poll::Ready(Ok(_)) => a_done = true,
                 Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
@@ -144,11 +167,9 @@ where
             }
         }
 
-        // Re-pin after borrowing above.
-        let a_pin = Pin::new(&mut *a);
-        let b_pin = Pin::new(&mut *b);
-
         if !b_done {
+            let a_pin = Pin::new(&mut *a);
+            let b_pin = Pin::new(&mut *b);
             match b_to_a.poll_copy(cx, b_pin, a_pin) {
                 Poll::Ready(Ok(_)) => b_done = true,
                 Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
@@ -157,10 +178,27 @@ where
         }
 
         if a_done && b_done {
-            Poll::Ready(Ok((a_to_b.amt, b_to_a.amt)))
-        } else {
-            Poll::Pending
+            return Poll::Ready(Ok((a_to_b.amt, b_to_a.amt)));
         }
+
+        // Exactly one direction has finished while the other is still open.
+        // Arm the grace window on that transition, then let it race the
+        // surviving direction: whichever resolves first ends the relay. The
+        // surviving direction is re-polled above on every wake, so if it drains
+        // before the timer fires we still return the full byte counts.
+        if a_done || b_done {
+            if !linger_armed {
+                linger_armed = true;
+                linger
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + RELAY_HALF_CLOSE_LINGER);
+            }
+            if linger.as_mut().poll(cx).is_ready() {
+                return Poll::Ready(Ok((a_to_b.amt, b_to_a.amt)));
+            }
+        }
+
+        Poll::Pending
     })
     .await
 }
@@ -190,6 +228,44 @@ mod tests {
 
         assert_eq!(up, 5, "a→b direction");
         assert_eq!(down, 5, "b→a direction");
+    }
+
+    // Regression: a peer that half-closes (sends EOF on its write side) and
+    // then holds its read side open forever must not pin the relay. Before the
+    // half-close linger, `copy_bidirectional_buf` waited for *both* directions
+    // to EOF, so this hung indefinitely — surfacing in production as leaked
+    // CLOSE-WAIT (inbound) / FIN-WAIT-2 (outbound) sockets.
+    #[tokio::test(start_paused = true)]
+    async fn half_closed_peer_does_not_pin_relay() {
+        use tokio::io::AsyncWriteExt;
+
+        // `a` is the relay's view of the "client": the client sends a byte then
+        // closes its write side, so a→b sees EOF. `b` is the relay's view of the
+        // "upstream", whose far end (`_upstream_held_open`) never sends and never
+        // closes, so b→a would otherwise block forever. The underscore-prefixed
+        // binding is kept (not dropped) for the whole test so `b` never sees EOF.
+        let (mut client, mut a) = duplex(64);
+        let (mut b, _upstream_held_open) = duplex(64);
+
+        client.write_all(b"x").await.unwrap();
+        client.shutdown().await.unwrap();
+
+        let mut buf1 = [0u8; RELAY_BUF_SIZE];
+        let mut buf2 = [0u8; RELAY_BUF_SIZE];
+
+        // With paused time the linger only elapses via the runtime's auto-advance
+        // once the future is genuinely stalled, so completion proves the timer —
+        // not real wall-clock — drove teardown.
+        let (up, down) = tokio::time::timeout(
+            RELAY_HALF_CLOSE_LINGER * 4,
+            copy_bidirectional_buf(&mut a, &mut b, &mut buf1, &mut buf2),
+        )
+        .await
+        .expect("relay must tear down within the linger window, not hang")
+        .expect("relay returns Ok after the linger reaps the stuck direction");
+
+        assert_eq!(up, 1, "the client's byte was relayed before teardown");
+        assert_eq!(down, 0, "upstream never sent anything");
     }
 
     #[tokio::test]

--- a/crates/meow-tunnel/src/relay.rs
+++ b/crates/meow-tunnel/src/relay.rs
@@ -26,7 +26,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 /// are long-lived and latency matters less than memory at 5k+ conns.
 pub const RELAY_BUF_SIZE: usize = 4 * 1024;
 
-/// Grace window granted to the surviving relay direction after the *other*
+/// Idle window granted to the surviving relay direction after the *other*
 /// direction has reached EOF.
 ///
 /// Without a bound, a peer that closes one half of the connection and then
@@ -35,9 +35,15 @@ pub const RELAY_BUF_SIZE: usize = 4 * 1024;
 /// inbound (client) side (the client sent FIN but meow never `close()`s its
 /// socket) and FIN-WAIT-2 on the outbound side. The reference mihomo kernel
 /// avoids this by tearing the whole relay down once *either* direction
-/// completes; this linger is the equivalent, but lenient: a normal
-/// simultaneous close drains in microseconds — far inside the window — so only
-/// genuinely half-stuck connections are reaped.
+/// completes; this linger is the equivalent, but lenient.
+///
+/// The window is an **idle timeout, not an absolute deadline**: it is re-armed
+/// every time the surviving direction transfers more bytes, so a legitimate
+/// half-closed connection that keeps streaming (e.g. a client that shuts down
+/// its write side after a request, then downloads a large response) is never
+/// truncated mid-transfer. Only a connection that goes genuinely silent for the
+/// full window — no progress in either direction — is reaped. A normal
+/// simultaneous close drains in microseconds, far inside the window.
 pub const RELAY_HALF_CLOSE_LINGER: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
@@ -155,6 +161,10 @@ where
     let linger = tokio::time::sleep(RELAY_HALF_CLOSE_LINGER);
     tokio::pin!(linger);
     let mut linger_armed = false;
+    // Bytes transferred by the surviving direction when the linger was last
+    // (re)armed. Used to re-arm the idle window on every byte of progress so an
+    // active half-closed transfer is never truncated. See `RELAY_HALF_CLOSE_LINGER`.
+    let mut linger_progress: u64 = 0;
 
     poll_fn(move |cx| {
         if !a_done {
@@ -182,13 +192,18 @@ where
         }
 
         // Exactly one direction has finished while the other is still open.
-        // Arm the grace window on that transition, then let it race the
-        // surviving direction: whichever resolves first ends the relay. The
-        // surviving direction is re-polled above on every wake, so if it drains
-        // before the timer fires we still return the full byte counts.
+        // Arm the idle window on that transition and re-arm it on every byte the
+        // surviving direction makes progress, then let it race that direction:
+        // whichever resolves first ends the relay. Because the window resets on
+        // progress, an actively-streaming half-closed connection is never
+        // truncated — only one that goes silent for the full window is reaped.
+        // The surviving direction is re-polled above on every wake, so if it
+        // drains before the timer fires we still return the full byte counts.
         if a_done || b_done {
-            if !linger_armed {
+            let surviving_amt = if a_done { b_to_a.amt } else { a_to_b.amt };
+            if !linger_armed || surviving_amt != linger_progress {
                 linger_armed = true;
+                linger_progress = surviving_amt;
                 linger
                     .as_mut()
                     .reset(tokio::time::Instant::now() + RELAY_HALF_CLOSE_LINGER);
@@ -266,6 +281,61 @@ mod tests {
 
         assert_eq!(up, 1, "the client's byte was relayed before teardown");
         assert_eq!(down, 0, "upstream never sent anything");
+    }
+
+    // Regression: a legitimate half-closed connection that keeps actively
+    // streaming on the surviving direction must NOT be truncated by the linger.
+    // The client shuts down its write side, then the upstream streams for far
+    // longer than one linger window, with each gap shorter than the window. An
+    // absolute-deadline linger would cut this off at `RELAY_HALF_CLOSE_LINGER`;
+    // the idle-timeout linger re-arms on every chunk and lets it all through.
+    #[tokio::test(start_paused = true)]
+    async fn active_half_closed_transfer_is_not_truncated() {
+        use tokio::io::AsyncWriteExt;
+
+        let (mut client, mut a) = duplex(64);
+        let (mut b, mut upstream) = duplex(64);
+
+        // Client sends one byte then half-closes — a→b sees EOF, arming the linger.
+        client.write_all(b"x").await.unwrap();
+        client.shutdown().await.unwrap();
+
+        // Upstream streams 6 chunks spaced at half the linger window (total span
+        // 3× the window), then closes. No single gap reaches the window, so the
+        // idle timer keeps getting re-armed and never reaps the live transfer.
+        let feeder = tokio::spawn(async move {
+            for _ in 0..6 {
+                tokio::time::sleep(RELAY_HALF_CLOSE_LINGER / 2).await;
+                upstream.write_all(b"yy").await.unwrap();
+            }
+            upstream.shutdown().await.unwrap();
+        });
+
+        let mut buf1 = [0u8; RELAY_BUF_SIZE];
+        let mut buf2 = [0u8; RELAY_BUF_SIZE];
+
+        // Drain `a` (the relay writes upstream bytes here) so the duplex buffer
+        // never backpressures and the relay can run to upstream's clean EOF.
+        let drain = tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut sink = Vec::new();
+            client.read_to_end(&mut sink).await.unwrap();
+            sink.len()
+        });
+
+        let (up, down) = copy_bidirectional_buf(&mut a, &mut b, &mut buf1, &mut buf2)
+            .await
+            .expect("relay completes via upstream EOF, not a truncating linger");
+
+        feeder.await.unwrap();
+        let drained = drain.await.unwrap();
+
+        assert_eq!(up, 1, "the client's byte was relayed");
+        assert_eq!(
+            down, 12,
+            "every upstream byte must be relayed — the active transfer is not truncated"
+        );
+        assert_eq!(drained, 12, "client received the full upstream stream");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`copy_bidirectional_buf` (`crates/meow-tunnel/src/relay.rs`) only returns once **both** relay directions reach EOF. When one peer closes a single half of the connection and the other holds its read side open forever, the future never completes and neither socket is dropped:

1. The LAN client disconnects (FIN). The `client→remote` direction reads EOF, propagates a write-shutdown to the upstream, and finishes.
2. meow's inbound socket is now in **CLOSE-WAIT** — the client's FIN was ACKed, but the socket is only closed when the whole future returns and the `TcpStream` is dropped.
3. `remote→client` keeps polling the upstream. If the upstream never sends data nor FIN, that direction parks forever.
4. The relay future never returns: the inbound socket lingers in **CLOSE-WAIT** and the outbound socket in **FIN-WAIT-2**.

This reproduced in the field as a growing pile of CLOSE-WAIT sockets on the inbound (SOCKS5/tproxy) side after clients went away. The reference mihomo kernel avoids this by tearing the relay down once *either* direction completes (`SetReadDeadline(now)`).

## Fix

Add a bounded **half-close linger**. Once one direction reaches EOF, the surviving direction is granted `RELAY_HALF_CLOSE_LINGER` (30s) to drain; if it hasn't completed by then, the relay returns and both sockets are dropped (closed). Normal simultaneous closes drain in microseconds — far inside the window — so only genuinely half-stuck connections are reaped. This is leak-free and strictly more lenient than mihomo's immediate teardown.

## Invariant notes (per CLAUDE.md relay rules)

- **Zero per-relay-setup heap allocation preserved.** The linger `Sleep` is stack-pinned via `tokio::pin!` (part of the future's frame, paid once at task spawn — not a per-call heap allocation). The 4 KiB relay buffers are unchanged.
- The `Sleep` is **not polled** — and therefore not registered with the timer driver — until one direction has already finished, i.e. only on the teardown path, never during steady-state data relay.

## Testing

- Adds `half_closed_peer_does_not_pin_relay`, a `start_paused` regression test: one side EOFs, the other holds open; asserts the relay tears down via the linger (returning `up=1, down=0`) instead of hanging.
- Existing `roundtrip_small` / `empty_streams` still pass.

> **Note:** The full-workspace regression bar (`cargo test --lib`, three-way clippy) could not be run in this environment — the `madeye/anytls-rs` git dependency is blocked by the session's egress policy (403) and its pinned revision isn't cached, so the workspace won't compile here. The modified `relay` module was verified in isolation (compiles clean, `fmt --check` clean, no clippy warnings on the changed code, all 3 unit tests pass). Please confirm against the full CI gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGg967gDTGqLYe1RtwdUGd)_