### PR TITLE
Publish meow-rs to crates.io + landing-page polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,12 +141,12 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "anytls-rs"
 version = "0.5.4"
-source = "git+https://github.com/madeye/anytls-rs.git?rev=e6134889d3abbfaa2cb7439969dbda2ef6930611#e6134889d3abbfaa2cb7439969dbda2ef6930611"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa494bfdf944c403ffb86d3387cb8a15422ca9a59af66fad50b941340aded56"
 dependencies = [
  "anyhow",
  "bytes",
  "chrono",
- "libc",
  "md5",
  "notify",
  "once_cell",
@@ -157,13 +157,12 @@ dependencies = [
  "serde",
  "sha2",
  "socket2 0.6.3",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "trust-dns-resolver",
  "x509-parser",
 ]
 
@@ -221,7 +220,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -1014,18 +1013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,13 +1405,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
- "idna 1.1.0",
+ "idna",
  "ipnet",
  "jni",
  "once_cell",
  "rand 0.10.1",
  "ring",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "url",
@@ -1673,16 +1660,6 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -1817,7 +1794,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -1936,12 +1913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,15 +1946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -2024,7 +1986,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2151,7 +2113,7 @@ dependencies = [
  "smol_str",
  "socket2 0.5.10",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -2212,7 +2174,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "sysinfo",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2273,7 +2235,7 @@ dependencies = [
  "smol_str",
  "socket2 0.5.10",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2294,7 +2256,7 @@ dependencies = [
  "regex",
  "smol_str",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "zstd",
 ]
@@ -2320,7 +2282,7 @@ dependencies = [
  "regex",
  "rustls",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-boring",
  "tokio-rustls",
@@ -2788,7 +2750,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2817,7 +2779,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2838,7 +2800,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2881,22 +2843,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2909,16 +2860,6 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3405,7 +3346,7 @@ dependencies = [
  "shadowsocks-crypto",
  "socket2 0.6.3",
  "spin",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-tfo",
  "trait-variant",
@@ -3630,31 +3571,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3982,50 +3903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand 0.8.6",
- "smallvec",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand 0.8.6",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,7 +3921,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4066,25 +3943,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-xid"
@@ -4121,7 +3983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna 1.1.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -4763,7 +4625,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -4902,7 +4764,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ version = "0.15.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"
+repository = "https://github.com/madeye/meow-rs"
+homepage = "https://madeye.github.io/meow-rs/"
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"
@@ -77,12 +79,11 @@ serde_json = "1"
 serde_yaml = "0.9"
 
 # Networking
-# Pinned to the madeye fork. Carries the `SocketProtector` registry +
-# `connect_tcp` / `bind_udp` helpers (Android protect hook), plus the
-# fd/stream-leak fix for issue #201 item 4 (madeye/anytls-rs#1: orphaned
-# client sessions, unclosed client streams, and the server outbound-socket
-# leak), now merged to the fork's main.
-anytls-rs = { git = "https://github.com/madeye/anytls-rs.git", rev = "e6134889d3abbfaa2cb7439969dbda2ef6930611" }
+# crates.io release of the madeye fork. 0.5.4 carries the `SocketProtector`
+# registry + `connect_tcp` / `bind_udp` helpers (Android protect hook) and the
+# fd/stream-leak fix for issue #201 item 4 (madeye/anytls-rs#1). A registry
+# version (not a git rev) is required to publish meow-proxy to crates.io.
+anytls-rs = { version = "0.5.4" }
 shadowsocks = { version = "1.21", default-features = false, features = ["aead-cipher", "aead-cipher-2022", "stream-cipher"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
@@ -211,13 +212,13 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common" }
-meow-trie = { path = "crates/meow-trie" }
-meow-dns = { path = "crates/meow-dns", default-features = false }
-meow-rules = { path = "crates/meow-rules" }
-meow-transport = { path = "crates/meow-transport" }
-meow-proxy = { path = "crates/meow-proxy", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel" }
-meow-listener = { path = "crates/meow-listener", default-features = false }
-meow-api = { path = "crates/meow-api" }
-meow-config = { path = "crates/meow-config", default-features = false }
+meow-common = { path = "crates/meow-common", version = "0.15.0" }
+meow-trie = { path = "crates/meow-trie", version = "0.15.0" }
+meow-dns = { path = "crates/meow-dns", version = "0.15.0", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.15.0" }
+meow-transport = { path = "crates/meow-transport", version = "0.15.0" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.15.0", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.15.0" }
+meow-listener = { path = "crates/meow-listener", version = "0.15.0", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.15.0" }
+meow-config = { path = "crates/meow-config", version = "0.15.0", default-features = false }

--- a/crates/meow-api/Cargo.toml
+++ b/crates/meow-api/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-api"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "REST API server (Axum) for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 meow-common = { workspace = true }

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -3,6 +3,12 @@ name = "meow-app"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "A high-performance, rule-based tunneling proxy kernel in Rust, compatible with mihomo (Clash.Meta)."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["proxy", "clash", "mihomo", "vpn", "networking"]
+categories = ["network-programming", "command-line-utilities"]
 
 [features]
 default = ["full", "boring-tls"]

--- a/crates/meow-common/Cargo.toml
+++ b/crates/meow-common/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-common"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "Core traits and types (ProxyAdapter, Rule, Metadata) for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 tokio = { workspace = true }

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-config"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "YAML configuration parsing for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell", "hysteria2"]

--- a/crates/meow-dns/Cargo.toml
+++ b/crates/meow-dns/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-dns"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "DNS resolver, cache, snooping (IP to domain), and FakeIP for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 default = ["encrypted", "dns-server"]

--- a/crates/meow-listener/Cargo.toml
+++ b/crates/meow-listener/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-listener"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "Inbound protocol listeners (Mixed/HTTP/SOCKS5/TProxy) for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 default = ["listener-http", "listener-socks5", "listener-mixed", "listener-tproxy"]

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-proxy"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "Proxy protocol implementations (Shadowsocks, Trojan, VLESS, ...) and groups for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 default = ["ss", "trojan", "vless", "vless-vision", "ech-tls-tunnel", "vmess", "snell", "hysteria2"]

--- a/crates/meow-rules/Cargo.toml
+++ b/crates/meow-rules/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-rules"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "Rule matching engine and parser (domain, IP-CIDR, GeoIP, process, logic) for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 meow-common = { workspace = true }

--- a/crates/meow-transport/Cargo.toml
+++ b/crates/meow-transport/Cargo.toml
@@ -3,6 +3,8 @@ name = "meow-transport"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 license.workspace = true
 description = "Reusable composable stream-transport layers (TLS, WS, gRPC, H2, HTTPUpgrade) for meow-rs"
 

--- a/crates/meow-trie/Cargo.toml
+++ b/crates/meow-trie/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-trie"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "Domain trie for efficient pattern matching in the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 

--- a/crates/meow-tunnel/Cargo.toml
+++ b/crates/meow-tunnel/Cargo.toml
@@ -3,6 +3,10 @@ name = "meow-tunnel"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "Core routing engine (TCP/UDP relay, rule dispatch, connection statistics) for the meow-rs proxy kernel."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 meow-common = { workspace = true }

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,12 +27,14 @@
   --ginger:#ED7E2B;
   --char:#17110C;
   --shadow:0 1px 0 #fff inset, 0 14px 30px -18px rgba(32,20,15,.35);
+  /* one shared vertical rhythm for every section */
+  --sec:clamp(56px,8vw,88px);
   --display:'Space Grotesk',system-ui,sans-serif;
   --body:'Hanken Grotesk',system-ui,sans-serif;
   --mono:'Space Mono',ui-monospace,'SF Mono',monospace;
 }
 *{margin:0;padding:0;box-sizing:border-box}
-html{scroll-behavior:smooth}
+html{scroll-behavior:smooth;overflow-x:clip}
 body{
   font-family:var(--body);
   background:var(--cream);
@@ -48,6 +50,7 @@ body{
 a{color:var(--salmon-deep);text-decoration:none}
 a:hover{text-decoration:underline}
 .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+@media(max-width:520px){.wrap{padding:0 18px}}
 .eyebrow{
   font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
   color:var(--pine);font-weight:700;
@@ -72,15 +75,16 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 @media(max-width:760px){.nav-links a:not(.nav-cta){display:none}}
 
 /* ── Hero ────────────────────────────────────────────── */
-.hero{padding:64px 0 24px;text-align:center}
-.hero .eyebrow{display:inline-flex;gap:8px;align-items:center;
+.hero{padding:clamp(40px,7vw,68px) 0 28px;text-align:center}
+.hero .eyebrow{display:inline-flex;gap:8px;align-items:center;max-width:100%;
   background:var(--paper);border:1px solid var(--kraft-line);padding:6px 12px;border-radius:999px}
+@media(max-width:520px){.hero .eyebrow{font-size:10.5px;letter-spacing:.12em}}
 .dot{width:7px;height:7px;border-radius:50%;background:var(--salmon);box-shadow:0 0 0 3px rgba(255,92,70,.18)}
 .hero h1{font-family:var(--display);font-weight:700;letter-spacing:-.035em;
   font-size:clamp(2.6rem,7vw,4.7rem);line-height:.98;margin:20px 0 14px}
 .hero h1 .ot{color:var(--salmon-deep)}
 .hero p.sub{color:var(--ink-soft);font-size:clamp(1.05rem,1.6vw,1.22rem);max-width:60ch;margin:0 auto}
-.cta-row{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin:28px 0 16px}
+.cta-row{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin:30px 0 18px}
 .btn{display:inline-flex;align-items:center;gap:9px;font-weight:700;font-size:15px;
   padding:13px 22px;border-radius:12px;border:1px solid transparent;transition:transform .12s ease,box-shadow .12s ease,background .15s}
 .btn:hover{text-decoration:none;transform:translateY(-2px)}
@@ -89,12 +93,23 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .btn-primary:hover{background:var(--salmon-deep);color:#fff}
 .btn-ghost{background:var(--paper);color:var(--ink);border-color:var(--kraft-line)}
 .btn-ghost:hover{border-color:var(--ink)}
-.install{display:inline-flex;align-items:center;gap:12px;font-family:var(--mono);font-size:14px;
-  background:var(--char);color:#FCEBC9;border-radius:12px;padding:11px 12px 11px 18px;border:1px solid #000;box-shadow:var(--shadow)}
-.install .pfx{color:var(--tangerine);user-select:none}
-.install button{font:inherit;font-family:var(--body);font-weight:700;font-size:12px;color:var(--char);
-  background:var(--tangerine);border:0;border-radius:7px;padding:6px 10px;cursor:pointer;letter-spacing:.04em}
+.install-row{display:flex;flex-direction:column;align-items:center;gap:11px;margin:0 auto;max-width:100%}
+.install{display:inline-flex;align-items:center;gap:10px;max-width:100%;font-family:var(--mono);font-size:13.5px;
+  background:var(--char);color:#FCEBC9;border-radius:12px;padding:11px 12px 11px 16px;border:1px solid #000;box-shadow:var(--shadow)}
+.install .cmd{display:inline-flex;align-items:center;gap:8px;min-width:0;overflow-x:auto;white-space:nowrap;scrollbar-width:none}
+.install .cmd::-webkit-scrollbar{display:none}
+.install .pfx{color:var(--tangerine);user-select:none;flex:0 0 auto}
+.install button{flex:0 0 auto;font:inherit;font-family:var(--body);font-weight:700;font-size:12px;color:var(--char);
+  background:var(--tangerine);border:0;border-radius:7px;padding:6px 11px;cursor:pointer;letter-spacing:.04em}
 .install button:hover{background:#ffb152}
+.install-alt{font-size:13px;font-weight:600;color:var(--ink-soft)}
+.install-alt:hover{color:var(--ink)}
+/* On phones the install command wraps instead of overflowing the viewport. */
+@media(max-width:520px){
+  .install-row{width:100%}
+  .install{font-size:12px;flex-direction:column;align-items:flex-start;gap:8px;width:100%;text-align:left}
+  .install .cmd{white-space:normal;word-break:break-all;overflow:visible;width:100%}
+}
 
 /* ── The signature: cat over the wall ────────────────── */
 .scene-band{padding:18px 0 8px}
@@ -104,13 +119,19 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .scene svg,.scene video{display:block;width:100%;height:auto}
 .scene svg{shape-rendering:crispEdges}
 .scene video{aspect-ratio:16/9;background:#FFECC6}
-.scene-tag{position:absolute;left:14px;bottom:12px;font-family:var(--mono);font-size:11px;
-  letter-spacing:.12em;text-transform:uppercase;color:#5E493B;opacity:.9;text-shadow:1px 1px 0 #FFECC6;pointer-events:none}
-@media(max-width:520px){.scene-tag{display:none}}
+/* Opaque caption chip parked over the video's burned-in sparkle watermark
+   (~91% across, ~84% down). Anchored right + vertically centred on the
+   watermark line so its solid body occludes the mark at any video width. */
+.scene-tag{position:absolute;right:4%;bottom:16%;transform:translateY(50%);
+  font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;
+  color:#FCEBC9;background:rgba(23,17,12,.92);border:1px solid rgba(0,0,0,.45);
+  border-radius:8px;padding:13px 12px;line-height:1;white-space:nowrap;
+  box-shadow:0 2px 10px rgba(0,0,0,.35);pointer-events:none}
+@media(max-width:520px){.scene-tag{font-size:9px;padding:10px 9px;right:3%}}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
 
 /* ── Guaranteed Analysis (the label) ─────────────────── */
-.analysis{padding:64px 0}
+.analysis{padding:var(--sec) 0}
 .analysis-grid{display:grid;grid-template-columns:1.05fr .95fr;gap:42px;align-items:center}
 @media(max-width:860px){.analysis-grid{grid-template-columns:1fr;gap:30px}}
 .analysis h2{font-family:var(--display);font-weight:700;font-size:clamp(1.9rem,3.6vw,2.7rem);letter-spacing:-.025em;line-height:1.05;margin:14px 0 14px}
@@ -146,7 +167,7 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .sec-head p{color:var(--ink-soft);margin-top:10px}
 
 /* ── Setup ──────────────────────────────────────────── */
-.setup{padding:64px 0;background:var(--paper);border-top:1px solid var(--kraft-line);border-bottom:1px solid var(--kraft-line)}
+.setup{padding:var(--sec) 0;background:var(--paper);border-top:1px solid var(--kraft-line);border-bottom:1px solid var(--kraft-line)}
 .setup-grid{display:grid;grid-template-columns:.9fr 1.1fr;gap:40px;align-items:center}
 @media(max-width:860px){.setup-grid{grid-template-columns:1fr;gap:26px}}
 .setup h2{font-family:var(--display);font-weight:700;font-size:clamp(1.8rem,3.4vw,2.5rem);letter-spacing:-.025em;line-height:1.08;margin:12px 0 12px}
@@ -161,7 +182,7 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .code .p{color:var(--salmon)}
 
 /* ── Features ───────────────────────────────────────── */
-.feat{padding:66px 0}
+.feat{padding:var(--sec) 0}
 .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(264px,1fr));gap:16px}
 .tin{background:var(--paper);border:1px solid var(--kraft-line);border-radius:16px;padding:22px;
   transition:transform .14s ease,box-shadow .14s ease,border-color .14s}
@@ -173,7 +194,7 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .tin code{font-family:var(--mono);font-size:.85em;background:var(--panel);padding:1px 5px;border-radius:5px}
 
 /* ── Architecture (dark inset blueprint) ────────────── */
-.arch{padding:66px 0}
+.arch{padding:var(--sec) 0}
 .blue{background:var(--char);border:1px solid #000;border-radius:20px;padding:14px 18px 20px;box-shadow:var(--shadow)}
 .blue .cap{display:flex;justify-content:space-between;align-items:center;padding:6px 4px 14px;
   font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#a9907a}
@@ -181,7 +202,7 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .blue svg{width:100%;max-width:820px;display:block;margin:0 auto}
 
 /* ── Platforms ──────────────────────────────────────── */
-.plat{padding:60px 0;background:var(--paper);border-top:1px solid var(--kraft-line);border-bottom:1px solid var(--kraft-line)}
+.plat{padding:var(--sec) 0;background:var(--paper);border-top:1px solid var(--kraft-line);border-bottom:1px solid var(--kraft-line)}
 .plat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px}
 .shelf{display:flex;gap:13px;align-items:center;background:var(--cream);border:1px solid var(--kraft-line);
   border-radius:14px;padding:16px}
@@ -191,7 +212,7 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .shelf span{font-family:var(--mono);font-size:11.5px;color:var(--ink-soft)}
 
 /* ── Crates table ───────────────────────────────────── */
-.crates{padding:66px 0}
+.crates{padding:var(--sec) 0}
 .tbl{width:100%;border-collapse:collapse;font-size:14px;
   background:var(--paper);border:1px solid var(--kraft-line);border-radius:14px;overflow:hidden}
 .tbl th{font-family:var(--mono);text-transform:uppercase;font-size:10.5px;letter-spacing:.1em;
@@ -202,7 +223,7 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .tbl td:first-child{font-family:var(--mono);font-size:12.5px;color:var(--salmon-deep);white-space:nowrap}
 
 /* ── Quick start ────────────────────────────────────── */
-.start{padding:66px 0;background:var(--paper);border-top:1px solid var(--kraft-line)}
+.start{padding:var(--sec) 0;background:var(--paper);border-top:1px solid var(--kraft-line)}
 .steps{display:grid;grid-template-columns:repeat(auto-fit,minmax(248px,1fr));gap:16px;counter-reset:s}
 .step{background:var(--cream);border:1px solid var(--kraft-line);border-radius:16px;padding:22px;position:relative}
 .step::before{counter-increment:s;content:counter(s,decimal-leading-zero);
@@ -214,9 +235,9 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
 .step pre .c{color:#8a7866}
 
 /* ── Final CTA ──────────────────────────────────────── */
-.cta{padding:78px 0;text-align:center}
+.cta{padding:var(--sec) 0;text-align:center}
 .cta-card{background:linear-gradient(150deg,var(--salmon),var(--tangerine));border-radius:24px;
-  padding:54px 28px;color:#fff;position:relative;overflow:hidden;border:2px solid var(--salmon-deep);box-shadow:0 18px 40px -22px rgba(226,62,44,.7)}
+  padding:clamp(40px,6vw,56px) clamp(22px,4vw,32px);color:#fff;position:relative;overflow:hidden;border:2px solid var(--salmon-deep);box-shadow:0 18px 40px -22px rgba(226,62,44,.7)}
 .cta-card h2{font-family:var(--display);font-weight:700;font-size:clamp(2rem,4.4vw,3rem);letter-spacing:-.03em;line-height:1.02}
 .cta-card p{max-width:48ch;margin:14px auto 26px;font-size:1.05rem;color:#fff5ef}
 .cta-card .btn-primary{background:#fff;color:var(--salmon-deep);border-color:#fff;box-shadow:0 8px 0 -2px rgba(0,0,0,.18)}
@@ -271,11 +292,13 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
     <div class="cta-row">
       <a class="btn btn-primary" href="./guide/">Read the docs</a>
       <a class="btn btn-ghost" href="https://github.com/madeye/meow-rs">View on GitHub</a>
-      <a class="btn btn-ghost" href="https://github.com/madeye/meow-rs/releases/latest">Download a build</a>
     </div>
-    <div class="install">
-      <span><span class="pfx">$</span> cargo build --release</span>
-      <button type="button" data-copy="cargo build --release">Copy</button>
+    <div class="install-row">
+      <div class="install">
+        <span class="cmd"><span class="pfx">$</span> cargo install meow-app</span>
+        <button type="button" data-copy="cargo install meow-app">Copy</button>
+      </div>
+      <a class="install-alt" href="https://github.com/madeye/meow-rs/releases/latest">or grab a prebuilt binary →</a>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Two related pieces, both already validated against reality.

## crates.io publishing (commit `ffc7d87`)

All 11 library/binary crates are now **published to crates.io at 0.15.0**, so `cargo install meow-app` works. This commit makes the repo match what's published:

- Added required metadata (`description` / `license` / `repository` / `homepage`) to all 11 crates.
- Added `version = "0.15.0"` to the internal path dependencies in `[workspace.dependencies]`.
- Repointed **`anytls-rs`** from the `madeye/anytls-rs` git fork to its crates.io **0.5.4** release (crates.io forbids git deps; same version the pinned git rev resolved to). `anytls` remains an opt-in, non-default feature.

`meow-bench` stays unpublished (internal benchmark binary).

## Landing-page polish (commit `a9988eb`)

- Opaque caption chip parked over the hero video's burned-in sparkle watermark (hidden at any width).
- Hero promotes `cargo install meow-app` with a quiet "prebuilt binary" secondary link; trimmed to a two-button CTA.
- Unified section vertical rhythm via a shared `--sec` token; hardened mobile breakpoints (eyebrow shrink, install-command wrap, overflow safety).

## Verification

- `cargo check --workspace` passes after the dependency changes.
- All 11 crates confirmed live at `0.15.0` (HTTP 200) and `cargo search meow-app` resolves.
- No Rust source changed — the publishes themselves verified each crate builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)