### PR TITLE
Add DNS results API

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -164,6 +164,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .route("/metrics", get(get_metrics))
         .route("/traffic", get(get_traffic))
+        .route("/dns/results", get(get_dns_results))
         .route("/dns/query", get(dns_query_get).post(dns_query))
         .route("/cache/dns/flush", post(flush_dns_cache))
         .route("/cache/fakeip/flush", post(flush_fakeip_cache))
@@ -483,6 +484,41 @@ struct DnsQueryRequest {
     name: String,
     #[serde(rename = "type")]
     qtype: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DnsResultsQuery {
+    search: Option<String>,
+    limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct DnsResultEntry {
+    name: String,
+    ips: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from_server: Option<String>,
+    ttl: u64,
+}
+
+async fn get_dns_results(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<DnsResultsQuery>,
+) -> Json<Vec<DnsResultEntry>> {
+    let limit = params.limit.unwrap_or(256).min(1024);
+    let results = state
+        .tunnel
+        .resolver()
+        .dns_results(params.search.as_deref(), limit)
+        .into_iter()
+        .map(|entry| DnsResultEntry {
+            name: entry.name,
+            ips: entry.ips.into_iter().map(|ip| ip.to_string()).collect(),
+            from_server: entry.source,
+            ttl: entry.ttl.as_secs(),
+        })
+        .collect();
+    Json(results)
 }
 
 async fn dns_query(

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -10,6 +10,7 @@ use meow_tunnel::Tunnel;
 use parking_lot::RwLock;
 use smallvec::smallvec;
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tower::ServiceExt;
@@ -399,6 +400,49 @@ async fn get_traffic() {
     let json = body_json(resp).await;
     assert_eq!(json["up"], 0);
     assert_eq!(json["down"], 0);
+}
+
+#[tokio::test]
+async fn dns_results_returns_searchable_cache_entries() {
+    let state = test_state_default();
+    state.tunnel.resolver().preload_cache_with_source(
+        "dns.google",
+        &[
+            IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4)),
+        ],
+        std::time::Duration::from_secs(300),
+        Some("8.8.8.8"),
+    );
+    state.tunnel.resolver().preload_cache_with_source(
+        "dns.alidns.com",
+        &[
+            IpAddr::V4(Ipv4Addr::new(223, 6, 6, 6)),
+            IpAddr::V4(Ipv4Addr::new(223, 5, 5, 5)),
+        ],
+        std::time::Duration::from_secs(300),
+        Some("223.5.5.5"),
+    );
+
+    let app = create_router(state);
+    let resp = app
+        .oneshot(
+            Request::get("/dns/results?search=google&limit=10")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let entries = json.as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], "dns.google");
+    assert_eq!(entries[0]["ips"][0], "8.8.8.8");
+    assert_eq!(entries[0]["ips"][1], "8.8.4.4");
+    assert_eq!(entries[0]["from_server"], "8.8.8.8");
+    assert!(entries[0]["ttl"].as_u64().unwrap() > 0);
 }
 
 #[tokio::test]

--- a/crates/meow-dns/src/cache.rs
+++ b/crates/meow-dns/src/cache.rs
@@ -35,6 +35,7 @@ pub type IpList = SmallVec<[IpAddr; 2]>;
 struct CacheEntry {
     ips: Box<[IpAddr]>,
     expire_at: Instant,
+    source: Option<Arc<str>>,
 }
 
 struct ReverseEntry {
@@ -71,6 +72,14 @@ pub struct DnsCache {
     /// Bounded per-shard LRU — entries past capacity are evicted in
     /// least-recently-used order.
     reverse: [Mutex<LruCache<IpAddr, ReverseEntry>>; SHARDS],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DnsCacheSnapshotEntry {
+    pub name: String,
+    pub ips: Vec<IpAddr>,
+    pub ttl: Duration,
+    pub source: Option<String>,
 }
 
 /// FNV-1a 32-bit hash over the bytes of `s`. Inline so it can be used on
@@ -134,6 +143,18 @@ impl DnsCache {
     /// Insert a resolved-domain record. Takes the IP list by reference to
     /// avoid forcing the caller to clone — the cache owns its own copy.
     pub fn put(&self, domain: &str, ips: &[IpAddr], ttl: Duration) {
+        self.put_with_source(domain, ips, ttl, None);
+    }
+
+    /// Insert a resolved-domain record and remember the upstream that supplied
+    /// it for DNS results panels.
+    pub fn put_with_source(
+        &self,
+        domain: &str,
+        ips: &[IpAddr],
+        ttl: Duration,
+        source: Option<&str>,
+    ) {
         let now = Instant::now();
         let expire_at = now + ttl;
         // Reverse entries get a longer floor so the IP → host mapping survives
@@ -164,6 +185,7 @@ impl DnsCache {
         let entry = CacheEntry {
             ips: ips.into(),
             expire_at,
+            source: source.map(Arc::from),
         };
         self.cache[shard_str(domain)].lock().put(key, entry);
     }
@@ -199,6 +221,30 @@ impl DnsCache {
 
     pub fn reverse_len(&self) -> usize {
         self.reverse.iter().map(|s| s.lock().len()).sum()
+    }
+
+    pub fn snapshot(&self) -> Vec<DnsCacheSnapshotEntry> {
+        let now = Instant::now();
+        let mut entries = Vec::new();
+        for shard in &self.cache {
+            let mut cache = shard.lock();
+            let expired: Vec<Arc<str>> = cache
+                .iter()
+                .filter(|(_, entry)| entry.expire_at <= now)
+                .map(|(name, _)| Arc::clone(name))
+                .collect();
+            for name in expired {
+                cache.pop(name.as_ref());
+            }
+            entries.extend(cache.iter().map(|(name, entry)| DnsCacheSnapshotEntry {
+                name: name.to_string(),
+                ips: entry.ips.to_vec(),
+                ttl: entry.expire_at.saturating_duration_since(now),
+                source: entry.source.as_ref().map(std::string::ToString::to_string),
+            }));
+        }
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        entries
     }
 
     /// Insert a reverse entry with an explicit expiry. Test-only: lets unit

--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -210,6 +210,38 @@ impl DnsClient {
         self
     }
 
+    /// Human-readable upstream identifier for API/UI surfaces.
+    pub fn upstream_label(&self) -> String {
+        let mut label = match &self.transport {
+            Transport::Udp { addr } | Transport::Tcp { addr } => socket_label(*addr, 53),
+            Transport::RCode { code } => format!("rcode:{code:?}"),
+            #[cfg(feature = "encrypted")]
+            Transport::Dot { addr, sni, .. } => {
+                if sni.is_empty() {
+                    socket_label(*addr, 853)
+                } else {
+                    sni.to_string()
+                }
+            }
+            #[cfg(feature = "encrypted")]
+            Transport::Doh {
+                addr, sni, path, ..
+            } => {
+                if sni.is_empty() {
+                    socket_label(*addr, 443)
+                } else if path.as_ref() == "/dns-query" {
+                    sni.to_string()
+                } else {
+                    format!("{sni}{path}")
+                }
+            }
+        };
+        if self.proxy.is_some() {
+            label.push_str("#PROXY");
+        }
+        label
+    }
+
     /// Send a query for `(name, record_type)` and return the parsed response
     /// `Message`. ID is randomised internally and the response's ID is not
     /// checked against the request — DoT/DoH/UDP-connected guarantee a 1:1
@@ -317,6 +349,14 @@ impl DnsClient {
                 tls,
             } => doh_exchange(*addr, sni, path, Arc::clone(tls), wire).await,
         }
+    }
+}
+
+fn socket_label(addr: SocketAddr, default_port: u16) -> String {
+    if addr.port() == default_port {
+        addr.ip().to_string()
+    } else {
+        addr.to_string()
     }
 }
 

--- a/crates/meow-dns/src/lib.rs
+++ b/crates/meow-dns/src/lib.rs
@@ -6,7 +6,7 @@ pub mod resolver;
 pub mod server;
 pub mod upstream;
 
-pub use cache::DnsCache;
+pub use cache::{DnsCache, DnsCacheSnapshotEntry};
 pub use client::{set_socket_factory, ClientError, DnsClient, SocketFactory};
 pub use fakeip::{FileStore, MemoryStore, Pool, PoolError, Skipper, SkipperMode, Store};
 pub use host_resolver_hook::ResolverHostHook;

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -1,4 +1,4 @@
-use crate::cache::DnsCache;
+use crate::cache::{DnsCache, DnsCacheSnapshotEntry};
 use crate::client::DnsClient;
 use crate::fakeip::{Pool, Skipper};
 use crate::upstream::{HostOrIp, NameServerEntry, NameServerUrl};
@@ -289,11 +289,21 @@ async fn system_nameservers() -> Vec<SocketAddr> {
 #[derive(Debug, Clone, Copy)]
 struct LookupFailed;
 
-async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<(Vec<IpAddr>, Duration)> {
+struct PoolLookupResult {
+    ips: Vec<IpAddr>,
+    ttl: Duration,
+    source: String,
+}
+
+async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<PoolLookupResult> {
     match clients.len() {
         0 => None,
         1 => match clients[0].lookup_ip(host).await {
-            Ok((ips, ttl)) if !ips.is_empty() => Some((ips, clamp_ttl(ttl))),
+            Ok((ips, ttl)) if !ips.is_empty() => Some(PoolLookupResult {
+                ips,
+                ttl: clamp_ttl(ttl),
+                source: clients[0].upstream_label(),
+            }),
             _ => None,
         },
         2 => {
@@ -306,16 +316,32 @@ async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<(Vec<IpAdd
             tokio::pin!(f2);
             tokio::select! {
                 r = &mut f1 => match r {
-                    Ok((ips, ttl)) if !ips.is_empty() => Some((ips, clamp_ttl(ttl))),
+                    Ok((ips, ttl)) if !ips.is_empty() => Some(PoolLookupResult {
+                        ips,
+                        ttl: clamp_ttl(ttl),
+                        source: clients[0].upstream_label(),
+                    }),
                     _ => match (&mut f2).await {
-                        Ok((ips, ttl)) if !ips.is_empty() => Some((ips, clamp_ttl(ttl))),
+                        Ok((ips, ttl)) if !ips.is_empty() => Some(PoolLookupResult {
+                            ips,
+                            ttl: clamp_ttl(ttl),
+                            source: clients[1].upstream_label(),
+                        }),
                         _ => None,
                     },
                 },
                 r = &mut f2 => match r {
-                    Ok((ips, ttl)) if !ips.is_empty() => Some((ips, clamp_ttl(ttl))),
+                    Ok((ips, ttl)) if !ips.is_empty() => Some(PoolLookupResult {
+                        ips,
+                        ttl: clamp_ttl(ttl),
+                        source: clients[1].upstream_label(),
+                    }),
                     _ => match (&mut f1).await {
-                        Ok((ips, ttl)) if !ips.is_empty() => Some((ips, clamp_ttl(ttl))),
+                        Ok((ips, ttl)) if !ips.is_empty() => Some(PoolLookupResult {
+                            ips,
+                            ttl: clamp_ttl(ttl),
+                            source: clients[0].upstream_label(),
+                        }),
                         _ => None,
                     },
                 },
@@ -330,18 +356,23 @@ async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<(Vec<IpAdd
             // an error String per failed attempt.
             let futs: Vec<_> = clients
                 .iter()
-                .map(|c| {
+                .enumerate()
+                .map(|(idx, c)| {
                     Box::pin(async move {
                         let (ips, ttl) = c.lookup_ip(host).await.map_err(|_| LookupFailed)?;
                         if ips.is_empty() {
                             return Err(LookupFailed);
                         }
-                        Ok((ips, clamp_ttl(ttl)))
+                        Ok((idx, ips, clamp_ttl(ttl)))
                     })
                 })
                 .collect();
             match futures::future::select_ok(futs).await {
-                Ok(((ips, ttl), _)) => Some((ips, ttl)),
+                Ok(((idx, ips, ttl), _)) => Some(PoolLookupResult {
+                    ips,
+                    ttl,
+                    source: clients[idx].upstream_label(),
+                }),
                 Err(_) => None,
             }
         }
@@ -590,8 +621,8 @@ impl Resolver {
             let mut map = HashMap::new();
             for host in &hostnames_needing_bootstrap {
                 match query_pool(&bootstrap_clients, host).await {
-                    Some((ips, _ttl)) if !ips.is_empty() => {
-                        map.insert(host.clone(), ips[0]);
+                    Some(result) if !result.ips.is_empty() => {
+                        map.insert(host.clone(), result.ips[0]);
                     }
                     _ => {
                         return Err(BootstrapError::CannotResolve {
@@ -856,28 +887,30 @@ impl Resolver {
         // Nameserver-policy lookup.
         if let Some(policy) = &self.policy {
             if let Some(entry) = policy.lookup(host) {
-                if let Some((ips, ttl)) = query_pool(&entry.nameservers, host).await {
+                if let Some(result) = query_pool(&entry.nameservers, host).await {
                     if let Some(ff) = &self.fallback_filter {
-                        if ff.ip_gated(&ips) {
+                        if ff.ip_gated(&result.ips) {
                             return self.try_fallback(host).await;
                         }
                     }
-                    self.cache.put(host, &ips, ttl);
-                    return Some(ips);
+                    self.cache
+                        .put_with_source(host, &result.ips, result.ttl, Some(&result.source));
+                    return Some(result.ips);
                 }
                 // Policy lookup failed: fall through to global nameservers.
             }
         }
 
         // Global nameservers (parallel, first-response wins).
-        if let Some((ips, ttl)) = query_pool(&self.main, host).await {
+        if let Some(result) = query_pool(&self.main, host).await {
             if let Some(ff) = &self.fallback_filter {
-                if ff.ip_gated(&ips) {
+                if ff.ip_gated(&result.ips) {
                     return self.try_fallback(host).await;
                 }
             }
-            self.cache.put(host, &ips, ttl);
-            return Some(ips);
+            self.cache
+                .put_with_source(host, &result.ips, result.ttl, Some(&result.source));
+            return Some(result.ips);
         }
 
         self.try_fallback(host).await
@@ -916,9 +949,10 @@ impl Resolver {
 
     async fn try_fallback(&self, host: &str) -> Option<Vec<IpAddr>> {
         let fallback = self.fallback.as_deref()?;
-        if let Some((ips, ttl)) = query_pool(fallback, host).await {
-            self.cache.put(host, &ips, ttl);
-            return Some(ips);
+        if let Some(result) = query_pool(fallback, host).await {
+            self.cache
+                .put_with_source(host, &result.ips, result.ttl, Some(&result.source));
+            return Some(result.ips);
         }
         None
     }
@@ -1017,6 +1051,28 @@ impl Resolver {
         self.cache.clear();
     }
 
+    pub fn dns_results(&self, search: Option<&str>, limit: usize) -> Vec<DnsCacheSnapshotEntry> {
+        let search = search
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_ascii_lowercase);
+        self.cache
+            .snapshot()
+            .into_iter()
+            .filter(|entry| {
+                search.as_ref().is_none_or(|needle| {
+                    entry.name.to_ascii_lowercase().contains(needle)
+                        || entry.ips.iter().any(|ip| ip.to_string().contains(needle))
+                        || entry
+                            .source
+                            .as_ref()
+                            .is_some_and(|source| source.to_ascii_lowercase().contains(needle))
+                })
+            })
+            .take(limit)
+            .collect()
+    }
+
     /// Seed the positive-resolution cache directly with a known mapping.
     ///
     /// Production lookups populate the cache from upstream queries; this is for
@@ -1024,6 +1080,18 @@ impl Resolver {
     /// the bound used by ordinary cached entries via `ttl`.
     pub fn preload_cache(&self, host: &str, ips: &[IpAddr], ttl: std::time::Duration) {
         self.cache.put(host, ips, ttl);
+    }
+
+    /// Seed the positive-resolution cache with a source label for API tests
+    /// and callers that already know the upstream answer source.
+    pub fn preload_cache_with_source(
+        &self,
+        host: &str,
+        ips: &[IpAddr],
+        ttl: std::time::Duration,
+        source: Option<&str>,
+    ) {
+        self.cache.put_with_source(host, ips, ttl, source);
     }
 }
 

--- a/crates/meow-dns/tests/dns_cache_test.rs
+++ b/crates/meow-dns/tests/dns_cache_test.rs
@@ -88,6 +88,30 @@ fn test_cache_clear() {
 }
 
 #[test]
+fn test_cache_snapshot_includes_source_and_ttl() {
+    let cache = DnsCache::new(100);
+    let ips = vec![
+        IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+        IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4)),
+    ];
+
+    cache.put_with_source(
+        "dns.google",
+        &ips,
+        Duration::from_secs(300),
+        Some("8.8.8.8"),
+    );
+
+    let entries = cache.snapshot();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].name, "dns.google");
+    assert_eq!(entries[0].ips, ips);
+    assert_eq!(entries[0].source.as_deref(), Some("8.8.8.8"));
+    assert!(entries[0].ttl <= Duration::from_secs(300));
+    assert!(entries[0].ttl > Duration::from_secs(0));
+}
+
+#[test]
 fn test_cache_lru_eviction_under_pressure() {
     // PR-D switched the cache to a sharded LRU (16 shards). Cap is the
     // total across all shards; per-shard floor is 8. Insert enough entries


### PR DESCRIPTION
Related to madeye/meow-ios#265.

Summary:
- add `GET /dns/results` with `search` and `limit` query params
- expose cached DNS result fields for the panel UI: domain name, IPs, source upstream, and TTL
- record the winning upstream label when DNS lookups populate the cache

Tests:
- `cargo fmt --check`
- `cargo clippy -p meow-dns -p meow-api --tests`
- `cargo test -p meow-dns --lib`
- `cargo test -p meow-api --test api_test`
- `cargo test -p meow-dns --test dns_cache_test`
- private Clash YAML config load and runtime smoke test

No private config, subscription URL, or node details are included in this PR.