### PR TITLE
docs(pages): document that Pages source must be GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,5 +1,14 @@
 name: Deploy GitHub Pages
 
+# IMPORTANT: the repository's Pages source must be set to "GitHub Actions"
+# (Settings -> Pages -> Build and deployment -> Source: GitHub Actions).
+# The documentation SPA lives in docs/guide/, which is build-only and
+# gitignored -- it exists solely in this workflow's uploaded artifact and is
+# never committed. If Pages is instead set to "Deploy from a branch" (e.g.
+# main /docs), the committed landing page (docs/index.html) still serves at
+# the site root, but /meow-rs/guide/ 404s because docs/guide/ is absent from
+# the branch. Keep the source on "GitHub Actions" so the built guide ships.
+
 on:
   push:
     branches: [main]

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@ dh_out.json
 .claude/scheduled_tasks.lock
 .antigravitycli/
 
-# VitePress docs build output (generated into docs/ by CI; see website/)
+# VitePress docs build output (generated into docs/ by CI; see website/).
+# Build-only: published via the Deploy GitHub Pages workflow's artifact, so
+# the repo's Pages source must be "GitHub Actions" (see .github/workflows/pages.yml).
 /docs/guide/
 website/node_modules
 website/.vitepress/cache


### PR DESCRIPTION
## What's broken

`https://madeye.github.io/meow-rs/guide/` 404s, while the site root (`https://madeye.github.io/meow-rs/`) works.

## Root cause

The documentation SPA at `docs/guide/` is **build-only and gitignored** (`.gitignore` → `/docs/guide/`). It is produced by the `Deploy GitHub Pages` workflow and exists only inside that workflow's uploaded artifact — it is never committed to the repo.

- The hand-built landing page `docs/index.html` **is** committed, so it serves at the site root regardless of how Pages is configured.
- `docs/guide/` is **not** committed, so it only exists when Pages serves the **workflow artifact**.

If the repository's Pages **Source** is set to "Deploy from a branch" (e.g. `main` `/docs`) instead of "GitHub Actions", Pages serves the committed branch — which has `docs/index.html` but no `docs/guide/` — and `/meow-rs/guide/` 404s. This matches the observed "root works, `/guide/` broken" symptom, and is consistent with the workflow runs being green (a workflow can deploy to the `github-pages` environment while the live Source is still a branch).

## The actual fix (repository setting)

**Settings → Pages → Build and deployment → Source: GitHub Actions.**

The existing `pages.yml` workflow already builds `website/` into `docs/guide/` and publishes the combined `docs/` artifact correctly — verified by reproducing the build locally (it produces `docs/guide/index.html` + assets served at `/meow-rs/guide/`). No workflow change is required; only the Pages source setting.

## What this PR changes

This PR doesn't change the build — it records the requirement in the repo so the breakage can't silently recur:

- Adds a header comment to `.github/workflows/pages.yml` explaining that the Pages source **must** be "GitHub Actions" because `docs/guide/` is build-only.
- Clarifies the `.gitignore` comment next to `/docs/guide/` to point at that requirement.

No generated files are committed, keeping the repo clean and the workflow as the single source of truth for the published docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APMzRhxSzhFP8G6YWocEgJ)_