### PR TITLE
fix(anytls): patch anytls-rs to madeye fork commit with Stream::close (#262)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,12 +141,12 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "anytls-rs"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa494bfdf944c403ffb86d3387cb8a15422ca9a59af66fad50b941340aded56"
+source = "git+https://github.com/madeye/anytls-rs?rev=e6134889d3abbfaa2cb7439969dbda2ef6930611#e6134889d3abbfaa2cb7439969dbda2ef6930611"
 dependencies = [
  "anyhow",
  "bytes",
  "chrono",
+ "libc",
  "md5",
  "notify",
  "once_cell",
@@ -157,12 +157,13 @@ dependencies = [
  "serde",
  "sha2",
  "socket2 0.6.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trust-dns-resolver",
  "x509-parser",
 ]
 
@@ -220,7 +221,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1013,6 +1014,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,13 +1418,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
- "idna",
+ "idna 1.1.0",
  "ipnet",
  "jni",
  "once_cell",
  "rand 0.10.1",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -1540,7 +1553,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1558,7 +1571,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1657,6 +1670,16 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -1794,7 +1817,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1913,6 +1936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +1975,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1986,7 +2024,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2113,7 +2151,7 @@ dependencies = [
  "smol_str",
  "socket2 0.5.10",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2174,7 +2212,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "sysinfo",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2235,7 +2273,7 @@ dependencies = [
  "smol_str",
  "socket2 0.5.10",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2256,7 +2294,7 @@ dependencies = [
  "regex",
  "smol_str",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
@@ -2282,7 +2320,7 @@ dependencies = [
  "regex",
  "rustls",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-boring",
  "tokio-rustls",
@@ -2750,7 +2788,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2778,8 +2816,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
- "thiserror",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2800,7 +2838,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2815,7 +2853,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2843,11 +2881,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2860,6 +2909,16 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3346,7 +3405,7 @@ dependencies = [
  "shadowsocks-crypto",
  "socket2 0.6.3",
  "spin",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tfo",
  "trait-variant",
@@ -3571,11 +3630,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3903,6 +3982,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.6",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.6",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,7 +4044,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3943,10 +4066,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -3983,7 +4121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -4249,7 +4387,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -4259,23 +4397,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -4290,32 +4415,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4335,24 +4438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -4625,7 +4710,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -4764,7 +4849,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.18",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,15 @@ serde_json = "1"
 serde_yaml = "0.9"
 
 # Networking
-# crates.io release of the madeye fork. 0.5.4 carries the `SocketProtector`
-# registry + `connect_tcp` / `bind_udp` helpers (Android protect hook) and the
-# fd/stream-leak fix for issue #201 item 4 (madeye/anytls-rs#1). A registry
-# version (not a git rev) is required to publish meow-proxy to crates.io.
+# Keep a registry version requirement so meow-proxy stays publishable to
+# crates.io (cargo publish rejects bare git deps). The `anytls` feature is
+# opt-in and off by default, so publish's verify build never compiles it.
+#
+# IMPORTANT: crates.io `anytls-rs@0.5.4` is jxo-me's UPSTREAM crate, which does
+# NOT have `Stream::close()`. meow's adapter calls `close()` (the fd/stream-leak
+# fix for #201 item 4, madeye/anytls-rs#1), which only exists in the madeye
+# fork. We therefore patch the registry crate to the fork commit that contains
+# `close()` via [patch.crates-io] at the bottom of this file (see issue #262).
 anytls-rs = { version = "0.5.4" }
 shadowsocks = { version = "1.21", default-features = false, features = ["aead-cipher", "aead-cipher-2022", "stream-cipher"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
@@ -222,3 +227,17 @@ meow-tunnel = { path = "crates/meow-tunnel", version = "0.15.1" }
 meow-listener = { path = "crates/meow-listener", version = "0.15.1", default-features = false }
 meow-api = { path = "crates/meow-api", version = "0.15.1" }
 meow-config = { path = "crates/meow-config", version = "0.15.1", default-features = false }
+
+# --- anytls fork patch (issue #262) ---------------------------------------
+# crates.io `anytls-rs@0.5.4` is jxo-me's upstream and lacks `Stream::close()`;
+# meow's adapter requires the madeye fork, whose `close()` (madeye/anytls-rs#1)
+# merged AFTER the fork's own `v0.5.4` tag. Pin the exact merge commit so the
+# `anytls` feature builds. The patched crate is itself `anytls-rs@0.5.4`, so it
+# satisfies the `version = "0.5.4"` requirement above without a version bump.
+#
+# NOTE: [patch] is local to this workspace and is stripped on publish — it does
+# NOT propagate to downstream consumers who pull meow-proxy from crates.io with
+# `anytls` enabled. The permanent fix is to publish the fork under a distinct
+# name (e.g. `anytls-meow`) and depend on that. Tracked in #262.
+[patch.crates-io]
+anytls-rs = { git = "https://github.com/madeye/anytls-rs", rev = "e6134889d3abbfaa2cb7439969dbda2ef6930611" }


### PR DESCRIPTION
Fixes the `anytls`-feature build break described in #262.

## Problem
`meow-proxy`'s anytls adapter calls `self.stream.close()` (`anytls_adapter.rs:259,270` — the fd/stream-leak fix for #201 item 4, madeye/anytls-rs#1). But crates.io `anytls-rs@0.5.4` is **jxo-me's upstream crate** (verified: `repository = github.com/jxo-me/anytls-rs`, published by `jxo-me`), which has **no `Stream::close()`**. That method only exists in the **madeye fork**, where it merged (`e6134889`) *after* the fork's own `v0.5.4` tag — so neither the registry crate nor that tag compiles.

Result: any build with `--features anytls` fails with `E0599: no method named close`, across v0.14.0 / v0.15.0 / v0.15.1. This is also why `clippy --all-features` is red in CI (e.g. on #263).

## Fix
Pin the registry crate to the exact fork merge commit via `[patch.crates-io]`:

```toml
[patch.crates-io]
anytls-rs = { git = "https://github.com/madeye/anytls-rs", rev = "e6134889d3abbfaa2cb7439969dbda2ef6930611" }
```

- The patched crate is itself `anytls-rs@0.5.4`, so it satisfies the existing `version = "0.5.4"` requirement — **no version bump**.
- The dep requirement stays a **registry version**, so `meow-proxy` remains publishable to crates.io. `anytls` is opt-in and off by default, so `cargo publish`'s verify build never compiles the anytls path.

## Caveat / follow-up
`[patch]` is workspace-local and stripped on publish, so it does **not** propagate to downstream consumers who pull `meow-proxy` from crates.io with `anytls` enabled — they'd still hit the broken upstream crate (and need their own patch). The permanent fix is to **publish the fork under a distinct name** (e.g. `anytls-meow`) and depend on that. That requires a crates.io publish from the fork repo, so I've left it as a follow-up rather than doing it unilaterally — happy to prep the fork rename if you want to go that route. Tracking stays in #262.

## Verification
All green locally, including the previously-failing path:
- ✅ `cargo build -p meow-proxy --features anytls` (the #262 repro)
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo clippy --all-targets --no-default-features -- -D warnings`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` ← was failing before
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- ✅ `cargo test --lib`

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)