### PR TITLE
feat(scripts): tproxy gateway setup helpers for Linux and macOS

### DIFF
--- a/docs/tproxy-gateway.md
+++ b/docs/tproxy-gateway.md
@@ -172,6 +172,13 @@ can switch with a one-line `enhanced-mode` change and a restart.
 
 ## Step 2 — gateway nftables rules
 
+> **Shortcut:** [`scripts/tproxy-gateway-linux.sh`](../scripts/tproxy-gateway-linux.sh)
+> generates and loads exactly the table below and enables forwarding —
+> `sudo scripts/tproxy-gateway-linux.sh up` (autodetects interface/IP; `down` to
+> remove, `status` to inspect). macOS has an experimental pf equivalent,
+> [`scripts/tproxy-gateway-macos.sh`](../scripts/tproxy-gateway-macos.sh). The
+> manual rules below are the reference the scripts implement.
+
 meow creates the `output`-chain table for its own traffic. Add this table for
 **forwarded** LAN traffic. Save as `/etc/meow/gateway.nft`:
 

--- a/scripts/tproxy-gateway-linux.sh
+++ b/scripts/tproxy-gateway-linux.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# tproxy-gateway-linux.sh — set up / tear down the firewall rules that make a
+# Linux host a transparent-proxy LAN gateway for meow.
+#
+# meow's built-in tproxy firewall only redirects the host's OWN traffic
+# (nftables `output` chain). This script adds the `prerouting` rules needed to
+# intercept traffic FORWARDED from other LAN devices, plus a DNS hijack — the
+# pieces meow does not create itself. See docs/tproxy-gateway.md for the full
+# explanation and the systemd wiring.
+#
+# Mechanism: nftables `nat` REDIRECT; meow recovers the original destination
+# (incl. fake-ip addresses) via SO_ORIGINAL_DST. TCP only — UDP/QUIC is not
+# intercepted (suppress it at the DNS layer with fake-ip's AAAA suppression).
+#
+# Usage:
+#   sudo ./tproxy-gateway-linux.sh up      [options]
+#   sudo ./tproxy-gateway-linux.sh down
+#   sudo ./tproxy-gateway-linux.sh status
+#
+# Options (for `up`):
+#   -i, --iface IFACE     LAN-facing interface        (default: default-route iface)
+#   -a, --lan-ip IP       this host's IP on IFACE     (default: autodetected)
+#   -p, --tproxy-port N   meow tproxy listener port   (default: 7893)
+#   -d, --dns-port N      meow DNS listener port      (default: 1053)
+#       --no-dns          do not hijack LAN :53 to meow
+#       --no-ipv6         do not redirect IPv6 (return it unproxied)
+#       --table NAME      nftables table name         (default: meow_gateway)
+#
+# Idempotent: `up` replaces any existing table of the same name.
+set -euo pipefail
+
+TABLE="meow_gateway"
+IFACE=""
+LAN_IP=""
+TPROXY_PORT="7893"
+DNS_PORT="1053"
+DO_DNS=1
+DO_IPV6=1
+
+die() { echo "error: $*" >&2; exit 1; }
+
+cmd="${1:-}"; shift || true
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -i|--iface)       IFACE="$2"; shift 2;;
+    -a|--lan-ip)      LAN_IP="$2"; shift 2;;
+    -p|--tproxy-port) TPROXY_PORT="$2"; shift 2;;
+    -d|--dns-port)    DNS_PORT="$2"; shift 2;;
+    --no-dns)         DO_DNS=0; shift;;
+    --no-ipv6)        DO_IPV6=0; shift;;
+    --table)          TABLE="$2"; shift 2;;
+    *) die "unknown option: $1";;
+  esac
+done
+
+[ "$(id -u)" = 0 ] || die "must run as root (nftables + sysctl)"
+command -v nft >/dev/null || die "nft (nftables) not found"
+
+case "$cmd" in
+  down)
+    nft list table inet "$TABLE" >/dev/null 2>&1 && nft delete table inet "$TABLE"
+    echo "removed nftables table inet $TABLE"
+    exit 0;;
+  status)
+    echo "# ip_forward: $(cat /proc/sys/net/ipv4/ip_forward)"
+    echo "# inet $TABLE:"
+    nft list table inet "$TABLE" 2>/dev/null || echo "  (not loaded)"
+    exit 0;;
+  up) ;;
+  ""|-h|--help) sed -n '2,40p' "$0"; exit 0;;
+  *) die "unknown command '$cmd' (use: up | down | status)";;
+esac
+
+# --- autodetect iface / IP ---
+[ -n "$IFACE" ] || IFACE="$(ip route show default 2>/dev/null | awk '/^default/{print $5; exit}')"
+[ -n "$IFACE" ] || die "could not autodetect LAN interface; pass --iface"
+[ -n "$LAN_IP" ] || LAN_IP="$(ip -4 -o addr show dev "$IFACE" 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1)"
+[ -n "$LAN_IP" ] || die "could not autodetect IP for $IFACE; pass --lan-ip"
+
+echo "Setting up transparent-proxy gateway:"
+echo "  interface   : $IFACE"
+echo "  host IP      : $LAN_IP"
+echo "  tproxy port  : $TPROXY_PORT"
+echo "  DNS hijack   : $([ "$DO_DNS" = 1 ] && echo ":53 -> $LAN_IP:$DNS_PORT" || echo disabled)"
+echo "  IPv6 redirect: $([ "$DO_IPV6" = 1 ] && echo enabled || echo disabled)"
+echo "  nft table    : inet $TABLE"
+
+# --- enable forwarding ---
+sysctl -wq net.ipv4.ip_forward=1
+[ "$DO_IPV6" = 1 ] && sysctl -wq net.ipv6.conf.all.forwarding=1 || true
+
+# --- build ruleset ---
+dns_rule=""
+[ "$DO_DNS" = 1 ] && dns_rule="meta nfproto ipv4 meta l4proto { tcp, udp } th dport 53 dnat ip to ${LAN_IP}:${DNS_PORT}"
+v6_guard=""
+[ "$DO_IPV6" = 1 ] || v6_guard="meta nfproto ipv6 return"
+
+nft -f - <<EOF
+table inet ${TABLE} {
+    # Destinations that must NOT be proxied. NOTE: the fake-ip range
+    # (e.g. 198.18.0.0/16) is deliberately absent — those MUST be redirected
+    # so meow can map fake IP -> domain.
+    set reserved4 {
+        type ipv4_addr; flags interval
+        elements = {
+            0.0.0.0/8, 10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16,
+            172.16.0.0/12, 192.168.0.0/16, 224.0.0.0/4, 240.0.0.0/4
+        }
+    }
+    set reserved6 {
+        type ipv6_addr; flags interval
+        elements = { ::1/128, fc00::/7, fe80::/10, ff00::/8 }
+    }
+    chain prerouting {
+        type nat hook prerouting priority dstnat; policy accept;
+        iifname != "${IFACE}" return
+        ${dns_rule}
+        fib daddr type local return
+        ip  daddr @reserved4 return
+        ip6 daddr @reserved6 return
+        ${v6_guard}
+        meta l4proto tcp redirect to :${TPROXY_PORT}
+    }
+}
+EOF
+
+echo "done. nftables table 'inet ${TABLE}' is active."
+echo
+echo "Next steps:"
+echo "  1. meow config: declare the tproxy listener on a NON-loopback address"
+echo "     (the top-level 'tproxy-port' binds 127.0.0.1 and will not catch"
+echo "     forwarded traffic):"
+echo "        listeners:"
+echo "          - { name: tproxy-gw, type: tproxy, listen: '::', port: ${TPROXY_PORT} }"
+echo "     and set dns.listen to 0.0.0.0:${DNS_PORT}."
+echo "  2. Point LAN clients' default route (and DNS) at ${LAN_IP}."
+echo "  3. Tear down with: sudo $0 down --table ${TABLE}"

--- a/scripts/tproxy-gateway-macos.sh
+++ b/scripts/tproxy-gateway-macos.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# tproxy-gateway-macos.sh — set up / tear down pf rules that make a macOS host a
+# transparent-proxy LAN gateway for meow.
+#
+# EXPERIMENTAL. meow's built-in macOS transparent proxy targets the host's OWN
+# traffic only (a pf anchor on lo0). Using macOS as a *forwarding* LAN gateway
+# is not officially supported and is provided here as a best-effort convenience;
+# the pf syntax is validated but the end-to-end path is not part of CI. On Linux
+# prefer tproxy-gateway-linux.sh (verified). See docs/tproxy-gateway.md.
+#
+# Mechanism: pf `rdr` redirects forwarded TCP to meow's tproxy listener on
+# 127.0.0.1; meow recovers the original destination via the pf NAT state table
+# (DIOCNATLOOK), which is keyed on the listen address — so the meow tproxy
+# listener MUST bind 127.0.0.1 (its macOS default; do NOT move it). TCP only.
+#
+# Usage:
+#   sudo ./tproxy-gateway-macos.sh up   [options]
+#   sudo ./tproxy-gateway-macos.sh down
+#   sudo ./tproxy-gateway-macos.sh status
+#
+# Options (for `up`):
+#   -i, --iface IFACE     LAN-facing interface       (default: default-route iface)
+#   -p, --tproxy-port N   meow tproxy listener port  (default: 7893)
+#   -d, --dns-port N      meow DNS listener port     (default: 1053)
+#       --no-dns          do not hijack LAN :53 to meow
+set -euo pipefail
+
+ANCHOR="com.meow.gateway"
+IFACE=""
+TPROXY_PORT="7893"
+DNS_PORT="1053"
+DO_DNS=1
+
+die() { echo "error: $*" >&2; exit 1; }
+
+cmd="${1:-}"; shift || true
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -i|--iface)       IFACE="$2"; shift 2;;
+    -p|--tproxy-port) TPROXY_PORT="$2"; shift 2;;
+    -d|--dns-port)    DNS_PORT="$2"; shift 2;;
+    --no-dns)         DO_DNS=0; shift;;
+    *) die "unknown option: $1";;
+  esac
+done
+
+[ "$(uname)" = "Darwin" ] || die "this script is for macOS; use tproxy-gateway-linux.sh on Linux"
+[ "$(id -u)" = 0 ] || die "must run as root (pfctl + sysctl)"
+
+case "$cmd" in
+  down)
+    pfctl -a "$ANCHOR" -F all >/dev/null 2>&1 || true
+    sysctl -w net.inet.ip.forwarding=0 >/dev/null 2>&1 || true
+    echo "flushed pf anchor '$ANCHOR' and disabled IPv4 forwarding"
+    echo "note: pf itself left enabled (pfctl -d to disable globally if you set it up)"
+    exit 0;;
+  status)
+    echo "# net.inet.ip.forwarding: $(sysctl -n net.inet.ip.forwarding)"
+    echo "# pf anchor $ANCHOR rules:"; pfctl -a "$ANCHOR" -sn 2>/dev/null || echo "  (none)"
+    exit 0;;
+  up) ;;
+  ""|-h|--help) sed -n '2,33p' "$0"; exit 0;;
+  *) die "unknown command '$cmd' (use: up | down | status)";;
+esac
+
+[ -n "$IFACE" ] || IFACE="$(route -n get default 2>/dev/null | awk '/interface:/{print $2; exit}')"
+[ -n "$IFACE" ] || die "could not autodetect LAN interface; pass --iface"
+
+echo "Setting up transparent-proxy gateway (EXPERIMENTAL):"
+echo "  interface   : $IFACE"
+echo "  tproxy port  : 127.0.0.1:$TPROXY_PORT"
+echo "  DNS hijack   : $([ "$DO_DNS" = 1 ] && echo ":53 -> 127.0.0.1:$DNS_PORT" || echo disabled)"
+echo "  pf anchor    : $ANCHOR"
+
+# Enable IPv4 forwarding.
+sysctl -w net.inet.ip.forwarding=1 >/dev/null
+
+# Reserved/private destinations that must NOT be proxied. The fake-ip range
+# (e.g. 198.18.0.0/16) is deliberately absent so meow can map it -> domain.
+reserved="{ 0.0.0.0/8, 10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.168.0.0/16, 224.0.0.0/4, 240.0.0.0/4 }"
+dns_rdr=""
+[ "$DO_DNS" = 1 ] && dns_rdr="rdr pass on ${IFACE} inet proto { tcp, udp } from any to any port 53 -> 127.0.0.1 port ${DNS_PORT}"
+
+ruleset="$(cat <<EOF
+# meow transparent-gateway anchor (${ANCHOR})
+no rdr on ${IFACE} inet proto tcp from any to ${reserved}
+${dns_rdr}
+rdr pass on ${IFACE} inet proto tcp from any to any -> 127.0.0.1 port ${TPROXY_PORT}
+EOF
+)"
+
+# Validate syntax, then load into the dedicated anchor and enable pf.
+echo "$ruleset" | pfctl -vnf - >/dev/null || die "pf ruleset failed validation"
+echo "$ruleset" | pfctl -a "$ANCHOR" -f - 2>/dev/null
+pfctl -e 2>/dev/null || true   # no-op / harmless if pf already enabled
+
+echo "done. pf anchor '${ANCHOR}' loaded."
+echo
+echo "Next steps:"
+echo "  1. meow config: keep the tproxy listener on 127.0.0.1 (macOS default) —"
+echo "     the pf NAT-state lookup is keyed to it. Set dns.listen to"
+echo "     127.0.0.1:${DNS_PORT} (or 0.0.0.0:${DNS_PORT})."
+echo "  2. Point LAN clients' default route (and DNS) at this host."
+echo "  3. Tear down with: sudo $0 down"
+echo
+echo "If the anchor's rules don't take effect, your main /etc/pf.conf may need a"
+echo "  rdr-anchor \"${ANCHOR}\"  and  anchor \"${ANCHOR}\"  reference (pf evaluates"
+echo "anchors only when the active ruleset calls them)."


### PR DESCRIPTION
## What

Adds two helper scripts under `scripts/` that automate the transparent-proxy **gateway** firewall — the platform-specific piece meow does *not* create itself (its built-in firewall only redirects the host's own `output`-chain traffic, not forwarded LAN traffic).

- **`scripts/tproxy-gateway-linux.sh`** — loads the `meow_gateway` nftables prerouting table (REDIRECT to the tproxy port + DNS hijack + loopback/RFC1918/reserved bypass) and enables IP forwarding. `up` / `down` / `status`; autodetects interface and LAN IP; flags for ports, `--no-dns`, `--no-ipv6`. This mirrors the verified production deployment.
- **`scripts/tproxy-gateway-macos.sh`** — pf-anchor equivalent (`rdr` to `127.0.0.1` + DNS hijack), following meow's own `firewall.rs` pf pattern. **Marked EXPERIMENTAL**: pf syntax is validated but macOS-as-forwarding-gateway is not part of CI.

`docs/tproxy-gateway.md` Step 2 now links both as a shortcut to the manual rules it documents.

## Validation

- `bash -n` clean on both.
- Linux nftables ruleset passes `nft -c` (check-only) on the live gateway; structurally identical to the running, verified `meow_gateway` table.
- macOS pf ruleset parses via `pfctl -nf`.
- Arg parsing / help / bad-arg handling exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)