### PR TITLE
chore(release): bump workspace to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "base64",
  "ipnet",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "proptest",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"
@@ -212,13 +212,13 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.15.0" }
-meow-trie = { path = "crates/meow-trie", version = "0.15.0" }
-meow-dns = { path = "crates/meow-dns", version = "0.15.0", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.15.0" }
-meow-transport = { path = "crates/meow-transport", version = "0.15.0" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.15.0", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.15.0" }
-meow-listener = { path = "crates/meow-listener", version = "0.15.0", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.15.0" }
-meow-config = { path = "crates/meow-config", version = "0.15.0", default-features = false }
+meow-common = { path = "crates/meow-common", version = "0.15.1" }
+meow-trie = { path = "crates/meow-trie", version = "0.15.1" }
+meow-dns = { path = "crates/meow-dns", version = "0.15.1", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.15.1" }
+meow-transport = { path = "crates/meow-transport", version = "0.15.1" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.15.1", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.15.1" }
+meow-listener = { path = "crates/meow-listener", version = "0.15.1", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.15.1" }
+meow-config = { path = "crates/meow-config", version = "0.15.1", default-features = false }


### PR DESCRIPTION
Stages the next release. `0.15.0` is permanently taken on crates.io, so the working tree now sits at **0.15.1**.

- Bumped `[workspace.package] version` and the 10 pinned internal dep versions in `[workspace.dependencies]` (all move together).
- `cargo update -w` refreshed `Cargo.lock`; `cargo check --workspace` passes.

To actually publish 0.15.1 later: merge this, ensure the `CARGO_REGISTRY_TOKEN` secret is set, then `git tag v0.15.1 && git push origin v0.15.1` to trigger `publish.yml`. See `docs/RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)