### PR TITLE
fix(tproxy): make meow's macOS pf transparent proxy actually work

### DIFF
--- a/crates/meow-listener/src/tproxy/firewall.rs
+++ b/crates/meow-listener/src/tproxy/firewall.rs
@@ -57,22 +57,30 @@ struct PlatformGuard {
 
 /// Build the pf anchor ruleset that the macOS code path feeds to `pfctl`.
 ///
-/// Order matters — pf is first-match-wins. Loop-avoidance bypasses come
-/// before the catch-all redirect.
+/// Order matters, but NOT as first-match-wins: `pfctl` requires rules grouped
+/// by category — options, normalization, queueing, **translation** (`rdr`),
+/// then **filtering** (`pass`/`block`) — and rejects a file that interleaves
+/// them ("Rules must be in order…"). So the `rdr` translation rule must come
+/// first, followed by the `pass` filter bypasses. (Translation and filtering
+/// are evaluated in separate passes regardless of file order, so the relative
+/// position of `rdr` vs `pass` does not change matching — only validity.)
 ///
 /// Extracted as a pure function so the macOS-specific syntax can be unit
 /// tested without invoking `pfctl(8)`.
 #[cfg(any(target_os = "macos", test))]
 pub(crate) fn build_pf_ruleset(uid: u32, listen_port: u16, bypass_ips: &[IpAddr]) -> String {
-    let mut rules = format!("pass out quick on lo0 proto tcp from any to any user {uid}\n");
+    // Translation first: redirect lo0 TCP to the local tproxy listener.
+    let mut rules =
+        format!("rdr pass on lo0 proto tcp from any to any -> 127.0.0.1 port {listen_port}\n");
+    // Then filtering bypasses (our own uid, loopback, upstream proxy servers).
+    let _ = writeln!(
+        rules,
+        "pass out quick on lo0 proto tcp from any to any user {uid}"
+    );
     rules.push_str("pass out quick on lo0 proto tcp from any to 127.0.0.0/8\n");
     for ip in bypass_ips {
         let _ = writeln!(rules, "pass out quick on lo0 proto tcp from any to {ip}");
     }
-    let _ = writeln!(
-        rules,
-        "rdr pass on lo0 proto tcp from any to any -> 127.0.0.1 port {listen_port}"
-    );
     rules
 }
 
@@ -83,7 +91,12 @@ impl PlatformGuard {
         _routing_mark: Option<u32>,
         bypass_ips: &[IpAddr],
     ) -> io::Result<Self> {
-        let anchor = "com.meow.tproxy".to_string();
+        // Nest under `com.apple/` so the default `/etc/pf.conf`'s
+        // `rdr-anchor "com.apple/*"` actually evaluates our rules. A sibling
+        // anchor (e.g. `com.meow.tproxy`) loads fine but is never referenced by
+        // the active ruleset, so its `rdr` never takes effect (verified: a
+        // sibling anchor does not intercept; a `com.apple/*` child does).
+        let anchor = "com.apple/com.meow.tproxy".to_string();
         let uid = unsafe { libc::getuid() };
 
         let rules = build_pf_ruleset(uid, listen_port, bypass_ips);
@@ -360,13 +373,15 @@ mod tests {
     }
 
     #[test]
-    fn pf_uid_bypass_appears_before_redirect() {
-        // pf is first-match-wins. If `rdr` lands before the UID-bypass our
-        // own outbound traffic (DIRECT) gets pulled back into the tunnel.
+    fn pf_rdr_precedes_filter_rules() {
+        // pfctl rejects a ruleset that places filtering (`pass`) before
+        // translation (`rdr`) — "Rules must be in order: …, translation,
+        // filtering". The `rdr` must therefore come first, or the anchor fails
+        // to load and the tproxy listener never starts (regression guard).
         let rs = build_pf_ruleset(501, 7893, &[]);
-        let uid_pos = rs.find("user 501").unwrap();
         let rdr_pos = rs.find("rdr pass").unwrap();
-        assert!(uid_pos < rdr_pos, "UID bypass must precede rdr:\n{rs}");
+        let uid_pos = rs.find("user 501").unwrap();
+        assert!(rdr_pos < uid_pos, "rdr must precede filter rules:\n{rs}");
     }
 
     #[test]

--- a/scripts/tproxy-gateway-macos.sh
+++ b/scripts/tproxy-gateway-macos.sh
@@ -25,7 +25,9 @@
 #       --no-dns          do not hijack LAN :53 to meow
 set -euo pipefail
 
-ANCHOR="com.meow.gateway"
+# Nested under com.apple/ so the default /etc/pf.conf `rdr-anchor "com.apple/*"`
+# actually evaluates the rules — a sibling anchor loads but is never referenced.
+ANCHOR="com.apple/com.meow.gateway"
 IFACE=""
 TPROXY_PORT="7893"
 DNS_PORT="1053"
@@ -103,6 +105,7 @@ echo "     127.0.0.1:${DNS_PORT} (or 0.0.0.0:${DNS_PORT})."
 echo "  2. Point LAN clients' default route (and DNS) at this host."
 echo "  3. Tear down with: sudo $0 down"
 echo
-echo "If the anchor's rules don't take effect, your main /etc/pf.conf may need a"
-echo "  rdr-anchor \"${ANCHOR}\"  and  anchor \"${ANCHOR}\"  reference (pf evaluates"
-echo "anchors only when the active ruleset calls them)."
+echo "Requires pf enabled with the default /etc/pf.conf (which has"
+echo "  rdr-anchor \"com.apple/*\"). The anchor is nested under com.apple/ so those"
+echo "rules are evaluated; if you run a custom pf ruleset, add a"
+echo "  rdr-anchor \"${ANCHOR}\"  reference yourself."

--- a/scripts/verify-tproxy-setup.sh
+++ b/scripts/verify-tproxy-setup.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# verify-tproxy-setup.sh — bring up / tear down a rig for testing meow's
+# *local-outbound* transparent proxy (the firewall meow auto-manages when a
+# tproxy listener is configured; NOT the LAN-gateway rules).
+#
+# `up` aliases a non-loopback IP onto the loopback (10.88.0.1), runs a TCP echo
+# server there, confirms the path is open, then starts meow with a tproxy
+# listener and a single `MATCH,REJECT` rule — and leaves it all running.
+# Then run verify-tproxy-test.sh to assert interception. `down` cleans up.
+#
+# REJECT (not DIRECT) avoids a redirect loop: on macOS the rdr is `on lo0`, so a
+# DIRECT relay back to the lo0 test IP would be re-redirected into meow.
+#
+# macOS loop-avoidance is UID-based, so meow skips its own uid — meow must run
+# as a different user than the test client. meow needs root for pf/nft anyway,
+# so it runs as root here; run THIS script (and the test) as a NON-root user.
+#
+# Usage:
+#   ./verify-tproxy-setup.sh up --meow /path/to/meow
+#   ./verify-tproxy-setup.sh down
+#   ./verify-tproxy-setup.sh status
+set -uo pipefail
+
+STATE_DIR="${TMPDIR:-/tmp}/meow-tproxy-verify"
+STATE="$STATE_DIR/state"
+LOG="$STATE_DIR/meow.log"
+CFG="$STATE_DIR/meow.yaml"
+ECHO_PY="$STATE_DIR/echo.py"
+MEOW_PIDF="$STATE_DIR/meow.pid"
+ECHO_PIDF="$STATE_DIR/echo.pid"
+
+TEST_IP="10.88.0.1"
+ECHO_PORT="9999"
+TPROXY_PORT="7893"
+DNS_PORT="15353"
+MEOW="${MEOW:-meow}"
+OS="$(uname)"
+
+die() { echo "error: $*" >&2; exit 2; }
+asroot() { if [ "$(id -u)" = 0 ]; then "$@"; else sudo "$@"; fi; }
+remove_alias() {
+  if [ "$OS" = Darwin ]; then asroot ifconfig lo0 -alias "$TEST_IP" 2>/dev/null || true
+  else asroot ip addr del "$TEST_IP/32" dev lo 2>/dev/null || true; fi
+}
+
+cmd="${1:-}"; shift || true
+while [ $# -gt 0 ]; do case "$1" in
+  --meow) MEOW="$2"; shift 2;;
+  -h|--help) sed -n '2,28p' "$0"; exit 0;;
+  *) die "unknown option: $1";;
+esac; done
+
+case "$cmd" in
+  down)
+    [ -f "$MEOW_PIDF" ] && asroot kill "$(cat "$MEOW_PIDF")" 2>/dev/null || true
+    [ -f "$ECHO_PIDF" ] && kill "$(cat "$ECHO_PIDF")" 2>/dev/null || true
+    sleep 1; remove_alias; rm -rf "$STATE_DIR"
+    echo "tproxy test rig torn down"; exit 0;;
+  status)
+    [ -f "$STATE" ] && cat "$STATE" || echo "(no rig up)"; exit 0;;
+  up) ;;
+  ""|-h|--help) sed -n '2,28p' "$0"; exit 0;;
+  *) die "unknown command '$cmd' (use: up | down | status)";;
+esac
+
+[ "$(id -u)" != 0 ] || die "run as a NON-root user (the test client must not be uid-bypassed); it sudo's where needed"
+command -v "$MEOW" >/dev/null 2>&1 || die "meow binary not found ($MEOW); pass --meow PATH"
+
+mkdir -p "$STATE_DIR"
+
+# 1. loopback alias
+if [ "$OS" = Darwin ]; then asroot ifconfig lo0 alias "$TEST_IP"
+else asroot ip addr add "$TEST_IP/32" dev lo 2>/dev/null || true; fi
+
+# 2. echo server (detached, survives this script)
+cat > "$ECHO_PY" <<'PY'
+import socket, sys
+ip, port = sys.argv[1], int(sys.argv[2])
+s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind((ip, port)); s.listen(8)
+while True:
+    c, _ = s.accept()
+    try: c.recv(1024); c.sendall(b"ECHO_OK\n")
+    finally: c.close()
+PY
+nohup python3 "$ECHO_PY" "$TEST_IP" "$ECHO_PORT" >/dev/null 2>&1 &
+echo $! > "$ECHO_PIDF"
+sleep 1
+
+# 3. baseline: without meow the path must be open, or the rig is broken
+BASE="$(printf 'HELLO\n' | nc -w 4 "$TEST_IP" "$ECHO_PORT" 2>/dev/null || true)"
+printf '%s' "$BASE" | grep -q ECHO_OK || { remove_alias; kill "$(cat "$ECHO_PIDF")" 2>/dev/null; die "baseline failed: echo server unreachable ('${BASE:-<none>}')"; }
+
+# 4. meow config: tproxy listener + MATCH,REJECT
+cat > "$CFG" <<EOF
+tproxy-port: $TPROXY_PORT
+mode: rule
+log-level: info
+dns: { enable: true, listen: "127.0.0.1:$DNS_PORT", enhanced-mode: normal, nameserver: ["127.0.0.1"] }
+proxies: []
+proxy-groups: []
+rules: [ "MATCH,REJECT" ]
+EOF
+
+# 5. meow as root, detached; wait up to 90s (first start may fetch geodata DBs)
+asroot bash -c "nohup '$MEOW' -f '$CFG' >'$LOG' 2>&1 & echo \$! > '$MEOW_PIDF'"
+for _ in $(seq 1 180); do
+  grep -qE "TProxy listener.*started" "$LOG" 2>/dev/null && break
+  asroot kill -0 "$(cat "$MEOW_PIDF" 2>/dev/null)" 2>/dev/null || break
+  sleep 0.5
+done
+
+cat > "$STATE" <<EOF
+OS=$OS
+TEST_IP=$TEST_IP
+ECHO_PORT=$ECHO_PORT
+TPROXY_PORT=$TPROXY_PORT
+LOG=$LOG
+MEOW_PID=$(cat "$MEOW_PIDF" 2>/dev/null)
+ECHO_PID=$(cat "$ECHO_PIDF" 2>/dev/null)
+EOF
+
+echo "tproxy test rig up (baseline path OK):"; sed 's/^/  /' "$STATE"
+echo "now run:  ./verify-tproxy-test.sh"
+echo "teardown: ./verify-tproxy-setup.sh down"

--- a/scripts/verify-tproxy-test.sh
+++ b/scripts/verify-tproxy-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# verify-tproxy-test.sh — assert that meow's local-outbound transparent proxy
+# actually intercepts the host's own traffic. Run AFTER verify-tproxy-setup.sh
+# brings up the rig. Re-runnable (handy while iterating on a meow fix).
+#
+# Checks (all must pass):
+#   tproxy_listener_started  — meow bound the tproxy listener
+#   pf_anchor_loaded /        — the redirect rules are installed
+#     nft_table_loaded
+#   connection_intercepted   — with MATCH,REJECT the echo server is NOT reached
+#                              (baseline proved it IS reachable without meow)
+#   meow_logged_original_dst — meow recovered + logged the original destination
+#
+# Run as a NON-root user: macOS loop-avoidance is UID-based, so a root client
+# would be bypassed and never intercepted.
+set -uo pipefail
+
+STATE_DIR="${TMPDIR:-/tmp}/meow-tproxy-verify"
+STATE="$STATE_DIR/state"
+[ -f "$STATE" ] || { echo "no rig found — run ./verify-tproxy-setup.sh up first" >&2; exit 2; }
+# shellcheck disable=SC1090
+. "$STATE"
+
+[ "$(id -u)" != 0 ] || echo "warning: running as root — the client may be uid-bypassed and not intercepted" >&2
+asroot() { if [ "$(id -u)" = 0 ]; then "$@"; else sudo "$@"; fi; }
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+
+echo "== meow local-outbound tproxy test ($OS) =="
+
+# 1. listener up
+if grep -qE "TProxy listener.*started" "$LOG"; then pass "tproxy_listener_started"; else fail "tproxy_listener_started"; fi
+
+# 2. firewall rules installed
+if [ "$OS" = Darwin ]; then
+  if asroot pfctl -a com.apple/com.meow.tproxy -sn 2>/dev/null | grep -q rdr; then pass "pf_anchor_loaded"; else fail "pf_anchor_loaded"; fi
+else
+  if asroot nft list table inet meow_tproxy >/dev/null 2>&1; then pass "nft_table_loaded"; else fail "nft_table_loaded"; fi
+fi
+
+# 3. interception: connect as the (non-root) user; MATCH,REJECT => no echo
+RESP="$(printf 'HELLO\n' | nc -w 4 "$TEST_IP" "$ECHO_PORT" 2>/dev/null || true)"
+sleep 1
+if printf '%s' "$RESP" | grep -q ECHO_OK; then fail "connection_intercepted (echo answered → NOT intercepted)"; else pass "connection_intercepted"; fi
+
+# 4. meow recovered the original destination
+if grep -q "$TEST_IP:$ECHO_PORT" "$LOG"; then pass "meow_logged_original_dst"; else fail "meow_logged_original_dst"; fi
+
+echo
+echo "== meow log (tail) =="; tail -6 "$LOG" 2>/dev/null | sed -E 's/\x1b\[[0-9;]*m//g'
+echo
+echo "== result: $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

meow's macOS **local-outbound** transparent proxy was non-functional. Two bugs in `crates/meow-listener/src/tproxy/firewall.rs` — both invisible to CI, since the macOS code path isn't compiled on the Linux runners — found by a new verification script run in a macOS VM.

### Bug 1 — pf rule ordering (listener never started)
`build_pf_ruleset` emitted the `pass` (filtering) bypasses before the `rdr` (translation) rule. `pfctl` requires translation before filtering and rejects otherwise (`Rules must be in order: …, translation, filtering`), so `FirewallGuard::setup` errored and the tproxy listener never bound. Fixed by emitting `rdr` first; flipped the unit test (`pf_rdr_precedes_filter_rules`) that had codified the wrong order.

### Bug 2 — anchor never evaluated (no interception)
Rules were loaded into anchor `com.meow.tproxy`, a **sibling** of `com.apple`, which the default `/etc/pf.conf`'s `rdr-anchor "com.apple/*"` never descends into — loaded but never applied. Fixed by nesting under `com.apple/com.meow.tproxy`. Verified directly: a sibling anchor does **not** intercept; a `com.apple/*` child **does**. Same fix applied to `scripts/tproxy-gateway-macos.sh`.

## Verification scripts (split: setup + test)

- `scripts/verify-tproxy-setup.sh` — brings up a rig (loopback alias + echo server + meow tproxy with `MATCH,REJECT`); `up`/`down`/`status`.
- `scripts/verify-tproxy-test.sh` — asserts listener up, rules loaded, connection intercepted, original dst recovered. Re-runnable against a live rig.

Progression in a macOS 26.4 VM: **listener-won't-start → 3/4 passing** (listener starts, anchor loads, connection intercepted).

## Validation
- `cargo fmt --all --check`, `cargo clippy -p meow-listener --all-targets -D warnings`, `cargo test -p meow-listener --lib` (31 passed) — all clean.

## Known limitation (follow-up, not fixed here)
The rdr-to-`127.0.0.1` connection on loopback doesn't complete its TCP handshake, so meow can't yet recover the original destination of an intercepted loopback connection (`meow_logged_original_dst` still fails). And `rdr on lo0` only covers loopback — real outbound via the physical interface is never intercepted. macOS tproxy needs further work (rdr on the real interface, martian-src/listen-addr handling) to be useful beyond loopback; these two fixes take it from "completely broken" to "interception correctly wired."

🤖 Generated with [Claude Code](https://claude.com/claude-code)