### PR TITLE
fix: serialize connection metadata (#241), mount external UI (#223), support dialer-proxy (#210)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2340,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -3810,10 +3826,19 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3995,6 +4020,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +917,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dhat"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1052,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2158,6 +2188,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "webpki-roots 0.26.11",
+ "zip",
 ]
 
 [[package]]
@@ -2364,6 +2395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3433,6 +3465,12 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -4852,10 +4890,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ hickory-proto = "0.26"
 # Web framework
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
 
 # GeoIP
 maxminddb = { version = "0.27", features = ["mmap"] }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,13 @@ ipv6: false
 # REST API
 external-controller: 127.0.0.1:9090
 secret: ""
+# Mount a third-party dashboard (metacubexd, yacd, …) at /ui instead of the
+# built-in panel. Point external-ui at a directory of static files; if the UI
+# lives in a sub-directory, set external-ui-name. Auto-download via
+# external-ui-url is not performed — populate the directory yourself.
+# external-ui: ./ui
+# external-ui-name: dist
+# external-ui-url: https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip
 
 # DNS
 dns:
@@ -63,6 +70,11 @@ proxies:
     sni: example.com
     skip-cert-verify: false
     udp: true
+    # dialer-proxy: reach this server *through* another proxy/group (chained
+    # dialing, mihomo-compatible). The referenced name may be any proxy or
+    # group; cycles are detected and ignored. TCP only — UDP is not routed
+    # through the dialer.
+    # dialer-proxy: "Proxy"
 
 # Proxy groups
 proxy-groups:

--- a/crates/meow-api/src/lib.rs
+++ b/crates/meow-api/src/lib.rs
@@ -11,9 +11,10 @@ use meow_tunnel::Tunnel;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::broadcast;
-use tracing::info;
+use tracing::{info, warn};
 
 pub struct ApiServer {
     tunnel: Tunnel,
@@ -25,6 +26,7 @@ pub struct ApiServer {
     proxy_providers: Arc<DashMap<String, Arc<ProxyProvider>>>,
     rule_providers: Arc<RwLock<HashMap<String, Arc<RuleProvider>>>>,
     listeners: Vec<NamedListener>,
+    external_ui: Option<PathBuf>,
 }
 
 impl ApiServer {
@@ -39,6 +41,7 @@ impl ApiServer {
         proxy_providers: Arc<DashMap<String, Arc<ProxyProvider>>>,
         rule_providers: Arc<RwLock<HashMap<String, Arc<RuleProvider>>>>,
         listeners: Vec<NamedListener>,
+        external_ui: Option<PathBuf>,
     ) -> Self {
         Self {
             tunnel,
@@ -50,6 +53,7 @@ impl ApiServer {
             proxy_providers,
             rule_providers,
             listeners,
+            external_ui,
         }
     }
 
@@ -63,6 +67,7 @@ impl ApiServer {
             proxy_providers: Arc::clone(&self.proxy_providers),
             rule_providers: Arc::clone(&self.rule_providers),
             listeners: self.listeners.clone(),
+            external_ui: self.resolve_external_ui(),
         });
 
         let app = routes::create_router(state);
@@ -72,5 +77,22 @@ impl ApiServer {
         info!("Web UI available at http://{}/ui", self.listen_addr);
         axum::serve(listener, app).await?;
         Ok(())
+    }
+
+    /// Validate the configured external-UI directory. Returns the path only when
+    /// it exists as a directory; otherwise logs a warning and falls back to the
+    /// built-in panel (issue #223).
+    fn resolve_external_ui(&self) -> Option<PathBuf> {
+        let dir = self.external_ui.as_ref()?;
+        if dir.is_dir() {
+            info!("Serving external Web UI from {}", dir.display());
+            Some(dir.clone())
+        } else {
+            warn!(
+                "external-ui directory {} not found; serving the built-in panel instead",
+                dir.display()
+            );
+            None
+        }
     }
 }

--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -41,6 +41,9 @@ pub struct AppState {
     pub rule_providers: Arc<RwLock<HashMap<String, Arc<RuleProvider>>>>,
     /// Snapshot of active named listeners (read-only, startup-time only in M1).
     pub listeners: Vec<NamedListener>,
+    /// Validated directory for a third-party web UI. When `Some`, it is served
+    /// at `/ui`; when `None`, the built-in panel is served (issue #223).
+    pub external_ui: Option<std::path::PathBuf>,
 }
 
 impl AppState {
@@ -214,14 +217,24 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     // Web UI is intentionally unauthenticated so dashboards can load and then
     // present a token prompt; this matches upstream mihomo behaviour.
-    let ui = Router::new()
-        .route("/ui", get(ui::serve_ui))
-        .route("/ui/{*rest}", get(ui::serve_ui));
+    //
+    // When `external-ui` is configured (issue #223) the static directory is
+    // served at `/ui` via tower-http's `ServeDir`; otherwise the built-in
+    // single-page panel is served.
+    let router = api.merge(ws_routes);
+    let router = if let Some(dir) = state.external_ui.clone() {
+        // `ServeDir` resolves `index.html` for the directory root and serves
+        // any nested asset; `nest_service("/ui", …)` strips the `/ui` prefix so
+        // both `/ui` and `/ui/<asset>` resolve. Dashboards (metacubexd, yacd)
+        // use hash routing, so no server-side SPA fallback is required.
+        router.nest_service("/ui", tower_http::services::ServeDir::new(dir))
+    } else {
+        router
+            .route("/ui", get(ui::serve_ui))
+            .route("/ui/{*rest}", get(ui::serve_ui))
+    };
 
-    api.merge(ws_routes)
-        .merge(ui)
-        .layer(CorsLayer::permissive())
-        .with_state(state)
+    router.layer(CorsLayer::permissive()).with_state(state)
 }
 
 // ── Basic endpoints ──────────────────────────────────────────────────

--- a/crates/meow-api/tests/api_logs_ws_test.rs
+++ b/crates/meow-api/tests/api_logs_ws_test.rs
@@ -42,6 +42,7 @@ fn make_state_with_cap(cap: usize) -> (Arc<AppState>, broadcast::Sender<LogMessa
         proxy_providers: Arc::new(DashMap::new()),
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
+        external_ui: None,
     });
     (state, log_tx)
 }

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -59,6 +59,7 @@ fn test_state(raw: RawConfig) -> Arc<AppState> {
         proxy_providers: Arc::new(DashMap::new()),
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
+        external_ui: None,
     })
 }
 
@@ -91,6 +92,7 @@ fn test_state_with_route(raw: RawConfig, named: Vec<(&str, Arc<dyn Proxy>)>) -> 
         proxy_providers: Arc::new(DashMap::new()),
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
+        external_ui: None,
     })
 }
 
@@ -125,6 +127,7 @@ fn test_state_with_secret(secret: &str) -> Arc<AppState> {
         proxy_providers: Arc::new(DashMap::new()),
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
+        external_ui: None,
     })
 }
 
@@ -169,6 +172,65 @@ async fn ui_wildcard_serves_same_html() {
     assert_eq!(resp.status(), StatusCode::OK);
     let body = body_string(resp).await;
     assert!(body.contains("<!DOCTYPE html>"));
+}
+
+// issue #223: when `external-ui` is configured, `/ui` serves the static
+// directory instead of the built-in panel.
+#[tokio::test]
+async fn external_ui_serves_static_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("index.html"),
+        "<html><body>third-party dashboard</body></html>",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("app.js"), "console.log('hi')").unwrap();
+
+    let resolver = Arc::new(Resolver::new(
+        vec!["8.8.8.8:53".parse().unwrap()],
+        vec![],
+        DnsMode::Normal,
+        DomainTrie::new(),
+        true,
+    ));
+    let tunnel = Tunnel::new(resolver);
+    let raw = test_raw_config();
+    let (proxies, rules) = meow_config::rebuild_from_raw(&raw).unwrap();
+    tunnel.update_proxies(proxies);
+    tunnel.update_rules(rules);
+    let state = Arc::new(AppState {
+        tunnel,
+        secret: None,
+        config_path: String::new(),
+        raw_config: Arc::new(RwLock::new(raw)),
+        log_tx: test_log_tx(),
+        proxy_providers: Arc::new(DashMap::new()),
+        rule_providers: Arc::new(RwLock::new(HashMap::new())),
+        listeners: vec![],
+        external_ui: Some(dir.path().to_path_buf()),
+    });
+    let app = create_router(state);
+
+    // `/ui` resolves index.html in the directory.
+    let resp = app
+        .clone()
+        .oneshot(Request::get("/ui").body(axum::body::Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(body_string(resp).await.contains("third-party dashboard"));
+
+    // A nested asset is served from the directory.
+    let resp = app
+        .oneshot(
+            Request::get("/ui/app.js")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(body_string(resp).await.contains("console.log"));
 }
 
 // ── Existing endpoint tests ──────────────────────────────────────
@@ -1605,6 +1667,7 @@ mod delay_support {
             proxy_providers: Arc::new(DashMap::new()),
             rule_providers: Arc::new(RwLock::new(HashMap::new())),
             listeners: vec![],
+            external_ui: None,
         })
     }
 
@@ -1656,6 +1719,7 @@ mod delay_support {
             proxy_providers: Arc::new(DashMap::new()),
             rule_providers: Arc::new(RwLock::new(HashMap::new())),
             listeners: vec![],
+            external_ui: None,
         })
     }
 }
@@ -2493,6 +2557,7 @@ fn test_state_with_hosts_entry() -> Arc<AppState> {
         proxy_providers: Arc::new(DashMap::new()),
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
+        external_ui: None,
     })
 }
 
@@ -2664,10 +2729,13 @@ async fn get_connections_entry_has_camel_case_shape() {
     assert_eq!(conn["upload"], 0);
     assert_eq!(conn["download"], 0);
     assert!(conn["start"].is_string());
-    assert!(
-        conn.get("metadata").is_none(),
-        "metadata stays serde-skipped"
-    );
+    // issue #241: metadata is now serialised (mihomo-compatible) so panels can
+    // render `host:port` as the connection title instead of the rule type.
+    let metadata = conn.get("metadata").expect("metadata is serialised");
+    assert_eq!(metadata["host"], "example.com");
+    assert_eq!(metadata["destinationPort"], 80);
+    assert_eq!(metadata["network"], "tcp");
+    assert_eq!(metadata["type"], "Http");
     assert!(
         conn.get("rule_payload").is_none(),
         "snake_case key must not appear"

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 [features]
 default = ["full", "boring-tls"]
 boring-tls = ["meow-config/boring-tls"]
+# Auto-download a third-party dashboard from `external-ui-url` (issue #223).
+# Off by default — adds the `zip` dependency (ADR-0007 binary-size caps).
+# Force-disabled at compile time on iOS/Android even if enabled.
+external-ui-download = ["meow-config/external-ui-download"]
 # Heap profiling via dhat crate — swaps global allocator; never enable in production.
 dhat-heap = ["dhat"]
 

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -509,16 +509,34 @@ async fn run(
 
     // Start REST API if configured
     if let Some(api_addr) = config.api.external_controller {
-        // external-ui-url has no auto-download (would require an unzip
-        // dependency that conflicts with ADR-0007 size caps); hint the user to
+        // `external-ui-url` auto-download is gated behind the optional
+        // `external-ui-download` feature (it pulls in the `zip` crate, against
+        // the ADR-0007 size caps). Without the feature we just hint the user to
         // populate the directory manually. See issue #223.
         if let (Some(url), Some(dir)) = (&config.api.external_ui_url, &config.api.external_ui) {
             if !dir.is_dir() {
-                warn!(
-                    "external-ui-url ({url}) is set but auto-download is unsupported; \
-                     download and extract the UI into {} manually",
-                    dir.display()
-                );
+                // Auto-download is gated behind `external-ui-download` AND is
+                // force-disabled on iOS/Android (mobile ships its own UI).
+                #[cfg(all(
+                    feature = "external-ui-download",
+                    not(any(target_os = "ios", target_os = "android"))
+                ))]
+                {
+                    if let Err(e) = meow_config::external_ui::download_external_ui(url, dir).await {
+                        warn!("failed to download external-ui from {url}: {e:#}");
+                    }
+                }
+                #[cfg(not(all(
+                    feature = "external-ui-download",
+                    not(any(target_os = "ios", target_os = "android"))
+                )))]
+                {
+                    warn!(
+                        "external-ui-url ({url}) is set but auto-download is unavailable in this \
+                         build; download and extract the UI into {} manually",
+                        dir.display()
+                    );
+                }
             }
         }
         let api_server = ApiServer::new(

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -20,7 +20,7 @@ use meow_tunnel::Tunnel;
 use parking_lot::RwLock;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[cfg(target_os = "linux")]
 const SERVICE_NAME: &str = "meow";
@@ -509,6 +509,18 @@ async fn run(
 
     // Start REST API if configured
     if let Some(api_addr) = config.api.external_controller {
+        // external-ui-url has no auto-download (would require an unzip
+        // dependency that conflicts with ADR-0007 size caps); hint the user to
+        // populate the directory manually. See issue #223.
+        if let (Some(url), Some(dir)) = (&config.api.external_ui_url, &config.api.external_ui) {
+            if !dir.is_dir() {
+                warn!(
+                    "external-ui-url ({url}) is set but auto-download is unsupported; \
+                     download and extract the UI into {} manually",
+                    dir.display()
+                );
+            }
+        }
         let api_server = ApiServer::new(
             tunnel.clone(),
             api_addr,
@@ -519,6 +531,7 @@ async fn run(
             Arc::clone(&proxy_providers),
             Arc::clone(&rule_providers),
             config.listeners.named.clone(),
+            config.api.external_ui.clone(),
         );
         tokio::spawn(async move {
             if let Err(e) = api_server.run().await {

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -17,6 +17,11 @@ snell = ["meow-proxy/snell"]
 boring-tls = ["meow-transport/boring-tls"]
 ech = ["meow-transport/ech"]
 ech-tls-tunnel = ["ss", "meow-proxy/ech-tls-tunnel"]
+# Auto-download + unzip a third-party dashboard from `external-ui-url` (issue
+# #223). Off by default: pulls in the `zip` crate, which grows the binary
+# against the ADR-0007 size caps. Even when enabled, the code path is
+# force-disabled on iOS/Android targets (see `src/lib.rs`).
+external-ui-download = ["dep:zip"]
 
 [dependencies]
 meow-common = { workspace = true }
@@ -44,6 +49,9 @@ rustls = { workspace = true }
 webpki-roots = { workspace = true }
 url = "2"
 httparse = "1"
+# Optional: only compiled when the `external-ui-download` feature is enabled.
+# `deflate` is the only codec GitHub release zips use; skip the heavier ones.
+zip = { version = "2", default-features = false, features = ["deflate"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/meow-config/src/external_ui.rs
+++ b/crates/meow-config/src/external_ui.rs
@@ -1,0 +1,163 @@
+//! Optional auto-download for a third-party web dashboard (issue #223).
+//!
+//! Compiled only with the `external-ui-download` feature. Fetches the zip named
+//! by `external-ui-url` and extracts it into the `external-ui` directory, so the
+//! API server can then serve it at `/ui`. Kept behind a feature because the
+//! `zip` dependency grows the binary against the ADR-0007 size caps.
+
+use anyhow::Context;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+/// Download the archive at `url` and extract it into `dir`.
+///
+/// GitHub branch/release zips wrap every entry in a single `<repo>-<ref>/`
+/// directory; that common top-level prefix is stripped so the dashboard's
+/// `index.html` lands directly in `dir`. Returns an error for the caller to log
+/// — a failed download is non-fatal (the server falls back to the built-in UI).
+pub async fn download_external_ui(url: &str, dir: &Path) -> anyhow::Result<()> {
+    info!("Downloading external UI from {url} into {}", dir.display());
+    let bytes = reqwest::get(url)
+        .await
+        .with_context(|| format!("request to {url} failed"))?
+        .error_for_status()
+        .with_context(|| format!("{url} returned an error status"))?
+        .bytes()
+        .await
+        .context("reading response body")?;
+
+    let dir_owned = dir.to_path_buf();
+    // Zip extraction is synchronous and CPU/IO bound; keep it off the runtime.
+    tokio::task::spawn_blocking(move || extract_zip(&bytes, &dir_owned))
+        .await
+        .context("extraction task panicked")??;
+    info!("external UI extracted to {}", dir.display());
+    Ok(())
+}
+
+fn extract_zip(bytes: &[u8], dir: &Path) -> anyhow::Result<()> {
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(bytes)).context("not a valid zip archive")?;
+    let strip = common_top_level(&archive);
+
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i)?;
+        // `enclosed_name` rejects absolute paths and `..` traversal — skip any
+        // entry that does not resolve to a safe relative path (zip-slip guard).
+        let Some(name) = entry.enclosed_name() else {
+            continue;
+        };
+        let rel = match &strip {
+            Some(prefix) => match name.strip_prefix(prefix) {
+                Ok(r) if !r.as_os_str().is_empty() => r.to_path_buf(),
+                _ => continue,
+            },
+            None => name,
+        };
+        let out = dir.join(rel);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out)?;
+        } else {
+            if let Some(parent) = out.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let mut f = std::fs::File::create(&out)
+                .with_context(|| format!("creating {}", out.display()))?;
+            std::io::copy(&mut entry, &mut f)?;
+        }
+    }
+    Ok(())
+}
+
+/// If every entry sits under one shared top-level directory, return it so it can
+/// be stripped; otherwise `None`.
+fn common_top_level(archive: &zip::ZipArchive<Cursor<&[u8]>>) -> Option<PathBuf> {
+    let mut names = archive.file_names();
+    let first = names.next()?;
+    let top = first.split('/').next().filter(|s| !s.is_empty())?;
+    let prefix = format!("{top}/");
+    if archive
+        .file_names()
+        .all(|n| n == top || n.starts_with(&prefix))
+    {
+        Some(PathBuf::from(top))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use zip::write::{SimpleFileOptions, ZipWriter};
+
+    /// Build an in-memory zip from `(path, contents)` entries (Stored, no codec
+    /// feature needed).
+    fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut w = ZipWriter::new(Cursor::new(&mut buf));
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            for (path, contents) in entries {
+                w.start_file(*path, opts).unwrap();
+                w.write_all(contents).unwrap();
+            }
+            w.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn strips_common_github_top_level_dir() {
+        // GitHub-style: everything under `metacubexd-gh-pages/`.
+        let zip = make_zip(&[
+            ("metacubexd-gh-pages/index.html", b"<html>dash</html>"),
+            ("metacubexd-gh-pages/assets/app.js", b"console.log(1)"),
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+        extract_zip(&zip, dir.path()).unwrap();
+
+        // The wrapping directory is stripped: index.html lands at the root.
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("index.html")).unwrap(),
+            "<html>dash</html>"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("assets/app.js")).unwrap(),
+            "console.log(1)"
+        );
+        assert!(!dir.path().join("metacubexd-gh-pages").exists());
+    }
+
+    #[test]
+    fn keeps_layout_when_no_common_prefix() {
+        let zip = make_zip(&[("index.html", b"root"), ("vendor/lib.js", b"v")]);
+        let dir = tempfile::tempdir().unwrap();
+        extract_zip(&zip, dir.path()).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("index.html")).unwrap(),
+            "root"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("vendor/lib.js")).unwrap(),
+            "v"
+        );
+    }
+
+    #[test]
+    fn rejects_zip_slip_traversal() {
+        // `enclosed_name()` returns None for `..` escapes, so the entry is
+        // skipped and nothing is written outside `dir`.
+        let zip = make_zip(&[("../escape.txt", b"pwned"), ("safe.txt", b"ok")]);
+        let dir = tempfile::tempdir().unwrap();
+        extract_zip(&zip, dir.path()).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("safe.txt")).unwrap(),
+            "ok"
+        );
+        assert!(!dir.path().parent().unwrap().join("escape.txt").exists());
+    }
+}

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -1,6 +1,13 @@
 pub mod auth;
 pub mod dns_parser;
 pub mod ech_dns;
+// Force-disabled on iOS/Android: mobile apps embed their own UI and must not
+// ship the unzip/download path regardless of the feature flag (issue #223).
+#[cfg(all(
+    feature = "external-ui-download",
+    not(any(target_os = "ios", target_os = "android"))
+))]
+pub mod external_ui;
 pub mod geodata;
 pub mod internal_http;
 pub mod proxy_parser;

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -116,6 +116,13 @@ pub struct ListenerConfig {
 pub struct ApiConfig {
     pub external_controller: Option<SocketAddr>,
     pub secret: Option<String>,
+    /// Resolved directory of static files for a third-party web UI, served at
+    /// `/ui` in place of the built-in panel. `None` keeps the built-in panel.
+    /// Already joined with `external-ui-name` when that was set (issue #223).
+    pub external_ui: Option<PathBuf>,
+    /// Download URL recorded from `external-ui-url`; auto-download is not
+    /// performed, but it is surfaced in a warning when the directory is absent.
+    pub external_ui_url: Option<String>,
 }
 
 pub async fn load_config(path: &str) -> Result<Config, anyhow::Error> {
@@ -215,6 +222,87 @@ pub fn rebuild_from_raw_with_cache_dir(
     resolver: Option<Arc<Resolver>>,
 ) -> Result<RebuildResult, anyhow::Error> {
     rebuild_from_raw_impl(raw, cache_dir, resolver, &HashMap::new(), None, None)
+}
+
+/// Apply per-outbound `dialer-proxy` wrappers in place (issue #210).
+///
+/// For every proxy that declares `dialer-proxy: <name>`, its registry entry is
+/// replaced by a [`meow_proxy::DialerProxyAdapter`] that dials the inner
+/// outbound through `<name>`. Nested dialer-proxies are wrapped deepest-first so
+/// each layer sees its dialer's final (already-wrapped) form, and dialer-proxy
+/// cycles are detected and skipped with a warning (the outbound then dials
+/// directly).
+///
+/// Note: this rewrites the registry entry, so direct rule references
+/// (`…,<proxy>`) and dialers that are groups both work. A proxy that is also a
+/// static member of a group keeps the dialer for direct references but not when
+/// reached via that group, because group members are resolved eagerly before
+/// this pass.
+fn apply_dialer_proxies(
+    proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
+    raw_proxies: &[HashMap<String, serde_yaml::Value>],
+) {
+    // Collect proxy -> dialer edges from the raw config.
+    let mut pending: Vec<(SmolStr, SmolStr)> = Vec::new();
+    for raw_proxy in raw_proxies {
+        let Some(name) = raw_proxy.get("name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(dialer) = raw_proxy
+            .get("dialer-proxy")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        if dialer == name {
+            warn!("proxy '{name}': dialer-proxy points to itself; dialing directly");
+            continue;
+        }
+        pending.push((SmolStr::from(name), SmolStr::from(dialer)));
+    }
+    if pending.is_empty() {
+        return;
+    }
+
+    // Names that declared a dialer-proxy — used to defer an edge until its
+    // dialer has reached its final wrapped form (nested dialer-proxies).
+    let needs_wrap: std::collections::HashSet<SmolStr> =
+        pending.iter().map(|(n, _)| n.clone()).collect();
+    let mut resolved: std::collections::HashSet<SmolStr> = std::collections::HashSet::new();
+
+    loop {
+        let mut progressed = false;
+        let mut deferred = Vec::new();
+        for (name, dialer) in std::mem::take(&mut pending) {
+            // Defer until the dialer is in its final form (either it never
+            // needed wrapping, or it has already been resolved this pass).
+            if needs_wrap.contains(&dialer) && !resolved.contains(&dialer) {
+                deferred.push((name, dialer));
+                continue;
+            }
+            progressed = true;
+            let Some(dialer_proxy) = proxies.get(&dialer).cloned() else {
+                warn!("proxy '{name}': dialer-proxy '{dialer}' not found; dialing directly");
+                resolved.insert(name);
+                continue;
+            };
+            // The inner outbound may have failed to parse earlier; skip if so.
+            if let Some(inner) = proxies.get(&name).cloned() {
+                let wrapped: Arc<dyn Proxy> =
+                    Arc::new(meow_proxy::DialerProxyAdapter::new(inner, dialer_proxy));
+                proxies.insert(name.clone(), wrapped);
+            }
+            resolved.insert(name);
+        }
+        pending = deferred;
+        if pending.is_empty() || !progressed {
+            break;
+        }
+    }
+    for (name, dialer) in pending {
+        warn!("proxy '{name}': dialer-proxy cycle involving '{dialer}' detected; dialing directly");
+    }
 }
 
 fn rebuild_from_raw_impl(
@@ -317,6 +405,10 @@ fn rebuild_from_raw_impl(
         }
         remaining = still_remaining;
     }
+
+    // Apply per-outbound `dialer-proxy` wrappers (issue #210). Runs after both
+    // leaf proxies and groups are built so a dialer may reference either.
+    apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]));
 
     let owned_ctx;
     let ctx = match shared_ctx {
@@ -1206,12 +1298,30 @@ async fn build_config(
     };
 
     // API config
+    let external_ui = raw
+        .external_ui
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(|base| {
+            let mut dir = PathBuf::from(base);
+            // mihomo nests the actual files under `external-ui-name` when present.
+            if let Some(name) = raw.external_ui_name.as_deref().filter(|s| !s.is_empty()) {
+                dir.push(name);
+            }
+            dir
+        });
     let api = ApiConfig {
         external_controller: raw
             .external_controller
             .as_deref()
             .and_then(|s| s.parse().ok()),
         secret: raw.secret.clone(),
+        external_ui,
+        external_ui_url: raw
+            .external_ui_url
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(String::from),
     };
 
     // Sniffer config — also handles deprecated `tproxy_sni` alias.
@@ -1246,6 +1356,103 @@ async fn build_config(
         raw,
         geodata,
     })
+}
+
+#[cfg(test)]
+mod dialer_proxy_tests {
+    use super::*;
+
+    fn simple_proxy(name: &str) -> Arc<dyn Proxy> {
+        // A bare DIRECT adapter is enough; we only assert on registry identity.
+        let direct = meow_proxy::DirectAdapter::new();
+        let _ = name; // name comes from the map key, not the adapter
+        Arc::new(proxy_parser::WrappedProxy::new(Box::new(direct)))
+    }
+
+    fn raw_proxy(name: &str, dialer: Option<&str>) -> HashMap<String, serde_yaml::Value> {
+        let mut m = HashMap::new();
+        m.insert(
+            "name".to_string(),
+            serde_yaml::Value::String(name.to_string()),
+        );
+        if let Some(d) = dialer {
+            m.insert(
+                "dialer-proxy".to_string(),
+                serde_yaml::Value::String(d.to_string()),
+            );
+        }
+        m
+    }
+
+    fn registry(names: &[&str]) -> HashMap<SmolStr, Arc<dyn Proxy>> {
+        names
+            .iter()
+            .map(|n| (SmolStr::from(*n), simple_proxy(n)))
+            .collect()
+    }
+
+    /// True when the registry entry for `name` was replaced (wrapped) relative
+    /// to `before`.
+    fn was_wrapped(
+        before: &HashMap<SmolStr, Arc<dyn Proxy>>,
+        after: &HashMap<SmolStr, Arc<dyn Proxy>>,
+        name: &str,
+    ) -> bool {
+        let b = before.get(name).expect("present before");
+        let a = after.get(name).expect("present after");
+        !Arc::ptr_eq(b, a)
+    }
+
+    #[test]
+    fn wraps_proxy_with_dialer() {
+        let mut proxies = registry(&["A", "fast"]);
+        let before = proxies.clone();
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("fast"))]);
+        assert!(was_wrapped(&before, &proxies, "A"));
+        assert!(!was_wrapped(&before, &proxies, "fast"));
+    }
+
+    #[test]
+    fn self_reference_is_skipped() {
+        let mut proxies = registry(&["A"]);
+        let before = proxies.clone();
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("A"))]);
+        assert!(!was_wrapped(&before, &proxies, "A"));
+    }
+
+    #[test]
+    fn missing_dialer_is_skipped() {
+        let mut proxies = registry(&["A"]);
+        let before = proxies.clone();
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("ghost"))]);
+        assert!(!was_wrapped(&before, &proxies, "A"));
+    }
+
+    #[test]
+    fn cycle_is_detected_and_skipped() {
+        let mut proxies = registry(&["A", "B"]);
+        let before = proxies.clone();
+        apply_dialer_proxies(
+            &mut proxies,
+            &[raw_proxy("A", Some("B")), raw_proxy("B", Some("A"))],
+        );
+        assert!(!was_wrapped(&before, &proxies, "A"));
+        assert!(!was_wrapped(&before, &proxies, "B"));
+    }
+
+    #[test]
+    fn nested_chain_wraps_deepest_first() {
+        // A -> B -> C: A and B are wrapped, C (no dialer-proxy) is untouched.
+        let mut proxies = registry(&["A", "B", "C"]);
+        let before = proxies.clone();
+        apply_dialer_proxies(
+            &mut proxies,
+            &[raw_proxy("A", Some("B")), raw_proxy("B", Some("C"))],
+        );
+        assert!(was_wrapped(&before, &proxies, "A"));
+        assert!(was_wrapped(&before, &proxies, "B"));
+        assert!(!was_wrapped(&before, &proxies, "C"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -90,6 +90,17 @@ pub struct RawConfig {
     pub log_level: Option<String>,
     pub ipv6: Option<bool>,
     pub external_controller: Option<String>,
+    /// Path to a directory of static files for a third-party web dashboard
+    /// (e.g. metacubexd, yacd). When set, it is served at `/ui` instead of the
+    /// built-in panel (issue #223, mihomo-compatible).
+    pub external_ui: Option<String>,
+    /// Optional sub-directory under `external-ui` that actually holds the UI
+    /// files. Mirrors mihomo's `external-ui-name`; the served directory is
+    /// `external-ui/external-ui-name` when set.
+    pub external_ui_name: Option<String>,
+    /// URL the UI archive can be downloaded from. Recorded for compatibility;
+    /// auto-download is not performed (see issue #223 notes).
+    pub external_ui_url: Option<String>,
     pub secret: Option<String>,
     pub dns: Option<RawDns>,
     pub proxies: Option<Vec<HashMap<String, serde_yaml::Value>>>,

--- a/crates/meow-proxy/src/group/dialer_proxy.rs
+++ b/crates/meow-proxy/src/group/dialer_proxy.rs
@@ -1,0 +1,200 @@
+//! Per-outbound `dialer-proxy` support (issue #210, mihomo-compatible).
+//!
+//! A `dialer-proxy` makes a single outbound establish its underlying connection
+//! *through* another proxy/group instead of dialling the OS socket directly:
+//!
+//! ```yaml
+//! - name: daniel
+//!   type: snell
+//!   server: ss.example.com
+//!   port: 8443
+//!   dialer-proxy: fast      # reach ss.example.com via the `fast` proxy
+//! ```
+//!
+//! This is exactly a two-hop relay chain `[dialer, inner]` where the final hop
+//! (`inner`) connects to the real target, so we reuse the existing relay dial
+//! algorithm (`relay::relay_tcp`) rather than introducing a second chained
+//! dialer (architect guidance on issue #210).  `DialerProxyAdapter` otherwise
+//! presents itself as the inner outbound — same name, type, address, and health
+//! — so dashboards and rules see no difference.
+//!
+//! ## Limitations (first implementation)
+//!
+//! - **UDP**: routing a UDP association through an arbitrary dialer requires
+//!   per-protocol UDP-over-proxy framing that meow-rs does not yet implement.
+//!   Dialling UDP *directly* would silently leak the real source path, so
+//!   `dial_udp` returns [`MeowError::UdpNotSupported`] (Class A, ADR-0002) when a
+//!   dialer-proxy is configured.
+//! - **As a relay hop**: when a dialer-proxy outbound itself appears inside a
+//!   `relay` chain, `connect_over` delegates to the inner adapter — the relay
+//!   chain already defines the path, so the per-outbound dialer is not applied a
+//!   second time.
+
+use async_trait::async_trait;
+use meow_common::{
+    AdapterType, DelayHistory, MeowError, Metadata, Proxy, ProxyAdapter, ProxyConn, ProxyHealth,
+    ProxyPacketConn, Result,
+};
+use std::sync::Arc;
+
+use super::relay::relay_tcp;
+
+/// Wraps an outbound so its underlying connection is dialled through `dialer`.
+pub struct DialerProxyAdapter {
+    /// The actual outbound (SS/Trojan/VLESS/Snell/…); identity is borrowed from
+    /// it so the wrapper is transparent to the API and rule engine.
+    inner: Arc<dyn Proxy>,
+    /// Front proxy/group the inner outbound dials through.
+    dialer: Arc<dyn Proxy>,
+    /// Pre-built `[dialer, inner]` chain handed to `relay_tcp`.
+    chain: Vec<Arc<dyn Proxy>>,
+}
+
+impl DialerProxyAdapter {
+    pub fn new(inner: Arc<dyn Proxy>, dialer: Arc<dyn Proxy>) -> Self {
+        let chain = vec![Arc::clone(&dialer), Arc::clone(&inner)];
+        Self {
+            inner,
+            dialer,
+            chain,
+        }
+    }
+
+    /// Name of the front dialer proxy/group (for diagnostics/tests).
+    pub fn dialer_name(&self) -> &str {
+        self.dialer.name()
+    }
+}
+
+#[async_trait]
+impl ProxyAdapter for DialerProxyAdapter {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn adapter_type(&self) -> AdapterType {
+        self.inner.adapter_type()
+    }
+
+    fn addr(&self) -> &str {
+        self.inner.addr()
+    }
+
+    /// UDP through an arbitrary dialer is not yet supported; see module docs.
+    fn support_udp(&self) -> bool {
+        false
+    }
+
+    async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        // `[dialer, inner]`: dialer dials inner's server, inner connects to the
+        // real target via `connect_over`.
+        relay_tcp(&self.chain, metadata).await
+    }
+
+    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        Err(MeowError::UdpNotSupported)
+    }
+
+    /// As a relay hop the chain already defines the path; do not re-apply the
+    /// per-outbound dialer. Delegate to the inner adapter's handshake.
+    async fn connect_over(
+        &self,
+        stream: Box<dyn ProxyConn>,
+        metadata: &Metadata,
+    ) -> Result<Box<dyn ProxyConn>> {
+        self.inner.connect_over(stream, metadata).await
+    }
+
+    fn unwrap_proxy(&self, metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
+        self.inner.unwrap_proxy(metadata)
+    }
+
+    fn health(&self) -> &ProxyHealth {
+        self.inner.health()
+    }
+}
+
+impl Proxy for DialerProxyAdapter {
+    fn alive(&self) -> bool {
+        self.inner.alive()
+    }
+
+    fn alive_for_url(&self, url: &str) -> bool {
+        self.inner.alive_for_url(url)
+    }
+
+    fn last_delay(&self) -> u16 {
+        self.inner.last_delay()
+    }
+
+    fn last_delay_for_url(&self, url: &str) -> u16 {
+        self.inner.last_delay_for_url(url)
+    }
+
+    fn delay_history(&self) -> Vec<DelayHistory> {
+        self.inner.delay_history()
+    }
+
+    fn members(&self) -> Option<Vec<String>> {
+        self.inner.members()
+    }
+
+    fn current(&self) -> Option<String> {
+        self.inner.current()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::test_support::MockProxy;
+    use meow_common::MeowError;
+
+    fn meta(host: &str, port: u16) -> Metadata {
+        Metadata {
+            host: host.into(),
+            dst_port: port,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn dial_tcp_routes_through_dialer_first() {
+        let dialer = MockProxy::new("fast");
+        let inner = MockProxy::new("daniel");
+        let adapter = DialerProxyAdapter::new(Arc::clone(&inner) as _, Arc::clone(&dialer) as _);
+
+        // dialer.dial_tcp errors at relay hop 0 → confirms the chain dials the
+        // front proxy first. The inner adapter is only reached via connect_over,
+        // so its dial_tcp counter stays at zero.
+        match adapter.dial_tcp(&meta("example.com", 443)).await {
+            Err(MeowError::RelayHopFailed { hop: 0, .. }) => {}
+            other => panic!("expected relay hop-0 failure, got {:?}", other.err()),
+        }
+        assert_eq!(dialer.dials(), 1, "front dialer must be dialled");
+        assert_eq!(
+            inner.dials(),
+            0,
+            "inner is reached via connect_over, not dial_tcp"
+        );
+    }
+
+    #[tokio::test]
+    async fn udp_is_unsupported() {
+        let adapter = DialerProxyAdapter::new(MockProxy::new("inner"), MockProxy::new_udp("fast"));
+        assert!(!adapter.support_udp());
+        match adapter.dial_udp(&meta("example.com", 53)).await {
+            Err(MeowError::UdpNotSupported) => {}
+            other => panic!("expected UdpNotSupported, got {:?}", other.err()),
+        }
+    }
+
+    #[test]
+    fn identity_delegates_to_inner() {
+        let inner = MockProxy::new("daniel");
+        let adapter = DialerProxyAdapter::new(inner, MockProxy::new("fast"));
+        assert_eq!(adapter.name(), "daniel");
+        assert_eq!(adapter.dialer_name(), "fast");
+        assert_eq!(adapter.adapter_type(), AdapterType::Direct); // MockProxy's type
+    }
+}

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -1,3 +1,4 @@
+pub mod dialer_proxy;
 pub mod fallback;
 pub mod load_balance;
 pub mod relay;

--- a/crates/meow-proxy/src/lib.rs
+++ b/crates/meow-proxy/src/lib.rs
@@ -47,6 +47,7 @@ pub mod vless_adapter;
 pub mod vmess;
 
 pub use direct::DirectAdapter;
+pub use group::dialer_proxy::DialerProxyAdapter;
 pub use group::fallback::FallbackGroup;
 pub use group::load_balance::{LbStrategy, LoadBalanceGroup};
 pub use group::relay::RelayGroup;

--- a/crates/meow-tunnel/src/statistics.rs
+++ b/crates/meow-tunnel/src/statistics.rs
@@ -10,9 +10,10 @@
 //     for the rule-match record.
 //   chains: Vec<String> (24 B struct, heap elems) → Vec<Arc<str>> (24 B struct,
 //     ref-counted elems — no per-element allocation for proxy names)
-// Public JSON shape is unchanged: Uuid serialises as hyphenated string via the
-// `serde` feature; SmolStr / Arc<str> / Vec<Arc<str>> all serialise as
-// string/array. Arc<Metadata> is serde-skipped so the wrapper type is invisible.
+// Public JSON shape: Uuid serialises as hyphenated string via the `serde`
+// feature; SmolStr / Arc<str> / Vec<Arc<str>> all serialise as string/array.
+// Arc<Metadata> serialises transparently as the inner `Metadata` under the
+// mihomo-compatible `metadata` key (issue #241).
 // Breaking change permitted by ADR-0009.
 
 use dashmap::DashMap;
@@ -58,7 +59,11 @@ pub struct ConnectionInfo {
     /// 16 B inline UUID; serialises as `"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`.
     pub id: Uuid,
     /// 8 B thin-ptr; refcount drop on close instead of 272 B drop chain.
-    #[serde(skip)]
+    /// Serialised as the mihomo-compatible `metadata` object (host, IPs, ports,
+    /// network, type, …) so panels can show `host:port` as the connection title
+    /// (issue #241). The `Arc` wrapper is transparent to serde — it serialises
+    /// the inner `Metadata`. Struct size is unchanged (still an 8 B thin-ptr);
+    /// only the `/connections` JSON payload grows.
     pub metadata: Arc<Metadata>,
     pub upload: i64,
     pub download: i64,

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -241,7 +241,7 @@ Upstream config keys documented at https://wiki.metacubex.one/. Checking `crates
 
 ### Supported
 
-`port`, `socks-port`, `mixed-port`, `allow-lan`, `bind-address`, `mode`, `log-level`, `ipv6`, `external-controller`, `secret`, `dns`, `proxies`, `proxy-groups`, `rules`, `rule-providers`, `tproxy-port`, `tproxy-sni`, `routing-mark`, and the custom `subscriptions`.
+`port`, `socks-port`, `mixed-port`, `allow-lan`, `bind-address`, `mode`, `log-level`, `ipv6`, `external-controller`, `secret`, `external-ui` / `external-ui-name` (serves a static third-party dashboard at `/ui`; `external-ui-url` is parsed but auto-download is not performed), `dns`, `proxies`, `proxy-groups`, `rules`, `rule-providers`, `tproxy-port`, `tproxy-sni`, `routing-mark`, and the custom `subscriptions`. Per-outbound `dialer-proxy` (chained dialing via any proxy/group, TCP) is supported on every outbound type.
 
 ### Missing top-level keys (gaps)
 
@@ -264,7 +264,7 @@ Upstream config keys documented at https://wiki.metacubex.one/. Checking `crates
 | `find-process-mode` | `off` / `strict` / `always` |
 | `tcp-concurrent` | Happy Eyeballs fast-open |
 | `unified-delay` | Delay histogram normalization |
-| `external-ui` / `external-ui-name` / `external-ui-url` | Dashboard auto-download |
+| `external-ui-url` auto-download | `external-ui` / `external-ui-name` serve a static dir; the zip auto-download is not implemented (avoids an unzip dependency vs. ADR-0007 size caps) |
 | `listeners` | Upstream's generic named-listener list (replaces per-port shortcuts) |
 | `sub-rules` | Named rule subsets referenced from main rules |
 | `proxy-providers` | External proxy lists (http/file) |

--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -622,9 +622,15 @@ The following are unsupported or intentionally rejected:
   built with the opt-in `anytls` feature wiring.
 - **Snell v1/v2** — hard error; use Snell v3/v4/v5.
 - **`vless` with `flow: xtls-rprx-direct`** — hard error; use `xtls-rprx-vision`.
-- **External dashboard mounting** (`external-ui`, `external-ui-name`,
-  `external-ui-url`) — not implemented yet; the built-in `/ui` dashboard is
-  served from the binary.
+- **External dashboard auto-download** (`external-ui-url`) — not performed.
+  `external-ui` / `external-ui-name` *are* supported: point them at a directory
+  of static files and it is served at `/ui` in place of the built-in dashboard.
+  You must download/extract the dashboard yourself; the zip is not fetched
+  automatically (avoids an unzip dependency against the binary-size caps).
+- **`dialer-proxy` UDP** — the per-outbound `dialer-proxy` field is supported for
+  TCP on every outbound (chained dialing through any proxy/group, with cycle
+  detection). UDP is not routed through the dialer; such associations are
+  refused rather than leaking the real source path.
 
 ---
 


### PR DESCRIPTION
Fixes #241, #223, #210.

## #241 — `GET /connections` now returns `metadata`
`ConnectionInfo.metadata` was `#[serde(skip)]`, so iOS/web panels fell back to the rule type for the connection title. `Metadata` already derives the mihomo-compatible Serialize shape; removing the skip implements **option A** from the issue. Struct size is unchanged (still an 8 B `Arc<Metadata>`); only the JSON payload grows.

## #223 — Mount a third-party dashboard
- New `external-ui` / `external-ui-name` config keys: when set, the static directory is served at `/ui` via `ServeDir` instead of the built-in panel.
- `external-ui-url` auto-download is behind a **default-off** `external-ui-download` cargo feature (it pulls in the `zip` crate, against the ADR-0007 size caps). Without the feature, a warning points the user to populate the directory manually.
- Auto-download strips the GitHub `<repo>-<ref>/` wrapper and rejects zip-slip traversal via `enclosed_name()`.
- The download/unzip path is **force-disabled on iOS/Android** (`not(target_os = "ios"/"android")`) even when the feature is enabled — mobile ships its own UI.

## #210 — Per-outbound `dialer-proxy`
- New `DialerProxyAdapter`: a dialer-proxy outbound is exactly a two-hop relay chain `[dialer, inner]`, so it **reuses the existing `relay_tcp`** algorithm rather than adding a second chained dialer (per maintainer guidance on the issue).
- Resolution runs after all proxies and groups are built (a dialer may be either), wraps nested dialers deepest-first, and detects/skips cycles + self-references with a warning.
- **Limitations** (documented in `docs/migration-from-go-mihomo.md`): UDP is refused rather than leaking the real source path (no UDP-over-dialer framing yet); the dialer does not apply when the outbound is reached via a group that captured it as a static member.

## Tests / regression
- Added: connection-metadata serialization, external-ui `ServeDir` routing, `DialerProxyAdapter` dial/UDP/identity, `apply_dialer_proxies` wrapping + cycle/self/missing/nested, zip extraction (strip / passthrough / zip-slip).
- `fmt --check`, 3-way clippy (default / no-default / all-features), doc (default + all-features), and `--lib` tests all green. iOS target compiles with the feature on (download path excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)