### PR TITLE
fix(deps): bump quinn-proto and memmap2 for RUSTSEC-2026-0185/-0186

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,9 +2013,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2787,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Resolves two open RustSec advisories with lockfile-only dependency bumps.

## Changes
| Advisory | Crate | From → To | Path | Issue |
|----------|-------|-----------|------|-------|
| RUSTSEC-2026-0185 | `quinn-proto` | 0.11.14 → 0.11.15 | `h3-quinn` → `meow-proxy` (HTTP/3) | #260 |
| RUSTSEC-2026-0186 | `memmap2` | 0.9.10 → 0.9.11 | transitive via `maxminddb` (GeoIP) | #261 |

- **#260 / quinn-proto** — remote memory exhaustion from unbounded out-of-order QUIC stream reassembly. Reachable through the HTTP/3 transport, so this is the higher-priority of the two.
- **#261 / memmap2** — unchecked pointer offset in `advise_range`/`flush_range`. Only reached via `maxminddb` reading local `.mmdb` GeoIP files; offsets aren't attacker-controlled in normal use, so low practical severity — bundled here since the fix is free.

Both are semver-compatible patch bumps (`cargo update -p quinn-proto -p memmap2`). No source changes.

## Verification
Regression bar run locally:
- ✅ `cargo build --release`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo clippy --all-targets --no-default-features -- -D warnings`
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- ✅ `cargo test --lib`

> Note: `cargo clippy --all-targets --all-features` fails, but this is the **pre-existing #262** `anytls` build break (registry `anytls-rs` 0.5.4 lacks `Stream::close()`), unrelated to these bumps. Tracked separately.

Closes #260
Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)