### PR TITLE
Release automation: crates.io publish workflow + checklist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,95 @@
+name: Publish to crates.io
+
+# Publishes all 11 workspace crates to crates.io in dependency order.
+#
+# Triggers:
+#   - push a tag `vX.Y.Z`  -> real publish (tag must match the workspace version)
+#   - workflow_dispatch    -> dry-run by default; untick "dry-run" to publish
+#
+# Requires the repository secret CARGO_REGISTRY_TOKEN (a crates.io API token
+# with publish-update + publish-new scope). See docs/RELEASING.md.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (package + verify only, no upload)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crates-io-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # BoringSSL (boring-tls, on by default for meow-config / meow-app) needs cmake.
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake
+
+      - name: Verify tag matches workspace version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          ver="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+          echo "tag=$tag workspace version=$ver"
+          if [ "$tag" != "$ver" ]; then
+            echo "::error::tag v$tag does not match workspace version $ver"
+            exit 1
+          fi
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          # Dry-run for manual runs unless explicitly disabled; always real on a tag.
+          args=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry-run }}" = "true" ]; then
+            args="--dry-run"
+            echo "Running in DRY-RUN mode (no uploads)."
+          fi
+
+          # Dependency-safe order (includes dev-dependency edges, e.g. meow-tunnel
+          # dev-depends on meow-config, so config precedes tunnel). meow-bench is
+          # intentionally not published.
+          crates=(
+            meow-common meow-trie meow-transport
+            meow-rules meow-dns meow-proxy
+            meow-config meow-tunnel meow-listener meow-api
+            meow-app
+          )
+
+          for c in "${crates[@]}"; do
+            echo "::group::publish $c"
+            if out=$(cargo publish -p "$c" $args 2>&1); then
+              echo "$out"
+            else
+              echo "$out"
+              # Idempotent: tolerate a version already on the registry so a
+              # re-run can resume after a partial release.
+              if echo "$out" | grep -qiE "already (exists|uploaded)|is already uploaded"; then
+                echo "$c already published at this version — continuing."
+              else
+                echo "::error::failed to publish $c"
+                exit 1
+              fi
+            fi
+            echo "::endgroup::"
+          done
+          echo "Done."

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,101 @@
+# Releasing meow-rs
+
+meow-rs ships as **11 crates** published together to [crates.io](https://crates.io)
+at a single workspace version. This is the checklist for cutting a release.
+
+> [!IMPORTANT]
+> **crates.io is append-only.** A published version can never be deleted, only
+> *yanked*. You can never re-publish the same version number. Every release must
+> bump the version. `0.15.0` is already taken — the next release is `0.15.1` (or
+> `0.16.0`).
+
+## One-time setup
+
+1. Create a crates.io API token at <https://crates.io/settings/tokens> with the
+   **publish-new** and **publish-update** scopes.
+2. Add it to the repo as the **`CARGO_REGISTRY_TOKEN`** Actions secret
+   (`Settings → Secrets and variables → Actions`). The
+   [`publish.yml`](../.github/workflows/publish.yml) workflow reads it.
+3. Confirm you own all 11 crate names on crates.io (you do, as of `0.15.0`).
+
+## The crates & publish order
+
+All crates share the workspace version (`[workspace.package] version` in the root
+`Cargo.toml`). `meow-bench` is **not** published. The publish order is dictated by
+dependencies — including **dev-dependencies**, which crates.io validates at publish
+time (e.g. `meow-tunnel` dev-depends on `meow-config`, so config goes first):
+
+```
+meow-common  meow-trie  meow-transport      (leaves, no internal deps)
+meow-rules   meow-dns                        (→ common, trie)
+meow-proxy                                   (→ common, dns, transport)
+meow-config                                  (→ common, trie, dns, rules, proxy)
+meow-tunnel                                  (→ …, + dev-dep on config)
+meow-listener  meow-api                      (→ tunnel, config)
+meow-app                                     (→ everything)
+```
+
+## Release steps
+
+1. **Green CI on `main`.** The release does not run the test suite; make sure
+   [`test.yml`](../.github/workflows/test.yml) is passing first.
+
+2. **Bump the version.** Edit `[workspace.package] version` in the root
+   `Cargo.toml`. Because the internal deps are pinned to that version (e.g.
+   `meow-common = { path = "…", version = "0.15.0" }`), bump those entries in
+   `[workspace.dependencies]` to match the new version too.
+
+3. **Refresh the lockfile.**
+   ```bash
+   cargo update -w        # re-resolve workspace members to the new version
+   cargo check --workspace
+   ```
+
+4. **PR & merge to `main`** with the version bump (e.g. `chore(release): 0.15.1`).
+
+5. **Tag and push** from the merged commit on `main`:
+   ```bash
+   git checkout main && git pull --ff-only
+   git tag v0.15.1
+   git push origin v0.15.1
+   ```
+   The tag push triggers [`publish.yml`](../.github/workflows/publish.yml), which
+   verifies the tag matches the workspace version and publishes all 11 crates in
+   order. (The workflow is idempotent — a re-run skips versions already on the
+   registry, so a partial release can resume.)
+
+6. **Dry-run option.** To rehearse without uploading, run the workflow manually
+   (`Actions → Publish to crates.io → Run workflow`) with **dry-run** left ticked.
+
+7. **Post-release.**
+   - Verify: `cargo install meow-app` (or `cargo info meow-app`).
+   - Cut a GitHub Release for the tag with notes / prebuilt binaries.
+
+## Rate limits
+
+- **New crate names:** burst of ~5, then ~1 per 10 minutes. This only bit the
+  *first* publish (0.15.0). It does **not** apply to new versions of existing
+  crates.
+- **New versions of existing crates:** a much higher limit, so a normal release
+  publishes all 11 crates back-to-back without throttling.
+
+## `anytls-rs`
+
+`anytls-rs` is an **opt-in, non-default** dependency (the `anytls` feature) pinned
+to its crates.io release in `[workspace.dependencies]` — crates.io forbids `git`
+dependencies, so it must stay a registry version, not the `madeye/anytls-rs` git
+fork. If you need a newer fork change, publish it to crates.io first, then bump the
+version here.
+
+## Manual fallback
+
+If the workflow is unavailable, publish locally (logged in via `cargo login`):
+
+```bash
+for c in meow-common meow-trie meow-transport \
+         meow-rules meow-dns meow-proxy \
+         meow-config meow-tunnel meow-listener meow-api \
+         meow-app; do
+  cargo publish -p "$c" || break   # waits for index propagation between crates
+done
+```


### PR DESCRIPTION
Follow-up to the 0.15.0 crates.io publish — makes future releases one-step.

## What's here

- **`.github/workflows/publish.yml`** — publishes all 11 crates to crates.io in dependency order (including dev-dependency edges, so `meow-config` precedes `meow-tunnel`; `meow-bench` excluded).
  - Triggers: push a `vX.Y.Z` tag (real publish, verifies the tag matches the workspace version) or run manually via `workflow_dispatch` (**dry-run by default**).
  - Idempotent: skips any version already on the registry, so a partial release can be resumed by re-running.
  - Installs `cmake` for the BoringSSL (`boring-tls`) verification build.
- **`docs/RELEASING.md`** — the release checklist: token setup, version bump, publish order, rate-limit behavior (the harsh new-crate limit only applied to 0.15.0), the `anytls-rs` registry constraint, and a manual fallback loop.

## Action required before first use

Add a repository secret **`CARGO_REGISTRY_TOKEN`** (crates.io API token with publish-new + publish-update scope). The workflow is inert until then, so merging this is safe.

## Verification

- `publish.yml` passes `actionlint` and parses as valid YAML.
- The next release must bump past `0.15.0` (permanently taken) — documented in `RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)