### PR TITLE
feat(scripts): add tproxy-local wrappers for Linux and macOS

### DIFF
--- a/docs/tproxy-gateway.md
+++ b/docs/tproxy-gateway.md
@@ -10,7 +10,10 @@ rules without any per-device proxy configuration.
 
 If you only want to transparently proxy traffic originating **on the meow host
 itself** (not forward other devices), most of this is unnecessary — set
-`tproxy-port` and meow's built-in firewall handles it. Read
+`tproxy-port` and meow's built-in firewall handles it. The
+[`scripts/tproxy-local-linux.sh`](../scripts/tproxy-local-linux.sh) /
+[`scripts/tproxy-local-macos.sh`](../scripts/tproxy-local-macos.sh) wrappers run
+meow that way (`up`/`down`/`status`) and confirm the auto-created firewall. Read
 [How meow's transparent proxy works](#how-meows-transparent-proxy-works) and
 [DNS mode](#dns-mode-fake-ip-vs-redir-host), then stop.
 

--- a/scripts/tproxy-local-linux.sh
+++ b/scripts/tproxy-local-linux.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# tproxy-local-linux.sh — run meow as a LOCAL transparent proxy for THIS host's
+# own outbound traffic (Linux / nftables).
+#
+# Unlike a gateway, you do NOT install firewall rules yourself: meow's built-in
+# firewall creates an `output`-chain nft REDIRECT (table `inet meow_tproxy`)
+# when a tproxy listener is configured, and removes it on exit. This wrapper
+# just runs meow with such a config and confirms the firewall came up. To
+# forward OTHER devices' traffic, use tproxy-gateway-linux.sh instead.
+#
+# Usage:
+#   sudo ./tproxy-local-linux.sh up [--config FILE] [--meow PATH]
+#   sudo ./tproxy-local-linux.sh down
+#   sudo ./tproxy-local-linux.sh status
+#
+# With no --config a minimal demo config (tproxy-port + MATCH,DIRECT) is used:
+# it proves interception works but does not proxy anywhere. Supply your own
+# config (with proxies + rules + a tproxy listener) for real use.
+set -uo pipefail
+
+STATE_DIR="/run/meow-tproxy-local"
+[ -w /run ] 2>/dev/null || STATE_DIR="${TMPDIR:-/tmp}/meow-tproxy-local"
+PIDF="$STATE_DIR/meow.pid"
+LOG="$STATE_DIR/meow.log"
+GENCFG="$STATE_DIR/meow.yaml"
+TABLE="meow_tproxy"           # the table meow auto-creates
+MEOW="${MEOW:-meow}"
+CONFIG=""
+
+die() { echo "error: $*" >&2; exit 2; }
+
+cmd="${1:-}"; shift || true
+while [ $# -gt 0 ]; do case "$1" in
+  --config) CONFIG="$2"; shift 2;;
+  --meow)   MEOW="$2"; shift 2;;
+  -h|--help) sed -n '2,21p' "$0"; exit 0;;
+  *) die "unknown option: $1";;
+esac; done
+
+fw_present() { nft list table inet "$TABLE" >/dev/null 2>&1; }
+
+case "$cmd" in
+  down)
+    [ -f "$PIDF" ] && kill "$(cat "$PIDF")" 2>/dev/null || true
+    sleep 1
+    if fw_present; then echo "warning: table inet $TABLE still present"; else echo "stopped; firewall removed"; fi
+    rm -rf "$STATE_DIR"; exit 0;;
+  status)
+    if [ -f "$PIDF" ] && kill -0 "$(cat "$PIDF")" 2>/dev/null; then echo "meow: running (pid $(cat "$PIDF"))"; else echo "meow: not running"; fi
+    if fw_present; then echo "firewall: table inet $TABLE present"; nft list table inet "$TABLE" 2>/dev/null | sed 's/^/  /'; else echo "firewall: absent"; fi
+    exit 0;;
+  up) ;;
+  ""|-h|--help) sed -n '2,21p' "$0"; exit 0;;
+  *) die "unknown command '$cmd' (use: up | down | status)";;
+esac
+
+[ "$(id -u)" = 0 ] || die "must run as root (nftables)"
+command -v nft >/dev/null || die "nft (nftables) not found"
+command -v "$MEOW" >/dev/null 2>&1 || die "meow binary not found ($MEOW); pass --meow PATH"
+mkdir -p "$STATE_DIR"
+
+if [ -n "$CONFIG" ]; then
+  CFG="$CONFIG"
+  echo "using config: $CFG"
+else
+  CFG="$GENCFG"
+  cat > "$CFG" <<EOF
+# Demo local-tproxy config (no real proxy — MATCH,DIRECT). Replace the proxies
+# and rules with your own; keep \`tproxy-port\` to enable transparent proxy.
+tproxy-port: 7893
+routing-mark: 9527
+mode: rule
+log-level: info
+dns: { enable: true, listen: "127.0.0.1:1053", enhanced-mode: normal, nameserver: ["1.1.1.1"] }
+proxies: []
+proxy-groups: []
+rules: [ "MATCH,DIRECT" ]
+EOF
+  echo "using generated demo config: $CFG (MATCH,DIRECT — no real proxy)"
+fi
+
+"$MEOW" -f "$CFG" -t >/dev/null 2>&1 || die "config failed validation ($MEOW -f $CFG -t)"
+grep -qE "^tproxy-port:|type: *tproxy" "$CFG" || echo "warning: config has no tproxy listener; meow will not set up a redirect"
+
+echo "note: the output-chain redirect captures this host's own new outbound TCP;"
+echo "      existing connections (including a remote SSH session managing this)"
+echo "      may reset as it activates."
+
+nohup "$MEOW" -f "$CFG" >"$LOG" 2>&1 &
+echo $! > "$PIDF"
+
+# Wait for the listener (first start may download geodata DBs).
+for _ in $(seq 1 180); do
+  grep -qE "TProxy listener.*started" "$LOG" 2>/dev/null && break
+  kill -0 "$(cat "$PIDF")" 2>/dev/null || { echo "meow exited early:"; tail -5 "$LOG"; exit 1; }
+  sleep 0.5
+done
+
+if fw_present; then
+  echo "local transparent proxy active — this host's own outbound TCP is intercepted."
+  echo "meow pid $(cat "$PIDF"); firewall: table inet $TABLE"
+  echo "stop with: sudo $0 down"
+else
+  echo "warning: meow started but table inet $TABLE is absent; check $LOG"
+  exit 1
+fi

--- a/scripts/tproxy-local-macos.sh
+++ b/scripts/tproxy-local-macos.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# tproxy-local-macos.sh — run meow as a LOCAL transparent proxy for THIS host's
+# own outbound traffic (macOS / pf).
+#
+# You do NOT install firewall rules yourself: meow's built-in firewall loads a
+# pf anchor (`com.apple/com.meow.tproxy`, rdr on lo0) when a tproxy listener is
+# configured, and flushes it on exit. This wrapper runs meow with such a config
+# and confirms the anchor came up. To forward OTHER devices' traffic, use
+# tproxy-gateway-macos.sh instead.
+#
+# NOTE (see GitHub issue on macOS tproxy): macOS interception is currently
+# loopback-only and the redirected connection's handshake does not complete, so
+# this does not yet proxy real outbound traffic. The wrapper still demonstrates
+# that the listener + pf anchor are installed correctly.
+#
+# Usage:
+#   sudo ./tproxy-local-macos.sh up [--config FILE] [--meow PATH]
+#   sudo ./tproxy-local-macos.sh down
+#   sudo ./tproxy-local-macos.sh status
+set -uo pipefail
+
+STATE_DIR="${TMPDIR:-/tmp}/meow-tproxy-local"
+PIDF="$STATE_DIR/meow.pid"
+LOG="$STATE_DIR/meow.log"
+GENCFG="$STATE_DIR/meow.yaml"
+ANCHOR="com.apple/com.meow.tproxy"   # the anchor meow auto-loads
+MEOW="${MEOW:-meow}"
+CONFIG=""
+
+die() { echo "error: $*" >&2; exit 2; }
+
+cmd="${1:-}"; shift || true
+while [ $# -gt 0 ]; do case "$1" in
+  --config) CONFIG="$2"; shift 2;;
+  --meow)   MEOW="$2"; shift 2;;
+  -h|--help) sed -n '2,24p' "$0"; exit 0;;
+  *) die "unknown option: $1";;
+esac; done
+
+[ "$(uname)" = Darwin ] || die "this script is for macOS; use tproxy-local-linux.sh on Linux"
+
+fw_present() { pfctl -a "$ANCHOR" -sn 2>/dev/null | grep -q rdr; }
+
+case "$cmd" in
+  down)
+    [ -f "$PIDF" ] && kill "$(cat "$PIDF")" 2>/dev/null || true
+    sleep 1
+    if fw_present; then echo "warning: anchor $ANCHOR still present"; else echo "stopped; pf anchor flushed"; fi
+    rm -rf "$STATE_DIR"; exit 0;;
+  status)
+    if [ -f "$PIDF" ] && kill -0 "$(cat "$PIDF")" 2>/dev/null; then echo "meow: running (pid $(cat "$PIDF"))"; else echo "meow: not running"; fi
+    if fw_present; then echo "firewall: pf anchor $ANCHOR present"; pfctl -a "$ANCHOR" -sn 2>/dev/null | sed 's/^/  /'; else echo "firewall: absent"; fi
+    exit 0;;
+  up) ;;
+  ""|-h|--help) sed -n '2,24p' "$0"; exit 0;;
+  *) die "unknown command '$cmd' (use: up | down | status)";;
+esac
+
+[ "$(id -u)" = 0 ] || die "must run as root (pfctl)"
+command -v "$MEOW" >/dev/null 2>&1 || die "meow binary not found ($MEOW); pass --meow PATH"
+mkdir -p "$STATE_DIR"
+
+if [ -n "$CONFIG" ]; then
+  CFG="$CONFIG"
+  echo "using config: $CFG"
+else
+  CFG="$GENCFG"
+  cat > "$CFG" <<EOF
+# Demo local-tproxy config (no real proxy — MATCH,DIRECT). Replace the proxies
+# and rules with your own; keep \`tproxy-port\` to enable transparent proxy.
+tproxy-port: 7893
+routing-mark: 9527
+mode: rule
+log-level: info
+dns: { enable: true, listen: "127.0.0.1:1053", enhanced-mode: normal, nameserver: ["1.1.1.1"] }
+proxies: []
+proxy-groups: []
+rules: [ "MATCH,DIRECT" ]
+EOF
+  echo "using generated demo config: $CFG (MATCH,DIRECT — no real proxy)"
+fi
+
+"$MEOW" -f "$CFG" -t >/dev/null 2>&1 || die "config failed validation ($MEOW -f $CFG -t)"
+grep -qE "^tproxy-port:|type: *tproxy" "$CFG" || echo "warning: config has no tproxy listener; meow will not set up a redirect"
+
+nohup "$MEOW" -f "$CFG" >"$LOG" 2>&1 &
+echo $! > "$PIDF"
+
+# Wait for the listener (first start may download geodata DBs).
+for _ in $(seq 1 180); do
+  grep -qE "TProxy listener.*started" "$LOG" 2>/dev/null && break
+  kill -0 "$(cat "$PIDF")" 2>/dev/null || { echo "meow exited early:"; tail -5 "$LOG"; exit 1; }
+  sleep 0.5
+done
+
+if fw_present; then
+  echo "local transparent proxy active — pf anchor $ANCHOR loaded."
+  echo "meow pid $(cat "$PIDF"). (See the macOS-tproxy note above re: loopback-only.)"
+  echo "stop with: sudo $0 down"
+else
+  echo "warning: meow started but pf anchor $ANCHOR is absent; check $LOG"
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds `scripts/tproxy-local-linux.sh` and `scripts/tproxy-local-macos.sh` — thin `up`/`down`/`status` wrappers that run meow as a **local** transparent proxy (proxying *this host's* own outbound traffic), the counterpart to the existing `tproxy-gateway-*` scripts.

## Why thin

Unlike the gateway case, local-outbound needs **no manual firewall rules**: meow's built-in firewall auto-creates them when a tproxy listener is configured —
- Linux: `output`-chain nft REDIRECT (`table inet meow_tproxy`),
- macOS: the `com.apple/com.meow.tproxy` pf anchor,

and removes them on exit (RAII). The wrappers just write a minimal demo config (or take `--config`), run meow, wait for the listener, and confirm the firewall came up; `down` stops meow and verifies removal.

## Verified in VMs
- **Linux** (Ubuntu 24.04): intercepts the host's own outbound TCP — meow logs e.g. `192.168.0.118:54350 --> 104.20.23.154:80 match MATCH() using DIRECT`; `down` removes the table. Wrapper warns that activation can reset existing host connections (output-redirect affects the host's own flows).
- **macOS** (26.4): loads/flushes the `com.apple/com.meow.tproxy` anchor cleanly via up/status/down. (Real interception remains loopback-only per the macOS tproxy follow-up issue; the lo0 anchor doesn't disrupt real connections.)

Linked from `docs/tproxy-gateway.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)