### PR TITLE
fix(anytls): FIN streams via control frame for registry anytls-rs

### DIFF
--- a/crates/meow-proxy/src/anytls_adapter.rs
+++ b/crates/meow-proxy/src/anytls_adapter.rs
@@ -10,11 +10,13 @@
 
 use std::io;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use anytls_rs::client::Client as AnytlsClient;
 use anytls_rs::padding::PaddingFactory;
+use anytls_rs::protocol::{Command, Frame};
 use anytls_rs::session::{Session, Stream as AnytlsStream};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -151,6 +153,7 @@ struct AnytlsConn {
     stream_id: u32,
     pending_read: Mutex<Option<PendingRead>>,
     pending_write: Mutex<Option<PendingWrite>>,
+    fin_sent: AtomicBool,
 }
 
 impl AnytlsConn {
@@ -162,7 +165,35 @@ impl AnytlsConn {
             stream_id,
             pending_read: Mutex::new(None),
             pending_write: Mutex::new(None),
+            fin_sent: AtomicBool::new(false),
         }
+    }
+
+    /// Best-effort FIN for just this stream, idempotent across `poll_shutdown`
+    /// and `Drop`. Emits a `Fin` control frame so the server releases the
+    /// proxied target connection and evicts the per-stream map entry (issue
+    /// #201 item 4). The session is pooled and multiplexes other streams, so
+    /// this must never close the session itself.
+    ///
+    /// The registry `anytls-rs` exposes only an async session writer (the
+    /// git fork's synchronous `Stream::close()` is not published), so the frame
+    /// is sent fire-and-forget on the current runtime. If no runtime is active
+    /// (e.g. dropped outside tokio), the FIN is skipped — the connection is
+    /// being torn down regardless.
+    fn fin_stream(&self) {
+        if self.fin_sent.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let session = Arc::clone(&self.session);
+        let stream_id = self.stream_id;
+        handle.spawn(async move {
+            let _ = session
+                .write_control_frame(Frame::control(Command::Fin, stream_id))
+                .await;
+        });
     }
 }
 
@@ -255,8 +286,8 @@ impl AsyncWrite for AnytlsConn {
         // the server releases the proxied target connection and evicts the
         // stream from the session maps. Without this the server-side proxied
         // socket and the session's per-stream map entry leaked on every dial
-        // (issue #201 item 4). Idempotent and lock-free.
-        self.stream.close();
+        // (issue #201 item 4). Idempotent.
+        self.fin_stream();
         Poll::Ready(Ok(()))
     }
 }
@@ -266,8 +297,8 @@ impl Drop for AnytlsConn {
         // Belt-and-suspenders: the relay path that drops the boxed `ProxyConn`
         // without first calling `poll_shutdown` (e.g. on a copy error) must
         // still FIN the stream so the proxied connection and map entry are
-        // released. `close()` is idempotent with `poll_shutdown`.
-        self.stream.close();
+        // released. `fin_stream` is idempotent with `poll_shutdown`.
+        self.fin_stream();
     }
 }
 


### PR DESCRIPTION
## Problem

`main` has been red on the `lint` gate since **#255** (`dcdfd38`). That commit switched the `anytls-rs` dependency from the git fork (rev `e6134889`, which added a `Stream::close()` method for the issue #201 item 4 fd/stream-leak fix) to the **published registry crate `0.5.4`**, which has no `Stream::close()`. As a result `cargo clippy --all-targets --all-features -- -D warnings` (which compiles the `anytls` feature) fails:

```
error[E0599]: no method named `close` found for struct `Arc<anytls_rs::Stream>`
  --> crates/meow-proxy/src/anytls_adapter.rs:259 and :270
```

This was found while CI-checking docs PR #258, which only inherits the breakage — this PR is the actual fix.

## Fix

Replace the two `self.stream.close()` calls with an equivalent built only from the `0.5.4` public API: emit a `Fin` control frame for this stream's id via `Session::write_control_frame(Frame::control(Command::Fin, stream_id))`.

This preserves the **issue #201 item 4** leak fix — on teardown the server still receives a FIN, so it releases the proxied target connection and evicts the per-stream map entry — while never closing the pooled session that multiplexes other streams.

Mechanics:
- The registry session writer is `async`, but `poll_shutdown` / `Drop` are synchronous, so the FIN is sent **fire-and-forget** on the current runtime.
- Guarded by `tokio::runtime::Handle::try_current()` — if dropped outside a tokio runtime (e.g. some tests), the FIN is skipped since the connection is being torn down anyway.
- An `AtomicBool` (`fin_sent`) makes it idempotent so `poll_shutdown` followed by `Drop` never double-sends.

The change is isolated to `crates/meow-proxy/src/anytls_adapter.rs`.

> Note: a fully equivalent alternative would be to publish the fork's `Stream::close()` to the `anytls-rs` registry crate and bump the dependency, but `anytls-rs` is a separate repository outside this PR's scope. This fix keeps everything in-tree and unblocks the `--all-features` lint gate.

## Verification

Run locally, all green:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`  ← previously failing, now passes
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test -p meow-proxy --features anytls --lib` → 278 passed (one unrelated `direct` IPv6-bind test fails only because this sandbox has no IPv6; it isn't touched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APMzRhxSzhFP8G6YWocEgJ)_