### PR TITLE
fix(anytls): vendor anytls-rs fork in-tree as meow-anytls (#262)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Publish to crates.io
 
-# Publishes all 11 workspace crates to crates.io in dependency order.
+# Publishes all 12 workspace crates to crates.io in dependency order.
 #
 # Triggers:
 #   - push a tag `vX.Y.Z`  -> real publish (tag must match the workspace version)
@@ -69,7 +69,7 @@ jobs:
           # dev-depends on meow-config, so config precedes tunnel). meow-bench is
           # intentionally not published.
           crates=(
-            meow-common meow-trie meow-transport
+            meow-common meow-trie meow-anytls meow-transport
             meow-rules meow-dns meow-proxy
             meow-config meow-tunnel meow-listener meow-api
             meow-app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,13 @@ Listeners (HTTP/SOCKS5/Mixed/TProxy)
 
 ### Workspace Crates
 
-The workspace has 12 crates (see also [ADR-0009](docs/adr/0009-cleanup-scope.md) for crate-boundary policy):
+The workspace has 13 crates (see also [ADR-0009](docs/adr/0009-cleanup-scope.md) for crate-boundary policy):
 
 | Crate | Purpose |
 |-------|---------|
 | `meow-common` | Core traits and types (`ProxyAdapter`, `Rule`, `Metadata`, `ConnContext`) — the "contracts" crate |
 | `meow-trie` | Domain trie for efficient pattern matching |
+| `meow-anytls` | Vendored fork of `anytls-rs` (lib name `anytls_rs`); MIT-licensed, in-tree to provide `Stream::close()` (see [#262](https://github.com/madeye/meow-rs/issues/262)). Pulled in only by `meow-proxy`'s opt-in `anytls` feature |
 | `meow-transport` | Composable stream-transport layers (TLS, WebSocket, gRPC, HTTP/2, HTTP Upgrade) — protocol-agnostic, no dep on other meow-rs crates (see [ADR-0001](docs/adr/0001-meow-transport-crate.md)) |
 | `meow-proxy` | Proxy protocol implementations (SS, Trojan, VLESS, Direct, Reject), groups (Selector, URLTest, Fallback, LoadBalance, Relay), and health probing |
 | `meow-rules` | Rule matching engine and parser (domain, IP-CIDR, GeoIP, process, logic composition) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,34 +139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "anytls-rs"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa494bfdf944c403ffb86d3387cb8a15422ca9a59af66fad50b941340aded56"
-dependencies = [
- "anyhow",
- "bytes",
- "chrono",
- "md5",
- "notify",
- "once_cell",
- "rand 0.9.4",
- "rcgen 0.14.8",
- "rustls",
- "rustls-pemfile",
- "serde",
- "sha2",
- "socket2 0.6.3",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "x509-parser",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,7 +192,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1013,6 +985,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,13 +1389,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
- "idna",
+ "idna 1.1.0",
  "ipnet",
  "jni",
  "once_cell",
  "rand 0.10.1",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -1660,6 +1644,16 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -1794,7 +1788,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1913,6 +1907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +1946,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1986,7 +1995,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2018,6 +2027,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "meow-anytls"
+version = "0.15.1"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "libc",
+ "md5",
+ "notify",
+ "once_cell",
+ "rand 0.9.4",
+ "rcgen 0.14.8",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "sha2",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "trust-dns-resolver",
+ "x509-parser",
 ]
 
 [[package]]
@@ -2113,7 +2150,7 @@ dependencies = [
  "smol_str",
  "socket2 0.5.10",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2174,7 +2211,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "sysinfo",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2203,7 +2240,6 @@ version = "0.15.1"
 dependencies = [
  "aes",
  "aes-gcm",
- "anytls-rs",
  "argon2",
  "async-trait",
  "base64",
@@ -2219,6 +2255,7 @@ dependencies = [
  "http",
  "libc",
  "md-5",
+ "meow-anytls",
  "meow-common",
  "meow-dns",
  "meow-transport",
@@ -2235,7 +2272,7 @@ dependencies = [
  "smol_str",
  "socket2 0.5.10",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2256,7 +2293,7 @@ dependencies = [
  "regex",
  "smol_str",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
@@ -2282,7 +2319,7 @@ dependencies = [
  "regex",
  "rustls",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-boring",
  "tokio-rustls",
@@ -2750,7 +2787,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2779,7 +2816,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2800,7 +2837,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2843,11 +2880,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2860,6 +2908,16 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3346,7 +3404,7 @@ dependencies = [
  "shadowsocks-crypto",
  "socket2 0.6.3",
  "spin",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tfo",
  "trait-variant",
@@ -3571,11 +3629,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3903,6 +3981,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.6",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.6",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,7 +4043,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3943,10 +4065,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -3983,7 +4120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -4625,7 +4762,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -4764,7 +4901,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.18",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/meow-common",
     "crates/meow-trie",
+    "crates/meow-anytls",
     "crates/meow-dns",
     "crates/meow-rules",
     "crates/meow-transport",
@@ -79,11 +80,11 @@ serde_json = "1"
 serde_yaml = "0.9"
 
 # Networking
-# crates.io release of the madeye fork. 0.5.4 carries the `SocketProtector`
-# registry + `connect_tcp` / `bind_udp` helpers (Android protect hook) and the
-# fd/stream-leak fix for issue #201 item 4 (madeye/anytls-rs#1). A registry
-# version (not a git rev) is required to publish meow-proxy to crates.io.
-anytls-rs = { version = "0.5.4" }
+# anytls is vendored in-tree as `crates/meow-anytls` (lib name `anytls_rs`).
+# crates.io `anytls-rs@0.5.4` is jxo-me's upstream and lacks `Stream::close()`,
+# which meow's adapter requires (madeye/anytls-rs#1, #201 item 4); vendoring the
+# madeye fork removes the registry/git dependency entirely. See #262 and
+# crates/meow-anytls/README.md.
 shadowsocks = { version = "1.21", default-features = false, features = ["aead-cipher", "aead-cipher-2022", "stream-cipher"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
@@ -214,6 +215,9 @@ proptest = "1"
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
 meow-common = { path = "crates/meow-common", version = "0.15.1" }
 meow-trie = { path = "crates/meow-trie", version = "0.15.1" }
+# Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
+# meow-proxy's `anytls` feature.
+meow-anytls = { path = "crates/meow-anytls", version = "0.15.1" }
 meow-dns = { path = "crates/meow-dns", version = "0.15.1", default-features = false }
 meow-rules = { path = "crates/meow-rules", version = "0.15.1" }
 meow-transport = { path = "crates/meow-transport", version = "0.15.1" }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -1,0 +1,80 @@
+# Vendored copy of the madeye fork of anytls-rs (github.com/madeye/anytls-rs),
+# pinned at the commit that adds `Stream::close()` (madeye/anytls-rs#1,
+# e6134889d3abbfaa2cb7439969dbda2ef6930611). Vendored in-tree to resolve #262:
+# crates.io `anytls-rs@0.5.4` is jxo-me's UPSTREAM crate and lacks `close()`,
+# so meow-proxy could not build the `anytls` feature against the registry.
+#
+# This crate is MIT-licensed (see LICENSE) — distinct from the workspace's
+# GPL-3.0 — and uses Rust edition 2024, so package metadata is declared
+# explicitly here rather than inherited from `[workspace.package]`.
+#
+# The package is renamed (`meow-anytls`) to avoid a crates.io name collision
+# with the upstream `anytls-rs`, while the library name stays `anytls_rs` so
+# dependents' `use anytls_rs::...` paths are unchanged.
+[package]
+name = "meow-anytls"
+version = "0.15.1"
+edition = "2024"
+rust-version = "1.89"
+description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
+license = "MIT"
+repository = "https://github.com/madeye/meow-rs"
+homepage = "https://madeye.github.io/meow-rs/"
+readme = "README.md"
+
+[lib]
+name = "anytls_rs"
+path = "src/lib.rs"
+
+[dependencies]
+tokio = { version = "1.48", features = [
+    "macros",
+    "rt-multi-thread",
+    "io-util",
+    "io-std",
+    "net",
+    "sync",
+    "time",
+    "signal",
+    "fs",
+] }
+
+# TLS — pinned to the `ring` crypto provider to match the rest of the workspace
+# (meow-proxy/meow-transport use ring, not the default aws-lc-rs), so this crate
+# does not independently request a second provider. meow installs ring as the
+# process default at startup (meow-app/main.rs), and the adapter builds its TLS
+# config with an explicit ring provider, so this crate's own `builder()`-based
+# helpers (used only by the dropped fork bins) are not on meow's runtime path.
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem", "ring"] }
+rustls-pemfile = "2"
+
+serde = { version = "1", features = ["derive"] }
+
+bytes = "1.10.1"
+tokio-util = { version = "0.7", features = ["codec"] }
+
+sha2 = "0.10"
+md5 = "0.8"
+
+rand = "0.9"
+
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+once_cell = "1.21"
+socket2 = "0.6"
+trust-dns-resolver = { version = "0.23", default-features = false, features = ["tokio-runtime"] }
+
+thiserror = "2.0"
+anyhow = "1.0"
+
+notify = "8.2"
+x509-parser = "0.18"
+chrono = "0.4"
+
+# libc is only used by the Android socket-protect helper (EINPROGRESS check on
+# the non-blocking connect). Off-Android the helper compiles down to a direct
+# `TcpStream::connect` / `UdpSocket::bind` and the dep is never pulled in.
+[target.'cfg(target_os = "android")'.dependencies]
+libc = "0.2"

--- a/crates/meow-anytls/LICENSE
+++ b/crates/meow-anytls/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Mickey and AnyTLS Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/crates/meow-anytls/README.md
+++ b/crates/meow-anytls/README.md
@@ -1,0 +1,39 @@
+# meow-anytls
+
+Vendored copy of the [madeye fork](https://github.com/madeye/anytls-rs) of
+`anytls-rs` — an async TLS proxy protocol implementation — pinned at the commit
+that adds `Stream::close()` (`madeye/anytls-rs#1`,
+`e6134889d3abbfaa2cb7439969dbda2ef6930611`).
+
+## Why it's vendored
+
+The `anytls-rs` crate on crates.io (`0.5.4`) is jxo-me's **upstream** project,
+which does **not** provide `Stream::close()`. meow-proxy's anytls adapter calls
+`close()` (the fd/stream-leak fix for issue #201 item 4), which only exists in
+the madeye fork — and merged *after* the fork's own `v0.5.4` tag. As a result
+meow-proxy could not compile the `anytls` feature against the registry
+(see [issue #262](https://github.com/madeye/meow-rs/issues/262)).
+
+Vendoring the fork's library source in-tree removes the external/registry
+dependency entirely, so the `anytls` feature builds from a clean checkout and
+meow-rs stays publishable to crates.io.
+
+## Layout
+
+- Library source only (`src/`); the upstream `src/bin`, `benches/`, `tests/`,
+  and example/script files are intentionally omitted.
+- The package is named `meow-anytls` (to avoid a crates.io name collision with
+  upstream `anytls-rs`), but the library name is `anytls_rs`, so dependents'
+  `use anytls_rs::...` paths are unchanged.
+
+## License
+
+MIT — see [LICENSE](LICENSE). Copyright (c) 2024 Mickey and AnyTLS Contributors,
+with fork modifications. This differs from the GPL-3.0 license of the rest of
+the meow-rs workspace.
+
+## Updating
+
+This is a point-in-time vendor. To refresh, re-copy `src/` from the madeye fork
+at the desired commit and update the pinned hash referenced above and in
+`Cargo.toml`.

--- a/crates/meow-anytls/src/client/client.rs
+++ b/crates/meow-anytls/src/client/client.rs
@@ -1,0 +1,328 @@
+//! AnyTLS Client implementation
+
+use crate::client::{SessionPool, SessionPoolConfig};
+use crate::padding::PaddingFactory;
+use crate::session::{Session, SessionHeartbeatConfig};
+use crate::util::{AnyTlsError, Result, configure_tcp_stream, hash_password, send_authentication};
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use tokio::time::Duration;
+use tokio_rustls::rustls::pki_types::ServerName;
+
+/// Client manages connections to AnyTLS servers
+pub struct Client {
+    password_hash: [u8; 32],
+    server_addr: String,
+    server_name: ServerName<'static>,
+    tls_config: Arc<tokio_rustls::TlsConnector>,
+    padding: Arc<PaddingFactory>,
+    session_pool: Arc<SessionPool>,
+    pool_config: SessionPoolConfig,
+}
+
+impl Client {
+    /// Create a new client with default session pool configuration
+    pub fn new(
+        password: &str,
+        server_addr: String,
+        server_name: ServerName<'static>,
+        tls_config: Arc<tokio_rustls::TlsConnector>,
+        padding: Arc<PaddingFactory>,
+    ) -> Self {
+        Self::with_pool_config(
+            password,
+            server_addr,
+            server_name,
+            tls_config,
+            padding,
+            crate::client::SessionPoolConfig::default(),
+        )
+    }
+
+    /// Create a new client with custom session pool configuration
+    pub fn with_pool_config(
+        password: &str,
+        server_addr: String,
+        server_name: ServerName<'static>,
+        tls_config: Arc<tokio_rustls::TlsConnector>,
+        padding: Arc<PaddingFactory>,
+        pool_config: crate::client::SessionPoolConfig,
+    ) -> Self {
+        let password_hash = hash_password(password);
+        let session_pool = Arc::new(SessionPool::with_config(pool_config.clone()));
+
+        tracing::debug!("[Client] Creating new client for server: {}", server_addr);
+
+        Self {
+            password_hash,
+            server_addr,
+            server_name,
+            tls_config,
+            padding,
+            session_pool,
+            pool_config,
+        }
+    }
+
+    /// Create a new stream by establishing or reusing a session
+    /// Returns (stream, session) so the caller can use session.write_data_frame for writing
+    pub async fn create_proxy_stream(
+        &self,
+        destination: (String, u16),
+    ) -> Result<(Arc<crate::session::Stream>, Arc<crate::session::Session>)> {
+        tracing::debug!(
+            "[Client] create_proxy_stream: {}:{}",
+            destination.0,
+            destination.1
+        );
+
+        // Get or create a session
+        let session = self.create_stream().await?;
+        tracing::debug!("[Client] Got session for proxy stream");
+
+        // Open a new stream in the session
+        let (stream, synack_rx) = session.open_stream().await?;
+        tracing::debug!(
+            "[Client] Opened stream {} in session, waiting for SYNACK",
+            stream.id()
+        );
+
+        // Write destination address to stream (SOCKS5 format)
+        // Use session's write_data_frame to send data without needing to unwrap Arc<Stream>
+        tracing::debug!(
+            "[Client] Writing destination address to stream {}: {}:{}",
+            stream.id(),
+            destination.0,
+            destination.1
+        );
+
+        // Prepare the SOCKS5 address bytes
+        let (addr, port) = destination;
+        let mut addr_bytes = Vec::new();
+
+        if let Ok(ipv4) = addr.parse::<Ipv4Addr>() {
+            // IPv4
+            tracing::trace!("[Client] Writing IPv4 address: {:?}", ipv4);
+            addr_bytes.push(0x01); // ATYP_IPV4
+            addr_bytes.extend_from_slice(&ipv4.octets());
+        } else if let Ok(ipv6) = addr.parse::<Ipv6Addr>() {
+            // IPv6
+            tracing::trace!("[Client] Writing IPv6 address: {:?}", ipv6);
+            addr_bytes.push(0x04); // ATYP_IPV6
+            addr_bytes.extend_from_slice(&ipv6.octets());
+        } else {
+            // Domain name
+            tracing::trace!("[Client] Writing domain name: {}", addr);
+            let domain_bytes = addr.as_bytes();
+            if domain_bytes.len() > 255 {
+                return Err(AnyTlsError::Protocol("Domain name too long".to_string()));
+            }
+            addr_bytes.push(0x03); // ATYP_DOMAIN
+            addr_bytes.push(domain_bytes.len() as u8);
+            addr_bytes.extend_from_slice(domain_bytes);
+        }
+
+        // Write port (2 bytes, big-endian)
+        tracing::trace!("[Client] Writing port: {}", port);
+        addr_bytes.extend_from_slice(&port.to_be_bytes());
+
+        // Use session's write_data_frame to send the address bytes
+        // This avoids the need to unwrap Arc<Stream> which fails when multiple references exist
+        let stream_id = stream.id();
+        use bytes::Bytes;
+        tracing::debug!(
+            "[Client] Writing destination address ({} bytes) to stream {}",
+            addr_bytes.len(),
+            stream_id
+        );
+
+        // Disable buffering before writing first data frame
+        // This is critical: in Go version, buffering is disabled when proxy writes SocksAddr
+        // This ensures buffered Settings frame is flushed along with the first data
+        session.disable_buffering();
+        tracing::debug!("[Client] Buffering disabled, buffer will be flushed");
+
+        session
+            .write_data_frame(stream_id, Bytes::from(addr_bytes))
+            .await?;
+
+        tracing::debug!(
+            "[Client] Successfully wrote destination address to stream {}",
+            stream_id
+        );
+        tracing::debug!(
+            "[Client] Waiting for SYNACK from server for stream {}...",
+            stream_id
+        );
+
+        // Wait for SYNACK with timeout (30 seconds default)
+        const DEFAULT_SYNACK_TIMEOUT: Duration = Duration::from_secs(30);
+
+        match tokio::time::timeout(DEFAULT_SYNACK_TIMEOUT, synack_rx).await {
+            Ok(Ok(Ok(()))) => {
+                tracing::debug!(
+                    "[Client] SYNACK received for stream {} - stream ready",
+                    stream_id
+                );
+                Ok((stream, session))
+            }
+            Ok(Ok(Err(e))) => {
+                tracing::error!("[Client] SYNACK error for stream {}: {}", stream_id, e);
+                let error_msg = e.to_string();
+                let error = AnyTlsError::Protocol(error_msg.clone());
+                stream.close_with_error(error).await;
+                Err(AnyTlsError::Protocol(error_msg))
+            }
+            Ok(Err(_)) => {
+                tracing::error!("[Client] SYNACK channel closed for stream {}", stream_id);
+                let error = AnyTlsError::Protocol("SYNACK channel closed".into());
+                stream.close_with_error(error).await;
+                Err(AnyTlsError::Protocol("SYNACK channel closed".into()))
+            }
+            Err(_) => {
+                tracing::error!(
+                    "[Client] SYNACK timeout for stream {} after {}s",
+                    stream_id,
+                    DEFAULT_SYNACK_TIMEOUT.as_secs()
+                );
+                let error_msg =
+                    format!("SYNACK timeout after {}s", DEFAULT_SYNACK_TIMEOUT.as_secs());
+                let error = AnyTlsError::Protocol(error_msg.clone());
+                stream.close_with_error(error).await;
+                Err(AnyTlsError::Protocol(error_msg))
+            }
+        }
+    }
+
+    /// Create a new stream by establishing or reusing a session
+    pub async fn create_stream(&self) -> Result<Arc<Session>> {
+        // Try to get an idle session from pool
+        if let Some(session) = self.session_pool.get_idle_session().await {
+            tracing::debug!("[Client] Reusing idle session from pool");
+            return Ok(session);
+        }
+
+        tracing::debug!("[Client] No idle session found, creating new session");
+        // Create new session
+        self.create_new_session().await
+    }
+
+    /// Create a new session with the server
+    async fn create_new_session(&self) -> Result<Arc<Session>> {
+        tracing::debug!("[Client] Creating new session to {}", self.server_addr);
+
+        // Establish TCP connection
+        tracing::trace!(
+            "[Client] Connecting TCP to {} (this may trigger DNS lookup)",
+            self.server_addr
+        );
+        // Dial via the socket-protect helper so a host VPN (Android) can
+        // call `VpnService.protect(fd)` on the outbound socket before the
+        // SYN — otherwise the connection loops back into the same VPN.
+        // Off-Android the helper degrades to `TcpStream::connect`.
+        let tcp_stream = match crate::util::socket_protect::connect_tcp(&self.server_addr).await {
+            Ok(stream) => stream,
+            Err(e) => {
+                tracing::error!("[Client] Failed to connect to {}: {}", self.server_addr, e);
+
+                // Provide helpful error messages
+                let error_str = format!("{}", e);
+                if error_str.contains("lookup")
+                    || error_str.contains("DNS")
+                    || error_str.contains("Try again")
+                {
+                    tracing::error!("[Client] DNS resolution failed for '{}'", self.server_addr);
+                    tracing::error!("[Client] Troubleshooting steps:");
+                    tracing::error!(
+                        "[Client]   1. Check if server address is correct: {}",
+                        self.server_addr
+                    );
+                    tracing::error!("[Client]   2. Try using IP address instead of hostname");
+                    tracing::error!(
+                        "[Client]   3. Test DNS: nslookup $(echo {} | cut -d: -f1)",
+                        self.server_addr
+                    );
+                    tracing::error!(
+                        "[Client]   4. Test TCP connection: nc -zv $(echo {} | cut -d: -f1) $(echo {} | cut -d: -f2)",
+                        self.server_addr,
+                        self.server_addr
+                    );
+                } else if error_str.contains("Connection refused") {
+                    tracing::error!(
+                        "[Client] Connection refused. Server may not be running or not listening on {}",
+                        self.server_addr
+                    );
+                } else if error_str.contains("Connection timed out") {
+                    tracing::error!(
+                        "[Client] Connection timed out. Check network connectivity and firewall settings"
+                    );
+                }
+
+                return Err(AnyTlsError::Io(e));
+            }
+        };
+        configure_tcp_stream(&tcp_stream, &self.server_addr);
+
+        tracing::debug!(
+            "[Client] TCP connection established to {}",
+            self.server_addr
+        );
+
+        // Perform TLS handshake
+        let server_name = self.server_name.clone();
+        tracing::trace!(
+            "[Client] Starting TLS handshake using SNI {:?}",
+            server_name
+        );
+        let tls_stream = self
+            .tls_config
+            .connect(server_name, tcp_stream)
+            .await
+            .map_err(|e| {
+                tracing::error!("[Client] TLS handshake failed: {}", e);
+                AnyTlsError::Tls(format!("TLS handshake failed: {}", e))
+            })?;
+        tracing::debug!("[Client] TLS handshake successful");
+
+        // Send authentication
+        // Split TLS stream into reader and writer
+        let (reader, mut writer) = tokio::io::split(tls_stream);
+        tracing::trace!("[Client] Sending authentication");
+        send_authentication(&mut writer, &self.password_hash, &self.padding).await?;
+        tracing::debug!("[Client] Authentication sent successfully");
+
+        // Create session with reader and writer
+        let heartbeat_config = SessionHeartbeatConfig {
+            interval: self.pool_config.check_interval,
+            timeout: self.pool_config.idle_timeout,
+        };
+        let session = Arc::new(Session::new_client(
+            reader,
+            writer,
+            self.padding.clone(),
+            Some(heartbeat_config),
+        ));
+
+        // Set sequence number for pool ordering (use timestamp-based counter)
+        static SEQ_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = SEQ_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        session.set_seq(seq);
+        tracing::debug!("[Client] Session created with seq={}", seq);
+
+        // Start session (send settings and start loops)
+        tracing::trace!("[Client] Starting client session");
+        session.clone().start_client().await?;
+        tracing::debug!("[Client] Client session started successfully");
+
+        // Store in pool
+        self.session_pool.add_idle_session(session.clone()).await;
+        tracing::debug!("[Client] Session added to pool");
+
+        Ok(session)
+    }
+
+    /// Stop the background cleanup task in the session pool (primarily for tests)
+    pub async fn stop_session_pool_cleanup(&self) {
+        self.session_pool.stop_cleanup_task().await;
+    }
+}

--- a/crates/meow-anytls/src/client/http_proxy.rs
+++ b/crates/meow-anytls/src/client/http_proxy.rs
@@ -1,0 +1,357 @@
+//! Minimal HTTP proxy implementation for AnyTLS client.
+//!
+//! Supports CONNECT tunneling as well as forwarding HTTP requests
+//! via the AnyTLS stream pool.
+
+use crate::client::Client;
+use crate::util::{AnyTlsError, Result};
+use bytes::Bytes;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const HEADER_TERMINATOR: &[u8] = b"\r\n\r\n";
+const MAX_HEADER_SIZE: usize = 64 * 1024;
+
+/// Start an HTTP proxy server that forwards traffic via AnyTLS.
+pub async fn start_http_proxy_server(listen_addr: &str, client: Arc<Client>) -> Result<()> {
+    let listener = TcpListener::bind(listen_addr).await?;
+    tracing::info!("[HTTP] Listening on {}", listen_addr);
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, addr)) => {
+                tracing::debug!("[HTTP] New connection from {}", addr);
+                let client_clone = Arc::clone(&client);
+                tokio::spawn(async move {
+                    if let Err(err) = handle_http_proxy_connection(stream, client_clone).await {
+                        tracing::error!("[HTTP] Connection error: {}", err);
+                    }
+                });
+            }
+            Err(e) => {
+                tracing::error!("[HTTP] Accept error: {}", e);
+            }
+        }
+    }
+}
+
+struct ParsedRequest {
+    method: String,
+    version: String,
+    host: String,
+    port: u16,
+    path: String,
+    is_connect: bool,
+    headers: Vec<String>,
+    body: Vec<u8>,
+}
+
+async fn handle_http_proxy_connection(
+    mut client_conn: TcpStream,
+    client: Arc<Client>,
+) -> Result<()> {
+    let (header_bytes, remaining) = read_http_header(&mut client_conn).await?;
+    let header_str = String::from_utf8(header_bytes.clone())
+        .map_err(|e| AnyTlsError::Protocol(format!("Invalid HTTP header encoding: {}", e)))?;
+
+    let request = parse_http_request(&header_str, remaining)?;
+
+    tracing::debug!(
+        "[HTTP] Request: method={} host={} port={} path={} connect={}",
+        request.method,
+        request.host,
+        request.port,
+        request.path,
+        request.is_connect
+    );
+
+    let destination = (request.host.clone(), request.port);
+    let (proxy_stream, session) = match client.create_proxy_stream(destination.clone()).await {
+        Ok(res) => res,
+        Err(err) => {
+            send_http_error(&mut client_conn, 502, "Bad Gateway").await?;
+            return Err(err);
+        }
+    };
+
+    if request.is_connect {
+        send_connect_success(&mut client_conn).await?;
+    } else {
+        let request_bytes = build_forward_request(&request)?;
+        session
+            .write_data_frame(proxy_stream.id(), Bytes::from(request_bytes))
+            .await?;
+        if !request.body.is_empty() {
+            session
+                .write_data_frame(proxy_stream.id(), Bytes::from(request.body.clone()))
+                .await?;
+        }
+    }
+
+    let (mut client_read, mut client_write) = tokio::io::split(client_conn);
+    let proxy_stream_read = Arc::clone(&proxy_stream);
+    let session_for_write = Arc::clone(&session);
+    let stream_id = proxy_stream.id();
+
+    tracing::debug!(
+        "[HTTP] Established tunnel for {}:{}, stream={}",
+        request.host,
+        request.port,
+        stream_id
+    );
+
+    let to_client = tokio::spawn(async move {
+        let reader = proxy_stream_read.reader();
+        let mut buf = vec![0u8; 8192];
+        loop {
+            let n = {
+                let mut guard = reader.lock().await;
+                match guard.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => n,
+                    Err(e) => {
+                        tracing::error!("[HTTP] Proxy stream read error: {}", e);
+                        break;
+                    }
+                }
+            };
+            if client_write.write_all(&buf[..n]).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let to_proxy = tokio::spawn(async move {
+        let mut buf = vec![0u8; 8192];
+        loop {
+            let n = match client_read.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::error!("[HTTP] Client read error: {}", e);
+                    break;
+                }
+            };
+            if let Err(e) = session_for_write
+                .write_data_frame(stream_id, Bytes::from(buf[..n].to_vec()))
+                .await
+            {
+                tracing::error!("[HTTP] Failed to send to proxy stream: {}", e);
+                break;
+            }
+        }
+    });
+
+    let _ = tokio::join!(to_client, to_proxy);
+
+    tracing::debug!(
+        "[HTTP] Connection to {}:{} closed (stream {})",
+        request.host,
+        request.port,
+        stream_id
+    );
+    Ok(())
+}
+
+async fn read_http_header(stream: &mut TcpStream) -> Result<(Vec<u8>, Vec<u8>)> {
+    let mut buf = Vec::with_capacity(1024);
+    let mut tmp = [0u8; 1024];
+
+    loop {
+        let n = stream.read(&mut tmp).await?;
+        if n == 0 {
+            return Err(AnyTlsError::Protocol(
+                "Connection closed before HTTP header complete".into(),
+            ));
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.len() > MAX_HEADER_SIZE {
+            return Err(AnyTlsError::Protocol("HTTP header too large".to_string()));
+        }
+        if let Some(end) = find_header_end(&buf) {
+            let header = buf[..end].to_vec();
+            let remaining = buf[end..].to_vec();
+            return Ok((header, remaining));
+        }
+    }
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(HEADER_TERMINATOR.len())
+        .position(|window| window == HEADER_TERMINATOR)
+        .map(|pos| pos + HEADER_TERMINATOR.len())
+}
+
+fn parse_http_request(header: &str, body: Vec<u8>) -> Result<ParsedRequest> {
+    let mut lines = header.split("\r\n");
+    let request_line = lines
+        .next()
+        .ok_or_else(|| AnyTlsError::Protocol("Missing HTTP request line".into()))?;
+
+    let mut parts = request_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| AnyTlsError::Protocol("Invalid HTTP request line".into()))?;
+    let target = parts
+        .next()
+        .ok_or_else(|| AnyTlsError::Protocol("Invalid HTTP request line".into()))?;
+    let version = parts.next().unwrap_or("HTTP/1.1");
+
+    let header_lines: Vec<String> = lines
+        .map(|line| line.to_string())
+        .filter(|line| !line.is_empty())
+        .collect();
+
+    let (host, port, path, is_connect) = determine_target(method, target, &header_lines)?;
+
+    Ok(ParsedRequest {
+        method: method.to_string(),
+        version: version.to_string(),
+        host,
+        port,
+        path,
+        is_connect,
+        headers: header_lines,
+        body,
+    })
+}
+
+fn determine_target(
+    method: &str,
+    target: &str,
+    headers: &[String],
+) -> Result<(String, u16, String, bool)> {
+    if method.eq_ignore_ascii_case("CONNECT") {
+        let (host, port) = split_host_port(target, 443)?;
+        return Ok((host, port, String::new(), true));
+    }
+
+    let mut host_header: Option<String> = None;
+    for header in headers {
+        if let Some(rest) = header.strip_prefix("Host:") {
+            host_header = Some(rest.trim().to_string());
+            break;
+        } else if let Some(rest) = header.strip_prefix("host:") {
+            host_header = Some(rest.trim().to_string());
+            break;
+        }
+    }
+
+    let mut host = String::new();
+    let mut port = 80u16;
+    let mut path = target.to_string();
+
+    if target.starts_with("http://") || target.starts_with("https://") {
+        let without_scheme = if let Some(pos) = target.find("://") {
+            &target[pos + 3..]
+        } else {
+            target
+        };
+        if let Some(pos) = without_scheme.find('/') {
+            host = without_scheme[..pos].to_string();
+            path = without_scheme[pos..].to_string();
+        } else {
+            host = without_scheme.to_string();
+            path = "/".to_string();
+        }
+
+        if target.starts_with("https://") {
+            port = 443;
+        }
+    } else if let Some(h) = host_header.clone() {
+        host = h;
+    }
+
+    if host.is_empty() {
+        return Err(AnyTlsError::Protocol(
+            "Host header missing for HTTP request".into(),
+        ));
+    }
+
+    let (host_only, port_resolved) = split_host_port(&host, port)?;
+    if !path.starts_with('/') && !path.starts_with('*') {
+        path = format!("/{}", path);
+    }
+
+    Ok((host_only, port_resolved, path, false))
+}
+
+fn split_host_port(value: &str, default_port: u16) -> Result<(String, u16)> {
+    if let Some(idx) = value.rfind(':') {
+        if value[..idx].contains(':') && !value.contains(']') {
+            // Probably IPv6 without brackets; require default
+            return Ok((value.to_string(), default_port));
+        }
+        let host_part = &value[..idx];
+        let port_part = &value[idx + 1..];
+        if let Ok(port) = port_part.parse::<u16>() {
+            return Ok((
+                host_part
+                    .trim()
+                    .trim_matches('[')
+                    .trim_matches(']')
+                    .to_string(),
+                port,
+            ));
+        }
+    }
+    Ok((
+        value.trim().trim_matches('[').trim_matches(']').to_string(),
+        default_port,
+    ))
+}
+
+fn build_forward_request(req: &ParsedRequest) -> Result<Vec<u8>> {
+    let mut new_request = Vec::new();
+    let request_line = format!(
+        "{} {} {}\r\n",
+        req.method,
+        if req.path.is_empty() { "/" } else { &req.path },
+        req.version
+    );
+    new_request.extend_from_slice(request_line.as_bytes());
+
+    let host_header_value = if req.port == 80 || req.port == 443 {
+        req.host.clone()
+    } else {
+        format!("{}:{}", req.host, req.port)
+    };
+
+    let mut host_written = false;
+    for header in &req.headers {
+        if header.is_empty() {
+            continue;
+        }
+        if header.to_ascii_lowercase().starts_with("host:") {
+            host_written = true;
+            new_request.extend_from_slice(format!("Host: {}\r\n", host_header_value).as_bytes());
+        } else {
+            new_request.extend_from_slice(header.as_bytes());
+            new_request.extend_from_slice(b"\r\n");
+        }
+    }
+    if !host_written {
+        new_request.extend_from_slice(format!("Host: {}\r\n", host_header_value).as_bytes());
+    }
+    new_request.extend_from_slice(b"\r\n");
+    Ok(new_request)
+}
+
+async fn send_connect_success(stream: &mut TcpStream) -> Result<()> {
+    stream
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await
+        .map_err(AnyTlsError::Io)
+}
+
+async fn send_http_error(stream: &mut TcpStream, code: u16, message: &str) -> Result<()> {
+    let body = format!(
+        "HTTP/1.1 {} {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        code, message
+    );
+    stream
+        .write_all(body.as_bytes())
+        .await
+        .map_err(AnyTlsError::Io)
+}

--- a/crates/meow-anytls/src/client/mod.rs
+++ b/crates/meow-anytls/src/client/mod.rs
@@ -1,0 +1,14 @@
+//! Client implementation for AnyTLS protocol
+
+#[allow(clippy::module_inception)]
+pub mod client;
+pub mod http_proxy;
+pub mod session_pool;
+pub mod socks5;
+pub mod udp_client;
+
+pub use client::*;
+pub use http_proxy::*;
+pub use session_pool::*;
+pub use socks5::*;
+pub use udp_client::*;

--- a/crates/meow-anytls/src/client/session_pool.rs
+++ b/crates/meow-anytls/src/client/session_pool.rs
@@ -1,0 +1,395 @@
+//! Session pool for connection reuse with configurable cleanup
+
+use crate::session::Session;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, Instant, interval};
+use tracing::{field, info_span};
+
+/// Configuration for session pool
+#[derive(Debug, Clone)]
+pub struct SessionPoolConfig {
+    /// Interval for checking idle sessions (default: 30s)
+    pub check_interval: Duration,
+
+    /// Idle timeout for sessions (default: 60s)
+    pub idle_timeout: Duration,
+
+    /// Minimum number of idle sessions to keep (default: 1)
+    pub min_idle_sessions: usize,
+}
+
+impl Default for SessionPoolConfig {
+    fn default() -> Self {
+        Self {
+            check_interval: Duration::from_secs(30),
+            idle_timeout: Duration::from_secs(60),
+            min_idle_sessions: 1,
+        }
+    }
+}
+
+/// Pooled session with metadata
+struct PooledSession {
+    seq: u64,
+    session: Arc<Session>,
+    idle_since: Instant,
+}
+
+/// SessionPool manages idle sessions for reuse with automatic cleanup
+pub struct SessionPool {
+    // Sessions stored by seq (BTreeMap for ordered access)
+    idle_sessions: Arc<RwLock<BTreeMap<u64, PooledSession>>>,
+
+    // Sequence counter (monotonically increasing)
+    next_seq: Arc<AtomicU64>,
+
+    // Configuration
+    config: SessionPoolConfig,
+
+    // Cleanup task handle
+    cleanup_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl Default for SessionPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionPool {
+    /// Create a new session pool with default configuration
+    pub fn new() -> Self {
+        Self::with_config(SessionPoolConfig::default())
+    }
+
+    /// Create a new session pool with custom configuration
+    pub fn with_config(config: SessionPoolConfig) -> Self {
+        let pool = Self {
+            idle_sessions: Arc::new(RwLock::new(BTreeMap::new())),
+            next_seq: Arc::new(AtomicU64::new(1)),
+            config,
+            cleanup_task: Arc::new(Mutex::new(None)),
+        };
+
+        // Start automatic cleanup task
+        pool.start_cleanup_task();
+
+        pool
+    }
+
+    /// Get the next sequence number
+    pub fn next_seq(&self) -> u64 {
+        self.next_seq.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Get an idle session for reuse (the most recent live one, largest seq).
+    ///
+    /// The session is **left in the pool** (peek-and-touch, not remove): AnyTLS
+    /// multiplexes many streams over one session, so the same session stays
+    /// available for concurrent and subsequent streams and is only retired by
+    /// the cleanup task once it is genuinely idle. Removing-without-returning
+    /// here was the FD-leak root cause (issue meow-rs#201): a reused session
+    /// became orphaned — held alive forever by its own heartbeat task — and
+    /// never freed its socket, exhausting file descriptors under churn.
+    ///
+    /// Closed sessions encountered along the way are pruned.
+    pub async fn get_idle_session(&self) -> Option<Arc<Session>> {
+        let mut sessions = self.idle_sessions.write().await;
+
+        let mut closed = Vec::new();
+        let mut chosen = None;
+        // Iterate newest-first; reuse the first live session.
+        for (seq, pooled) in sessions.iter_mut().rev() {
+            if pooled.session.is_closed() {
+                closed.push(*seq);
+                continue;
+            }
+            pooled.idle_since = Instant::now();
+            tracing::debug!("[SessionPool] Reusing idle session (seq={})", pooled.seq);
+            chosen = Some(Arc::clone(&pooled.session));
+            break;
+        }
+
+        for seq in closed {
+            sessions.remove(&seq);
+        }
+
+        if chosen.is_none() {
+            tracing::debug!("[SessionPool] No idle sessions available");
+        }
+        chosen
+    }
+
+    /// Add a session to the idle pool
+    pub async fn add_idle_session(&self, session: Arc<Session>) {
+        if session.is_closed() {
+            tracing::debug!("[SessionPool] Session already closed, skipping add to pool");
+            return;
+        }
+        let seq = session.seq();
+
+        let pooled = PooledSession {
+            seq,
+            session,
+            idle_since: Instant::now(),
+        };
+
+        let mut sessions = self.idle_sessions.write().await;
+        sessions.insert(seq, pooled);
+
+        tracing::debug!(
+            "[SessionPool] ➕ Added session to pool (seq={}, total_idle={})",
+            seq,
+            sessions.len()
+        );
+    }
+
+    /// Get current number of idle sessions
+    pub async fn idle_count(&self) -> usize {
+        self.idle_sessions.read().await.len()
+    }
+
+    /// Clean up expired idle sessions
+    pub async fn cleanup_expired(&self) {
+        let now = Instant::now();
+        let mut sessions = self.idle_sessions.write().await;
+
+        if sessions.is_empty() {
+            return;
+        }
+
+        let initial_count = sessions.len();
+        let cleanup_span = info_span!(
+            "anytls.session_pool.cleanup",
+            idle_initial = initial_count as u64,
+            removed = field::Empty,
+            remaining = field::Empty
+        );
+        let _cleanup_guard = cleanup_span.enter();
+        let mut to_remove = Vec::new();
+        let mut active_count = 0;
+
+        // Iterate from oldest to newest (ascending seq order)
+        for (seq, pooled) in sessions.iter() {
+            let idle_duration = now.duration_since(pooled.idle_since);
+
+            if pooled.session.is_closed() {
+                to_remove.push(*seq);
+                continue;
+            }
+
+            // Never retire a session that is still carrying streams — pooled
+            // sessions are reused in place (see `get_idle_session`), so an
+            // active long-lived stream can outlive the idle timeout.
+            if pooled.session.has_active_streams().await {
+                active_count += 1;
+                continue;
+            }
+
+            // Keep sessions that haven't expired
+            if idle_duration < self.config.idle_timeout {
+                active_count += 1;
+                continue;
+            }
+
+            // Keep at least min_idle_sessions
+            if active_count < self.config.min_idle_sessions {
+                active_count += 1;
+                tracing::trace!(
+                    "[SessionPool] Keeping expired session (seq={}) to maintain min_idle={}",
+                    seq,
+                    self.config.min_idle_sessions
+                );
+                continue;
+            }
+
+            // Mark for removal
+            tracing::debug!(
+                "[SessionPool] 🗑️ Marking session for cleanup (seq={}, idle_for={:.1}s)",
+                seq,
+                idle_duration.as_secs_f64()
+            );
+            to_remove.push(*seq);
+        }
+
+        // Remove expired sessions
+        for seq in &to_remove {
+            if let Some(pooled) = sessions.remove(seq) {
+                // Close the session
+                if let Err(e) = pooled.session.close().await {
+                    tracing::warn!("[SessionPool] Failed to close session {}: {}", seq, e);
+                }
+            }
+        }
+
+        let removed = to_remove.len();
+        if removed > 0 {
+            tracing::debug!(
+                "[SessionPool] Cleaned up {} expired sessions ({} -> {} idle)",
+                removed,
+                initial_count,
+                sessions.len()
+            );
+        }
+        cleanup_span.record("removed", removed as u64);
+        cleanup_span.record("remaining", sessions.len() as u64);
+    }
+
+    /// Start automatic cleanup task
+    fn start_cleanup_task(&self) {
+        let idle_sessions = Arc::clone(&self.idle_sessions);
+        let check_interval = self.config.check_interval;
+        let idle_timeout = self.config.idle_timeout;
+        let min_idle = self.config.min_idle_sessions;
+        let cleanup_task_handle = Arc::clone(&self.cleanup_task);
+
+        let handle = tokio::spawn(async move {
+            let mut interval_timer = interval(check_interval);
+
+            tracing::debug!(
+                "[SessionPool] Cleanup task started (interval={:?}, timeout={:?}, min_idle={})",
+                check_interval,
+                idle_timeout,
+                min_idle
+            );
+
+            loop {
+                interval_timer.tick().await;
+
+                // Perform cleanup
+                let now = Instant::now();
+                let mut sessions = idle_sessions.write().await;
+
+                if sessions.is_empty() {
+                    continue;
+                }
+
+                let mut to_remove = Vec::new();
+                let mut active_count = 0;
+
+                for (seq, pooled) in sessions.iter() {
+                    let idle_duration = now.duration_since(pooled.idle_since);
+
+                    if pooled.session.is_closed() {
+                        to_remove.push(*seq);
+                        continue;
+                    }
+
+                    // Don't retire a session still carrying streams.
+                    if pooled.session.has_active_streams().await {
+                        active_count += 1;
+                        continue;
+                    }
+
+                    if idle_duration < idle_timeout {
+                        active_count += 1;
+                        continue;
+                    }
+
+                    if active_count < min_idle {
+                        active_count += 1;
+                        continue;
+                    }
+
+                    to_remove.push(*seq);
+                }
+
+                if !to_remove.is_empty() {
+                    for seq in &to_remove {
+                        if let Some(pooled) = sessions.remove(seq)
+                            && let Err(e) = pooled.session.close().await
+                        {
+                            tracing::warn!("[SessionPool] Failed to close session {}: {}", seq, e);
+                        }
+                    }
+
+                    tracing::debug!(
+                        "[SessionPool] Auto-cleanup: removed {} expired sessions",
+                        to_remove.len()
+                    );
+                }
+            }
+        });
+
+        // Store the handle
+        if let Ok(mut task) = cleanup_task_handle.try_lock() {
+            *task = Some(handle);
+        };
+    }
+
+    /// Stop cleanup task (called on drop)
+    pub async fn stop_cleanup_task(&self) {
+        let mut task_guard = self.cleanup_task.lock().await;
+        if let Some(handle) = task_guard.take() {
+            handle.abort();
+            tracing::debug!("[SessionPool] Cleanup task stopped");
+        }
+    }
+}
+
+impl Drop for SessionPool {
+    fn drop(&mut self) {
+        // Attempt to stop cleanup task
+        // Note: This is best-effort since Drop is sync
+        if let Ok(mut task) = self.cleanup_task.try_lock()
+            && let Some(handle) = task.take()
+        {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = SessionPoolConfig::default();
+        assert_eq!(config.check_interval, Duration::from_secs(30));
+        assert_eq!(config.idle_timeout, Duration::from_secs(60));
+        assert_eq!(config.min_idle_sessions, 1);
+    }
+
+    #[test]
+    fn test_custom_config() {
+        let config = SessionPoolConfig {
+            check_interval: Duration::from_secs(10),
+            idle_timeout: Duration::from_secs(30),
+            min_idle_sessions: 5,
+        };
+
+        assert_eq!(config.check_interval, Duration::from_secs(10));
+        assert_eq!(config.idle_timeout, Duration::from_secs(30));
+        assert_eq!(config.min_idle_sessions, 5);
+    }
+
+    #[tokio::test]
+    async fn test_session_pool_creation() {
+        let pool = SessionPool::new();
+        assert_eq!(pool.idle_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_next_seq() {
+        let pool = SessionPool::new();
+        let seq1 = pool.next_seq();
+        let seq2 = pool.next_seq();
+        let seq3 = pool.next_seq();
+
+        assert_eq!(seq1, 1);
+        assert_eq!(seq2, 2);
+        assert_eq!(seq3, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_idle_session_empty() {
+        let pool = SessionPool::new();
+        let session = pool.get_idle_session().await;
+        assert!(session.is_none());
+    }
+}

--- a/crates/meow-anytls/src/client/socks5.rs
+++ b/crates/meow-anytls/src/client/socks5.rs
@@ -1,0 +1,476 @@
+//! SOCKS5 protocol implementation for AnyTLS client
+//!
+//! Implements RFC 1928 SOCKS5 protocol to accept client connections
+//! and forward them through AnyTLS Stream
+
+use crate::client::Client;
+use crate::util::{AnyTlsError, Result};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// SOCKS5 version
+const SOCKS5_VERSION: u8 = 0x05;
+
+/// SOCKS5 authentication methods
+const AUTH_NO_AUTHENTICATION: u8 = 0x00;
+const AUTH_NOT_ACCEPTABLE: u8 = 0xFF;
+
+/// SOCKS5 command types
+#[allow(dead_code)]
+const CMD_CONNECT: u8 = 0x01;
+#[allow(dead_code)]
+const CMD_BIND: u8 = 0x02;
+#[allow(dead_code)]
+const CMD_UDP_ASSOCIATE: u8 = 0x03;
+
+/// SOCKS5 address types
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
+
+/// SOCKS5 reply codes
+const REPLY_SUCCEEDED: u8 = 0x00;
+const REPLY_GENERAL_FAILURE: u8 = 0x01;
+#[allow(dead_code)]
+const REPLY_CONNECTION_NOT_ALLOWED: u8 = 0x02;
+#[allow(dead_code)]
+const REPLY_NETWORK_UNREACHABLE: u8 = 0x03;
+#[allow(dead_code)]
+const REPLY_HOST_UNREACHABLE: u8 = 0x04;
+#[allow(dead_code)]
+const REPLY_CONNECTION_REFUSED: u8 = 0x05;
+#[allow(dead_code)]
+const REPLY_TTL_EXPIRED: u8 = 0x06;
+#[allow(dead_code)]
+const REPLY_COMMAND_NOT_SUPPORTED: u8 = 0x07;
+#[allow(dead_code)]
+const REPLY_ADDRESS_TYPE_NOT_SUPPORTED: u8 = 0x08;
+
+/// SOCKS5 address representation
+#[derive(Debug, Clone)]
+struct Socks5Addr {
+    addr: String,
+    port: u16,
+}
+
+/// Start SOCKS5 server that accepts connections and forwards them through Client
+pub async fn start_socks5_server(listen_addr: &str, client: Arc<Client>) -> Result<()> {
+    let listener = TcpListener::bind(listen_addr).await?;
+
+    tracing::info!("[SOCKS5] Listening on {}", listen_addr);
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, addr)) => {
+                tracing::debug!("[SOCKS5] New connection from {}", addr);
+
+                let client_clone = Arc::clone(&client);
+                tokio::spawn(async move {
+                    if let Err(e) = handle_socks5_connection(stream, client_clone).await {
+                        tracing::error!("[SOCKS5] Connection error: {}", e);
+                    }
+                });
+            }
+            Err(e) => {
+                tracing::error!("[SOCKS5] Accept error: {}", e);
+            }
+        }
+    }
+}
+
+/// Handle a single SOCKS5 connection
+async fn handle_socks5_connection(
+    mut client_conn: tokio::net::TcpStream,
+    client: Arc<Client>,
+) -> Result<()> {
+    // Step 1: Authentication negotiation
+    tracing::debug!("[SOCKS5] Starting authentication negotiation");
+    authenticate(&mut client_conn).await?;
+    tracing::debug!("[SOCKS5] Authentication completed");
+
+    // Step 2: Read connection request
+    tracing::debug!("[SOCKS5] Reading connection request");
+    let (dest_addr, _cmd) = read_connection_request(&mut client_conn).await?;
+    tracing::debug!(
+        "[SOCKS5] Connection request: {}:{}",
+        dest_addr.addr,
+        dest_addr.port
+    );
+
+    // Step 3: Create proxy connection through AnyTLS
+    tracing::debug!(
+        "[SOCKS5] Creating proxy stream to {}:{}",
+        dest_addr.addr,
+        dest_addr.port
+    );
+    let (proxy_stream, session) = match client
+        .create_proxy_stream((dest_addr.addr.clone(), dest_addr.port))
+        .await
+    {
+        Ok((stream, sess)) => {
+            tracing::debug!(
+                "[SOCKS5] Proxy stream created successfully for {}:{}, stream_id={}",
+                dest_addr.addr,
+                dest_addr.port,
+                stream.id()
+            );
+            tracing::debug!("[SOCKS5] Session status: closed={}", sess.is_closed());
+            (stream, sess)
+        }
+        Err(e) => {
+            tracing::error!(
+                "[SOCKS5] Failed to create proxy stream to {}:{}: {}",
+                dest_addr.addr,
+                dest_addr.port,
+                e
+            );
+            // Try to provide more helpful error messages
+            let error_str = format!("{}", e);
+            if error_str.contains("lookup")
+                || error_str.contains("DNS")
+                || error_str.contains("Try again")
+            {
+                tracing::error!(
+                    "[SOCKS5] DNS resolution failed. Server address may be incorrect or unreachable."
+                );
+                tracing::error!(
+                    "[SOCKS5] Check: 1) Server is running, 2) Server address is correct, 3) Network connectivity"
+                );
+            }
+            send_connection_reply(&mut client_conn, REPLY_GENERAL_FAILURE, dest_addr.clone())
+                .await?;
+            return Err(e);
+        }
+    };
+    let stream_id = proxy_stream.id();
+
+    // Step 4: Send success reply
+    tracing::debug!("[SOCKS5] Sending success reply to client");
+    send_connection_reply(&mut client_conn, REPLY_SUCCEEDED, dest_addr.clone()).await?;
+    tracing::debug!("[SOCKS5] Success reply sent");
+
+    // Step 5: Bidirectional data forwarding
+    tracing::debug!(
+        "[SOCKS5] Starting bidirectional data forwarding for stream {}",
+        stream_id
+    );
+    tracing::debug!(
+        "[SOCKS5] Session recv_loop should be running: {}",
+        !session.is_closed()
+    );
+    let (mut client_read, mut client_write) = tokio::io::split(client_conn);
+
+    // ===== 新实现：不再需要 Arc<Mutex<>> 包装！=====
+    // 直接克隆 Arc<Stream> 用于两个任务
+    let proxy_stream_read = Arc::clone(&proxy_stream);
+    let session_for_write: Arc<crate::session::Session> = Arc::clone(&session);
+
+    tracing::debug!("[SOCKS5] Spawning Task1 and Task2 for stream {}", stream_id);
+
+    let task1 = tokio::spawn(async move {
+        tracing::debug!("[SOCKS5-Task1] Task started for stream {}", stream_id);
+
+        // 获取 reader 的引用（无需锁整个 stream）
+        let reader_mutex = proxy_stream_read.reader();
+        let mut buf = vec![0u8; 8192];
+        let mut iteration = 0u64;
+
+        loop {
+            iteration += 1;
+
+            // 获取 reader 的锁并读取
+            let n = {
+                let mut reader = reader_mutex.lock().await;
+                match reader.read(&mut buf).await {
+                    Ok(0) => {
+                        tracing::debug!(
+                            "[SOCKS5-Task1] Proxy stream EOF (stream_id={}, iteration={})",
+                            stream_id,
+                            iteration
+                        );
+                        break;
+                    }
+                    Ok(n) => {
+                        tracing::debug!(
+                            "[SOCKS5-Task1] Read {} bytes from proxy stream (iteration={})",
+                            n,
+                            iteration
+                        );
+                        n
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "[SOCKS5-Task1] Proxy stream read error: {} (iteration={})",
+                            e,
+                            iteration
+                        );
+                        break;
+                    }
+                }
+            }; // reader 锁在这里释放
+
+            // 写入 SOCKS5 客户端（无锁）
+            if client_write.write_all(&buf[..n]).await.is_err() {
+                tracing::error!(
+                    "[SOCKS5-Task1] Client write error (iteration={})",
+                    iteration
+                );
+                break;
+            }
+
+            tracing::trace!(
+                "[SOCKS5-Task1] Forwarded {} bytes to client (iteration={})",
+                n,
+                iteration
+            );
+        }
+
+        tracing::debug!(
+            "[SOCKS5-Task1] Task completed for stream {} after {} iterations",
+            stream_id,
+            iteration
+        );
+    });
+
+    let task2 = tokio::spawn(async move {
+        tracing::debug!(
+            "[SOCKS5-Task2] Task spawned, starting client->proxy forwarding for stream {}",
+            stream_id
+        );
+        use bytes::Bytes;
+        let mut buf = vec![0u8; 8192];
+        let mut iteration = 0u64;
+
+        // Yield to ensure task is actually running
+        tokio::task::yield_now().await;
+
+        loop {
+            iteration += 1;
+            tracing::trace!(
+                "[SOCKS5-Task2] Iteration {}: Attempting to read from SOCKS5 client",
+                iteration
+            );
+
+            let n = match client_read.read(&mut buf).await {
+                Ok(0) => {
+                    tracing::debug!(
+                        "[SOCKS5-Task2] SOCKS5 client read EOF (iteration {})",
+                        iteration
+                    );
+                    break;
+                }
+                Ok(n) => {
+                    tracing::debug!(
+                        "[SOCKS5-Task2] Read {} bytes from SOCKS5 client (iteration {})",
+                        n,
+                        iteration
+                    );
+                    // Log first few bytes for debugging (only in trace mode)
+                    if iteration == 1 && n > 0 {
+                        let preview_len = std::cmp::min(n, 50);
+                        tracing::trace!(
+                            "[SOCKS5-Task2] First {} bytes: {:?}",
+                            preview_len,
+                            &buf[..preview_len]
+                        );
+                    }
+                    n
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "[SOCKS5-Task2] Error reading from SOCKS5 client: {} (iteration {})",
+                        e,
+                        iteration
+                    );
+                    break;
+                }
+            };
+
+            // Use session.write_data_frame to send data without unwrapping Arc<Stream>
+            tracing::debug!(
+                "[SOCKS5-Task2] Writing {} bytes to proxy stream {} via session (iteration {})",
+                n,
+                stream_id,
+                iteration
+            );
+            match session_for_write
+                .write_data_frame(stream_id, Bytes::from(buf[..n].to_vec()))
+                .await
+            {
+                Ok(_) => {
+                    tracing::trace!(
+                        "[SOCKS5-Task2] Forwarded {} bytes to proxy stream {} (iteration {})",
+                        n,
+                        stream_id,
+                        iteration
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "[SOCKS5-Task2] Error writing {} bytes to proxy stream {}: {} (iteration {})",
+                        n,
+                        stream_id,
+                        e,
+                        iteration
+                    );
+                    break;
+                }
+            }
+        }
+        tracing::debug!(
+            "[SOCKS5-Task2] Task2 (client->proxy) finished for stream {} after {} iterations",
+            stream_id,
+            iteration
+        );
+    });
+
+    tracing::debug!(
+        "[SOCKS5] Tasks spawned, waiting for completion (stream {})",
+        stream_id
+    );
+    let (result1, result2) = tokio::join!(task1, task2);
+    tracing::debug!("[SOCKS5] Both tasks completed for stream {}", stream_id);
+    if let Err(e) = result1 {
+        tracing::error!("[SOCKS5] Task1 error: {:?}", e);
+    }
+    if let Err(e) = result2 {
+        tracing::error!("[SOCKS5] Task2 error: {:?}", e);
+    }
+
+    tracing::debug!(
+        "[SOCKS5] Connection to {}:{} closed",
+        dest_addr.addr,
+        dest_addr.port
+    );
+    Ok(())
+}
+
+/// Perform SOCKS5 authentication handshake
+async fn authenticate(conn: &mut tokio::net::TcpStream) -> Result<()> {
+    // Read client greeting: [VER (1) | NMETHODS (1) | METHODS (NMETHODS)]
+    let mut buf = [0u8; 2];
+    conn.read_exact(&mut buf).await?;
+
+    let version = buf[0];
+    if version != SOCKS5_VERSION {
+        return Err(AnyTlsError::Protocol(format!(
+            "Unsupported SOCKS version: {}",
+            version
+        )));
+    }
+
+    let nmethods = buf[1] as usize;
+    if nmethods == 0 {
+        return Err(AnyTlsError::Protocol(
+            "No authentication methods provided".to_string(),
+        ));
+    }
+
+    let mut methods = vec![0u8; nmethods];
+    conn.read_exact(&mut methods).await?;
+
+    // Check if NO AUTHENTICATION is supported
+    let supports_no_auth = methods.contains(&AUTH_NO_AUTHENTICATION);
+
+    // Send server selection: [VER (1) | METHOD (1)]
+    if supports_no_auth {
+        conn.write_all(&[SOCKS5_VERSION, AUTH_NO_AUTHENTICATION])
+            .await?;
+    } else {
+        conn.write_all(&[SOCKS5_VERSION, AUTH_NOT_ACCEPTABLE])
+            .await?;
+        return Err(AnyTlsError::Protocol(
+            "Client does not support NO AUTHENTICATION".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Read SOCKS5 connection request
+/// Returns (destination address, command)
+async fn read_connection_request(conn: &mut tokio::net::TcpStream) -> Result<(Socks5Addr, u8)> {
+    // Read request header: [VER (1) | CMD (1) | RSV (1) | ATYP (1)]
+    let mut header = [0u8; 4];
+    conn.read_exact(&mut header).await?;
+
+    let version = header[0];
+    if version != SOCKS5_VERSION {
+        return Err(AnyTlsError::Protocol(format!(
+            "Invalid SOCKS version: {}",
+            version
+        )));
+    }
+
+    let cmd = header[1];
+    let _rsv = header[2]; // Reserved, should be 0x00
+    let atyp = header[3];
+
+    // Read address based on ATYP
+    let addr = match atyp {
+        ATYP_IPV4 => {
+            let mut ip_buf = [0u8; 4];
+            conn.read_exact(&mut ip_buf).await?;
+            IpAddr::V4(Ipv4Addr::from(ip_buf)).to_string()
+        }
+        ATYP_DOMAIN => {
+            let mut len_buf = [0u8; 1];
+            conn.read_exact(&mut len_buf).await?;
+            let domain_len = len_buf[0] as usize;
+            if domain_len == 0 || domain_len > 255 {
+                return Err(AnyTlsError::Protocol("Invalid domain length".to_string()));
+            }
+            let mut domain_buf = vec![0u8; domain_len];
+            conn.read_exact(&mut domain_buf).await?;
+            String::from_utf8(domain_buf)
+                .map_err(|e| AnyTlsError::Protocol(format!("Invalid domain name: {}", e)))?
+        }
+        ATYP_IPV6 => {
+            let mut ip_buf = [0u8; 16];
+            conn.read_exact(&mut ip_buf).await?;
+            IpAddr::V6(Ipv6Addr::from(ip_buf)).to_string()
+        }
+        _ => {
+            return Err(AnyTlsError::Protocol(format!(
+                "Unsupported address type: 0x{:02x}",
+                atyp
+            )));
+        }
+    };
+
+    // Read port (2 bytes, big-endian)
+    let mut port_buf = [0u8; 2];
+    conn.read_exact(&mut port_buf).await?;
+    let port = u16::from_be_bytes(port_buf);
+
+    Ok((Socks5Addr { addr, port }, cmd))
+}
+
+/// Send SOCKS5 connection reply
+async fn send_connection_reply(
+    conn: &mut tokio::net::TcpStream,
+    reply: u8,
+    _addr: Socks5Addr,
+) -> Result<()> {
+    // Reply format: [VER (1) | REP (1) | RSV (1) | ATYP (1) | BND.ADDR (variable) | BND.PORT (2)]
+    // For simplicity, we'll use IPv4 0.0.0.0:0 as bound address
+    let reply_buf = vec![
+        SOCKS5_VERSION,
+        reply,
+        0x00, // RSV
+        ATYP_IPV4,
+        0x00,
+        0x00,
+        0x00,
+        0x00, // BND.ADDR (0.0.0.0)
+        0x00,
+        0x00, // BND.PORT (0)
+    ];
+
+    conn.write_all(&reply_buf).await?;
+    conn.flush().await?;
+
+    Ok(())
+}

--- a/crates/meow-anytls/src/client/udp_client.rs
+++ b/crates/meow-anytls/src/client/udp_client.rs
@@ -1,0 +1,366 @@
+//! Client-side UDP over TCP implementation
+//!
+//! Implements sing-box udp-over-tcp v2 protocol (Connect format)
+
+use crate::client::Client;
+use crate::util::{AnyTlsError, Result};
+use bytes::{BufMut, Bytes, BytesMut};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::Mutex;
+
+const MAX_UDP_PACKET_SIZE: usize = 65535;
+
+/// Magic address for UDP over TCP v2
+pub const UDP_OVER_TCP_MAGIC_ADDR: &str = "sp.v2.udp-over-tcp.arpa";
+
+impl Client {
+    /// Create a UDP over TCP proxy connection
+    ///
+    /// This creates a special stream to the magic address "sp.v2.udp-over-tcp.arpa"
+    /// and then sends the actual UDP target address in the initial request.
+    ///
+    /// # Arguments
+    /// * `local_addr` - Local address to bind UDP socket to (e.g. "127.0.0.1:0")
+    /// * `target_addr` - Target UDP server address
+    ///
+    /// # Returns
+    /// Local UDP socket address that the application should connect to
+    pub async fn create_udp_proxy(
+        &self,
+        local_addr: &str,
+        target_addr: SocketAddr,
+    ) -> Result<SocketAddr> {
+        tracing::debug!(
+            "[UDP Client] Creating UDP over TCP proxy: local={}, target={}",
+            local_addr,
+            target_addr
+        );
+
+        // Step 1: Create a stream to the magic address
+        let magic_destination = (UDP_OVER_TCP_MAGIC_ADDR.to_string(), 0);
+        let (stream, _session) = self.create_proxy_stream(magic_destination).await?;
+
+        tracing::debug!(
+            "[UDP Client] Created stream {} for UDP over TCP",
+            stream.id()
+        );
+
+        // Step 2: Send initial request (isConnect + target address)
+        let initial_request = encode_initial_request(target_addr)?;
+
+        tracing::debug!(
+            "[UDP Client] Sending initial request ({} bytes) for stream {}",
+            initial_request.len(),
+            stream.id()
+        );
+
+        // Send the initial request
+        stream
+            .send_data(initial_request)
+            .map_err(|e| AnyTlsError::Protocol(format!("Failed to send initial request: {}", e)))?;
+
+        tracing::debug!(
+            "[UDP Client] Initial request sent to stream {}",
+            stream.id()
+        );
+
+        // Step 3: Create local UDP socket via the socket-protect helper so a
+        // host VPN (Android) can call `VpnService.protect(fd)` before the
+        // bind — otherwise relayed datagrams loop back into the same VPN.
+        // Off-Android the helper degrades to `UdpSocket::bind`.
+        let local_udp = crate::util::socket_protect::bind_udp(local_addr)
+            .await
+            .map_err(|e| {
+                tracing::error!("[UDP Client] Failed to bind UDP socket: {}", e);
+                AnyTlsError::Io(e)
+            })?;
+
+        let bound_addr = local_udp.local_addr()?;
+        tracing::debug!("[UDP Client] Local UDP socket bound to {}", bound_addr);
+
+        // Step 4: Start bidirectional forwarding
+        let stream_clone = stream.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = udp_proxy_loop(local_udp, stream_clone).await {
+                tracing::error!("[UDP Client] Proxy loop error: {}", e);
+            }
+        });
+
+        tracing::debug!(
+            "[UDP Client] UDP proxy started: {} <-> {}",
+            bound_addr,
+            target_addr
+        );
+
+        Ok(bound_addr)
+    }
+}
+
+/// Encode initial request for UDP over TCP v2
+///
+/// Format:
+/// ```text
+/// | isConnect | ATYP | Address | Port |
+/// | u8 (=1)   | u8   | variable| u16be|
+/// ```
+fn encode_initial_request(target: SocketAddr) -> Result<Bytes> {
+    let mut buf = BytesMut::new();
+
+    // isConnect = 1 (use Connect format)
+    buf.put_u8(1);
+
+    // Encode target address in SOCKS5 format
+    match target {
+        SocketAddr::V4(addr) => {
+            buf.put_u8(0x01); // IPv4
+            buf.put_slice(&addr.ip().octets());
+            buf.put_u16(addr.port());
+        }
+        SocketAddr::V6(addr) => {
+            buf.put_u8(0x04); // IPv6
+            buf.put_slice(&addr.ip().octets());
+            buf.put_u16(addr.port());
+        }
+    }
+
+    Ok(buf.freeze())
+}
+
+/// Main UDP proxy loop: bidirectional forwarding between local UDP and remote stream
+async fn udp_proxy_loop(local_udp: UdpSocket, stream: Arc<crate::session::Stream>) -> Result<()> {
+    let stream_id = stream.id();
+
+    tracing::debug!("[UDP Client] Starting proxy loop for stream {}", stream_id);
+
+    let last_peer = Arc::new(Mutex::new(None::<SocketAddr>));
+
+    // Bidirectional forwarding
+    tokio::select! {
+        result = udp_to_stream(&local_udp, &stream, last_peer.clone()) => {
+            if let Err(e) = result {
+                tracing::error!("[UDP Client] UDP → Stream error: {}", e);
+                return Err(e);
+            }
+        }
+        result = stream_to_udp(&local_udp, &stream, last_peer.clone()) => {
+            if let Err(e) = result {
+                tracing::error!("[UDP Client] Stream → UDP error: {}", e);
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// UDP → Stream: Read from local UDP, encode and send to stream
+async fn udp_to_stream(
+    udp: &UdpSocket,
+    stream: &Arc<crate::session::Stream>,
+    last_peer: Arc<Mutex<Option<SocketAddr>>>,
+) -> Result<()> {
+    let stream_id = stream.id();
+
+    tracing::debug!(
+        "[UDP Client] UDP → Stream task started for stream {}",
+        stream_id
+    );
+
+    let mut buf = vec![0u8; MAX_UDP_PACKET_SIZE];
+
+    loop {
+        // Receive from local UDP
+        let (len, addr) = match udp.recv_from(&mut buf).await {
+            Ok((len, addr)) => (len, addr),
+            Err(e) => {
+                tracing::error!("[UDP Client] Failed to receive from UDP: {}", e);
+                return Err(AnyTlsError::Io(e));
+            }
+        };
+
+        {
+            let mut guard = last_peer.lock().await;
+            *guard = Some(addr);
+        }
+
+        tracing::trace!("[UDP Client] UDP → Stream: {} bytes from {}", len, addr);
+
+        // Encode packet: Length (2 bytes) + Data
+        let packet = encode_udp_packet(&buf[..len])?;
+
+        // Send to stream
+        stream.send_data(packet).map_err(|e| {
+            tracing::error!("[UDP Client] Failed to send to stream: {}", e);
+            AnyTlsError::Protocol("Channel send failed".into())
+        })?;
+    }
+}
+
+/// Stream → UDP: Read from stream, decode and send to local UDP
+async fn stream_to_udp(
+    udp: &UdpSocket,
+    stream: &Arc<crate::session::Stream>,
+    last_peer: Arc<Mutex<Option<SocketAddr>>>,
+) -> Result<()> {
+    let stream_id = stream.id();
+    let reader = stream.reader();
+
+    tracing::debug!(
+        "[UDP Client] Stream → UDP task started for stream {}",
+        stream_id
+    );
+
+    // We need to track the peer address for sending back
+    // In a real implementation, the first packet might contain address info
+    // For now, we'll just send to a fixed address or handle it differently
+    loop {
+        let mut reader_guard = reader.lock().await;
+
+        // Read one UDP packet (Length + Data format)
+        let payload = match read_udp_packet(&mut reader_guard).await {
+            Ok(data) => data,
+            Err(e) => {
+                if e.to_string().contains("UnexpectedEof") || e.to_string().contains("EOF") {
+                    tracing::debug!("[UDP Client] Stream closed (EOF), stopping Stream → UDP");
+                    break;
+                }
+                tracing::error!("[UDP Client] Failed to read UDP packet from stream: {}", e);
+                return Err(e);
+            }
+        };
+
+        drop(reader_guard);
+
+        if payload.is_empty() {
+            tracing::debug!("[UDP Client] Empty packet, stream might be closed");
+            break;
+        }
+
+        tracing::trace!("[UDP Client] Stream → UDP: {} bytes", payload.len());
+
+        // Determine the most recent peer address we received from
+        let target = { *last_peer.lock().await };
+
+        if let Some(addr) = target {
+            let sent = udp.send_to(&payload, addr).await?;
+
+            if sent != payload.len() {
+                tracing::warn!(
+                    "[UDP Client] Partial UDP send: {} / {} bytes",
+                    sent,
+                    payload.len()
+                );
+            }
+        } else {
+            tracing::warn!(
+                "[UDP Client] No peer address known yet, dropping {}-byte packet",
+                payload.len()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Read one UDP packet from stream
+///
+/// Format: | Length (2 bytes BE) | Payload |
+async fn read_udp_packet(reader: &mut crate::session::StreamReader) -> Result<Vec<u8>> {
+    // Read 2-byte length (Big-Endian)
+    let mut len_buf = [0u8; 2];
+    reader
+        .read_exact(&mut len_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let len = u16::from_be_bytes(len_buf) as usize;
+
+    if len == 0 {
+        return Ok(Vec::new());
+    }
+
+    if len > MAX_UDP_PACKET_SIZE {
+        return Err(AnyTlsError::Protocol(format!(
+            "UDP packet too large: {} bytes",
+            len
+        )));
+    }
+
+    // Read the actual payload
+    let mut data = vec![0u8; len];
+    reader
+        .read_exact(&mut data)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    Ok(data)
+}
+
+/// Encode UDP packet (simple format)
+///
+/// Format: | Length (2 bytes BE) | Payload |
+fn encode_udp_packet(payload: &[u8]) -> Result<Bytes> {
+    let mut buf = BytesMut::new();
+
+    if payload.len() > MAX_UDP_PACKET_SIZE {
+        return Err(AnyTlsError::Protocol(format!(
+            "UDP packet too large: {} bytes",
+            payload.len()
+        )));
+    }
+
+    // Write length (2 bytes, Big-Endian)
+    buf.put_u16(payload.len() as u16);
+
+    // Write payload
+    buf.put_slice(payload);
+
+    Ok(buf.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_initial_request_ipv4() {
+        let addr: SocketAddr = "8.8.8.8:53".parse().unwrap();
+        let encoded = encode_initial_request(addr).unwrap();
+
+        // Should be: isConnect (1) + ATYP (1) + IPv4 (4) + Port (2) = 8 bytes
+        assert_eq!(encoded.len(), 8);
+        assert_eq!(encoded[0], 1); // isConnect = 1
+        assert_eq!(encoded[1], 0x01); // IPv4
+        assert_eq!(&encoded[2..6], &[8, 8, 8, 8]); // IP
+        assert_eq!(u16::from_be_bytes([encoded[6], encoded[7]]), 53); // Port
+    }
+
+    #[test]
+    fn test_encode_initial_request_ipv6() {
+        let addr: SocketAddr = "[2001:4860:4860::8888]:53".parse().unwrap();
+        let encoded = encode_initial_request(addr).unwrap();
+
+        // Should be: isConnect (1) + ATYP (1) + IPv6 (16) + Port (2) = 20 bytes
+        assert_eq!(encoded.len(), 20);
+        assert_eq!(encoded[0], 1); // isConnect = 1
+        assert_eq!(encoded[1], 0x04); // IPv6
+        assert_eq!(u16::from_be_bytes([encoded[18], encoded[19]]), 53); // Port
+    }
+
+    #[test]
+    fn test_encode_udp_packet() {
+        let payload = b"Hello, UDP!";
+        let encoded = encode_udp_packet(payload).unwrap();
+
+        // Check length prefix
+        let len = u16::from_be_bytes([encoded[0], encoded[1]]) as usize;
+        assert_eq!(len, payload.len());
+        assert_eq!(encoded.len(), 2 + payload.len());
+
+        // Check payload
+        assert_eq!(&encoded[2..], payload);
+    }
+}

--- a/crates/meow-anytls/src/lib.rs
+++ b/crates/meow-anytls/src/lib.rs
@@ -1,0 +1,35 @@
+//! AnyTLS protocol implementation in Rust
+//!
+//! A proxy protocol attempting to mitigate TLS in TLS fingerprinting issues.
+//!
+//! # Architecture
+//!
+//! - **protocol**: Frame and codec implementation
+//! - **session**: Session and stream management
+//! - **padding**: Traffic obfuscation padding
+//! - **util**: Utilities (error handling, auth, TLS config)
+//! - **client**: Client implementation
+//! - **server**: Server implementation
+
+/// Client implementation
+pub mod client;
+/// Padding module for traffic obfuscation
+pub mod padding;
+/// Protocol layer: Frame and codec implementation
+pub mod protocol;
+/// Server implementation
+pub mod server;
+/// Session layer: Session and stream management
+pub mod session;
+/// Utility modules (error, auth, TLS, etc.)
+pub mod util;
+
+pub use client::*;
+pub use padding::*;
+pub use protocol::*;
+pub use session::*;
+pub use util::*;
+
+// Re-export commonly used types
+pub use util::auth::{authenticate_client, hash_password, send_authentication};
+pub use util::error::{AnyTlsError, Result};

--- a/crates/meow-anytls/src/padding/factory.rs
+++ b/crates/meow-anytls/src/padding/factory.rs
@@ -1,0 +1,175 @@
+use crate::padding::CHECK_MARK;
+use crate::util::StringMap;
+use std::sync::Arc;
+
+/// Default padding scheme
+pub const DEFAULT_PADDING_SCHEME: &str = r#"stop=8
+0=30-30
+1=100-400
+2=400-500,c,500-1000,c,500-1000,c,500-1000,c,500-1000
+3=9-9,500-1000
+4=500-1000
+5=500-1000
+6=500-1000
+7=500-1000"#;
+
+/// PaddingFactory generates padding sizes according to the scheme
+#[derive(Debug, Clone)]
+pub struct PaddingFactory {
+    scheme: StringMap,
+    raw_scheme: Vec<u8>,
+    stop: u32,
+    md5: String,
+}
+
+/// Global padding factory
+static DEFAULT_FACTORY: std::sync::OnceLock<Arc<PaddingFactory>> = std::sync::OnceLock::new();
+
+impl PaddingFactory {
+    /// Create a new PaddingFactory from raw scheme bytes
+    pub fn new(raw_scheme: &[u8]) -> Result<Self, String> {
+        let scheme = StringMap::from_bytes(raw_scheme);
+
+        let stop = scheme
+            .get("stop")
+            .ok_or_else(|| "missing 'stop' in padding scheme".to_string())?
+            .parse::<u32>()
+            .map_err(|_| "invalid 'stop' value".to_string())?;
+
+        let md5_hash = md5::compute(raw_scheme);
+        let md5 = format!("{:x}", md5_hash);
+
+        Ok(Self {
+            scheme,
+            raw_scheme: raw_scheme.to_vec(),
+            stop,
+            md5,
+        })
+    }
+
+    /// Get the default padding factory
+    ///
+    /// Note: This is not the `Default` trait implementation to avoid confusion
+    /// with creating a new factory. This returns a shared singleton instance.
+    #[allow(clippy::should_implement_trait)]
+    pub fn default() -> Arc<Self> {
+        DEFAULT_FACTORY
+            .get_or_init(|| {
+                Arc::new(
+                    Self::new(DEFAULT_PADDING_SCHEME.as_bytes())
+                        .expect("default padding scheme should be valid"),
+                )
+            })
+            .clone()
+    }
+
+    /// Update the default padding factory
+    pub fn update_default(raw_scheme: &[u8]) -> Result<(), String> {
+        let factory = Arc::new(Self::new(raw_scheme)?);
+        DEFAULT_FACTORY
+            .set(factory)
+            .map_err(|_| "failed to update default factory".to_string())
+    }
+
+    /// Get the stop value
+    pub fn stop(&self) -> u32 {
+        self.stop
+    }
+
+    /// Get the MD5 hash of the scheme
+    pub fn md5(&self) -> &str {
+        &self.md5
+    }
+
+    /// Get the raw scheme bytes
+    pub fn raw_scheme(&self) -> &[u8] {
+        &self.raw_scheme
+    }
+
+    /// Generate record payload sizes for a given packet number
+    /// Returns a vector of sizes, where CHECK_MARK (-1) indicates a check point
+    pub fn generate_record_payload_sizes(&self, pkt: u32) -> Vec<i32> {
+        let key = pkt.to_string();
+        let Some(spec) = self.scheme.get(&key) else {
+            return Vec::new();
+        };
+
+        let mut sizes = Vec::new();
+        let parts: Vec<&str> = spec.split(',').collect();
+
+        for part in parts {
+            let part = part.trim();
+            if part == "c" {
+                sizes.push(CHECK_MARK);
+                continue;
+            }
+
+            if let Some((min_str, max_str)) = part.split_once('-') {
+                let min_val = min_str.trim().parse::<i64>().unwrap_or(0);
+                let max_val = max_str.trim().parse::<i64>().unwrap_or(0);
+
+                if min_val <= 0 || max_val <= 0 {
+                    continue;
+                }
+
+                let (min_val, max_val) = (min_val.min(max_val), min_val.max(max_val));
+
+                if min_val == max_val {
+                    sizes.push(min_val as i32);
+                } else {
+                    let size = rand::random_range(min_val..=max_val);
+                    sizes.push(size as i32);
+                }
+            }
+        }
+
+        sizes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_factory() {
+        let factory = PaddingFactory::default();
+        assert_eq!(factory.stop(), 8);
+        assert!(!factory.md5().is_empty());
+    }
+
+    #[test]
+    fn test_generate_sizes() {
+        let factory = PaddingFactory::default();
+
+        // Packet 0 should be 30-30 (fixed)
+        let sizes = factory.generate_record_payload_sizes(0);
+        assert_eq!(sizes, vec![30]);
+
+        // Packet 1 should be 100-400 (random in range)
+        let sizes = factory.generate_record_payload_sizes(1);
+        assert_eq!(sizes.len(), 1);
+        assert!(sizes[0] >= 100 && sizes[0] <= 400);
+    }
+
+    #[test]
+    fn test_check_mark() {
+        let scheme = r#"stop=3
+2=400-500,c,500-1000"#;
+        let factory = PaddingFactory::new(scheme.as_bytes()).unwrap();
+        let sizes = factory.generate_record_payload_sizes(2);
+
+        assert!(sizes.len() >= 3);
+        assert!(sizes[0] >= 400 && sizes[0] <= 500);
+        assert_eq!(sizes[1], CHECK_MARK);
+        assert!(sizes[2] >= 500 && sizes[2] <= 1000);
+    }
+
+    #[test]
+    fn test_md5_hash() {
+        let factory1 = PaddingFactory::default();
+        let factory2 = PaddingFactory::new(DEFAULT_PADDING_SCHEME.as_bytes()).unwrap();
+
+        assert_eq!(factory1.md5(), factory2.md5());
+    }
+}

--- a/crates/meow-anytls/src/padding/mod.rs
+++ b/crates/meow-anytls/src/padding/mod.rs
@@ -1,0 +1,7 @@
+/// Padding factory for traffic obfuscation
+pub mod factory;
+
+pub use factory::*;
+
+/// Check mark in padding scheme, indicates should check if data remains
+pub const CHECK_MARK: i32 = -1;

--- a/crates/meow-anytls/src/protocol/codec.rs
+++ b/crates/meow-anytls/src/protocol/codec.rs
@@ -1,0 +1,168 @@
+use crate::protocol::frame::{Command, Frame, HEADER_OVERHEAD_SIZE};
+use bytes::{BufMut, Bytes, BytesMut};
+use std::io;
+use tokio_util::codec::{Decoder, Encoder};
+
+/// Frame codec for encoding and decoding AnyTLS frames
+pub struct FrameCodec;
+
+impl Decoder for FrameCodec {
+    type Item = Frame;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        use bytes::Buf;
+
+        // Need at least header size to decode
+        if src.len() < HEADER_OVERHEAD_SIZE {
+            tracing::trace!(
+                "[FrameCodec] decode: Not enough data for header (have {}, need {})",
+                src.len(),
+                HEADER_OVERHEAD_SIZE
+            );
+            return Ok(None);
+        }
+
+        // Save position before parsing header
+        let before_header = src.len();
+
+        // Save first few bytes for debugging
+        let header_preview = if src.len() >= 20 {
+            format!("{:?}", &src[..20])
+        } else {
+            format!("{:?}", &src[..])
+        };
+
+        // Parse header WITHOUT consuming bytes (use peek methods)
+        // We'll only consume them if we have enough payload
+        let mut header_reader = &src[..HEADER_OVERHEAD_SIZE];
+        let cmd_byte = header_reader.get_u8();
+        let cmd = Command::from(cmd_byte);
+        let stream_id = header_reader.get_u32();
+        let data_len = header_reader.get_u16() as usize;
+
+        tracing::debug!(
+            "[FrameCodec] decode: Parsing header (buffer had {} bytes, preview: {})",
+            before_header,
+            header_preview
+        );
+        tracing::debug!(
+            "[FrameCodec] decode: Parsed header cmd={:?} (byte={}), stream_id={}, data_len={}",
+            cmd,
+            cmd_byte,
+            stream_id,
+            data_len
+        );
+
+        // Check if we have enough data (header + payload)
+        let total_needed = HEADER_OVERHEAD_SIZE + data_len;
+        if src.len() < total_needed {
+            tracing::debug!(
+                "[FrameCodec] decode: Not enough data for complete frame (have {}, need {})",
+                src.len(),
+                total_needed
+            );
+            // Reserve space for the remaining data
+            src.reserve(total_needed - src.len());
+            return Ok(None);
+        }
+
+        // Now consume the header and payload
+        src.advance(HEADER_OVERHEAD_SIZE);
+
+        // Extract data
+        let data = if data_len > 0 {
+            src.split_to(data_len).freeze()
+        } else {
+            Bytes::new()
+        };
+
+        tracing::debug!(
+            "[FrameCodec] decode: Successfully decoded frame cmd={:?}, stream_id={}, data_len={}",
+            cmd,
+            stream_id,
+            data_len
+        );
+
+        Ok(Some(Frame {
+            cmd,
+            stream_id,
+            data,
+        }))
+    }
+}
+
+impl Encoder<Frame> for FrameCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, item: Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let data_len = item.data.len();
+
+        // Reserve space: header + data
+        dst.reserve(HEADER_OVERHEAD_SIZE + data_len);
+
+        // Write header
+        dst.put_u8(item.cmd.into());
+        dst.put_u32(item.stream_id);
+        dst.put_u16(data_len as u16);
+
+        // Write data
+        if !item.data.is_empty() {
+            dst.extend_from_slice(&item.data);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_encode_decode() {
+        let mut codec = FrameCodec;
+        let frame = Frame::data(123, Bytes::from("hello world"));
+
+        let mut buf = BytesMut::new();
+        codec.encode(frame.clone(), &mut buf).unwrap();
+
+        let decoded = codec.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(decoded.cmd, frame.cmd);
+        assert_eq!(decoded.stream_id, frame.stream_id);
+        assert_eq!(decoded.data, frame.data);
+    }
+
+    #[tokio::test]
+    async fn test_encode_decode_control_frame() {
+        let mut codec = FrameCodec;
+        let frame = Frame::control(Command::Syn, 456);
+
+        let mut buf = BytesMut::new();
+        codec.encode(frame.clone(), &mut buf).unwrap();
+
+        let decoded = codec.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(decoded, frame);
+    }
+
+    #[tokio::test]
+    async fn test_decode_incomplete_frame() {
+        let mut codec = FrameCodec;
+        let mut buf = BytesMut::from(&[1u8, 0, 0, 0, 0][..]); // Only 5 bytes, need 7
+
+        assert!(codec.decode(&mut buf).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_decode_incomplete_data() {
+        let mut codec = FrameCodec;
+        let mut buf = BytesMut::new();
+        buf.put_u8(Command::Push as u8);
+        buf.put_u32(789);
+        buf.put_u16(100); // Claims 100 bytes data
+        buf.put_u8(0); // But only 1 byte available
+
+        let result = codec.decode(&mut buf);
+        assert!(result.unwrap().is_none()); // Should return None, not error
+    }
+}

--- a/crates/meow-anytls/src/protocol/frame.rs
+++ b/crates/meow-anytls/src/protocol/frame.rs
@@ -1,0 +1,139 @@
+use bytes::Bytes;
+
+/// Frame header size: 1 (cmd) + 4 (stream_id) + 2 (data_len) = 7 bytes
+pub const HEADER_OVERHEAD_SIZE: usize = 7;
+
+/// Command types for AnyTLS protocol frames
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Command {
+    /// Padding data (waste bytes for traffic obfuscation)
+    Waste = 0,
+    /// Open a new stream
+    Syn = 1,
+    /// Push data through the stream
+    Push = 2,
+    /// Close the stream (EOF mark)
+    Fin = 3,
+    /// Client settings sent to server
+    Settings = 4,
+    /// Alert message
+    Alert = 5,
+    /// Update padding scheme
+    UpdatePaddingScheme = 6,
+    /// Server acknowledges stream open (since protocol version 2)
+    SynAck = 7,
+    /// Keep-alive request
+    HeartRequest = 8,
+    /// Keep-alive response
+    HeartResponse = 9,
+    /// Server settings sent to client (since protocol version 2)
+    ServerSettings = 10,
+}
+
+impl From<u8> for Command {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Command::Waste,
+            1 => Command::Syn,
+            2 => Command::Push,
+            3 => Command::Fin,
+            4 => Command::Settings,
+            5 => Command::Alert,
+            6 => Command::UpdatePaddingScheme,
+            7 => Command::SynAck,
+            8 => Command::HeartRequest,
+            9 => Command::HeartResponse,
+            10 => Command::ServerSettings,
+            _ => Command::Waste, // Unknown command, treat as waste
+        }
+    }
+}
+
+impl From<Command> for u8 {
+    fn from(cmd: Command) -> Self {
+        cmd as u8
+    }
+}
+
+/// Frame defines a packet from or to be multiplexed into a single connection
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Frame {
+    /// Command type
+    pub cmd: Command,
+    /// Stream identifier (0 for control frames)
+    pub stream_id: u32,
+    /// Frame payload data
+    pub data: Bytes,
+}
+
+impl Frame {
+    /// Create a new frame
+    pub fn new(cmd: Command, stream_id: u32) -> Self {
+        Self {
+            cmd,
+            stream_id,
+            data: Bytes::new(),
+        }
+    }
+
+    /// Create a new frame with data
+    pub fn with_data(cmd: Command, stream_id: u32, data: Bytes) -> Self {
+        Self {
+            cmd,
+            stream_id,
+            data,
+        }
+    }
+
+    /// Create a control frame (no data)
+    pub fn control(cmd: Command, stream_id: u32) -> Self {
+        Self::new(cmd, stream_id)
+    }
+
+    /// Create a data frame
+    pub fn data(stream_id: u32, data: Bytes) -> Self {
+        Self::with_data(Command::Push, stream_id, data)
+    }
+
+    /// Get the total frame size (header + data)
+    pub fn total_size(&self) -> usize {
+        HEADER_OVERHEAD_SIZE + self.data.len()
+    }
+
+    /// Check if this is a control frame (no data)
+    pub fn is_control(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_conversion() {
+        assert_eq!(Command::from(0), Command::Waste);
+        assert_eq!(Command::from(1), Command::Syn);
+        assert_eq!(u8::from(Command::Syn), 1);
+    }
+
+    #[test]
+    fn test_frame_creation() {
+        let frame = Frame::control(Command::Syn, 123);
+        assert_eq!(frame.cmd, Command::Syn);
+        assert_eq!(frame.stream_id, 123);
+        assert!(frame.data.is_empty());
+        assert_eq!(frame.total_size(), HEADER_OVERHEAD_SIZE);
+    }
+
+    #[test]
+    fn test_frame_with_data() {
+        let data = Bytes::from("hello");
+        let frame = Frame::data(456, data.clone());
+        assert_eq!(frame.cmd, Command::Push);
+        assert_eq!(frame.stream_id, 456);
+        assert_eq!(frame.data, data);
+        assert_eq!(frame.total_size(), HEADER_OVERHEAD_SIZE + 5);
+    }
+}

--- a/crates/meow-anytls/src/protocol/mod.rs
+++ b/crates/meow-anytls/src/protocol/mod.rs
@@ -1,0 +1,7 @@
+/// Frame codec for encoding and decoding
+pub mod codec;
+/// Frame definitions and structures
+pub mod frame;
+
+pub use codec::*;
+pub use frame::*;

--- a/crates/meow-anytls/src/server/handler.rs
+++ b/crates/meow-anytls/src/server/handler.rs
@@ -1,0 +1,542 @@
+//! Server connection handlers
+
+use crate::protocol::{Command, Frame};
+use crate::session::{Session, Stream};
+use crate::util::{AnyTlsError, Result, configure_tcp_stream, resolve_host_with_cache};
+use bytes::Bytes;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::{Duration, timeout};
+
+/// Handler trait for processing new streams
+pub trait StreamHandler: Send + Sync {
+    /// Handle a new stream
+    fn handle_stream(
+        &self,
+        stream: Arc<Stream>,
+        session: Arc<crate::session::Session>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + '_>>;
+}
+
+/// Default stream handler that proxies TCP connections
+pub struct TcpProxyHandler {
+    // Destination will be read from stream
+}
+
+impl Default for TcpProxyHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TcpProxyHandler {
+    /// Create a new TCP proxy handler
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl StreamHandler for TcpProxyHandler {
+    fn handle_stream(
+        &self,
+        stream: Arc<Stream>,
+        session: Arc<crate::session::Session>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async move {
+            let stream_id = stream.id();
+            let peer_version = session.peer_version();
+            tracing::debug!(
+                "[Proxy] Handling stream {} (peer_version={})",
+                stream_id,
+                peer_version
+            );
+
+            // Read SOCKS5 address to determine the destination
+            let destination = match read_socks_addr(stream.clone()).await {
+                Ok(addr) => addr,
+                Err(e) => {
+                    tracing::error!("[Proxy] Failed to read SOCKS5 address: {}", e);
+                    return Err(e);
+                }
+            };
+
+            tracing::info!(
+                "[Proxy] Destination: {}:{}",
+                destination.addr,
+                destination.port
+            );
+
+            // Check if this is a UDP over TCP request
+            if destination.addr.contains("udp-over-tcp.arpa") {
+                tracing::debug!("[Proxy] Detected UDP over TCP request");
+                if peer_version >= 2 {
+                    tracing::debug!(
+                        "[Proxy] Sending SYNACK for UDP stream {} (connection established)",
+                        stream_id
+                    );
+                    let synack_frame = Frame::control(Command::SynAck, stream_id);
+                    if let Err(e) = session.write_control_frame(synack_frame).await {
+                        tracing::error!("[Proxy] Failed to send SYNACK: {}", e);
+                        return Err(e);
+                    }
+                }
+                crate::server::udp_proxy::handle_udp_over_tcp(stream).await
+            } else {
+                // Regular TCP proxy
+                proxy_tcp_connection_with_synack_internal(
+                    stream,
+                    session,
+                    stream_id,
+                    peer_version,
+                    destination,
+                )
+                .await
+            }
+        })
+    }
+}
+
+/// SOCKS5 address (similar to Go's M.Socksaddr)
+#[derive(Debug, Clone)]
+struct SocksAddr {
+    addr: String,
+    port: u16,
+}
+
+/// Read SOCKS5 address format from stream
+/// Format: [ATYP (1 byte) | ADDR (variable) | PORT (2 bytes)]
+///
+/// 新实现：直接使用 StreamReader，无需额外的 Mutex 包装
+async fn read_socks_addr(stream: Arc<Stream>) -> Result<SocksAddr> {
+    let stream_id = stream.id();
+    tracing::debug!(
+        "[Proxy] read_socks_addr: Starting to read SOCKS5 address from stream {}",
+        stream_id
+    );
+
+    // 获取 reader 的引用
+    let reader_mutex = stream.reader();
+
+    // Read ATYP byte first
+    tracing::trace!(
+        "[Proxy] read_socks_addr: Reading ATYP byte from stream {}",
+        stream_id
+    );
+    let mut atyp_buf = [0u8; 1];
+    {
+        let mut reader = reader_mutex.lock().await;
+        reader
+            .read(&mut atyp_buf)
+            .await
+            .map_err(|e| AnyTlsError::Protocol(format!("Failed to read address type: {}", e)))?;
+    }
+    tracing::trace!(
+        "[Proxy] read_socks_addr: Read ATYP={:02x} from stream {}",
+        atyp_buf[0],
+        stream_id
+    );
+
+    let atyp = atyp_buf[0];
+    let addr =
+        match atyp {
+            0x01 => {
+                // IPv4: 4 bytes
+                tracing::trace!(
+                    "[Proxy] read_socks_addr: Reading IPv4 address (stream {})",
+                    stream_id
+                );
+                let mut ip_buf = [0u8; 4];
+                {
+                    let mut reader = reader_mutex.lock().await;
+                    reader.read_exact(&mut ip_buf).await.map_err(|e| {
+                        AnyTlsError::Protocol(format!("Failed to read IPv4: {}", e))
+                    })?;
+                }
+                IpAddr::V4(Ipv4Addr::from(ip_buf)).to_string()
+            }
+            0x03 => {
+                // Domain name: [LEN (1 byte) | DOMAIN (LEN bytes)]
+                tracing::trace!(
+                    "[Proxy] read_socks_addr: Reading domain name (stream {})",
+                    stream_id
+                );
+                let mut len_buf = [0u8; 1];
+                {
+                    let mut reader = reader_mutex.lock().await;
+                    reader.read_exact(&mut len_buf).await.map_err(|e| {
+                        AnyTlsError::Protocol(format!("Failed to read domain length: {}", e))
+                    })?;
+                }
+
+                let domain_len = len_buf[0] as usize;
+                tracing::trace!(
+                    "[Proxy] read_socks_addr: Domain length={} (stream {})",
+                    domain_len,
+                    stream_id
+                );
+                if domain_len == 0 || domain_len > 255 {
+                    return Err(AnyTlsError::Protocol("Invalid domain length".to_string()));
+                }
+
+                let mut domain_buf = vec![0u8; domain_len];
+                {
+                    let mut reader = reader_mutex.lock().await;
+                    reader.read_exact(&mut domain_buf).await.map_err(|e| {
+                        AnyTlsError::Protocol(format!("Failed to read domain: {}", e))
+                    })?;
+                }
+
+                String::from_utf8(domain_buf)
+                    .map_err(|e| AnyTlsError::Protocol(format!("Invalid domain name: {}", e)))?
+            }
+            0x04 => {
+                // IPv6: 16 bytes
+                tracing::trace!(
+                    "[Proxy] read_socks_addr: Reading IPv6 address (stream {})",
+                    stream_id
+                );
+                let mut ip_buf = [0u8; 16];
+                {
+                    let mut reader = reader_mutex.lock().await;
+                    reader.read_exact(&mut ip_buf).await.map_err(|e| {
+                        AnyTlsError::Protocol(format!("Failed to read IPv6: {}", e))
+                    })?;
+                }
+                IpAddr::V6(Ipv6Addr::from(ip_buf)).to_string()
+            }
+            _ => {
+                return Err(AnyTlsError::Protocol(format!(
+                    "Unsupported address type: 0x{:02x}",
+                    atyp
+                )));
+            }
+        };
+
+    // Read port (2 bytes, big-endian)
+    tracing::trace!(
+        "[Proxy] read_socks_addr: Reading port (stream {})",
+        stream_id
+    );
+    let mut port_buf = [0u8; 2];
+    {
+        let mut reader = reader_mutex.lock().await;
+        reader
+            .read_exact(&mut port_buf)
+            .await
+            .map_err(|e| AnyTlsError::Protocol(format!("Failed to read port: {}", e)))?;
+    }
+    let port = u16::from_be_bytes(port_buf);
+
+    tracing::debug!(
+        "[Proxy] read_socks_addr: Successfully read address {}:{} from stream {}",
+        addr,
+        port,
+        stream_id
+    );
+    Ok(SocksAddr { addr, port })
+}
+
+/// Proxy TCP connection with SYNACK support (internal version with destination already provided)
+async fn proxy_tcp_connection_with_synack_internal(
+    stream: Arc<Stream>,
+    session: Arc<Session>,
+    stream_id: u32,
+    peer_version: u8,
+    destination: SocksAddr,
+) -> Result<()> {
+    tracing::debug!(
+        "[Proxy] proxy_tcp_connection_with_synack: Starting for stream {} (peer_version={})",
+        stream_id,
+        peer_version
+    );
+    tracing::debug!(
+        "[Proxy] Connecting to {}:{}",
+        destination.addr,
+        destination.port
+    );
+
+    let target_display = format!("{}:{}", destination.addr, destination.port);
+    let target_socket = if let Ok(ip) = destination.addr.parse::<IpAddr>() {
+        SocketAddr::new(ip, destination.port)
+    } else {
+        resolve_host_with_cache(&destination.addr, destination.port)
+            .await
+            .map_err(|err| {
+                tracing::error!(
+                    "[Proxy] DNS resolution failed for {}: {}",
+                    target_display,
+                    err
+                );
+                err
+            })?
+    };
+
+    // Create outbound TCP connection with timeout
+    // Default 15s timeout for DNS resolution + TCP handshake
+    // This prevents hanging on slow/unreachable targets
+    let connect_timeout = Duration::from_secs(15);
+    let outbound = match timeout(connect_timeout, TcpStream::connect(target_socket)).await {
+        Ok(Ok(conn)) => {
+            configure_tcp_stream(&conn, &target_display);
+            tracing::info!("[Proxy] Successfully connected to {}", target_display);
+            conn
+        }
+        Ok(Err(e)) => {
+            tracing::error!("[Proxy] Failed to connect to {}: {}", target_display, e);
+            // Send SYNACK with error if protocol version >= 2
+            // Note: All streams should receive SYNACK in protocol v2+, including stream_id=1
+            if peer_version >= 2 {
+                let error_msg = format!("Failed to connect to {}: {}", target_display, e);
+                let synack_frame =
+                    Frame::with_data(Command::SynAck, stream_id, Bytes::from(error_msg));
+                if let Err(send_err) = session.write_control_frame(synack_frame).await {
+                    tracing::error!("[Proxy] Failed to send SYNACK with error: {}", send_err);
+                }
+            }
+            return Err(AnyTlsError::Protocol(format!(
+                "Failed to connect to {}: {}",
+                target_display, e
+            )));
+        }
+        Err(_) => {
+            let error_msg = format!(
+                "Connection timeout ({}s) to {}",
+                connect_timeout.as_secs(),
+                target_display
+            );
+            tracing::error!("[Proxy] {}", error_msg);
+            // Send SYNACK with timeout error
+            if peer_version >= 2 {
+                let synack_frame =
+                    Frame::with_data(Command::SynAck, stream_id, Bytes::from(error_msg.clone()));
+                if let Err(send_err) = session.write_control_frame(synack_frame).await {
+                    tracing::error!("[Proxy] Failed to send SYNACK with error: {}", send_err);
+                }
+            }
+            return Err(AnyTlsError::Protocol(error_msg));
+        }
+    };
+
+    // Send SYNACK after successful connection (protocol v >= 2)
+    // Note: All streams should receive SYNACK in protocol v2+, including stream_id=1
+    // Similar to Go's ReportHandshakeSuccess - called after TCP connection is established
+    if peer_version >= 2 {
+        tracing::debug!(
+            "[Proxy] Sending SYNACK for stream {} (connection established)",
+            stream_id
+        );
+        let synack_frame = Frame::control(Command::SynAck, stream_id);
+        if let Err(e) = session.write_control_frame(synack_frame).await {
+            tracing::error!("[Proxy] Failed to send SYNACK: {}", e);
+            return Err(e);
+        }
+        tracing::debug!("[Proxy] SYNACK sent for stream {}", stream_id);
+    }
+
+    // Now forward data bidirectionally
+    tracing::debug!(
+        "[Proxy] proxy_tcp_connection_with_synack: Calling proxy_tcp_connection_data_forwarding for stream {}",
+        stream_id
+    );
+    proxy_tcp_connection_data_forwarding(stream, outbound, destination).await
+}
+
+/// Forward data between stream and outbound connection
+///
+/// 新实现：完全移除 Mutex 包装，直接使用 Stream
+/// Stream 内部的 reader 和 writer 已经分离，无锁竞争
+async fn proxy_tcp_connection_data_forwarding(
+    stream: Arc<Stream>,
+    outbound: TcpStream,
+    destination: SocksAddr,
+) -> Result<()> {
+    let stream_id = stream.id();
+    tracing::debug!(
+        "[Proxy] Starting data forwarding for stream {} to {}:{}",
+        stream_id,
+        destination.addr,
+        destination.port
+    );
+
+    // 分离 outbound 的读写
+    let (mut outbound_read, mut outbound_write) = tokio::io::split(outbound);
+
+    // ===== 关键改变：不再需要 Arc<Mutex<>> 包装！=====
+    // 直接克隆 Arc<Stream> 用于两个任务
+    let stream_for_read = Arc::clone(&stream);
+    let stream_for_write = Arc::clone(&stream);
+    let bytes_to_outbound = Arc::new(AtomicU64::new(0));
+    let bytes_to_client = Arc::new(AtomicU64::new(0));
+
+    // Task 1: Stream -> Outbound（从 stream 读取，写入 outbound）
+    tracing::debug!(
+        "[Proxy] Spawning Task1 (stream->outbound) for stream {}",
+        stream_id
+    );
+    let bytes_to_outbound_clone = Arc::clone(&bytes_to_outbound);
+    let task1 = tokio::spawn(async move {
+        tracing::debug!("[Proxy-Task1] Task started for stream {}", stream_id);
+
+        // 获取 reader 的引用（无需锁整个 stream）
+        let reader_mutex = stream_for_read.reader();
+        let mut buf = vec![0u8; 8192];
+        let mut iteration = 0u64;
+
+        loop {
+            iteration += 1;
+
+            // 获取 reader 的锁并读取
+            // 注意：锁只在读取时持有，不影响 Task2 的写入
+            let n = {
+                let mut reader = reader_mutex.lock().await;
+                match reader.read(&mut buf).await {
+                    Ok(0) => {
+                        tracing::debug!(
+                            "[Proxy-Task1] Stream EOF (stream_id={}, iteration={})",
+                            stream_id,
+                            iteration
+                        );
+                        break;
+                    }
+                    Ok(n) => {
+                        tracing::debug!(
+                            "[Proxy-Task1] Read {} bytes from stream {} (iteration={})",
+                            n,
+                            stream_id,
+                            iteration
+                        );
+                        n
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "[Proxy-Task1] Stream read error (stream_id={}, iteration={}): {}",
+                            stream_id,
+                            iteration,
+                            e
+                        );
+                        break;
+                    }
+                }
+            }; // reader 锁在这里释放
+
+            // 写入 outbound（无锁）
+            if let Err(e) = outbound_write.write_all(&buf[..n]).await {
+                tracing::error!("[Proxy-Task1] Outbound write error: {}", e);
+                break;
+            }
+            bytes_to_outbound_clone.fetch_add(n as u64, Ordering::Relaxed);
+
+            tracing::trace!(
+                "[Proxy-Task1] Forwarded {} bytes to outbound (iteration={})",
+                n,
+                iteration
+            );
+        }
+
+        tracing::debug!(
+            "[Proxy-Task1] Task completed for stream {} after {} iterations",
+            stream_id,
+            iteration
+        );
+    });
+
+    // Task 2: Outbound -> Stream（从 outbound 读取，写入 stream）
+    tracing::debug!(
+        "[Proxy] Spawning Task2 (outbound->stream) for stream {}",
+        stream_id
+    );
+    let bytes_to_client_clone = Arc::clone(&bytes_to_client);
+    let task2 = tokio::spawn(async move {
+        tracing::debug!("[Proxy-Task2] Task started for stream {}", stream_id);
+        let mut buf = vec![0u8; 8192];
+        let mut iteration = 0u64;
+
+        loop {
+            iteration += 1;
+
+            // 从 outbound 读取（无锁）
+            let n = match outbound_read.read(&mut buf).await {
+                Ok(0) => {
+                    tracing::debug!(
+                        "[Proxy-Task2] Outbound EOF (stream_id={}, iteration={})",
+                        stream_id,
+                        iteration
+                    );
+                    break;
+                }
+                Ok(n) => {
+                    tracing::debug!(
+                        "[Proxy-Task2] Read {} bytes from outbound (iteration={})",
+                        n,
+                        iteration
+                    );
+                    n
+                }
+                Err(e) => {
+                    tracing::error!("[Proxy-Task2] Outbound read error: {}", e);
+                    break;
+                }
+            };
+
+            // 写入 stream（使用 send_data，完全无锁！）
+            use bytes::Bytes;
+            if let Err(e) = stream_for_write.send_data(Bytes::copy_from_slice(&buf[..n])) {
+                tracing::error!(
+                    "[Proxy-Task2] Stream write error (stream_id={}, iteration={}): {:?}",
+                    stream_id,
+                    iteration,
+                    e
+                );
+                break;
+            }
+            bytes_to_client_clone.fetch_add(n as u64, Ordering::Relaxed);
+
+            tracing::trace!(
+                "[Proxy-Task2] Wrote {} bytes to stream {} (iteration={})",
+                n,
+                stream_id,
+                iteration
+            );
+        }
+
+        tracing::debug!(
+            "[Proxy-Task2] Task completed for stream {} after {} iterations",
+            stream_id,
+            iteration
+        );
+    });
+
+    // Tear down as soon as EITHER direction finishes. Previously this waited
+    // for BOTH tasks (`join!`): when the client closed its stream (FIN), task1
+    // hit stream-EOF and exited, but task2 stayed blocked reading the still-open
+    // target, so `join!` never returned and the outbound TCP socket (its fd)
+    // leaked for the life of the process — one per proxied stream. Cancelling
+    // the surviving half drops its socket end and closes the target connection.
+    tracing::debug!(
+        "[Proxy] Waiting for either task to complete for stream {}",
+        stream_id
+    );
+    let mut task1 = task1;
+    let mut task2 = task2;
+    tokio::select! {
+        _ = &mut task1 => { task2.abort(); }
+        _ = &mut task2 => { task1.abort(); }
+    }
+    let outbound_bytes = bytes_to_outbound.load(Ordering::Relaxed);
+    let client_bytes = bytes_to_client.load(Ordering::Relaxed);
+
+    tracing::debug!(
+        stream_id = stream_id,
+        bytes_outbound = outbound_bytes,
+        bytes_client = client_bytes,
+        "[Proxy] Connection closed for stream {} to {}:{}",
+        stream_id,
+        destination.addr,
+        destination.port
+    );
+
+    Ok(())
+}

--- a/crates/meow-anytls/src/server/mod.rs
+++ b/crates/meow-anytls/src/server/mod.rs
@@ -1,0 +1,10 @@
+//! Server implementation for AnyTLS protocol
+
+pub mod handler;
+#[allow(clippy::module_inception)]
+pub mod server;
+pub mod udp_proxy;
+
+pub use handler::*;
+pub use server::*;
+pub use udp_proxy::*;

--- a/crates/meow-anytls/src/server/server.rs
+++ b/crates/meow-anytls/src/server/server.rs
@@ -1,0 +1,307 @@
+//! AnyTLS Server implementation
+
+use crate::padding::PaddingFactory;
+use crate::server::handler::{StreamHandler, TcpProxyHandler};
+use crate::session::Session;
+use crate::util::{
+    AnyTlsError, Result, StringMap, authenticate_client, configure_tcp_stream, hash_password,
+};
+use std::sync::{Arc, RwLock};
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+use tracing::{Instrument, Span, field, info_span};
+
+/// Server manages AnyTLS server connections
+pub struct Server {
+    password_hash: [u8; 32],
+    tls_config: Arc<RwLock<Arc<TlsAcceptor>>>,
+    padding: Arc<PaddingFactory>,
+    on_new_stream: Option<Arc<dyn Fn(Arc<crate::session::Stream>) + Send + Sync + 'static>>,
+    server_settings: Option<StringMap>,
+}
+
+impl Server {
+    /// Create a new server
+    pub fn new(
+        password: &str,
+        tls_config: Arc<TlsAcceptor>,
+        padding: Arc<PaddingFactory>,
+        server_settings: Option<StringMap>,
+    ) -> Self {
+        let password_hash = hash_password(password);
+
+        Self {
+            password_hash,
+            tls_config: Arc::new(RwLock::new(tls_config)),
+            padding,
+            on_new_stream: None,
+            server_settings,
+        }
+    }
+
+    /// Create a new server with reloadable TLS config
+    pub fn new_with_reloadable_tls(
+        password: &str,
+        tls_config: Arc<RwLock<Arc<TlsAcceptor>>>,
+        padding: Arc<PaddingFactory>,
+        server_settings: Option<StringMap>,
+    ) -> Self {
+        let password_hash = hash_password(password);
+
+        Self {
+            password_hash,
+            tls_config,
+            padding,
+            on_new_stream: None,
+            server_settings,
+        }
+    }
+
+    /// Set callback for new streams
+    pub fn with_stream_handler<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(Arc<crate::session::Stream>) + Send + Sync + 'static,
+    {
+        self.on_new_stream = Some(Arc::new(callback));
+        self
+    }
+
+    /// Start the server and listen for connections
+    pub async fn listen(&self, addr: &str) -> Result<()> {
+        let listener = TcpListener::bind(addr).await?;
+
+        tracing::info!("[Server] Listening on {}", addr);
+
+        loop {
+            match listener.accept().await {
+                Ok((stream, addr)) => {
+                    let tls_config = self.tls_config.read().unwrap().clone();
+                    let password_hash = self.password_hash;
+                    let padding = Arc::clone(&self.padding);
+                    let on_new_stream = self.on_new_stream.clone();
+                    let server_settings = self.server_settings.clone();
+                    let span = info_span!(
+                        "anytls.connection",
+                        peer_addr = %addr,
+                        session_id = field::Empty
+                    );
+
+                    tokio::spawn(
+                        async move {
+                            if let Err(e) = handle_connection(
+                                stream,
+                                tls_config,
+                                password_hash,
+                                padding,
+                                on_new_stream,
+                                server_settings,
+                            )
+                            .await
+                            {
+                                tracing::error!("[Server] Connection error: {}", e);
+                            }
+                        }
+                        .instrument(span),
+                    );
+                }
+                Err(e) => {
+                    tracing::error!("[Server] Accept error: {}", e);
+                }
+            }
+        }
+    }
+}
+
+/// Handle a single TCP connection
+async fn handle_connection(
+    tcp_stream: tokio::net::TcpStream,
+    tls_config: Arc<TlsAcceptor>,
+    password_hash: [u8; 32],
+    padding: Arc<PaddingFactory>,
+    on_new_stream: Option<Arc<dyn Fn(Arc<crate::session::Stream>) + Send + Sync + 'static>>,
+    server_settings: Option<StringMap>,
+) -> Result<()> {
+    let peer_addr = tcp_stream
+        .peer_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    configure_tcp_stream(&tcp_stream, &peer_addr);
+    let handshake_span = info_span!(
+        "anytls.handshake",
+        peer_addr = %peer_addr,
+        session_id = field::Empty,
+        tls_version = field::Empty,
+        cipher_suite = field::Empty
+    );
+    let _handshake_guard = handshake_span.enter();
+    tracing::info!("[Server] New connection from {}", peer_addr);
+    // Perform TLS handshake
+    tracing::debug!("[Server] Starting TLS handshake");
+    let tls_stream = tls_config.accept(tcp_stream).await.map_err(|e| {
+        tracing::error!("[Server] TLS handshake failed: {}", e);
+        AnyTlsError::Tls(format!("TLS handshake failed: {}", e))
+    })?;
+    tracing::debug!("[Server] TLS handshake successful");
+    let (_, server_connection) = tls_stream.get_ref();
+    if let Some(protocol) = server_connection.protocol_version() {
+        handshake_span.record("tls_version", field::display(format!("{:?}", protocol)));
+    }
+    if let Some(suite) = server_connection.negotiated_cipher_suite() {
+        handshake_span.record(
+            "cipher_suite",
+            field::display(format!("{:?}", suite.suite())),
+        );
+    }
+
+    // Authenticate client
+    tracing::debug!("[Server] Authenticating client");
+    let (mut reader, writer) = tokio::io::split(tls_stream);
+    authenticate_client(&mut reader, &password_hash, &padding).await?;
+    tracing::debug!("[Server] Client authenticated");
+
+    // Create callback channel for new streams
+    let (stream_callback_tx, mut stream_callback_rx) =
+        tokio::sync::mpsc::unbounded_channel::<Arc<crate::session::Stream>>();
+
+    // Create server session
+    let mut session = Session::new_server(reader, writer, padding);
+    session.set_server_settings(server_settings.clone());
+
+    // Set callback channel in session
+    session.set_stream_callback(stream_callback_tx);
+
+    let session = Arc::new(session);
+    let session_id = session.id();
+    Span::current().record("session_id", session_id);
+    handshake_span.record("session_id", field::display(session_id));
+
+    tracing::info!(
+        session_id = session_id,
+        peer_addr = %peer_addr,
+        "[Server] Session {} created",
+        session_id
+    );
+
+    // Handle new streams in a task
+    if let Some(callback) = on_new_stream {
+        tracing::debug!("[Server] Using custom stream callback");
+        tokio::spawn(async move {
+            while let Some(stream) = stream_callback_rx.recv().await {
+                tracing::debug!(
+                    "[Server] Received stream {} in custom callback",
+                    stream.id()
+                );
+                // Spawn a new task for each stream to handle it asynchronously
+                let stream_clone = Arc::clone(&stream);
+                let callback_clone = Arc::clone(&callback);
+                let stream_id = stream_clone.id();
+                let stream_span =
+                    info_span!("anytls.stream.callback", session_id = session_id, stream_id);
+                tokio::spawn(
+                    async move {
+                        callback_clone(stream_clone);
+                    }
+                    .instrument(stream_span),
+                );
+            }
+        });
+    } else {
+        // Use default TCP proxy handler if no callback is provided
+        tracing::debug!("[Server] Using default TCP proxy handler");
+        let session_for_handler = Arc::clone(&session);
+        tokio::spawn(async move {
+            while let Some(stream) = stream_callback_rx.recv().await {
+                tracing::debug!(
+                    "[Server] Received stream {} for default handler",
+                    stream.id()
+                );
+                let stream_clone = Arc::clone(&stream);
+                let session_clone = Arc::clone(&session_for_handler);
+                // Create a new handler instance for each stream (TcpProxyHandler is small and stateless)
+                let handler = TcpProxyHandler::new();
+                let stream_id = stream_clone.id();
+                let stream_span = info_span!(
+                    "anytls.stream.proxy",
+                    session_id = session_clone.id(),
+                    stream_id
+                );
+                tokio::spawn(
+                    async move {
+                        if let Err(e) = handler.handle_stream(stream_clone, session_clone).await {
+                            tracing::error!("[Proxy] Handler error: {}", e);
+                        }
+                    }
+                    .instrument(stream_span),
+                );
+            }
+        });
+    }
+
+    // Start receive loop
+    tracing::debug!("[Server] Starting receive loop");
+    let session_clone = Arc::clone(&session);
+    let recv_span = info_span!(
+        "anytls.session.recv_loop",
+        session_id = session_clone.id(),
+        peer_addr = %peer_addr
+    );
+    tokio::spawn(
+        async move {
+            tracing::debug!("[Server] recv_loop task spawned");
+            match session_clone.recv_loop().await {
+                Ok(()) => {
+                    tracing::debug!("[Server] recv_loop task completed normally");
+                }
+                Err(AnyTlsError::Io(e)) => {
+                    // Check if this is a close_notify error (normal connection close)
+                    let error_msg = e.to_string();
+                    if error_msg.contains("close_notify")
+                        || error_msg.contains("unexpected EOF")
+                        || e.kind() == std::io::ErrorKind::UnexpectedEof
+                    {
+                        tracing::debug!(
+                            "[Server] recv_loop task ended: Connection closed by client (no close_notify) - this is normal"
+                        );
+                    } else {
+                        tracing::error!("[Server] recv_loop task error: {}", e);
+                    }
+                }
+                Err(AnyTlsError::SessionClosed) => {
+                    tracing::debug!("[Server] recv_loop task ended: Session closed");
+                }
+                Err(e) => {
+                    tracing::error!("[Server] recv_loop task error: {}", e);
+                }
+            }
+        }
+        .instrument(recv_span),
+    );
+
+    // Start stream data processing
+    tracing::debug!("[Server] Starting stream data processing");
+    let session_clone = Arc::clone(&session);
+    let process_span = info_span!(
+        "anytls.session.process_stream_data",
+        session_id = session_clone.id(),
+        peer_addr = %peer_addr
+    );
+    tokio::spawn(
+        async move {
+            tracing::debug!("[Server] process_stream_data task spawned");
+            if let Err(e) = session_clone.process_stream_data().await {
+                tracing::error!("[Server] process_stream_data task error: {}", e);
+            } else {
+                tracing::debug!("[Server] process_stream_data task completed normally");
+            }
+        }
+        .instrument(process_span),
+    );
+
+    tracing::debug!("[Server] Connection handler setup complete");
+
+    // Wait for connection to close
+    // The connection will be managed by the spawned tasks
+    // In a production implementation, we'd wait for the session to close
+
+    Ok(())
+}

--- a/crates/meow-anytls/src/server/udp_proxy.rs
+++ b/crates/meow-anytls/src/server/udp_proxy.rs
@@ -1,0 +1,471 @@
+//! UDP over TCP proxy implementation
+//!
+//! Implements sing-box udp-over-tcp v2 protocol (Connect format)
+//!
+//! # Protocol Format
+//!
+//! ## Request (sent once at stream start):
+//! ```text
+//! | isConnect | ATYP | Address | Port |
+//! | u8 (=1)   | u8   | variable| u16be|
+//! ```
+//!
+//! ## Data packets (Connect format, isConnect=1):
+//! ```text
+//! | Length | Data     |
+//! | u16be  | variable |
+//! ```
+//!
+//! Reference: <https://github.com/SagerNet/sing-box/blob/dev-next/docs/configuration/shared/udp-over-tcp.md>
+
+use crate::session::{Stream, StreamReader};
+use crate::util::{AnyTlsError, Result, resolve_host_with_cache};
+use bytes::{BufMut, Bytes, BytesMut};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::net::UdpSocket;
+use tracing::{field, info_span};
+
+const MAX_UDP_PACKET_SIZE: usize = 65535;
+
+/// Handle UDP over TCP stream
+///
+/// Target address should be "sp.v2.udp-over-tcp.arpa"
+///
+/// # Protocol
+///
+/// sing-box udp-over-tcp v2:
+/// 1. First, read initial request containing target address (SOCKS5 format)
+/// 2. Then, each packet: Length (2 bytes BE) + Payload
+/// 3. Bidirectional forwarding between Stream and UDP socket
+///
+/// Reference: <https://github.com/SagerNet/sing-box/blob/dev-next/docs/configuration/shared/udp-over-tcp.md>
+pub async fn handle_udp_over_tcp(stream: Arc<Stream>) -> Result<()> {
+    let stream_id = stream.id();
+    let udp_span = info_span!(
+        "anytls.udp.proxy",
+        stream_id,
+        local_udp = field::Empty,
+        target = field::Empty,
+        packets_in = field::Empty,
+        packets_out = field::Empty,
+        bytes_in = field::Empty,
+        bytes_out = field::Empty
+    );
+    let _udp_guard = udp_span.enter();
+
+    tracing::debug!("[UDP] Starting UDP over TCP proxy for stream {}", stream_id);
+
+    let reader = stream.reader();
+    let mut reader_guard = reader.lock().await;
+
+    // Step 1: Read initial request (contains target address)
+    // Format: SOCKS5 address (ATYP + Address + Port)
+    let target_addr = match read_initial_request(&mut reader_guard).await {
+        Ok(addr) => addr,
+        Err(e) => {
+            tracing::error!("[UDP] Failed to read initial request: {}", e);
+            return Err(e);
+        }
+    };
+    udp_span.record("target", field::display(target_addr));
+
+    tracing::debug!("[UDP] Target UDP address: {}", target_addr);
+
+    drop(reader_guard);
+
+    // Step 2: Create UDP socket (bind to any available port)
+    let udp_socket = UdpSocket::bind("0.0.0.0:0").await.map_err(|e| {
+        tracing::error!("[UDP] Failed to create UDP socket: {}", e);
+        AnyTlsError::Io(e)
+    })?;
+
+    let local_addr = udp_socket.local_addr()?;
+    tracing::debug!("[UDP] Created UDP socket on {}", local_addr);
+    udp_span.record("local_udp", field::display(local_addr));
+
+    let packets_stream_to_udp = Arc::new(AtomicU64::new(0));
+    let bytes_stream_to_udp = Arc::new(AtomicU64::new(0));
+    let packets_udp_to_stream = Arc::new(AtomicU64::new(0));
+    let bytes_udp_to_stream = Arc::new(AtomicU64::new(0));
+
+    // Step 3: Send handshake success (if needed, similar to Go's ReportHandshakeSuccess)
+    // In our case, we can just start forwarding
+
+    // Step 4: Bidirectional forwarding
+    tokio::select! {
+        result = stream_to_udp(
+            &stream,
+            &udp_socket,
+            &target_addr,
+            Arc::clone(&packets_stream_to_udp),
+            Arc::clone(&bytes_stream_to_udp)
+        ) => {
+            if let Err(e) = result {
+                tracing::error!("[UDP] Stream → UDP error: {}", e);
+                return Err(e);
+            }
+        }
+        result = udp_to_stream(
+            &stream,
+            &udp_socket,
+            &target_addr,
+            Arc::clone(&packets_udp_to_stream),
+            Arc::clone(&bytes_udp_to_stream)
+        ) => {
+            if let Err(e) = result {
+                tracing::error!("[UDP] UDP → Stream error: {}", e);
+                return Err(e);
+            }
+        }
+    }
+
+    let packets_out = packets_stream_to_udp.load(Ordering::Relaxed);
+    let bytes_out = bytes_stream_to_udp.load(Ordering::Relaxed);
+    let packets_in = packets_udp_to_stream.load(Ordering::Relaxed);
+    let bytes_in = bytes_udp_to_stream.load(Ordering::Relaxed);
+    udp_span.record("packets_out", packets_out);
+    udp_span.record("bytes_out", bytes_out);
+    udp_span.record("packets_in", packets_in);
+    udp_span.record("bytes_in", bytes_in);
+
+    tracing::debug!(
+        "[UDP] UDP over TCP proxy completed for stream {} (packets_out={}, packets_in={})",
+        stream_id,
+        packets_out,
+        packets_in
+    );
+    Ok(())
+}
+
+/// Read initial request from stream
+///
+/// Format (sing-box udp-over-tcp v2 request):
+/// ```text
+/// | isConnect | ATYP | Address | Port |
+/// | u8        | u8   | variable| u16be|
+/// ```
+///
+/// Returns the target SocketAddr
+async fn read_initial_request(reader: &mut StreamReader) -> Result<SocketAddr> {
+    // Read isConnect (1 byte)
+    let mut is_connect_buf = [0u8; 1];
+    reader
+        .read_exact(&mut is_connect_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let is_connect = is_connect_buf[0];
+
+    if is_connect != 1 {
+        // We only support connect format (isConnect=1)
+        return Err(AnyTlsError::Protocol(format!(
+            "Unsupported UDP over TCP format: isConnect={}",
+            is_connect
+        )));
+    }
+
+    tracing::debug!("[UDP] Using Connect format (isConnect=1)");
+
+    // Read ATYP (1 byte)
+    let mut atyp_buf = [0u8; 1];
+    reader
+        .read_exact(&mut atyp_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let atyp = atyp_buf[0];
+
+    match atyp {
+        0x01 => {
+            // IPv4: 4 bytes IP + 2 bytes port
+            let mut ip_buf = [0u8; 4];
+            reader
+                .read_exact(&mut ip_buf)
+                .await
+                .map_err(AnyTlsError::Io)?;
+
+            let mut port_buf = [0u8; 2];
+            reader
+                .read_exact(&mut port_buf)
+                .await
+                .map_err(AnyTlsError::Io)?;
+
+            let ip = std::net::Ipv4Addr::from(ip_buf);
+            let port = u16::from_be_bytes(port_buf);
+
+            Ok(SocketAddr::from((ip, port)))
+        }
+        0x04 => {
+            // IPv6: 16 bytes IP + 2 bytes port
+            let mut ip_buf = [0u8; 16];
+            reader
+                .read_exact(&mut ip_buf)
+                .await
+                .map_err(AnyTlsError::Io)?;
+
+            let mut port_buf = [0u8; 2];
+            reader
+                .read_exact(&mut port_buf)
+                .await
+                .map_err(AnyTlsError::Io)?;
+
+            let ip = std::net::Ipv6Addr::from(ip_buf);
+            let port = u16::from_be_bytes(port_buf);
+
+            Ok(SocketAddr::from((ip, port)))
+        }
+        0x03 => {
+            // Domain: length (1 byte) + domain + 2 bytes port
+            let mut len_buf = [0u8; 1];
+            reader
+                .read_exact(&mut len_buf)
+                .await
+                .map_err(AnyTlsError::Io)?;
+
+            let domain_len = len_buf[0] as usize;
+            if domain_len == 0 || domain_len > 255 {
+                return Err(AnyTlsError::Protocol("Invalid domain length".into()));
+            }
+
+            let mut domain_buf = vec![0u8; domain_len];
+            reader
+                .read_exact(&mut domain_buf)
+                .await
+                .map_err(AnyTlsError::Io)?;
+
+            let domain = String::from_utf8(domain_buf)
+                .map_err(|e| AnyTlsError::Protocol(format!("Invalid domain name: {}", e)))?;
+
+            let mut port_buf = [0u8; 2];
+            reader
+                .read_exact(&mut port_buf)
+                .await
+                .map_err(AnyTlsError::Io)?;
+
+            let port = u16::from_be_bytes(port_buf);
+
+            // Resolve domain name with caching and timeout
+            let addr = resolve_host_with_cache(&domain, port).await?;
+
+            Ok(addr)
+        }
+        _ => Err(AnyTlsError::Protocol(format!(
+            "Unknown address type: {}",
+            atyp
+        ))),
+    }
+}
+
+/// Stream → UDP: Read packets from Stream, decode and send to UDP
+///
+/// Protocol: Each packet is Length (2 bytes BE) + Payload
+/// The payload is pure UDP data (target address already known from initial request)
+async fn stream_to_udp(
+    stream: &Stream,
+    udp: &UdpSocket,
+    target_addr: &SocketAddr,
+    packets_counter: Arc<AtomicU64>,
+    bytes_counter: Arc<AtomicU64>,
+) -> Result<()> {
+    let stream_id = stream.id();
+    let reader = stream.reader();
+    let mut reader_guard = reader.lock().await;
+
+    tracing::debug!("[UDP] Stream → UDP task started for stream {}", stream_id);
+
+    loop {
+        // Read one UDP packet (Length + Payload format)
+        let payload = match read_udp_packet(&mut reader_guard).await {
+            Ok(data) => data,
+            Err(e) => {
+                if e.to_string().contains("UnexpectedEof") || e.to_string().contains("EOF") {
+                    tracing::debug!("[UDP] Stream closed (EOF), stopping Stream → UDP");
+                    break;
+                }
+                tracing::error!("[UDP] Failed to read UDP packet from stream: {}", e);
+                return Err(e);
+            }
+        };
+
+        if payload.is_empty() {
+            tracing::debug!("[UDP] Empty packet, stream might be closed");
+            break;
+        }
+
+        tracing::trace!(
+            "[UDP] Stream → UDP: {} bytes to {}",
+            payload.len(),
+            target_addr
+        );
+
+        // Send to UDP (target address already known from initial request)
+        let sent = udp.send_to(&payload, target_addr).await?;
+
+        if sent != payload.len() {
+            tracing::warn!("[UDP] Partial UDP send: {} / {} bytes", sent, payload.len());
+        }
+        packets_counter.fetch_add(1, Ordering::Relaxed);
+        bytes_counter.fetch_add(sent as u64, Ordering::Relaxed);
+    }
+
+    Ok(())
+}
+
+/// UDP → Stream: Read from UDP, encode and send to Stream
+///
+/// Protocol: Each packet is Length (2 bytes BE) + Payload
+/// The payload is pure UDP data (source address info might be embedded, but for simplicity
+/// we just send the data since the connection is already established)
+async fn udp_to_stream(
+    stream: &Stream,
+    udp: &UdpSocket,
+    _target_addr: &SocketAddr,
+    packets_counter: Arc<AtomicU64>,
+    bytes_counter: Arc<AtomicU64>,
+) -> Result<()> {
+    let stream_id = stream.id();
+
+    tracing::debug!("[UDP] UDP → Stream task started for stream {}", stream_id);
+
+    let mut buf = vec![0u8; MAX_UDP_PACKET_SIZE];
+
+    loop {
+        // Receive from UDP
+        let (len, addr) = match udp.recv_from(&mut buf).await {
+            Ok((len, addr)) => (len, addr),
+            Err(e) => {
+                tracing::error!("[UDP] Failed to receive from UDP: {}", e);
+                return Err(AnyTlsError::Io(e));
+            }
+        };
+
+        tracing::trace!("[UDP] UDP → Stream: {} bytes from {}", len, addr);
+
+        // Encode: Length (2 bytes BE) + Payload
+        // Note: According to sing-box protocol, the payload is just the UDP data
+        // The source address info is not included in each packet (connection is established)
+        let packet = encode_udp_packet_simple(&buf[..len])?;
+
+        // Send to Stream using the send_data method
+        if let Err(e) = stream.send_data(packet) {
+            tracing::error!("[UDP] Failed to send to stream: {}", e);
+            return Err(AnyTlsError::Protocol("Channel send failed".into()));
+        }
+        packets_counter.fetch_add(1, Ordering::Relaxed);
+        bytes_counter.fetch_add(len as u64, Ordering::Relaxed);
+    }
+}
+
+/// Read one UDP packet from Stream
+///
+/// Format: | Length (2 bytes BE) | Payload |
+/// Returns the payload (without length prefix)
+async fn read_udp_packet(reader: &mut StreamReader) -> Result<Vec<u8>> {
+    // Read 2-byte length (Big-Endian)
+    let mut len_buf = [0u8; 2];
+    reader
+        .read_exact(&mut len_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let len = u16::from_be_bytes(len_buf) as usize;
+
+    if len == 0 {
+        return Ok(Vec::new());
+    }
+
+    if len > MAX_UDP_PACKET_SIZE {
+        return Err(AnyTlsError::Protocol(format!(
+            "UDP packet too large: {} bytes",
+            len
+        )));
+    }
+
+    // Read the actual payload
+    let mut data = vec![0u8; len];
+    reader
+        .read_exact(&mut data)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    Ok(data)
+}
+
+/// Encode UDP packet (simple format)
+///
+/// Format (sing-box v2 after initial request):
+/// | Length (2 bytes BE) | Payload |
+///
+/// The payload is pure UDP data (no address encoding needed)
+fn encode_udp_packet_simple(payload: &[u8]) -> Result<Bytes> {
+    let mut buf = BytesMut::new();
+
+    if payload.len() > MAX_UDP_PACKET_SIZE {
+        return Err(AnyTlsError::Protocol(format!(
+            "UDP packet too large: {} bytes",
+            payload.len()
+        )));
+    }
+
+    // Write length (2 bytes, Big-Endian)
+    buf.put_u16(payload.len() as u16);
+
+    // Write payload
+    buf.put_slice(payload);
+
+    Ok(buf.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_udp_packet_length() {
+        // Test that we can encode and decode length correctly
+        let payload = b"Test UDP data";
+        let encoded = encode_udp_packet_simple(payload).unwrap();
+
+        // Check length prefix
+        let len = u16::from_be_bytes([encoded[0], encoded[1]]) as usize;
+        assert_eq!(len, payload.len());
+        assert_eq!(encoded.len(), 2 + payload.len());
+
+        // Check payload
+        assert_eq!(&encoded[2..], payload);
+    }
+
+    #[test]
+    fn test_encode_empty_packet() {
+        let payload = b"";
+        let encoded = encode_udp_packet_simple(payload).unwrap();
+
+        // Should have 2-byte length header with value 0
+        assert_eq!(encoded.len(), 2);
+        assert_eq!(u16::from_be_bytes([encoded[0], encoded[1]]), 0);
+    }
+
+    #[test]
+    fn test_encode_large_packet() {
+        let payload = vec![0u8; 65535]; // Max UDP packet size
+        let result = encode_udp_packet_simple(&payload);
+        assert!(result.is_ok());
+
+        let encoded = result.unwrap();
+        assert_eq!(encoded.len(), 2 + 65535);
+        assert_eq!(u16::from_be_bytes([encoded[0], encoded[1]]), 65535);
+    }
+
+    #[test]
+    fn test_encode_too_large_packet() {
+        let payload = vec![0u8; 65536]; // Too large
+        let result = encode_udp_packet_simple(&payload);
+        assert!(result.is_err());
+
+        if let Err(e) = result {
+            assert!(e.to_string().contains("too large"));
+        }
+    }
+}

--- a/crates/meow-anytls/src/session/mod.rs
+++ b/crates/meow-anytls/src/session/mod.rs
@@ -1,0 +1,8 @@
+#[allow(clippy::module_inception)]
+pub mod session;
+pub mod stream;
+pub mod stream_reader;
+
+pub use session::{Session, SessionHeartbeatConfig};
+pub use stream::Stream;
+pub use stream_reader::StreamReader;

--- a/crates/meow-anytls/src/session/session.rs
+++ b/crates/meow-anytls/src/session/session.rs
@@ -1,0 +1,1599 @@
+//! Session implementation for AnyTLS protocol
+
+use crate::padding::PaddingFactory;
+use crate::protocol::{Command, Frame, FrameCodec};
+use crate::session::Stream;
+use crate::util::{AnyTlsError, Result, StringMap};
+use bytes::{Bytes, BytesMut};
+use md5;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{Notify, RwLock, mpsc};
+use tokio::time::{self, Duration, Instant, MissedTickBehavior};
+use tracing::{field, info_span};
+
+static SESSION_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+use tokio_util::codec::Decoder;
+
+/// Type alias for new stream callback channel
+type NewStreamCallback =
+    Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Arc<Stream>>>>>;
+
+#[derive(Clone)]
+pub struct SessionHeartbeatConfig {
+    pub interval: Duration,
+    pub timeout: Duration,
+}
+
+struct HeartbeatState {
+    interval: Duration,
+    timeout: Duration,
+    last_received: tokio::sync::Mutex<Instant>,
+}
+
+/// Session manages multiple streams over a single TLS connection
+type StreamDataReceiver = mpsc::UnboundedReceiver<(u32, Bytes)>;
+
+pub struct Session {
+    id: u64,
+    // Connection reader and writer (split TLS stream)
+    reader: Arc<tokio::sync::Mutex<Box<dyn AsyncRead + Send + Unpin>>>,
+    writer: Arc<tokio::sync::Mutex<Box<dyn AsyncWrite + Send + Unpin>>>,
+
+    // Stream management - using Arc for sharing
+    streams: Arc<RwLock<HashMap<u32, Arc<Stream>>>>,
+    stream_id: Arc<std::sync::atomic::AtomicU32>,
+
+    // Channel for receiving data from streams
+    stream_data_tx: mpsc::UnboundedSender<(u32, Bytes)>,
+    stream_data_rx: Arc<tokio::sync::Mutex<Option<StreamDataReceiver>>>,
+
+    // Channel for sending data to streams (stream_id -> sender)
+    stream_receive_tx: Arc<RwLock<HashMap<u32, mpsc::UnboundedSender<Bytes>>>>,
+
+    // Session state
+    is_closed: Arc<std::sync::atomic::AtomicBool>,
+
+    // Padding factory (wrapped in Arc for potential updates)
+    padding: Arc<RwLock<Arc<PaddingFactory>>>,
+
+    // Client/Server specific
+    is_client: bool,
+    send_padding: bool,
+    pkt_counter: Arc<std::sync::atomic::AtomicU32>,
+
+    // Peer version
+    #[allow(dead_code)]
+    peer_version: Arc<std::sync::atomic::AtomicU8>,
+
+    // Session sequence number (for pool ordering)
+    seq: Arc<std::sync::atomic::AtomicU64>,
+
+    // Buffering state
+    buffering: Arc<std::sync::atomic::AtomicBool>,
+    buffer: Arc<tokio::sync::Mutex<Vec<u8>>>,
+
+    // Server callback for new streams (optional)
+    on_new_stream: Option<NewStreamCallback>,
+
+    // Optional server settings to send to client
+    server_settings: Option<StringMap>,
+
+    // Heartbeat configuration (client side)
+    heartbeat: Option<Arc<HeartbeatState>>,
+    close_notify: Arc<Notify>,
+}
+
+impl Session {
+    async fn handle_io_error(&self, context: &str, error: std::io::Error) -> AnyTlsError {
+        tracing::error!(
+            session_id = self.id(),
+            ctx = context,
+            "[Session] IO error during {}: {}",
+            context,
+            error
+        );
+        if let Err(close_err) = self.close().await {
+            tracing::warn!(
+                session_id = self.id(),
+                "[Session] Failed to close session after IO error: {}",
+                close_err
+            );
+        }
+        AnyTlsError::Io(error)
+    }
+
+    /// Create a new client session
+    pub fn new_client<R, W>(
+        reader: R,
+        writer: W,
+        padding: Arc<PaddingFactory>,
+        heartbeat: Option<SessionHeartbeatConfig>,
+    ) -> Self
+    where
+        R: AsyncRead + Send + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        let (stream_data_tx, stream_data_rx) = mpsc::unbounded_channel();
+        let id = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let heartbeat_state = heartbeat.map(|cfg| {
+            Arc::new(HeartbeatState {
+                interval: cfg.interval,
+                timeout: cfg.timeout,
+                last_received: tokio::sync::Mutex::new(Instant::now()),
+            })
+        });
+
+        Self {
+            id,
+            reader: Arc::new(tokio::sync::Mutex::new(Box::new(reader))),
+            writer: Arc::new(tokio::sync::Mutex::new(Box::new(writer))),
+            streams: Arc::new(RwLock::new(HashMap::new())),
+            stream_id: Arc::new(std::sync::atomic::AtomicU32::new(1)),
+            stream_data_tx,
+            stream_data_rx: Arc::new(tokio::sync::Mutex::new(Some(stream_data_rx))),
+            stream_receive_tx: Arc::new(RwLock::new(HashMap::new())),
+            is_closed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            padding: Arc::new(RwLock::new(padding)),
+            is_client: true,
+            send_padding: true,
+            pkt_counter: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            peer_version: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            buffering: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            buffer: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            on_new_stream: None,
+            server_settings: None,
+            heartbeat: heartbeat_state,
+            close_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Create a new server session
+    pub fn new_server<R, W>(reader: R, writer: W, padding: Arc<PaddingFactory>) -> Self
+    where
+        R: AsyncRead + Send + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        let (stream_data_tx, stream_data_rx) = mpsc::unbounded_channel();
+        let id = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        Self {
+            id,
+            reader: Arc::new(tokio::sync::Mutex::new(Box::new(reader))),
+            writer: Arc::new(tokio::sync::Mutex::new(Box::new(writer))),
+            streams: Arc::new(RwLock::new(HashMap::new())),
+            stream_id: Arc::new(std::sync::atomic::AtomicU32::new(1)),
+            stream_data_tx,
+            stream_data_rx: Arc::new(tokio::sync::Mutex::new(Some(stream_data_rx))),
+            stream_receive_tx: Arc::new(RwLock::new(HashMap::new())),
+            is_closed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            padding: Arc::new(RwLock::new(padding)),
+            is_client: false,
+            send_padding: false,
+            pkt_counter: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            peer_version: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            buffering: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            buffer: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            on_new_stream: None,
+            server_settings: None,
+            heartbeat: None,
+            close_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Session identifier (unique per runtime)
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Set callback for new streams (server side only)
+    pub fn set_stream_callback(
+        &mut self,
+        callback: tokio::sync::mpsc::UnboundedSender<Arc<Stream>>,
+    ) {
+        if !self.is_client {
+            self.on_new_stream = Some(Arc::new(tokio::sync::Mutex::new(Some(callback))));
+        }
+    }
+
+    /// Set server settings to send back to clients during handshake (server side)
+    pub fn set_server_settings(&mut self, settings: Option<StringMap>) {
+        self.server_settings = settings;
+    }
+
+    /// Check if session is closed
+    pub fn is_closed(&self) -> bool {
+        self.is_closed.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Whether the session currently carries any open streams.
+    ///
+    /// Used by the session pool's cleanup task to avoid closing a pooled
+    /// session that is still serving traffic (e.g. a long-running download).
+    /// Accurate now that client streams are evicted on close (`Stream::close`
+    /// emits a FIN and removes the maps).
+    pub async fn has_active_streams(&self) -> bool {
+        !self.streams.read().await.is_empty()
+    }
+
+    /// Close the session
+    pub async fn close(&self) -> Result<()> {
+        let already_closed = self
+            .is_closed
+            .swap(true, std::sync::atomic::Ordering::Relaxed);
+        if already_closed {
+            return Ok(());
+        }
+        self.close_notify.notify_waiters();
+
+        // Close stream data receiver so process_stream_data exits
+        // Close all streams and notify pending waiters
+        {
+            let mut streams = self.streams.write().await;
+            let mut receive_map = self.stream_receive_tx.write().await;
+            for (stream_id, stream) in streams.drain() {
+                stream.close_with_error(AnyTlsError::SessionClosed).await;
+                stream.notify_synack(Err(AnyTlsError::SessionClosed)).await;
+                receive_map.remove(&stream_id);
+            }
+        }
+
+        // Attempt to shutdown writer gracefully
+        {
+            let mut writer = self.writer.lock().await;
+            match time::timeout(Duration::from_secs(1), writer.shutdown()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::debug!(
+                        session_id = self.id,
+                        "[Session] Writer shutdown failed during close: {}",
+                        e
+                    );
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        session_id = self.id,
+                        "[Session] Writer shutdown timed out during close"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Start the receive loop (should be run in a tokio task)
+    pub async fn recv_loop(&self) -> Result<()> {
+        let session_id = self.id();
+        let role = if self.is_client { "client" } else { "server" };
+        let recv_span = info_span!(
+            "anytls.session.recv",
+            session_id,
+            role = %role,
+            bytes_in = field::Empty,
+            iterations = field::Empty
+        );
+        let _recv_guard = recv_span.enter();
+        tracing::debug!(
+            session_id = session_id,
+            is_client = self.is_client,
+            "[Session] recv_loop started"
+        );
+        let mut codec = FrameCodec;
+        let mut buffer = BytesMut::with_capacity(8192);
+        let mut iteration = 0u64;
+        let mut total_bytes_in: usize = 0;
+
+        loop {
+            iteration += 1;
+            if self.is_closed() {
+                tracing::debug!(
+                    session_id = session_id,
+                    "[Session] recv_loop: Session closed (iteration {})",
+                    iteration
+                );
+                break;
+            }
+
+            // Read data from connection
+            tracing::trace!(
+                session_id = session_id,
+                "[Session] recv_loop: Acquiring reader lock (iteration {})",
+                iteration
+            );
+            let mut reader = self.reader.lock().await;
+            tracing::trace!(
+                session_id = session_id,
+                "[Session] recv_loop: Reader lock acquired, calling read_buf (iteration {})",
+                iteration
+            );
+            let n = match reader.read_buf(&mut buffer).await {
+                Ok(n) => {
+                    tracing::trace!(
+                        session_id = session_id,
+                        "[Session] recv_loop: read_buf returned {} bytes (iteration {})",
+                        n,
+                        iteration
+                    );
+                    n
+                }
+                Err(e) => {
+                    // Check if this is a "close_notify" error (common and harmless)
+                    let error_msg = e.to_string();
+                    let is_close_notify_error = error_msg.contains("close_notify")
+                        || error_msg.contains("unexpected EOF")
+                        || e.kind() == std::io::ErrorKind::UnexpectedEof;
+
+                    if is_close_notify_error {
+                        // This is a normal connection close without TLS close_notify
+                        // Many clients (especially HTTP clients) do this
+                        tracing::debug!(
+                            session_id = session_id,
+                            "[Session] recv_loop: Connection closed by peer (no close_notify) - this is normal (iteration {})",
+                            iteration
+                        );
+                        let _ = self.close().await;
+                        break;
+                    } else {
+                        // This is a real error
+                        let err = self.handle_io_error("recv_loop_read", e).await;
+                        return Err(err);
+                    }
+                }
+            };
+            drop(reader);
+            tracing::trace!(
+                session_id = session_id,
+                "[Session] recv_loop: Reader lock released (iteration {})",
+                iteration
+            );
+
+            if n == 0 {
+                // Connection closed
+                tracing::debug!(
+                    session_id = session_id,
+                    "[Session] recv_loop: Connection closed (read 0 bytes, iteration {})",
+                    iteration
+                );
+                let _ = self.close().await;
+                break;
+            }
+
+            tracing::debug!(
+                session_id = session_id,
+                "[Session] recv_loop: Read {} bytes, buffer size={} (iteration {})",
+                n,
+                buffer.len(),
+                iteration
+            );
+
+            total_bytes_in += n;
+
+            // Decode frames
+            let mut frame_count = 0u32;
+            let buffer_before_decode = buffer.len();
+            while let Some(frame) = codec.decode(&mut buffer)? {
+                frame_count += 1;
+                tracing::debug!(
+                    session_id = session_id,
+                    "[Session] recv_loop: Decoded frame #{}: cmd={:?}, stream_id={}, data_len={} (iteration {}, buffer before={}, after={})",
+                    frame_count,
+                    frame.cmd,
+                    frame.stream_id,
+                    frame.data.len(),
+                    iteration,
+                    buffer_before_decode,
+                    buffer.len()
+                );
+                self.handle_frame(frame).await?;
+            }
+            if frame_count == 0 && n > 0 {
+                tracing::debug!(
+                    session_id = session_id,
+                    "[Session] recv_loop: No frames decoded from {} bytes read (iteration {}, buffer size={})",
+                    n,
+                    iteration,
+                    buffer.len()
+                );
+                tracing::trace!(
+                    session_id = session_id,
+                    "[Session] recv_loop: Buffer contents (first 50 bytes): {:?}",
+                    if buffer.len() >= 50 {
+                        &buffer[..50]
+                    } else {
+                        &buffer[..]
+                    }
+                );
+            }
+        }
+
+        tracing::debug!(
+            session_id = session_id,
+            "[Session] recv_loop: Exiting after {} iterations",
+            iteration
+        );
+        tracing::debug!(
+            session_id = session_id,
+            bytes_in = total_bytes_in as u64,
+            iterations = iteration,
+            "[Session] recv_loop completed"
+        );
+        recv_span.record("bytes_in", total_bytes_in as u64);
+        recv_span.record("iterations", iteration);
+        Ok(())
+    }
+
+    /// Handle an incoming frame from connection
+    async fn handle_frame(&self, frame: Frame) -> Result<()> {
+        let session_id = self.id();
+        tracing::debug!(
+            session_id = session_id,
+            "[Session] handle_frame: Processing frame cmd={:?}, stream_id={}, data_len={}",
+            frame.cmd,
+            frame.stream_id,
+            frame.data.len()
+        );
+        match frame.cmd {
+            Command::Push => {
+                // Data frame - forward to stream
+                let data_len = frame.data.len();
+                tracing::debug!(
+                    session_id = session_id,
+                    "[Session] handle_frame: Received PSH frame for stream {}, length={}",
+                    frame.stream_id,
+                    data_len
+                );
+
+                let receive_map = self.stream_receive_tx.read().await;
+                tracing::trace!(
+                    session_id = session_id,
+                    "[Session] handle_frame: Acquired stream_receive_tx read lock for stream {}",
+                    frame.stream_id
+                );
+
+                if let Some(tx) = receive_map.get(&frame.stream_id) {
+                    tracing::trace!(
+                        session_id = session_id,
+                        "[Session] handle_frame: Found receiver for stream {}, sending {} bytes",
+                        frame.stream_id,
+                        data_len
+                    );
+                    match tx.send(frame.data.clone()) {
+                        Ok(_) => {
+                            tracing::debug!(
+                                session_id = session_id,
+                                "[Session] handle_frame: Successfully sent {} bytes to stream {} via channel",
+                                data_len,
+                                frame.stream_id
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                session_id = session_id,
+                                "[Session] handle_frame: Failed to send {} bytes to stream {} via channel: {}",
+                                data_len,
+                                frame.stream_id,
+                                e
+                            );
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        session_id = session_id,
+                        "[Session] handle_frame: No receiver found for stream {} (available streams: {:?})",
+                        frame.stream_id,
+                        receive_map.keys().collect::<Vec<_>>()
+                    );
+                }
+                drop(receive_map);
+                tracing::trace!(
+                    session_id = session_id,
+                    "[Session] handle_frame: Released stream_receive_tx read lock"
+                );
+            }
+            Command::Syn => {
+                // Stream open (server side)
+                if !self.is_client {
+                    let stream_id = frame.stream_id;
+                    tracing::debug!(
+                        session_id = session_id,
+                        "[Session] Received SYN for stream {} (server side)",
+                        stream_id
+                    );
+
+                    let (receive_tx, receive_rx) = mpsc::unbounded_channel();
+
+                    // 创建 StreamReader
+                    let reader = crate::session::StreamReader::new(stream_id, receive_rx);
+
+                    // Server side: create stream without waiting for SYNACK
+                    // The receiver is discarded since server doesn't need it
+                    let (stream, _synack_rx) =
+                        Stream::new(stream_id, reader, self.stream_data_tx.clone());
+
+                    let stream = Arc::new(stream);
+
+                    {
+                        let mut receive_map = self.stream_receive_tx.write().await;
+                        receive_map.insert(stream_id, receive_tx);
+                    }
+
+                    {
+                        let mut streams = self.streams.write().await;
+                        streams.insert(stream_id, stream.clone());
+                    }
+
+                    tracing::trace!(
+                        session_id = session_id,
+                        "[Session] Stream {} stored and ready for callback",
+                        stream_id
+                    );
+
+                    // Notify callback if set
+                    if let Some(callback_guard) = &self.on_new_stream {
+                        let callback = callback_guard.lock().await;
+                        if let Some(tx) = callback.as_ref() {
+                            tracing::debug!(
+                                session_id = session_id,
+                                "[Session] Sending stream {} to callback",
+                                stream_id
+                            );
+                            let _ = tx.send(stream.clone());
+                        } else {
+                            tracing::warn!(
+                                session_id = session_id,
+                                "[Session] No callback set for stream {}",
+                                stream_id
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            session_id = session_id,
+                            "[Session] No callback guard for stream {}",
+                            stream_id
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        session_id = session_id,
+                        "[Session] Received SYN on client side (unexpected)"
+                    );
+                }
+            }
+            Command::SynAck => {
+                // Server acknowledges stream open (client side)
+                if self.is_client {
+                    tracing::debug!(
+                        session_id = session_id,
+                        "[Session] Received SYNACK for stream {}",
+                        frame.stream_id
+                    );
+
+                    let streams = self.streams.read().await;
+                    if let Some(stream) = streams.get(&frame.stream_id) {
+                        // If data is present, it's an error message
+                        if !frame.data.is_empty() {
+                            let error_msg = String::from_utf8_lossy(&frame.data).to_string();
+                            tracing::error!(
+                                session_id = session_id,
+                                "[Session] Stream {} error from server: {}",
+                                frame.stream_id,
+                                error_msg
+                            );
+
+                            // Notify stream about the error
+                            let error =
+                                AnyTlsError::Protocol(format!("Server error: {}", error_msg));
+                            stream.notify_synack(Err(error)).await;
+                        } else {
+                            tracing::info!(
+                                session_id = session_id,
+                                "[Session] Stream {} SYNACK received (success) - stream is ready",
+                                frame.stream_id
+                            );
+                            // Notify stream about success
+                            stream.notify_synack(Ok(())).await;
+                        }
+                    } else {
+                        tracing::warn!(
+                            session_id = session_id,
+                            "[Session] Received SYNACK for unknown stream {}",
+                            frame.stream_id
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        session_id = session_id,
+                        "[Session] Received SYNACK on server side (unexpected)"
+                    );
+                }
+            }
+            Command::Fin => {
+                // Stream close
+                tracing::debug!(
+                    session_id = session_id,
+                    "[Session] FIN received for stream {}, closing",
+                    frame.stream_id
+                );
+                let mut streams = self.streams.write().await;
+                streams.remove(&frame.stream_id);
+                let mut receive_map = self.stream_receive_tx.write().await;
+                receive_map.remove(&frame.stream_id);
+            }
+            Command::Settings => {
+                // Client settings (server side)
+                if !self.is_client && !frame.data.is_empty() {
+                    let settings = StringMap::from_bytes(&frame.data);
+
+                    // Check padding-md5
+                    if let Some(client_md5) = settings.get("padding-md5") {
+                        let padding_guard = self.padding.read().await;
+                        let server_md5 = padding_guard.md5();
+                        if client_md5 != server_md5 {
+                            // Send UpdatePaddingScheme
+                            tracing::debug!(
+                                "[Session] Client padding-md5 mismatch, sending update"
+                            );
+                            let raw_scheme = padding_guard.raw_scheme();
+                            let update_frame = Frame::with_data(
+                                Command::UpdatePaddingScheme,
+                                0,
+                                Bytes::copy_from_slice(raw_scheme),
+                            );
+                            self.write_frame(update_frame).await?;
+                        }
+                    }
+
+                    // Check client version
+                    if let Some(v_str) = settings.get("v")
+                        && let Ok(v) = v_str.parse::<u8>()
+                        && v >= 2
+                    {
+                        self.peer_version
+                            .store(v, std::sync::atomic::Ordering::Relaxed);
+
+                        // Send ServerSettings
+                        let mut server_settings = StringMap::new();
+                        server_settings.insert("v", "2");
+                        if let Some(extra) = &self.server_settings {
+                            for (k, v) in extra.clone().into_vec() {
+                                server_settings.insert(k, v);
+                            }
+                        }
+                        let server_settings_frame = Frame::with_data(
+                            Command::ServerSettings,
+                            0,
+                            Bytes::from(server_settings.to_bytes()),
+                        );
+                        self.write_frame(server_settings_frame).await?;
+                    }
+                }
+            }
+            Command::ServerSettings => {
+                // Server settings (client side)
+                if self.is_client && !frame.data.is_empty() {
+                    let settings = StringMap::from_bytes(&frame.data);
+                    if let Some(v_str) = settings.get("v")
+                        && let Ok(v) = v_str.parse::<u8>()
+                    {
+                        self.peer_version
+                            .store(v, std::sync::atomic::Ordering::Relaxed);
+                        tracing::debug!("[Session] Server version: {}", v);
+                    }
+                }
+            }
+            Command::UpdatePaddingScheme => {
+                // Server updates padding scheme (client side)
+                if self.is_client && !frame.data.is_empty() {
+                    let raw_scheme = frame.data.as_ref();
+                    match PaddingFactory::update_default(raw_scheme) {
+                        Ok(_) => {
+                            let md5_hash = md5::compute(raw_scheme);
+                            tracing::info!("[Session] Padding scheme updated: {:x}", md5_hash);
+                            // Update the session's padding factory
+                            let mut padding_guard = self.padding.write().await;
+                            *padding_guard = PaddingFactory::default();
+                        }
+                        Err(e) => {
+                            let md5_hash = md5::compute(raw_scheme);
+                            tracing::warn!(
+                                "[Session] Failed to update padding scheme {:x}: {}",
+                                md5_hash,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+            Command::Alert => {
+                // Alert message - fatal error, should close session
+                let alert_msg = if !frame.data.is_empty() {
+                    String::from_utf8_lossy(&frame.data).to_string()
+                } else {
+                    "Unknown alert".to_string()
+                };
+                tracing::error!("[Session] Received Alert frame (fatal): {}", alert_msg);
+                // Close all streams
+                let mut streams = self.streams.write().await;
+                for (stream_id, stream) in streams.drain() {
+                    let error = AnyTlsError::Protocol(format!(
+                        "Session closed due to alert: {}",
+                        alert_msg
+                    ));
+                    stream.close_with_error(error).await;
+                    tracing::debug!("[Session] Closed stream {} due to alert", stream_id);
+                }
+                drop(streams);
+                // Mark session as closed
+                self.is_closed
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                return Err(AnyTlsError::Protocol(format!("Alert: {}", alert_msg)));
+            }
+            Command::HeartRequest => {
+                // Heartbeat request - respond with HeartResponse
+                tracing::debug!(
+                    "[Session] Received HeartRequest (stream_id={})",
+                    frame.stream_id
+                );
+
+                // Send HeartResponse immediately
+                let response = Frame::control(Command::HeartResponse, frame.stream_id);
+
+                if let Err(e) = self.write_control_frame(response).await {
+                    tracing::error!("[Session] Failed to send HeartResponse: {}", e);
+                    return Err(e);
+                }
+
+                tracing::debug!(
+                    "[Session] Sent HeartResponse (stream_id={})",
+                    frame.stream_id
+                );
+            }
+            Command::HeartResponse => {
+                // Heartbeat response - log for now
+                tracing::debug!(
+                    "[Session] Received HeartResponse (stream_id={})",
+                    frame.stream_id
+                );
+
+                if let Some(heartbeat_state) = &self.heartbeat {
+                    let mut last = heartbeat_state.last_received.lock().await;
+                    *last = Instant::now();
+                }
+            }
+            _ => {
+                // Unhandled command - log and ignore
+                tracing::debug!(
+                    "[Session] Unhandled command: {:?} (stream_id={})",
+                    frame.cmd,
+                    frame.stream_id
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Create a new stream (client side)
+    /// Returns the stream and SYNACK receiver for timeout detection
+    pub async fn open_stream(
+        &self,
+    ) -> Result<(Arc<Stream>, tokio::sync::oneshot::Receiver<Result<()>>)> {
+        if self.is_closed() {
+            tracing::warn!("[Session] Attempted to open stream on closed session");
+            return Err(AnyTlsError::SessionClosed);
+        }
+
+        let stream_id = self
+            .stream_id
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        tracing::debug!(
+            "[Session] Opening new stream {} (client={})",
+            stream_id,
+            self.is_client
+        );
+
+        // Create channels for this stream
+        let (receive_tx, receive_rx) = mpsc::unbounded_channel();
+
+        // 创建 StreamReader
+        let reader = crate::session::StreamReader::new(stream_id, receive_rx);
+
+        let (stream, synack_rx) = Stream::new(stream_id, reader, self.stream_data_tx.clone());
+
+        let stream = Arc::new(stream);
+
+        // Store the receive_tx for sending data to this stream
+        {
+            let mut receive_map = self.stream_receive_tx.write().await;
+            receive_map.insert(stream_id, receive_tx);
+        }
+
+        // Store the stream
+        {
+            let mut streams = self.streams.write().await;
+            streams.insert(stream_id, stream.clone());
+        }
+
+        tracing::trace!("[Session] Stream {} stored in session", stream_id);
+
+        // Send SYN frame
+        tracing::trace!("[Session] Sending SYN frame for stream {}", stream_id);
+        let frame = Frame::control(Command::Syn, stream_id);
+        self.write_frame(frame).await?;
+        tracing::debug!("[Session] SYN frame sent for stream {}", stream_id);
+
+        Ok((stream, synack_rx))
+    }
+
+    /// Disable buffering (this will flush buffer on next write)
+    pub fn disable_buffering(&self) {
+        self.buffering
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Write a data frame to connection
+    pub async fn write_data_frame(&self, stream_id: u32, data: Bytes) -> Result<()> {
+        tracing::trace!(
+            session_id = self.id(),
+            stream_id,
+            bytes = data.len(),
+            "[Session] write_data_frame: stream_id={}, data_len={}",
+            stream_id,
+            data.len()
+        );
+        let frame = Frame::data(stream_id, data);
+        self.write_frame(frame).await
+    }
+
+    /// Write a control frame to connection
+    pub async fn write_control_frame(&self, frame: Frame) -> Result<()> {
+        self.write_frame(frame).await
+    }
+
+    /// Write a frame to the connection
+    pub async fn write_frame(&self, frame: Frame) -> Result<()> {
+        use tokio_util::codec::Encoder;
+        let frame_cmd = frame.cmd;
+        let frame_stream_id = frame.stream_id;
+        let mut codec = FrameCodec;
+        let mut buffer = BytesMut::new();
+        codec.encode(frame, &mut buffer)?;
+        tracing::trace!(
+            session_id = self.id(),
+            "[Session] write_frame: encoded frame cmd={:?}, stream_id={}, buffer_len={}",
+            frame_cmd,
+            frame_stream_id,
+            buffer.len()
+        );
+
+        // Check if buffering
+        if self.buffering.load(std::sync::atomic::Ordering::Relaxed) {
+            tracing::trace!(
+                "[Session] write_frame: Buffering frame cmd={:?}, stream_id={}",
+                frame_cmd,
+                frame_stream_id
+            );
+            let mut buf = self.buffer.lock().await;
+            let old_len = buf.len();
+            buf.extend_from_slice(&buffer);
+            tracing::debug!(
+                "[Session] write_frame: Buffered frame (buffer size: {} -> {})",
+                old_len,
+                buf.len()
+            );
+            return Ok(());
+        }
+
+        // Flush buffer if any
+        {
+            let mut buf = self.buffer.lock().await;
+            if !buf.is_empty() {
+                let buffered_len = buf.len();
+                tracing::debug!(
+                    "[Session] write_frame: Flushing {} buffered bytes along with new frame ({} bytes)",
+                    buffered_len,
+                    buffer.len()
+                );
+
+                // Log first frame's header for debugging
+                if buffered_len >= 7 {
+                    tracing::debug!(
+                        "[Session] First buffered frame header: cmd={}, stream_id={:?}, data_len={:?}",
+                        buf[0],
+                        u32::from_be_bytes([buf[1], buf[2], buf[3], buf[4]]),
+                        u16::from_be_bytes([buf[5], buf[6]])
+                    );
+                }
+
+                let mut combined = BytesMut::from(&buf[..]);
+                combined.extend_from_slice(&buffer);
+                buffer = combined;
+                buf.clear();
+            }
+        }
+
+        // Log what we're about to send
+        if buffer.len() >= 7 {
+            tracing::info!(
+                "[Session] About to send frame header: cmd={}, stream_id={:?}, data_len={:?}, total_buffer_len={}",
+                buffer[0],
+                u32::from_be_bytes([buffer[1], buffer[2], buffer[3], buffer[4]]),
+                u16::from_be_bytes([buffer[5], buffer[6]]),
+                buffer.len()
+            );
+        }
+
+        // Write with padding if enabled
+        self.write_with_padding(buffer).await
+    }
+
+    /// Write buffer to connection with padding applied
+    async fn write_with_padding(&self, mut buffer: BytesMut) -> Result<()> {
+        use crate::padding::CHECK_MARK;
+        use crate::protocol::{Command, HEADER_OVERHEAD_SIZE};
+        use bytes::BufMut;
+
+        if !self.send_padding {
+            // No padding, write directly
+            tracing::trace!(
+                "[Session] write_with_padding: Writing {} bytes without padding",
+                buffer.len()
+            );
+            let mut writer = self.writer.lock().await;
+            if let Err(e) = writer.write_all(&buffer).await {
+                return Err(self.handle_io_error("write_without_padding", e).await);
+            }
+            if let Err(e) = writer.flush().await {
+                return Err(self.handle_io_error("flush_without_padding", e).await);
+            }
+            tracing::info!(
+                "[Session] write_with_padding: Successfully wrote {} bytes to connection",
+                buffer.len()
+            );
+            return Ok(());
+        }
+
+        // Increment packet counter
+        let pkt = self
+            .pkt_counter
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let padding_factory = {
+            let padding_guard = self.padding.read().await;
+            padding_guard.clone()
+        };
+        let stop = padding_factory.stop();
+
+        if pkt >= stop {
+            // Stop padding after stop packets
+            // Note: We should probably disable send_padding, but that requires mutable access
+            // For now, just write directly
+            let mut writer = self.writer.lock().await;
+            if let Err(e) = writer.write_all(&buffer).await {
+                return Err(self.handle_io_error("write_no_padding_stop", e).await);
+            }
+            if let Err(e) = writer.flush().await {
+                return Err(self.handle_io_error("flush_no_padding_stop", e).await);
+            }
+            return Ok(());
+        }
+
+        // Get padding sizes for this packet
+        let pkt_sizes = padding_factory.generate_record_payload_sizes(pkt);
+
+        // If no sizes defined, write directly
+        if pkt_sizes.is_empty() {
+            let mut writer = self.writer.lock().await;
+            if let Err(e) = writer.write_all(&buffer).await {
+                return Err(self.handle_io_error("write_no_padding_sizes", e).await);
+            }
+            if let Err(e) = writer.flush().await {
+                return Err(self.handle_io_error("flush_no_padding_sizes", e).await);
+            }
+            return Ok(());
+        }
+
+        let mut writer = self.writer.lock().await;
+
+        for size in pkt_sizes {
+            let remain_payload_len = buffer.len();
+
+            if size == CHECK_MARK {
+                // Check mark: if no remaining payload, return early
+                if remain_payload_len == 0 {
+                    break;
+                }
+                // Otherwise continue to next size
+                continue;
+            }
+
+            let size = size as usize;
+
+            tracing::trace!(
+                "[Session] write_with_padding: Processing size={}, remain_payload_len={}",
+                size,
+                remain_payload_len
+            );
+
+            if remain_payload_len > size {
+                // This packet is all payload - send exactly size bytes
+                // Note: This may split a frame in the middle, but that's okay for TLS records
+                // The receiver will reassemble frames from the stream
+                tracing::debug!(
+                    "[Session] write_with_padding: Splitting payload: sending {} bytes (remain={})",
+                    size,
+                    remain_payload_len
+                );
+                if size >= 7 {
+                    tracing::debug!(
+                        "[Session] write_with_padding: First 7 bytes being sent: {:?}",
+                        &buffer[..7]
+                    );
+                }
+                if let Err(e) = writer.write_all(&buffer[..size]).await {
+                    return Err(self.handle_io_error("write_padding_split_payload", e).await);
+                }
+                buffer = buffer.split_off(size);
+            } else if remain_payload_len > 0 {
+                // This packet contains payload + padding
+                let padding_len = size.saturating_sub(remain_payload_len + HEADER_OVERHEAD_SIZE);
+
+                if padding_len > 0 {
+                    // Create padding frame (cmdWaste)
+                    let mut padding_frame =
+                        BytesMut::with_capacity(HEADER_OVERHEAD_SIZE + padding_len);
+                    padding_frame.put_u8(Command::Waste as u8);
+                    padding_frame.put_u32(0); // stream_id = 0
+                    padding_frame.put_u16(padding_len as u16);
+                    padding_frame.put_slice(&vec![0u8; padding_len]); // padding data (zeros)
+
+                    // Combine payload and padding
+                    buffer.put_slice(&padding_frame);
+                }
+
+                if let Err(e) = writer.write_all(&buffer).await {
+                    return Err(self.handle_io_error("write_padding_payload_frame", e).await);
+                }
+                buffer.clear();
+            } else {
+                // This packet is all padding
+                let mut padding_frame = BytesMut::with_capacity(HEADER_OVERHEAD_SIZE + size);
+                padding_frame.put_u8(Command::Waste as u8);
+                padding_frame.put_u32(0); // stream_id = 0
+                padding_frame.put_u16(size as u16);
+                padding_frame.put_slice(&vec![0u8; size]); // padding data (zeros)
+
+                if let Err(e) = writer.write_all(&padding_frame).await {
+                    return Err(self.handle_io_error("write_padding_frame_only", e).await);
+                }
+            }
+        }
+
+        // Write any remaining payload
+        if !buffer.is_empty() {
+            tracing::trace!(
+                "[Session] write_with_padding: Writing {} remaining payload bytes",
+                buffer.len()
+            );
+            if let Err(e) = writer.write_all(&buffer).await {
+                return Err(self.handle_io_error("write_remaining_payload", e).await);
+            }
+        }
+
+        tracing::trace!("[Session] write_with_padding: Flushing writer");
+        if let Err(e) = writer.flush().await {
+            return Err(self.handle_io_error("flush_with_padding", e).await);
+        }
+        tracing::debug!("[Session] write_with_padding: Successfully wrote and flushed data");
+        Ok(())
+    }
+
+    /// Start the client session (send settings and start recv loop)
+    pub async fn start_client(self: Arc<Self>) -> Result<()> {
+        use crate::util::StringMap;
+
+        // Send settings frame
+        let mut settings = StringMap::new();
+        settings.insert("v", "2");
+        settings.insert("client", "anytls-rs/0.1.0");
+        let padding_md5 = {
+            let padding_guard = self.padding.read().await;
+            padding_guard.md5().to_string()
+        };
+        settings.insert("padding-md5", padding_md5);
+
+        let frame = Frame::with_data(Command::Settings, 0, Bytes::from(settings.to_bytes()));
+
+        self.buffering
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.write_frame(frame).await?;
+
+        // Start receive loop in background
+        let session = Arc::clone(&self);
+        tokio::spawn(async move {
+            tracing::debug!(
+                "[Session] recv_loop task spawned (client={})",
+                session.is_client
+            );
+            match session.recv_loop().await {
+                Ok(()) => {
+                    tracing::debug!("[Session] recv_loop task completed normally");
+                }
+                Err(AnyTlsError::Io(e)) => {
+                    // Check if this is a close_notify error (normal connection close)
+                    let error_msg = e.to_string();
+                    if error_msg.contains("close_notify")
+                        || error_msg.contains("unexpected EOF")
+                        || e.kind() == std::io::ErrorKind::UnexpectedEof
+                    {
+                        tracing::debug!(
+                            "[Session] recv_loop task ended: Connection closed by peer (no close_notify) - this is normal"
+                        );
+                    } else {
+                        tracing::error!("[Session] recv_loop task error: {}", e);
+                    }
+                }
+                Err(AnyTlsError::SessionClosed) => {
+                    tracing::debug!("[Session] recv_loop task ended: Session closed");
+                }
+                Err(e) => {
+                    tracing::error!("[Session] recv_loop task error: {}", e);
+                }
+            }
+            // The read side is gone: mark the session closed so the pool stops
+            // handing it out, its writer half is shut down, and the heartbeat
+            // task exits — otherwise a server-closed session lingered in the
+            // pool (heartbeat keeping its socket open) and leaked its fd.
+            let _ = session.close().await;
+        });
+
+        // Start stream data processing in background
+        let session = Arc::clone(&self);
+        tokio::spawn(async move {
+            tracing::debug!(
+                "[Session] process_stream_data task spawned (client={})",
+                session.is_client
+            );
+            if let Err(e) = session.process_stream_data().await {
+                tracing::error!("[Session] process_stream_data task error: {}", e);
+            } else {
+                tracing::debug!("[Session] process_stream_data task completed normally");
+            }
+        });
+
+        if let Some(heartbeat_state) = self.heartbeat.as_ref().map(Arc::clone) {
+            let session = Arc::clone(&self);
+            tokio::spawn(async move {
+                let session_id = session.id();
+                let mut ticker = time::interval(heartbeat_state.interval);
+                ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+                loop {
+                    ticker.tick().await;
+
+                    if session.is_closed() {
+                        tracing::debug!(
+                            session_id = session_id,
+                            "[Session] Heartbeat loop exiting because session is closed"
+                        );
+                        break;
+                    }
+
+                    let last_seen = {
+                        let guard = heartbeat_state.last_received.lock().await;
+                        Instant::now().saturating_duration_since(*guard)
+                    };
+
+                    if last_seen > heartbeat_state.timeout {
+                        tracing::warn!(
+                            session_id = session_id,
+                            elapsed_ms = last_seen.as_millis() as u64,
+                            "[Session] Heartbeat timeout detected; closing session"
+                        );
+                        if let Err(e) = session.close().await {
+                            tracing::error!(
+                                session_id = session_id,
+                                "[Session] Failed to close session after heartbeat timeout: {}",
+                                e
+                            );
+                        }
+                        break;
+                    }
+
+                    if let Err(e) = session
+                        .write_control_frame(Frame::control(Command::HeartRequest, 0))
+                        .await
+                    {
+                        tracing::error!(
+                            session_id = session_id,
+                            "[Session] Failed to send HeartRequest: {}",
+                            e
+                        );
+                        if let Err(close_err) = session.close().await {
+                            tracing::warn!(
+                                session_id = session_id,
+                                "[Session] Failed to close session after heartbeat error: {}",
+                                close_err
+                            );
+                        }
+                        break;
+                    }
+
+                    tracing::trace!(
+                        session_id = session_id,
+                        "[Session] Heartbeat request sent successfully"
+                    );
+                }
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Process stream data from channels (should be run in a task)
+    pub async fn process_stream_data(&self) -> Result<()> {
+        let session_id = self.id();
+        let role = if self.is_client { "client" } else { "server" };
+        let process_span = info_span!(
+            "anytls.session.process_stream_data",
+            session_id,
+            role = %role,
+            bytes_out = field::Empty,
+            iterations = field::Empty
+        );
+        let _process_guard = process_span.enter();
+        tracing::debug!(
+            session_id = session_id,
+            is_client = self.is_client,
+            "[Session] process_stream_data started"
+        );
+        let mut iteration = 0u64;
+        let mut total_bytes_out: usize = 0;
+        let close_notify = Arc::clone(&self.close_notify);
+        let receiver = {
+            let mut guard = self.stream_data_rx.lock().await;
+            guard.take()
+        };
+
+        let Some(mut receiver) = receiver else {
+            tracing::debug!(
+                session_id = session_id,
+                "[Session] process_stream_data: Receiver already taken, nothing to process"
+            );
+            return Ok(());
+        };
+        // Process data from streams and send as frames
+        loop {
+            iteration += 1;
+            tracing::trace!(
+                session_id = session_id,
+                "[Session] process_stream_data: Waiting for data from streams (iteration {})",
+                iteration
+            );
+            let result = tokio::select! {
+                biased;
+                _ = close_notify.notified() => {
+                    tracing::debug!(
+                        session_id = session_id,
+                        "[Session] process_stream_data: Received close notification (iteration {})",
+                        iteration
+                    );
+                    break;
+                }
+                result = receiver.recv() => result,
+            };
+
+            match result {
+                Some((stream_id, data)) => {
+                    if self.is_closed() {
+                        tracing::debug!(
+                            session_id = session_id,
+                            "[Session] process_stream_data: Session closed, breaking (iteration {})",
+                            iteration
+                        );
+                        break;
+                    }
+                    if data.is_empty() {
+                        // Stream-close sentinel (see `Stream::close`): emit a
+                        // FIN for this stream so the peer evicts its slot, then
+                        // drop our own stream maps. This keeps `streams` /
+                        // `stream_receive_tx` bounded over a long-lived session
+                        // instead of growing one entry per opened stream.
+                        tracing::debug!(
+                            session_id = session_id,
+                            "[Session] process_stream_data: closing stream {} (FIN)",
+                            stream_id
+                        );
+                        let _ = self
+                            .write_control_frame(Frame::control(Command::Fin, stream_id))
+                            .await;
+                        self.streams.write().await.remove(&stream_id);
+                        self.stream_receive_tx.write().await.remove(&stream_id);
+                        continue;
+                    }
+                    let data_len = data.len();
+                    tracing::debug!(
+                        session_id = session_id,
+                        "[Session] process_stream_data: Received {} bytes from stream {} (iteration {})",
+                        data_len,
+                        stream_id,
+                        iteration
+                    );
+                    // Send data frame
+                    let write_result = self.write_data_frame(stream_id, data).await;
+                    match write_result {
+                        Ok(_) => {
+                            total_bytes_out += data_len;
+                            tracing::debug!(
+                                session_id = session_id,
+                                "[Session] process_stream_data: Successfully wrote data frame for stream {} (iteration {})",
+                                stream_id,
+                                iteration
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                session_id = session_id,
+                                "[Session] process_stream_data: Failed to write data frame for stream {}: {} (iteration {})",
+                                stream_id,
+                                e,
+                                iteration
+                            );
+                            return Err(e);
+                        }
+                    }
+                }
+                None => {
+                    tracing::debug!(
+                        session_id = session_id,
+                        "[Session] process_stream_data: Channel closed, exiting after {} iterations",
+                        iteration
+                    );
+                    break;
+                }
+            }
+        }
+
+        tracing::debug!(
+            session_id = session_id,
+            "[Session] process_stream_data: Exiting after {} iterations",
+            iteration
+        );
+        tracing::info!(
+            session_id = session_id,
+            bytes_out = total_bytes_out as u64,
+            iterations = iteration,
+            "[Session] process_stream_data completed"
+        );
+        process_span.record("bytes_out", total_bytes_out as u64);
+        process_span.record("iterations", iteration);
+        Ok(())
+    }
+
+    /// Get session sequence number
+    pub fn seq(&self) -> u64 {
+        self.seq.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Set session sequence number
+    pub fn set_seq(&self, seq: u64) {
+        self.seq.store(seq, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Get peer version
+    pub fn peer_version(&self) -> u8 {
+        self.peer_version.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::padding::PaddingFactory;
+    use tokio::io::{DuplexStream, duplex};
+
+    /// 创建一对连接的双工流（用于测试）
+    fn create_connected_streams() -> (DuplexStream, DuplexStream) {
+        duplex(8192)
+    }
+
+    /// 创建测试用的 PaddingFactory
+    fn create_test_padding() -> Arc<PaddingFactory> {
+        use crate::padding::DEFAULT_PADDING_SCHEME;
+        Arc::new(PaddingFactory::new(DEFAULT_PADDING_SCHEME.as_bytes()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_request_response() {
+        // 初始化日志
+        let _ = tracing_subscriber::fmt::try_init();
+
+        // 创建一对连接的流
+        let (client_stream, server_stream) = create_connected_streams();
+        let (client_read, client_write) = tokio::io::split(client_stream);
+        let (server_read, server_write) = tokio::io::split(server_stream);
+
+        let padding = create_test_padding();
+
+        // 创建客户端和服务器 Session
+        let client_session = Arc::new(Session::new_client(
+            client_read,
+            client_write,
+            padding.clone(),
+            None,
+        ));
+
+        let server_session = Arc::new(Session::new_server(server_read, server_write, padding));
+
+        // 手动启动 recv_loop 任务
+        let client_clone = client_session.clone();
+        tokio::spawn(async move {
+            let _ = client_clone.recv_loop().await;
+        });
+
+        let server_clone = server_session.clone();
+        tokio::spawn(async move {
+            let _ = server_clone.recv_loop().await;
+        });
+
+        // 启动 process_stream_data 任务
+        let client_clone2 = client_session.clone();
+        tokio::spawn(async move {
+            let _ = client_clone2.process_stream_data().await;
+        });
+
+        let server_clone2 = server_session.clone();
+        tokio::spawn(async move {
+            let _ = server_clone2.process_stream_data().await;
+        });
+
+        // 等待一下让任务启动
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // 客户端发送 HeartRequest
+        let heart_request = Frame::control(Command::HeartRequest, 0);
+        client_session
+            .write_control_frame(heart_request)
+            .await
+            .unwrap();
+
+        // 等待服务器处理和响应
+        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+        // 测试通过标准：Session 没有关闭
+        assert!(
+            !client_session.is_closed(),
+            "Client session should not be closed"
+        );
+        assert!(
+            !server_session.is_closed(),
+            "Server session should not be closed"
+        );
+
+        tracing::debug!("Heartbeat request-response test passed");
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_multiple_requests() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let (client_stream, server_stream) = create_connected_streams();
+        let (client_read, client_write) = tokio::io::split(client_stream);
+        let (server_read, server_write) = tokio::io::split(server_stream);
+
+        let padding = create_test_padding();
+
+        let client_session = Arc::new(Session::new_client(
+            client_read,
+            client_write,
+            padding.clone(),
+            None,
+        ));
+
+        let server_session = Arc::new(Session::new_server(server_read, server_write, padding));
+
+        // 启动任务
+        let client_clone = client_session.clone();
+        tokio::spawn(async move {
+            let _ = client_clone.recv_loop().await;
+        });
+        let server_clone = server_session.clone();
+        tokio::spawn(async move {
+            let _ = server_clone.recv_loop().await;
+        });
+        let client_clone2 = client_session.clone();
+        tokio::spawn(async move {
+            let _ = client_clone2.process_stream_data().await;
+        });
+        let server_clone2 = server_session.clone();
+        tokio::spawn(async move {
+            let _ = server_clone2.process_stream_data().await;
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // 发送多个心跳请求
+        for i in 0..5 {
+            let heart_request = Frame::control(Command::HeartRequest, i);
+            client_session
+                .write_control_frame(heart_request)
+                .await
+                .unwrap();
+
+            // 等待响应
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        }
+
+        // 额外等待确保所有响应都被处理
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        // Session 应该仍然正常
+        assert!(
+            !client_session.is_closed(),
+            "Client session should not be closed after multiple heartbeats"
+        );
+        assert!(
+            !server_session.is_closed(),
+            "Server session should not be closed after multiple heartbeats"
+        );
+
+        tracing::debug!("Multiple heartbeat requests test passed");
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_bidirectional() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let (stream1, stream2) = create_connected_streams();
+        let (read1, write1) = tokio::io::split(stream1);
+        let (read2, write2) = tokio::io::split(stream2);
+
+        let padding = create_test_padding();
+
+        let session1 = Arc::new(Session::new_client(read1, write1, padding.clone(), None));
+
+        let session2 = Arc::new(Session::new_server(read2, write2, padding));
+
+        // 启动任务
+        let s1_clone = session1.clone();
+        tokio::spawn(async move {
+            let _ = s1_clone.recv_loop().await;
+        });
+        let s2_clone = session2.clone();
+        tokio::spawn(async move {
+            let _ = s2_clone.recv_loop().await;
+        });
+        let s1_clone2 = session1.clone();
+        tokio::spawn(async move {
+            let _ = s1_clone2.process_stream_data().await;
+        });
+        let s2_clone2 = session2.clone();
+        tokio::spawn(async move {
+            let _ = s2_clone2.process_stream_data().await;
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Session 1 发送心跳给 Session 2
+        session1
+            .write_control_frame(Frame::control(Command::HeartRequest, 0))
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Session 2 发送心跳给 Session 1
+        session2
+            .write_control_frame(Frame::control(Command::HeartRequest, 1))
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // 双方都应该正常
+        assert!(!session1.is_closed());
+        assert!(!session2.is_closed());
+
+        tracing::debug!("Bidirectional heartbeat test passed");
+    }
+}

--- a/crates/meow-anytls/src/session/stream.rs
+++ b/crates/meow-anytls/src/session/stream.rs
@@ -1,0 +1,340 @@
+//! Stream implementation for AnyTLS protocol
+//!
+//! Stream provides a duplex communication channel that implements AsyncRead and AsyncWrite
+
+use crate::session::StreamReader;
+use crate::util::{AnyTlsError, Result};
+use bytes::Bytes;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::{mpsc, oneshot};
+
+/// Stream represents a single data stream within a Session
+/// It implements AsyncRead and AsyncWrite to be used as a connection
+pub struct Stream {
+    id: u32,
+
+    // ===== 读取部分：使用独立的 StreamReader =====
+    // Arc<Mutex<>> 是为了在 poll_read 中获取 &mut
+    reader: Arc<tokio::sync::Mutex<StreamReader>>,
+
+    // ===== 写入部分：直接使用 channel，无需锁 =====
+    writer_tx: mpsc::UnboundedSender<(u32, Bytes)>,
+
+    // ===== SYNACK 通知 (用于超时检测) =====
+    synack_tx: Arc<tokio::sync::Mutex<Option<oneshot::Sender<Result<()>>>>>,
+
+    // ===== 状态管理 =====
+    is_closed: Arc<AtomicBool>,
+    close_error: Arc<tokio::sync::Mutex<Option<AnyTlsError>>>,
+
+    // Guards the one-shot stream-close sentinel so a FIN is emitted at most
+    // once regardless of how many times `close()`/`poll_shutdown` fire.
+    fin_sent: Arc<AtomicBool>,
+}
+
+impl Stream {
+    /// Create a new stream
+    ///
+    /// # Arguments
+    /// * `id` - Stream ID
+    /// * `reader` - StreamReader 用于读取数据
+    /// * `writer_tx` - 发送数据到 Session 的 channel
+    ///
+    /// # Returns
+    /// (Stream, Receiver) - The receiver can be used to wait for SYNACK
+    pub fn new(
+        id: u32,
+        reader: StreamReader,
+        writer_tx: mpsc::UnboundedSender<(u32, Bytes)>,
+    ) -> (Self, oneshot::Receiver<Result<()>>) {
+        let (synack_tx, synack_rx) = oneshot::channel();
+
+        let stream = Self {
+            id,
+            reader: Arc::new(tokio::sync::Mutex::new(reader)),
+            writer_tx,
+            synack_tx: Arc::new(tokio::sync::Mutex::new(Some(synack_tx))),
+            is_closed: Arc::new(AtomicBool::new(false)),
+            close_error: Arc::new(tokio::sync::Mutex::new(None)),
+            fin_sent: Arc::new(AtomicBool::new(false)),
+        };
+
+        (stream, synack_rx)
+    }
+
+    /// Notify that SYNACK has been received
+    ///
+    /// # Arguments
+    /// * `result` - Ok(()) for success, Err for error
+    pub async fn notify_synack(&self, result: Result<()>) {
+        let mut tx_guard = self.synack_tx.lock().await;
+        match tx_guard.take() {
+            Some(tx) => {
+                let result_clone = match &result {
+                    Ok(()) => Ok(()),
+                    Err(e) => Err(AnyTlsError::Protocol(e.to_string())),
+                };
+                let _ = tx.send(result_clone);
+                tracing::debug!(
+                    "[Stream] SYNACK notified for stream {}: {:?}",
+                    self.id,
+                    result.is_ok()
+                );
+            }
+            _ => {
+                tracing::warn!("[Stream] SYNACK already notified for stream {}", self.id);
+            }
+        }
+    }
+
+    /// Get stream ID
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// Close the stream with error (can be called with `Arc<Stream>`)
+    pub async fn close_with_error(&self, err: AnyTlsError) {
+        if self
+            .is_closed
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            tracing::warn!(
+                stream_id = self.id,
+                cause = %err,
+                "[Stream] Closing stream with error"
+            );
+            *self.close_error.lock().await = Some(err);
+        }
+    }
+
+    /// Check if stream is closed
+    pub fn is_closed(&self) -> bool {
+        self.is_closed.load(Ordering::Relaxed)
+    }
+
+    /// Gracefully close this client stream.
+    ///
+    /// Signals the owning session (via the writer channel's empty-`Bytes`
+    /// sentinel — see `Session::process_stream_data`) to emit a `Fin` frame
+    /// for this stream id and evict it from the session's stream maps. Without
+    /// this, client streams were never removed from `Session::streams` /
+    /// `Session::stream_receive_tx` and never FIN-acked to the peer, so both
+    /// maps grew unbounded for the life of the (long-lived, pooled) session.
+    ///
+    /// Lock-free and idempotent, so it is safe to call from `poll_shutdown`
+    /// or a `Drop` impl on a wrapper type.
+    pub fn close(&self) {
+        self.is_closed.store(true, Ordering::Relaxed);
+        if self
+            .fin_sent
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            // Best-effort: if the session writer task is already gone the
+            // stream is being torn down anyway, so a send error is harmless.
+            let _ = self.writer_tx.send((self.id, Bytes::new()));
+        }
+    }
+
+    /// Get a reference to the reader (for direct access in handlers)
+    pub fn reader(&self) -> &Arc<tokio::sync::Mutex<StreamReader>> {
+        &self.reader
+    }
+
+    /// Send data through the writer channel (无锁方式)
+    ///
+    /// 这个方法可以被多个任务并发调用，无需任何锁
+    pub fn send_data(
+        &self,
+        data: Bytes,
+    ) -> std::result::Result<(), mpsc::error::SendError<(u32, Bytes)>> {
+        self.writer_tx.send((self.id, data))
+    }
+}
+
+// Stream is not meant to be cloned - use Arc<Stream> instead
+// This implementation is only for compatibility with HashMap storage
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let stream_id = self.id;
+        let remaining = buf.remaining();
+
+        // 使用 tokio::task::block_in_place 同步读取
+        // 这避免了复杂的 Future polling 和借用问题
+        let reader = Arc::clone(&self.reader);
+
+        // 创建读取 future
+        let mut read_fut = Box::pin(async move {
+            let mut reader_guard = reader.lock().await;
+            let mut temp_buf = vec![0u8; remaining];
+            let n = reader_guard.read(&mut temp_buf).await?;
+            Ok::<(usize, Vec<u8>), std::io::Error>((n, temp_buf))
+        });
+
+        // Poll the future
+        match read_fut.as_mut().poll(cx) {
+            Poll::Ready(Ok((n, temp_buf))) => {
+                if n > 0 {
+                    buf.put_slice(&temp_buf[..n]);
+                    tracing::trace!(
+                        "[Stream] poll_read: Read {} bytes (stream_id={})",
+                        n,
+                        stream_id
+                    );
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => {
+                tracing::error!(
+                    "[Stream] poll_read: Error reading (stream_id={}): {}",
+                    stream_id,
+                    e
+                );
+                Poll::Ready(Err(e))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let stream_id = self.id;
+        let buf_len = buf.len();
+        tracing::trace!(
+            "[Stream] poll_write: stream_id={}, buf_len={}",
+            stream_id,
+            buf_len
+        );
+
+        if self.is_closed.load(Ordering::Relaxed) {
+            tracing::warn!("[Stream] poll_write: Stream {} is closed", stream_id);
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "stream closed",
+            )));
+        }
+
+        // Send data to session via channel
+        let data = Bytes::copy_from_slice(buf);
+        tracing::trace!(
+            "[Stream] poll_write: Sending {} bytes to channel for stream {}",
+            buf_len,
+            stream_id
+        );
+        match self.writer_tx.send((self.id, data)) {
+            Ok(_) => {
+                tracing::debug!(
+                    "[Stream] poll_write: Successfully sent {} bytes to channel for stream {}",
+                    buf_len,
+                    stream_id
+                );
+                Poll::Ready(Ok(buf.len()))
+            }
+            Err(e) => {
+                tracing::error!(
+                    "[Stream] poll_write: Failed to send {} bytes to channel for stream {}: {:?}",
+                    buf_len,
+                    stream_id,
+                    e
+                );
+                Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "session channel closed",
+                )))
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        // Emit a FIN and evict this stream from the session maps.
+        self.close();
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::StreamReader;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn test_stream_write() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (_reader_tx, reader_rx) = mpsc::unbounded_channel();
+
+        let reader = StreamReader::new(1, reader_rx);
+        let (mut stream, _synack_rx) = Stream::new(1, reader, tx);
+
+        // 写入数据
+        stream.write_all(b"hello").await.unwrap();
+
+        // 验证数据发送到 channel
+        let (stream_id, data) = rx.recv().await.unwrap();
+        assert_eq!(stream_id, 1);
+        assert_eq!(data.as_ref(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn test_stream_read() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (reader_tx, reader_rx) = mpsc::unbounded_channel();
+
+        let reader = StreamReader::new(1, reader_rx);
+        let (mut stream, _synack_rx) = Stream::new(1, reader, tx);
+
+        // 发送数据到 reader
+        reader_tx.send(Bytes::from("world")).unwrap();
+
+        // 读取数据
+        let mut buf = vec![0u8; 10];
+        let n = stream.read(&mut buf).await.unwrap();
+
+        assert_eq!(n, 5);
+        assert_eq!(&buf[..n], b"world");
+    }
+
+    #[tokio::test]
+    async fn test_stream_read_write() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (reader_tx, reader_rx) = mpsc::unbounded_channel();
+
+        let reader = StreamReader::new(1, reader_rx);
+        let (mut stream, _synack_rx) = Stream::new(1, reader, tx);
+
+        // 同时读写
+        reader_tx.send(Bytes::from("input")).unwrap();
+        stream.write_all(b"output").await.unwrap();
+
+        // 验证读取
+        let mut buf = vec![0u8; 10];
+        let n = stream.read(&mut buf).await.unwrap();
+        assert_eq!(n, 5);
+        assert_eq!(&buf[..n], b"input");
+
+        // 验证写入
+        let (stream_id, data) = rx.recv().await.unwrap();
+        assert_eq!(stream_id, 1);
+        assert_eq!(data.as_ref(), b"output");
+    }
+}

--- a/crates/meow-anytls/src/session/stream_reader.rs
+++ b/crates/meow-anytls/src/session/stream_reader.rs
@@ -1,0 +1,235 @@
+//! StreamReader - 独立的流读取器
+//!
+//! 负责从 Session 接收数据并提供给上层读取
+//! 与 Stream 的写入操作完全分离
+
+use bytes::Bytes;
+use std::io;
+use tokio::sync::mpsc;
+
+/// StreamReader 管理单个流的读取状态
+///
+/// 设计要点：
+/// 1. reader_rx 和 reader_buffer 在同一个结构内，无需额外的锁
+/// 2. 外部通过 &mut self 访问，保证互斥
+/// 3. 不持有 Stream 的引用，完全独立
+pub struct StreamReader {
+    /// 流 ID（用于日志）
+    id: u32,
+
+    /// 从 Session 接收数据的 channel
+    /// 注意：recv() 是 async 方法，需要 &mut self
+    reader_rx: mpsc::UnboundedReceiver<Bytes>,
+
+    /// 缓冲不完整的数据
+    /// 当 read buffer 小于接收到的数据时使用
+    reader_buffer: Vec<u8>,
+
+    /// EOF 标志
+    eof: bool,
+}
+
+impl StreamReader {
+    /// 创建新的 StreamReader
+    pub fn new(id: u32, reader_rx: mpsc::UnboundedReceiver<Bytes>) -> Self {
+        Self {
+            id,
+            reader_rx,
+            reader_buffer: Vec::new(),
+            eof: false,
+        }
+    }
+
+    /// 读取数据到 buffer
+    ///
+    /// 实现逻辑：
+    /// 1. 优先从 reader_buffer 读取
+    /// 2. buffer 为空时从 channel 接收
+    /// 3. 处理 EOF 情况
+    pub async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // 1. 先检查 EOF
+        if self.eof && self.reader_buffer.is_empty() {
+            return Ok(0);
+        }
+
+        // 2. 从 buffer 读取（如果有数据）
+        if !self.reader_buffer.is_empty() {
+            let n = std::cmp::min(self.reader_buffer.len(), buf.len());
+            buf[..n].copy_from_slice(&self.reader_buffer[..n]);
+            self.reader_buffer.drain(..n);
+
+            tracing::trace!(
+                "[StreamReader] Read {} bytes from buffer (stream_id={}, buffer_remaining={})",
+                n,
+                self.id,
+                self.reader_buffer.len()
+            );
+
+            return Ok(n);
+        }
+
+        // 3. buffer 为空，从 channel 接收新数据
+        match self.reader_rx.recv().await {
+            Some(data) => {
+                let data_len = data.len();
+                tracing::debug!(
+                    "[StreamReader] Received {} bytes from channel (stream_id={})",
+                    data_len,
+                    self.id
+                );
+
+                // 直接填充到 buf
+                let n = std::cmp::min(data.len(), buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+
+                // 剩余数据放入 buffer
+                if n < data.len() {
+                    self.reader_buffer.extend_from_slice(&data[n..]);
+                    tracing::trace!(
+                        "[StreamReader] Stored {} bytes in buffer (stream_id={})",
+                        data.len() - n,
+                        self.id
+                    );
+                }
+
+                Ok(n)
+            }
+            None => {
+                // Channel 关闭，表示 EOF
+                tracing::debug!(
+                    "[StreamReader] Channel closed (EOF) for stream_id={}",
+                    self.id
+                );
+                self.eof = true;
+                Ok(0)
+            }
+        }
+    }
+
+    /// 获取流 ID
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// 检查是否到达 EOF
+    pub fn is_eof(&self) -> bool {
+        self.eof
+    }
+
+    /// 获取缓冲区大小（用于诊断）
+    pub fn buffer_len(&self) -> usize {
+        self.reader_buffer.len()
+    }
+
+    /// 精确读取指定数量的字节（辅助方法）
+    ///
+    /// 类似于 AsyncReadExt::read_exact，但使用我们自己的 read() 方法
+    pub async fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        let mut offset = 0;
+        let total = buf.len();
+
+        while offset < total {
+            let n = self.read(&mut buf[offset..]).await?;
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!("Failed to read exact {} bytes, only read {}", total, offset),
+                ));
+            }
+            offset += n;
+        }
+
+        Ok(())
+    }
+}
+
+// StreamReader 不需要实现 Clone
+// 因为它包含 UnboundedReceiver（不可 Clone）
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_stream_reader_basic() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut reader = StreamReader::new(1, rx);
+
+        // 发送数据
+        tx.send(Bytes::from("hello")).unwrap();
+
+        // 读取数据
+        let mut buf = vec![0u8; 10];
+        let n = reader.read(&mut buf).await.unwrap();
+
+        assert_eq!(n, 5);
+        assert_eq!(&buf[..n], b"hello");
+    }
+
+    #[tokio::test]
+    async fn test_stream_reader_buffering() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut reader = StreamReader::new(1, rx);
+
+        // 发送较大的数据
+        tx.send(Bytes::from("hello world")).unwrap();
+
+        // 分两次读取
+        let mut buf = vec![0u8; 5];
+
+        let n1 = reader.read(&mut buf).await.unwrap();
+        assert_eq!(n1, 5);
+        assert_eq!(&buf[..n1], b"hello");
+
+        let n2 = reader.read(&mut buf).await.unwrap();
+        assert_eq!(n2, 5);
+        assert_eq!(&buf[..n2], b" worl");
+
+        let n3 = reader.read(&mut buf).await.unwrap();
+        assert_eq!(n3, 1);
+        assert_eq!(&buf[..n3], b"d");
+    }
+
+    #[tokio::test]
+    async fn test_stream_reader_eof() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut reader = StreamReader::new(1, rx);
+
+        // 关闭 channel
+        drop(tx);
+
+        // 读取应该返回 0（EOF）
+        let mut buf = vec![0u8; 10];
+        let n = reader.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0);
+        assert!(reader.is_eof());
+    }
+
+    #[tokio::test]
+    async fn test_stream_reader_multiple_chunks() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut reader = StreamReader::new(1, rx);
+
+        // 发送多个数据块
+        tx.send(Bytes::from("chunk1")).unwrap();
+        tx.send(Bytes::from("chunk2")).unwrap();
+        tx.send(Bytes::from("chunk3")).unwrap();
+
+        // 关闭 channel 以触发 EOF
+        drop(tx);
+
+        let mut buf = vec![0u8; 100];
+        let mut total = Vec::new();
+
+        // 读取所有数据
+        loop {
+            let n = reader.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            total.extend_from_slice(&buf[..n]);
+        }
+
+        assert_eq!(total, b"chunk1chunk2chunk3");
+    }
+}

--- a/crates/meow-anytls/src/util/auth.rs
+++ b/crates/meow-anytls/src/util/auth.rs
@@ -1,0 +1,147 @@
+//! Authentication utilities for AnyTLS protocol
+
+use crate::padding::PaddingFactory;
+use crate::util::{AnyTlsError, Result};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Compute SHA256 hash of password
+pub fn hash_password(password: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(password.as_bytes());
+    hasher.finalize().into()
+}
+
+/// Authenticate a client connection (server side)
+///
+/// Reads authentication data from the connection:
+/// - SHA256(password) (32 bytes)
+/// - padding0_length (2 bytes, big-endian)
+/// - padding0 (variable length)
+pub async fn authenticate_client<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+    expected_password_hash: &[u8; 32],
+    _padding_factory: &Arc<PaddingFactory>,
+) -> Result<()> {
+    // Read SHA256(password)
+    let mut password_hash = [0u8; 32];
+    reader.read_exact(&mut password_hash).await?;
+
+    // Verify password
+    if password_hash != *expected_password_hash {
+        return Err(AnyTlsError::AuthenticationFailed);
+    }
+
+    // Read padding0_length
+    let mut padding_len_bytes = [0u8; 2];
+    reader.read_exact(&mut padding_len_bytes).await?;
+    let padding_len = u16::from_be_bytes(padding_len_bytes) as usize;
+
+    // Read padding0
+    if padding_len > 0 {
+        let mut padding = vec![0u8; padding_len];
+        reader.read_exact(&mut padding).await?;
+        // Padding is discarded
+    }
+
+    Ok(())
+}
+
+/// Send authentication data (client side)
+///
+/// Writes authentication data to the connection:
+/// - SHA256(password) (32 bytes)
+/// - padding0_length (2 bytes, big-endian)
+/// - padding0 (variable length)
+pub async fn send_authentication<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    password_hash: &[u8; 32],
+    padding_factory: &Arc<PaddingFactory>,
+) -> Result<()> {
+    // Write SHA256(password)
+    writer.write_all(password_hash).await?;
+
+    // Get padding0 length from padding scheme
+    let padding_sizes = padding_factory.generate_record_payload_sizes(0);
+    let padding_len = padding_sizes.first().copied().unwrap_or(0);
+
+    // Ensure padding_len is non-negative
+    let padding_len = if padding_len < 0 {
+        0
+    } else {
+        padding_len as u16
+    };
+
+    // Write padding0_length
+    writer.write_all(&padding_len.to_be_bytes()).await?;
+
+    // Write padding0
+    if padding_len > 0 {
+        let padding = vec![0u8; padding_len as usize];
+        writer.write_all(&padding).await?;
+    }
+
+    writer.flush().await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::padding::PaddingFactory;
+    use tokio::io::duplex;
+
+    #[tokio::test]
+    async fn test_authentication_success() {
+        let password = "test_password";
+        let password_hash = hash_password(password);
+
+        let (mut client, mut server) = duplex(1024);
+        let padding = PaddingFactory::default();
+
+        // Client sends authentication
+        send_authentication(&mut client, &password_hash, &padding)
+            .await
+            .unwrap();
+
+        // Server authenticates
+        authenticate_client(&mut server, &password_hash, &padding)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_authentication_failure() {
+        let password = "test_password";
+        let password_hash = hash_password(password);
+        let wrong_hash = hash_password("wrong_password");
+
+        let (mut client, mut server) = duplex(1024);
+        let padding = PaddingFactory::default();
+
+        // Client sends authentication with correct password
+        send_authentication(&mut client, &password_hash, &padding)
+            .await
+            .unwrap();
+
+        // Server authenticates with wrong password - should fail
+        let result = authenticate_client(&mut server, &wrong_hash, &padding).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            AnyTlsError::AuthenticationFailed
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_hash_password() {
+        let hash1 = hash_password("test");
+        let hash2 = hash_password("test");
+        let hash3 = hash_password("different");
+
+        assert_eq!(hash1, hash2);
+        assert_ne!(hash1, hash3);
+    }
+}

--- a/crates/meow-anytls/src/util/cert_analyzer.rs
+++ b/crates/meow-anytls/src/util/cert_analyzer.rs
@@ -1,0 +1,410 @@
+//! Certificate analysis and information extraction
+
+use crate::util::{AnyTlsError, Result};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use x509_parser::prelude::*;
+
+/// Certificate information
+#[derive(Debug, Clone)]
+pub struct CertificateInfo {
+    /// Subject (certificate owner)
+    pub subject: String,
+    /// Issuer (who signed the certificate)
+    pub issuer: String,
+    /// Serial number
+    pub serial_number: String,
+    /// Valid from (Not Before)
+    pub not_before: SystemTime,
+    /// Valid until (Not After)
+    pub not_after: SystemTime,
+    /// Signature algorithm
+    pub signature_algorithm: String,
+    /// Public key algorithm
+    pub public_key_algorithm: String,
+    /// Subject Alternative Names
+    pub san_names: Vec<String>,
+    /// Whether certificate is self-signed
+    pub is_self_signed: bool,
+    /// Days until expiration (can be negative if expired)
+    pub days_until_expiry: i64,
+}
+
+/// Certificate status
+#[derive(Debug, Clone, PartialEq)]
+pub enum CertStatus {
+    /// Certificate is valid
+    Valid,
+    /// Certificate is expiring soon (days remaining)
+    ExpiringWarning(u64),
+    /// Certificate has expired
+    Expired,
+    /// Certificate is invalid (reason)
+    Invalid(String),
+}
+
+impl CertificateInfo {
+    /// Parse certificate from PEM file
+    pub fn from_pem_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let mut file = File::open(&path).map_err(|e| {
+            AnyTlsError::Tls(format!(
+                "Failed to open certificate file {:?}: {}",
+                path.as_ref(),
+                e
+            ))
+        })?;
+
+        let mut pem_data = Vec::new();
+        file.read_to_end(&mut pem_data).map_err(|e| {
+            AnyTlsError::Tls(format!(
+                "Failed to read certificate file {:?}: {}",
+                path.as_ref(),
+                e
+            ))
+        })?;
+
+        Self::from_pem_bytes(&pem_data)
+    }
+
+    /// Parse certificate from PEM bytes
+    pub fn from_pem_bytes(pem_data: &[u8]) -> Result<Self> {
+        // Use rustls-pemfile to parse PEM
+        let mut reader = BufReader::new(pem_data);
+        let certs = rustls_pemfile::certs(&mut reader)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| AnyTlsError::Tls(format!("Failed to parse PEM certificates: {}", e)))?;
+
+        if certs.is_empty() {
+            return Err(AnyTlsError::Tls("No certificates found in PEM data".into()));
+        }
+
+        // Parse X.509 certificate from the first certificate
+        let (_, cert) = X509Certificate::from_der(certs[0].as_ref())
+            .map_err(|e| AnyTlsError::Tls(format!("Failed to parse X.509 certificate: {}", e)))?;
+
+        Self::from_x509(&cert)
+    }
+
+    /// Extract information from X.509 certificate
+    fn from_x509(cert: &X509Certificate) -> Result<Self> {
+        // Extract subject
+        let subject = cert.subject().to_string();
+
+        // Extract issuer
+        let issuer = cert.issuer().to_string();
+
+        // Extract serial number
+        let serial_number = cert
+            .serial
+            .to_str_radix(16)
+            .chars()
+            .collect::<Vec<_>>()
+            .chunks(2)
+            .map(|chunk| chunk.iter().collect::<String>())
+            .collect::<Vec<_>>()
+            .join(":");
+
+        // Extract validity period
+        let not_before = asn1_time_to_system_time(&cert.validity().not_before)?;
+        let not_after = asn1_time_to_system_time(&cert.validity().not_after)?;
+
+        // Calculate days until expiry
+        let now = SystemTime::now();
+        let days_until_expiry = match not_after.duration_since(now) {
+            Ok(duration) => (duration.as_secs() / 86400) as i64,
+            Err(_) => {
+                // Certificate has expired
+                let duration = now.duration_since(not_after).unwrap();
+                -((duration.as_secs() / 86400) as i64)
+            }
+        };
+
+        // Extract signature algorithm
+        let signature_algorithm = format!("{:?}", cert.signature_algorithm.algorithm);
+
+        // Extract public key algorithm
+        let public_key_algorithm = format!("{:?}", cert.public_key().algorithm.algorithm);
+
+        // Extract SANs (Subject Alternative Names)
+        let mut san_names = Vec::new();
+        if let Ok(Some(san_ext)) = cert.subject_alternative_name() {
+            for name in &san_ext.value.general_names {
+                match name {
+                    GeneralName::DNSName(dns) => {
+                        san_names.push(dns.to_string());
+                    }
+                    GeneralName::IPAddress(ip) => {
+                        san_names.push(format!("{:?}", ip));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Check if self-signed
+        let is_self_signed = cert.subject() == cert.issuer();
+
+        Ok(CertificateInfo {
+            subject,
+            issuer,
+            serial_number,
+            not_before,
+            not_after,
+            signature_algorithm,
+            public_key_algorithm,
+            san_names,
+            is_self_signed,
+            days_until_expiry,
+        })
+    }
+
+    /// Get certificate status
+    pub fn status(&self, warning_days: u64) -> CertStatus {
+        if self.days_until_expiry < 0 {
+            CertStatus::Expired
+        } else if (self.days_until_expiry as u64) < warning_days {
+            CertStatus::ExpiringWarning(self.days_until_expiry as u64)
+        } else {
+            CertStatus::Valid
+        }
+    }
+
+    /// Check if certificate is expired
+    pub fn is_expired(&self) -> bool {
+        self.days_until_expiry < 0
+    }
+
+    /// Check if certificate is expiring soon
+    pub fn is_expiring_soon(&self, warning_days: u64) -> bool {
+        self.days_until_expiry >= 0 && (self.days_until_expiry as u64) < warning_days
+    }
+
+    /// Format certificate info for display
+    pub fn display(&self) -> String {
+        let mut output = String::new();
+        output.push_str(&format!("Subject: {}\n", self.subject));
+        output.push_str(&format!("Issuer: {}\n", self.issuer));
+        output.push_str(&format!("Serial Number: {}\n", self.serial_number));
+        output.push_str(&format!(
+            "Valid From: {}\n",
+            format_system_time(self.not_before)
+        ));
+        output.push_str(&format!(
+            "Valid Until: {}\n",
+            format_system_time(self.not_after)
+        ));
+        output.push_str(&format!("Days Until Expiry: {}\n", self.days_until_expiry));
+        output.push_str(&format!(
+            "Signature Algorithm: {}\n",
+            self.signature_algorithm
+        ));
+        output.push_str(&format!(
+            "Public Key Algorithm: {}\n",
+            self.public_key_algorithm
+        ));
+        output.push_str(&format!("Self-Signed: {}\n", self.is_self_signed));
+        if !self.san_names.is_empty() {
+            output.push_str(&format!("SANs: {}\n", self.san_names.join(", ")));
+        }
+        output
+    }
+
+    /// Format certificate info as a single-line summary
+    pub fn summary(&self) -> String {
+        format!(
+            "CN={}, Issuer={}, expires in {} days",
+            extract_cn(&self.subject).unwrap_or("unknown"),
+            extract_cn(&self.issuer).unwrap_or("unknown"),
+            self.days_until_expiry
+        )
+    }
+}
+
+/// Convert ASN.1 time to SystemTime
+fn asn1_time_to_system_time(asn1_time: &ASN1Time) -> Result<SystemTime> {
+    // Convert to Unix timestamp
+    let unix_timestamp = asn1_time.timestamp();
+
+    if unix_timestamp < 0 {
+        return Err(AnyTlsError::Tls(
+            "Invalid timestamp (before UNIX epoch)".into(),
+        ));
+    }
+
+    Ok(UNIX_EPOCH + Duration::from_secs(unix_timestamp as u64))
+}
+
+/// Format SystemTime as human-readable string
+fn format_system_time(time: SystemTime) -> String {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => {
+            let secs = duration.as_secs();
+            let datetime = chrono::DateTime::from_timestamp(secs as i64, 0)
+                .unwrap_or(chrono::DateTime::UNIX_EPOCH);
+            datetime.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+        }
+        Err(_) => "Invalid time".to_string(),
+    }
+}
+
+/// Extract Common Name (CN) from subject/issuer string
+fn extract_cn(dn: &str) -> Option<&str> {
+    // Simple extraction of CN= field
+    for part in dn.split(',') {
+        let part = part.trim();
+        if let Some(cn) = part.strip_prefix("CN=") {
+            return Some(cn);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_cn() {
+        assert_eq!(extract_cn("CN=example.com, O=Test"), Some("example.com"));
+        assert_eq!(
+            extract_cn("O=Test, CN=example.com, C=US"),
+            Some("example.com")
+        );
+        assert_eq!(extract_cn("O=Test, C=US"), None);
+    }
+
+    #[test]
+    fn test_extract_cn_with_spaces() {
+        // Leading/trailing spaces in the whole string
+        assert_eq!(extract_cn(" CN=example.com "), Some("example.com"));
+        // Spaces around commas
+        assert_eq!(
+            extract_cn("O=Test , CN=example.com , C=US"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn test_cert_status() {
+        let info = CertificateInfo {
+            subject: "CN=test".to_string(),
+            issuer: "CN=issuer".to_string(),
+            serial_number: "123".to_string(),
+            not_before: SystemTime::now(),
+            not_after: SystemTime::now() + Duration::from_secs(86400 * 90),
+            signature_algorithm: "SHA256".to_string(),
+            public_key_algorithm: "RSA".to_string(),
+            san_names: vec![],
+            is_self_signed: false,
+            days_until_expiry: 90,
+        };
+
+        // Test Valid status
+        assert!(matches!(info.status(30), CertStatus::Valid));
+
+        // Test ExpiringWarning status
+        let info_expiring = CertificateInfo {
+            days_until_expiry: 20,
+            ..info.clone()
+        };
+        assert!(matches!(
+            info_expiring.status(30),
+            CertStatus::ExpiringWarning(20)
+        ));
+
+        // Test Expired status
+        let info_expired = CertificateInfo {
+            days_until_expiry: -1,
+            ..info.clone()
+        };
+        assert!(matches!(info_expired.status(30), CertStatus::Expired));
+    }
+
+    #[test]
+    fn test_is_expired() {
+        let info_valid = CertificateInfo {
+            subject: "CN=test".to_string(),
+            issuer: "CN=issuer".to_string(),
+            serial_number: "123".to_string(),
+            not_before: SystemTime::now(),
+            not_after: SystemTime::now() + Duration::from_secs(86400 * 30),
+            signature_algorithm: "SHA256".to_string(),
+            public_key_algorithm: "RSA".to_string(),
+            san_names: vec![],
+            is_self_signed: false,
+            days_until_expiry: 30,
+        };
+        assert!(!info_valid.is_expired());
+
+        let info_expired = CertificateInfo {
+            days_until_expiry: -10,
+            ..info_valid.clone()
+        };
+        assert!(info_expired.is_expired());
+    }
+
+    #[test]
+    fn test_is_expiring_soon() {
+        let info = CertificateInfo {
+            subject: "CN=test".to_string(),
+            issuer: "CN=issuer".to_string(),
+            serial_number: "123".to_string(),
+            not_before: SystemTime::now(),
+            not_after: SystemTime::now() + Duration::from_secs(86400 * 20),
+            signature_algorithm: "SHA256".to_string(),
+            public_key_algorithm: "RSA".to_string(),
+            san_names: vec![],
+            is_self_signed: false,
+            days_until_expiry: 20,
+        };
+
+        assert!(info.is_expiring_soon(30));
+        assert!(!info.is_expiring_soon(10));
+    }
+
+    #[test]
+    fn test_cert_summary() {
+        let info = CertificateInfo {
+            subject: "CN=example.com, O=Test Corp".to_string(),
+            issuer: "CN=Test CA, O=Test".to_string(),
+            serial_number: "123456".to_string(),
+            not_before: SystemTime::now(),
+            not_after: SystemTime::now() + Duration::from_secs(86400 * 90),
+            signature_algorithm: "SHA256withRSA".to_string(),
+            public_key_algorithm: "RSA".to_string(),
+            san_names: vec!["example.com".to_string(), "www.example.com".to_string()],
+            is_self_signed: false,
+            days_until_expiry: 90,
+        };
+
+        let summary = info.summary();
+        assert!(summary.contains("example.com"));
+        assert!(summary.contains("Test CA"));
+        assert!(summary.contains("90"));
+    }
+
+    #[test]
+    fn test_cert_display() {
+        let info = CertificateInfo {
+            subject: "CN=test.com".to_string(),
+            issuer: "CN=CA".to_string(),
+            serial_number: "abc123".to_string(),
+            not_before: SystemTime::UNIX_EPOCH + Duration::from_secs(1000000),
+            not_after: SystemTime::UNIX_EPOCH + Duration::from_secs(2000000),
+            signature_algorithm: "SHA256".to_string(),
+            public_key_algorithm: "RSA".to_string(),
+            san_names: vec!["test.com".to_string()],
+            is_self_signed: true,
+            days_until_expiry: 100,
+        };
+
+        let display = info.display();
+        assert!(display.contains("Subject: CN=test.com"));
+        assert!(display.contains("Issuer: CN=CA"));
+        assert!(display.contains("Serial Number: abc123"));
+        assert!(display.contains("Self-Signed: true"));
+        assert!(display.contains("SANs: test.com"));
+    }
+}

--- a/crates/meow-anytls/src/util/cert_reloader.rs
+++ b/crates/meow-anytls/src/util/cert_reloader.rs
@@ -1,0 +1,341 @@
+//! Certificate reloader with file watching and hot reload support
+
+use crate::util::{AnyTlsError, CertificateInfo, Result, create_server_config_from_files};
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio_rustls::TlsAcceptor;
+use tracing::{debug, error, info, warn};
+
+/// Certificate reloader configuration
+#[derive(Debug, Clone)]
+pub struct CertReloaderConfig {
+    /// Path to certificate file
+    pub cert_path: PathBuf,
+    /// Path to private key file
+    pub key_path: PathBuf,
+    /// Enable file watching
+    pub watch_enabled: bool,
+    /// Debounce time in milliseconds
+    pub debounce_ms: u64,
+    /// Check certificate expiry
+    pub check_expiry: bool,
+    /// Warning threshold in days
+    pub expiry_warning_days: u64,
+}
+
+impl Default for CertReloaderConfig {
+    fn default() -> Self {
+        Self {
+            cert_path: PathBuf::from("cert.pem"),
+            key_path: PathBuf::from("key.pem"),
+            watch_enabled: true,
+            debounce_ms: 500,
+            check_expiry: true,
+            expiry_warning_days: 30,
+        }
+    }
+}
+
+/// Certificate reloader
+pub struct CertReloader {
+    config: CertReloaderConfig,
+    tls_acceptor: Arc<RwLock<Arc<TlsAcceptor>>>,
+    cert_info: Arc<RwLock<Option<CertificateInfo>>>,
+    reload_count: Arc<RwLock<u64>>,
+    last_reload: Arc<RwLock<Option<Instant>>>,
+}
+
+impl CertReloader {
+    /// Create a new certificate reloader
+    pub fn new(config: CertReloaderConfig) -> Result<Self> {
+        // Load initial certificate
+        let tls_config = create_server_config_from_files(&config.cert_path, &config.key_path)?;
+        let tls_acceptor = Arc::new(TlsAcceptor::from(tls_config));
+
+        // Analyze certificate
+        let cert_info = CertificateInfo::from_pem_file(&config.cert_path).ok();
+
+        if let Some(ref info) = cert_info {
+            info!(
+                "[CertReloader] Initial certificate loaded: {}",
+                info.summary()
+            );
+
+            // Check expiry
+            if config.check_expiry {
+                if info.is_expired() {
+                    error!("[CertReloader] WARNING: Certificate has expired!");
+                } else if info.is_expiring_soon(config.expiry_warning_days) {
+                    warn!(
+                        "[CertReloader] WARNING: Certificate expiring in {} days",
+                        info.days_until_expiry
+                    );
+                }
+            }
+
+            // Display full info
+            debug!("[CertReloader] Certificate details:\n{}", info.display());
+        }
+
+        Ok(Self {
+            config,
+            tls_acceptor: Arc::new(RwLock::new(tls_acceptor)),
+            cert_info: Arc::new(RwLock::new(cert_info)),
+            reload_count: Arc::new(RwLock::new(0)),
+            last_reload: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Get current TLS acceptor (snapshot)
+    pub fn get_acceptor(&self) -> Arc<TlsAcceptor> {
+        self.tls_acceptor.read().unwrap().clone()
+    }
+
+    /// Get TLS acceptor reference for hot-reloading
+    pub fn get_acceptor_ref(&self) -> Arc<RwLock<Arc<TlsAcceptor>>> {
+        self.tls_acceptor.clone()
+    }
+
+    /// Get current certificate info
+    pub fn get_cert_info(&self) -> Option<CertificateInfo> {
+        self.cert_info.read().unwrap().clone()
+    }
+
+    /// Get reload count
+    pub fn get_reload_count(&self) -> u64 {
+        *self.reload_count.read().unwrap()
+    }
+
+    /// Get last reload time
+    pub fn get_last_reload(&self) -> Option<Instant> {
+        *self.last_reload.read().unwrap()
+    }
+
+    /// Reload certificate manually
+    pub fn reload(&self) -> Result<()> {
+        let start = Instant::now();
+        info!("[CertReloader] Reloading certificate...");
+
+        // Load new certificate
+        let new_config =
+            create_server_config_from_files(&self.config.cert_path, &self.config.key_path)?;
+        let new_acceptor = Arc::new(TlsAcceptor::from(new_config));
+
+        // Analyze new certificate
+        let new_cert_info = CertificateInfo::from_pem_file(&self.config.cert_path)?;
+
+        // Log changes
+        if let Some(ref old_info) = *self.cert_info.read().unwrap() {
+            if old_info.serial_number != new_cert_info.serial_number {
+                info!(
+                    "[CertReloader] Certificate changed: {} -> {}",
+                    old_info.summary(),
+                    new_cert_info.summary()
+                );
+            } else {
+                debug!("[CertReloader] Certificate reloaded (same serial number)");
+            }
+        }
+
+        // Check expiry
+        if self.config.check_expiry {
+            if new_cert_info.is_expired() {
+                return Err(AnyTlsError::Tls("New certificate has expired".to_string()));
+            } else if new_cert_info.is_expiring_soon(self.config.expiry_warning_days) {
+                warn!(
+                    "[CertReloader] WARNING: New certificate expiring in {} days",
+                    new_cert_info.days_until_expiry
+                );
+            }
+        }
+
+        // Update atomically
+        *self.tls_acceptor.write().unwrap() = new_acceptor;
+        *self.cert_info.write().unwrap() = Some(new_cert_info.clone());
+        *self.reload_count.write().unwrap() += 1;
+        *self.last_reload.write().unwrap() = Some(Instant::now());
+
+        let elapsed = start.elapsed();
+        info!(
+            "[CertReloader] Certificate reload completed in {:?}",
+            elapsed
+        );
+        info!(
+            "[CertReloader] New certificate: {}",
+            new_cert_info.summary()
+        );
+
+        Ok(())
+    }
+
+    /// Start watching certificate files for changes
+    pub fn start_watching(self: Arc<Self>) -> Result<()> {
+        if !self.config.watch_enabled {
+            debug!("[CertReloader] File watching is disabled");
+            return Ok(());
+        }
+
+        info!(
+            "[CertReloader] Starting file watcher for: {:?} and {:?}",
+            self.config.cert_path, self.config.key_path
+        );
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let debounce_duration = Duration::from_millis(self.config.debounce_ms);
+
+        // Create watcher
+        let mut watcher = RecommendedWatcher::new(
+            move |res: notify::Result<Event>| {
+                if let Ok(event) = res
+                    && matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_))
+                {
+                    let _ = tx.send(event);
+                }
+            },
+            Config::default(),
+        )
+        .map_err(|e| AnyTlsError::Tls(format!("Failed to create file watcher: {}", e)))?;
+
+        // Watch certificate file
+        watcher
+            .watch(&self.config.cert_path, RecursiveMode::NonRecursive)
+            .map_err(|e| {
+                AnyTlsError::Tls(format!(
+                    "Failed to watch certificate file {:?}: {}",
+                    self.config.cert_path, e
+                ))
+            })?;
+
+        // Watch key file
+        watcher
+            .watch(&self.config.key_path, RecursiveMode::NonRecursive)
+            .map_err(|e| {
+                AnyTlsError::Tls(format!(
+                    "Failed to watch key file {:?}: {}",
+                    self.config.key_path, e
+                ))
+            })?;
+
+        // Spawn watcher task
+        let reloader = Arc::clone(&self);
+        tokio::spawn(async move {
+            let _watcher = watcher; // Keep watcher alive
+
+            let mut last_reload = Instant::now();
+
+            while let Some(_event) = rx.recv().await {
+                // Debounce: only reload if enough time has passed
+                let now = Instant::now();
+                if now.duration_since(last_reload) < debounce_duration {
+                    debug!("[CertReloader] Debouncing file change event");
+                    continue;
+                }
+
+                debug!("[CertReloader] File change detected, reloading...");
+
+                // Small delay to ensure file write is complete
+                tokio::time::sleep(Duration::from_millis(100)).await;
+
+                match reloader.reload() {
+                    Ok(()) => {
+                        info!("[CertReloader] Certificate reloaded successfully");
+                        last_reload = now;
+                    }
+                    Err(e) => {
+                        error!("[CertReloader] Failed to reload certificate: {}", e);
+                        warn!("[CertReloader] Keeping current certificate active");
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Check certificate expiry periodically
+    pub fn start_expiry_checker(self: Arc<Self>, check_interval: Duration) {
+        if !self.config.check_expiry {
+            return;
+        }
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(check_interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                interval.tick().await;
+
+                if let Some(ref info) = *self.cert_info.read().unwrap() {
+                    if info.is_expired() {
+                        error!(
+                            "[CertReloader] CRITICAL: Certificate has expired! {}",
+                            info.summary()
+                        );
+                    } else if info.is_expiring_soon(self.config.expiry_warning_days) {
+                        warn!(
+                            "[CertReloader] WARNING: Certificate expiring in {} days! {}",
+                            info.days_until_expiry,
+                            info.summary()
+                        );
+                    } else {
+                        debug!(
+                            "[CertReloader] Certificate status: {} days until expiry",
+                            info.days_until_expiry
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    /// Display current certificate information
+    pub fn show_cert_info(&self) {
+        if let Some(ref info) = *self.cert_info.read().unwrap() {
+            println!("\n=== TLS Certificate Information ===\n");
+            print!("{}", info.display());
+            println!("===================================\n");
+        } else {
+            println!("No certificate information available");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cert_reloader_config_default() {
+        let config = CertReloaderConfig::default();
+        assert!(config.watch_enabled);
+        assert_eq!(config.debounce_ms, 500);
+        assert!(config.check_expiry);
+        assert_eq!(config.expiry_warning_days, 30);
+    }
+
+    #[test]
+    fn test_cert_reloader_config_custom() {
+        let config = CertReloaderConfig {
+            cert_path: PathBuf::from("/custom/cert.pem"),
+            key_path: PathBuf::from("/custom/key.pem"),
+            watch_enabled: false,
+            debounce_ms: 1000,
+            check_expiry: false,
+            expiry_warning_days: 15,
+        };
+
+        assert!(!config.watch_enabled);
+        assert_eq!(config.debounce_ms, 1000);
+        assert!(!config.check_expiry);
+        assert_eq!(config.expiry_warning_days, 15);
+    }
+
+    // Integration test with actual certificate files would require:
+    // 1. Creating valid test certificates
+    // 2. Writing them to temp files
+    // 3. Testing the reload mechanism
+    // This is better suited for integration tests rather than unit tests
+}

--- a/crates/meow-anytls/src/util/dns_cache.rs
+++ b/crates/meow-anytls/src/util/dns_cache.rs
@@ -1,0 +1,228 @@
+//! Simple async DNS cache to reduce repeated lookups for popular domains.
+
+use crate::util::{AnyTlsError, Result};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::io::{Error, ErrorKind};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::net::lookup_host;
+use tokio::sync::RwLock;
+use tracing::{debug, info, trace};
+use trust_dns_resolver::TokioAsyncResolver;
+use trust_dns_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
+
+/// TTL for cached DNS entries.
+const DEFAULT_TTL: Duration = Duration::from_secs(60);
+/// Timeout for DNS lookup operations.
+const DNS_TIMEOUT: Duration = Duration::from_secs(10);
+
+static DNS_CACHE: Lazy<DnsCache> = Lazy::new(DnsCache::new);
+static DNS_RESOLVER: Lazy<RwLock<Option<Arc<TokioAsyncResolver>>>> =
+    Lazy::new(|| RwLock::new(None));
+
+struct CacheEntry {
+    addresses: Vec<SocketAddr>,
+    expires_at: Instant,
+    next_index: usize,
+}
+
+pub struct DnsCache {
+    inner: RwLock<HashMap<String, CacheEntry>>,
+}
+
+impl DnsCache {
+    fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+
+    async fn get(&self, host: &str) -> Option<SocketAddr> {
+        let cache = self.inner.read().await;
+        if let Some(entry) = cache.get(host)
+            && Instant::now() <= entry.expires_at
+            && !entry.addresses.is_empty()
+        {
+            let index = entry.next_index % entry.addresses.len();
+            let addr = entry.addresses[index];
+            trace!("[DNS] Cache hit for {} -> {}", host, addr);
+            return Some(addr);
+        }
+        None
+    }
+
+    async fn insert(&self, host: String, addresses: Vec<SocketAddr>) {
+        let mut cache = self.inner.write().await;
+        cache.insert(
+            host,
+            CacheEntry {
+                addresses,
+                expires_at: Instant::now() + DEFAULT_TTL,
+                next_index: 0,
+            },
+        );
+    }
+
+    async fn advance(&self, host: &str) {
+        let mut cache = self.inner.write().await;
+        if let Some(entry) = cache.get_mut(host) {
+            entry.next_index = entry.next_index.wrapping_add(1);
+        }
+    }
+
+    async fn clear(&self) {
+        let mut cache = self.inner.write().await;
+        cache.clear();
+    }
+}
+
+/// Resolve a hostname with caching and timeout.
+pub async fn resolve_host_with_cache(host: &str, port: u16) -> Result<SocketAddr> {
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(SocketAddr::new(ip, port));
+    }
+
+    if let Some(addr) = DNS_CACHE.get(host).await {
+        DNS_CACHE.advance(host).await;
+        return Ok(addr);
+    }
+
+    let resolver_opt = DNS_RESOLVER.read().await.clone();
+    let mut addresses: Vec<SocketAddr> = if let Some(resolver) = resolver_opt {
+        let lookup = tokio::time::timeout(DNS_TIMEOUT, resolver.lookup_ip(host))
+            .await
+            .map_err(|_| {
+                AnyTlsError::Protocol(format!(
+                    "DNS resolution timeout ({}s) for {}",
+                    DNS_TIMEOUT.as_secs(),
+                    host
+                ))
+            })?
+            .map_err(|err| {
+                AnyTlsError::Io(Error::other(format!(
+                    "DNS resolution failed for {}: {}",
+                    host, err
+                )))
+            })?;
+        let mut addrs = Vec::new();
+        for ip in lookup.iter() {
+            addrs.push(SocketAddr::new(ip, port));
+        }
+        addrs
+    } else {
+        let lookup_future = lookup_host((host, port));
+        tokio::time::timeout(DNS_TIMEOUT, lookup_future)
+            .await
+            .map_err(|_| {
+                AnyTlsError::Protocol(format!(
+                    "DNS resolution timeout ({}s) for {}",
+                    DNS_TIMEOUT.as_secs(),
+                    host
+                ))
+            })?
+            .map_err(|err| {
+                AnyTlsError::Io(Error::other(format!(
+                    "DNS resolution failed for {}: {}",
+                    host, err
+                )))
+            })?
+            .collect::<Vec<_>>()
+    };
+
+    if addresses.is_empty() {
+        return Err(AnyTlsError::Protocol(format!(
+            "No address found for {}",
+            host
+        )));
+    }
+
+    // Sort to keep stability across runs (helps caching)
+    addresses.sort_unstable_by_key(|addr| match addr.ip() {
+        IpAddr::V4(ip) => (0, ip.octets().to_vec()),
+        IpAddr::V6(ip) => (1, ip.octets().to_vec()),
+    });
+
+    debug!(
+        "[DNS] Resolved {} -> {} entries (ttl={}s)",
+        host,
+        addresses.len(),
+        DEFAULT_TTL.as_secs()
+    );
+
+    DNS_CACHE.insert(host.to_string(), addresses.clone()).await;
+    DNS_CACHE.advance(host).await;
+    Ok(addresses[0])
+}
+
+pub async fn set_custom_dns_servers(servers: &[String]) -> Result<()> {
+    let mut parsed_servers = Vec::new();
+    for raw in servers {
+        let socket = parse_dns_server(raw)
+            .map_err(|err| AnyTlsError::Config(format!("Invalid DNS server '{}': {}", raw, err)))?;
+        parsed_servers.push(socket);
+    }
+
+    let mut resolver_guard = DNS_RESOLVER.write().await;
+
+    if parsed_servers.is_empty() {
+        *resolver_guard = None;
+        DNS_CACHE.clear().await;
+        info!("[DNS] Using system DNS resolver");
+        return Ok(());
+    }
+
+    let mut resolver_config = ResolverConfig::new();
+    for server in &parsed_servers {
+        resolver_config.add_name_server(NameServerConfig::new(*server, Protocol::Udp));
+        resolver_config.add_name_server(NameServerConfig::new(*server, Protocol::Tcp));
+    }
+
+    let resolver = TokioAsyncResolver::tokio(resolver_config, ResolverOpts::default());
+    *resolver_guard = Some(Arc::new(resolver));
+    DNS_CACHE.clear().await;
+
+    info!(
+        "[DNS] Custom DNS servers configured: {}",
+        parsed_servers
+            .iter()
+            .map(|addr| addr.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    Ok(())
+}
+
+fn parse_dns_server(entry: &str) -> std::io::Result<SocketAddr> {
+    let trimmed = entry.trim();
+    if trimmed.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "DNS server address is empty",
+        ));
+    }
+
+    if let Ok(addr) = trimmed.parse::<SocketAddr>() {
+        return Ok(addr);
+    }
+
+    // Allow IPv6 without port (e.g., "2001:4860:4860::8888")
+    if let Ok(ip) = trimmed.parse::<IpAddr>() {
+        return Ok(SocketAddr::new(ip, 53));
+    }
+
+    // Allow bracketed IPv6 without port (e.g., "[2001:4860:4860::8888]")
+    if trimmed.starts_with('[')
+        && trimmed.ends_with(']')
+        && let Ok(ip) = trimmed[1..trimmed.len() - 1].parse::<IpAddr>()
+    {
+        return Ok(SocketAddr::new(ip, 53));
+    }
+
+    Err(Error::new(
+        ErrorKind::InvalidInput,
+        format!("invalid DNS server '{}'", entry),
+    ))
+}

--- a/crates/meow-anytls/src/util/error.rs
+++ b/crates/meow-anytls/src/util/error.rs
@@ -1,0 +1,44 @@
+use thiserror::Error;
+
+/// AnyTLS protocol errors
+#[derive(Error, Debug)]
+pub enum AnyTlsError {
+    /// IO error from underlying system calls
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// TLS-related error
+    #[error("TLS error: {0}")]
+    Tls(String),
+
+    /// Protocol violation or parsing error
+    #[error("Protocol error: {0}")]
+    Protocol(String),
+
+    /// Authentication failed (wrong password or credentials)
+    #[error("Authentication failed")]
+    AuthenticationFailed,
+
+    /// Stream ID not found in session
+    #[error("Stream not found: {0}")]
+    StreamNotFound(u32),
+
+    /// Session has been closed
+    #[error("Session closed")]
+    SessionClosed,
+
+    /// Invalid or malformed frame
+    #[error("Invalid frame: {0}")]
+    InvalidFrame(String),
+
+    /// Padding scheme error
+    #[error("Padding scheme error: {0}")]
+    PaddingScheme(String),
+
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    Config(String),
+}
+
+/// Result type alias
+pub type Result<T> = std::result::Result<T, AnyTlsError>;

--- a/crates/meow-anytls/src/util/mod.rs
+++ b/crates/meow-anytls/src/util/mod.rs
@@ -1,0 +1,28 @@
+pub mod auth;
+/// Certificate analysis and information extraction
+pub mod cert_analyzer;
+/// Certificate reloader with hot reload support
+pub mod cert_reloader;
+pub mod dns_cache;
+/// Error types and Result alias
+pub mod error;
+pub mod net;
+/// Android `VpnService.protect(fd)` integration hook for outbound sockets.
+pub mod socket_protect;
+/// String-based key-value map implementation
+pub mod string_map;
+pub mod tls;
+
+pub use auth::*;
+pub use cert_analyzer::*;
+pub use cert_reloader::*;
+pub use dns_cache::*;
+pub use error::*;
+pub use net::*;
+#[cfg(target_os = "android")]
+pub use socket_protect::{
+    SocketProtector, clear_socket_protector, set_socket_protector, socket_protector,
+};
+pub use socket_protect::{bind_udp, connect_tcp};
+pub use string_map::*;
+pub use tls::*;

--- a/crates/meow-anytls/src/util/net.rs
+++ b/crates/meow-anytls/src/util/net.rs
@@ -1,0 +1,31 @@
+//! Network-related utilities (TCP tuning)
+
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tracing::debug;
+
+/// Enable low-latency options on a TCP stream (best-effort).
+pub fn configure_tcp_stream(stream: &TcpStream, context: &str) {
+    if let Err(err) = stream.set_nodelay(true) {
+        debug!(
+            "[Net] Failed to enable TCP_NODELAY for {}: {}",
+            context, err
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    {
+        use socket2::{SockRef, TcpKeepalive};
+
+        let keepalive = TcpKeepalive::new()
+            .with_time(Duration::from_secs(120))
+            .with_interval(Duration::from_secs(30));
+
+        if let Err(err) = SockRef::from(stream).set_tcp_keepalive(&keepalive) {
+            debug!(
+                "[Net] Failed to configure TCP keepalive for {}: {}",
+                context, err
+            );
+        }
+    }
+}

--- a/crates/meow-anytls/src/util/socket_protect.rs
+++ b/crates/meow-anytls/src/util/socket_protect.rs
@@ -1,0 +1,177 @@
+//! Outbound-socket protector hook for Android `VpnService.protect(fd)`.
+//!
+//! When `anytls-rs` runs *inside* an Android VPN app, every outbound socket
+//! it opens must bypass the VPN itself — otherwise packets to the AnyTLS
+//! server (and the per-stream UDP relay) loop back into the tunnel and
+//! deadlock. Android exposes a per-fd hook for this:
+//! `android.net.VpnService.protect(int fd)`. This module is the single
+//! place a host VPN can install that hook; the client-side dial sites in
+//! [`crate::client`] go through [`connect_tcp`] / [`bind_udp`], which
+//! call the installed protector before `connect()` / `bind()` so the very
+//! first SYN / UDP datagram already bypasses the tunnel.
+//!
+//! The protector trait and global setter are compiled only on Android. On
+//! every other target [`connect_tcp`] / [`bind_udp`] degrade to the same
+//! plain tokio code path used historically — so call sites need no `cfg`
+//! guards.
+
+use std::io;
+
+use tokio::net::{TcpStream, ToSocketAddrs, UdpSocket};
+
+#[cfg(target_os = "android")]
+mod android {
+    use super::*;
+    use std::net::SocketAddr;
+    use std::os::fd::{AsRawFd, RawFd};
+    use std::sync::{Arc, RwLock};
+
+    /// Hook invoked on every outbound socket fd just before `connect()` /
+    /// `bind()`. Typically a thin JNI shim around
+    /// `android.net.VpnService.protect(int)`.
+    ///
+    /// Implementations must not block — the call runs on the async runtime
+    /// worker that is dialing the socket.
+    pub trait SocketProtector: Send + Sync {
+        /// Protect `fd`. Returning `Err` aborts the connect/bind and the
+        /// error propagates back to the caller.
+        fn protect(&self, fd: RawFd) -> io::Result<()>;
+    }
+
+    static PROTECTOR: RwLock<Option<Arc<dyn SocketProtector>>> = RwLock::new(None);
+
+    /// Install the global socket protector. Call once during VPN startup,
+    /// before any AnyTLS client dials.
+    ///
+    /// Re-installing is allowed (e.g. VPN tear-down / re-create); the new
+    /// protector takes effect on the next outbound socket.
+    pub fn set_socket_protector(protector: Arc<dyn SocketProtector>) {
+        if let Ok(mut guard) = PROTECTOR.write() {
+            *guard = Some(protector);
+        }
+    }
+
+    /// Remove the currently installed protector, if any.
+    pub fn clear_socket_protector() {
+        if let Ok(mut guard) = PROTECTOR.write() {
+            *guard = None;
+        }
+    }
+
+    /// Snapshot of the currently-installed protector.
+    pub fn socket_protector() -> Option<Arc<dyn SocketProtector>> {
+        PROTECTOR.read().ok().and_then(|g| g.clone())
+    }
+
+    pub(super) async fn connect_tcp_protected(
+        dest: SocketAddr,
+        protector: &dyn SocketProtector,
+    ) -> io::Result<TcpStream> {
+        use socket2::{Domain, Protocol, Socket, Type};
+
+        let domain = if dest.is_ipv4() {
+            Domain::IPV4
+        } else {
+            Domain::IPV6
+        };
+        let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+        protector.protect(socket.as_raw_fd())?;
+        socket.set_nonblocking(true)?;
+
+        match socket.connect(&dest.into()) {
+            Ok(()) => {}
+            Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+            Err(e) => return Err(e),
+        }
+
+        let std_stream: std::net::TcpStream = socket.into();
+        let stream = TcpStream::from_std(std_stream)?;
+        stream.writable().await?;
+        if let Some(err) = stream.take_error()? {
+            return Err(err);
+        }
+        Ok(stream)
+    }
+
+    pub(super) fn bind_udp_protected(
+        local: SocketAddr,
+        protector: &dyn SocketProtector,
+    ) -> io::Result<UdpSocket> {
+        use socket2::{Domain, Protocol, Socket, Type};
+
+        let domain = if local.is_ipv4() {
+            Domain::IPV4
+        } else {
+            Domain::IPV6
+        };
+        let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+        protector.protect(socket.as_raw_fd())?;
+        socket.set_nonblocking(true)?;
+        socket.bind(&local.into())?;
+
+        let std_socket: std::net::UdpSocket = socket.into();
+        UdpSocket::from_std(std_socket)
+    }
+}
+
+#[cfg(target_os = "android")]
+pub use android::{
+    SocketProtector, clear_socket_protector, set_socket_protector, socket_protector,
+};
+
+/// Dial an outbound TCP stream. On Android, applies the installed
+/// `SocketProtector` (if any) to the socket fd before `connect()` so the
+/// connection bypasses the VPN. On every other target this is equivalent to
+/// [`TcpStream::connect`].
+///
+/// Accepts the same address forms as [`TcpStream::connect`]. When the
+/// Android protector path is taken, addresses are resolved first via
+/// `tokio::net::lookup_host` and each resolved `SocketAddr` is tried in
+/// turn.
+pub async fn connect_tcp<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
+    #[cfg(target_os = "android")]
+    {
+        if let Some(p) = android::socket_protector() {
+            let mut last_err: Option<io::Error> = None;
+            let mut any = false;
+            for resolved in tokio::net::lookup_host(addr).await? {
+                any = true;
+                match android::connect_tcp_protected(resolved, p.as_ref()).await {
+                    Ok(s) => return Ok(s),
+                    Err(e) => last_err = Some(e),
+                }
+            }
+            return Err(last_err.unwrap_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    if any {
+                        "connect_tcp: all candidates failed"
+                    } else {
+                        "connect_tcp: no addresses resolved"
+                    },
+                )
+            }));
+        }
+    }
+    TcpStream::connect(addr).await
+}
+
+/// Bind an outbound UDP socket. On Android, applies the installed
+/// `SocketProtector` (if any) to the socket fd before `bind()`. On every
+/// other target this is equivalent to [`UdpSocket::bind`].
+pub async fn bind_udp<A: ToSocketAddrs>(local: A) -> io::Result<UdpSocket> {
+    #[cfg(target_os = "android")]
+    {
+        if let Some(p) = android::socket_protector() {
+            let resolved = tokio::net::lookup_host(local)
+                .await?
+                .next()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "bind_udp: no address resolved")
+                })?;
+            return android::bind_udp_protected(resolved, p.as_ref());
+        }
+    }
+    UdpSocket::bind(local).await
+}

--- a/crates/meow-anytls/src/util/string_map.rs
+++ b/crates/meow-anytls/src/util/string_map.rs
@@ -1,0 +1,125 @@
+use std::collections::HashMap;
+
+/// StringMap is a simple key-value map for protocol settings
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StringMap(HashMap<String, String>);
+
+impl StringMap {
+    /// Create a new empty StringMap
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Create a new StringMap with the specified capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(HashMap::with_capacity(capacity))
+    }
+
+    /// Insert a key-value pair into the map
+    pub fn insert(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.0.insert(key.into(), value.into());
+    }
+
+    /// Get a value by key
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.0.get(key)
+    }
+
+    /// Check if the map contains a key
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.0.contains_key(key)
+    }
+
+    /// Get the number of key-value pairs in the map
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Check if the map is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Convert to bytes in format: "key=value\nkey2=value2\n..."
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut lines = Vec::new();
+        for (key, value) in &self.0 {
+            lines.push(format!("{}={}", key, value));
+        }
+        lines.join("\n").into_bytes()
+    }
+
+    /// Parse from bytes in format: "key=value\nkey2=value2\n..."
+    pub fn from_bytes(data: &[u8]) -> Self {
+        let mut map = HashMap::new();
+        let text = String::from_utf8_lossy(data);
+
+        for line in text.lines() {
+            if let Some((key, value)) = line.split_once('=') {
+                map.insert(key.trim().to_string(), value.trim().to_string());
+            }
+        }
+
+        Self(map)
+    }
+
+    /// Convert to Vec of (key, value) pairs
+    pub fn into_vec(self) -> Vec<(String, String)> {
+        self.0.into_iter().collect()
+    }
+}
+
+impl std::ops::Deref for StringMap {
+    type Target = HashMap<String, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for StringMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<HashMap<String, String>> for StringMap {
+    fn from(map: HashMap<String, String>) -> Self {
+        Self(map)
+    }
+}
+
+impl From<StringMap> for HashMap<String, String> {
+    fn from(val: StringMap) -> Self {
+        val.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_map_basic() {
+        let mut map = StringMap::new();
+        map.insert("key1", "value1");
+        map.insert("key2", "value2");
+
+        assert_eq!(map.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(map.get("key2"), Some(&"value2".to_string()));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_string_map_serialization() {
+        let mut map = StringMap::new();
+        map.insert("v", "2");
+        map.insert("client", "anytls-rs/0.1.0");
+
+        let bytes = map.to_bytes();
+        let restored = StringMap::from_bytes(&bytes);
+
+        assert_eq!(restored.get("v"), Some(&"2".to_string()));
+        assert_eq!(restored.get("client"), Some(&"anytls-rs/0.1.0".to_string()));
+    }
+}

--- a/crates/meow-anytls/src/util/tls.rs
+++ b/crates/meow-anytls/src/util/tls.rs
@@ -1,0 +1,230 @@
+//! TLS utilities for certificate generation and configuration
+
+use crate::util::{AnyTlsError, Result};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::ServerConfig;
+use rustls::{ClientConfig, RootCertStore};
+use std::sync::Arc;
+use std::{fs::File, io::BufReader, path::Path};
+
+impl From<rustls::Error> for AnyTlsError {
+    fn from(err: rustls::Error) -> Self {
+        AnyTlsError::Tls(format!("rustls error: {}", err))
+    }
+}
+
+impl From<rcgen::Error> for AnyTlsError {
+    fn from(err: rcgen::Error) -> Self {
+        AnyTlsError::Tls(format!("rcgen error: {}", err))
+    }
+}
+
+/// Generate a self-signed certificate for testing
+///
+/// This generates a certificate similar to the Go version:
+/// - ECDSA P-256 key (default for rcgen, better performance than RSA 2048)
+/// - Valid for reasonable duration (rcgen default, typically 1 year)
+/// - Server authentication usage
+/// - Supports localhost and custom server names
+pub fn generate_key_pair() -> Result<(CertificateDer<'static>, PrivateKeyDer<'static>)> {
+    generate_key_pair_with_name(None)
+}
+
+/// Generate a self-signed certificate with a specific server name
+pub fn generate_key_pair_with_name(
+    server_name: Option<&str>,
+) -> Result<(CertificateDer<'static>, PrivateKeyDer<'static>)> {
+    // Determine server name to use
+    let name = server_name.unwrap_or("localhost");
+
+    // Use rcgen's simple API to generate self-signed certificate
+    // This is the recommended approach for basic use cases
+    let subject_alt_names = vec![name.to_string(), "localhost".to_string()];
+    let certified_key = rcgen::generate_simple_self_signed(subject_alt_names)?;
+
+    // Serialize to DER format
+    let cert_der = certified_key.cert.der();
+    let key_der = certified_key.signing_key.serialize_der();
+
+    // Convert to rustls types
+    // CertificateDer implements From<&[u8]>, but we need 'static lifetime
+    // So we clone into a Vec<u8> and use it
+    let cert_der_vec: Vec<u8> = cert_der.to_vec();
+    let cert_der: CertificateDer<'static> = cert_der_vec.into();
+    let key_der: PrivateKeyDer<'static> = PrivateKeyDer::Pkcs8(key_der.into());
+
+    Ok((cert_der, key_der))
+}
+
+/// Create a server TLS config with a generated certificate
+pub fn create_server_config() -> Result<Arc<ServerConfig>> {
+    let (cert, key) = generate_key_pair()?;
+
+    let config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key)?;
+
+    Ok(Arc::new(config))
+}
+
+/// Create a server TLS config by loading certificate/private key from disk (PEM).
+pub fn create_server_config_from_files<P: AsRef<Path>>(
+    cert_path: P,
+    key_path: P,
+) -> Result<Arc<ServerConfig>> {
+    let cert_file = File::open(&cert_path).map_err(AnyTlsError::Io)?;
+    let mut cert_reader = BufReader::new(cert_file);
+    let certs = rustls_pemfile::certs(&mut cert_reader)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| AnyTlsError::Tls(format!("failed to parse certificate: {e}")))?;
+    if certs.is_empty() {
+        return Err(AnyTlsError::Tls(format!(
+            "no certificates found in {:?}",
+            cert_path.as_ref()
+        )));
+    }
+
+    let key_file = File::open(&key_path).map_err(AnyTlsError::Io)?;
+    let mut key_reader = BufReader::new(key_file);
+    let key = rustls_pemfile::private_key(&mut key_reader)
+        .map_err(|e| AnyTlsError::Tls(format!("failed to parse private key: {e}")))?
+        .ok_or_else(|| {
+            AnyTlsError::Tls(format!("no private key found in {:?}", key_path.as_ref()))
+        })?;
+
+    let config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)?;
+
+    Ok(Arc::new(config))
+}
+
+/// Certificate verifier that accepts all certificates (for testing only)
+/// Similar to Go's InsecureSkipVerify: true
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        // Accept all certificates (for testing only)
+        // This is similar to Go's InsecureSkipVerify: true
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        // Support common signature schemes
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ED448,
+        ]
+    }
+}
+
+/// Create a client TLS config with insecure verification (for testing)
+/// This accepts self-signed certificates, similar to Go's InsecureSkipVerify: true
+pub fn create_client_config() -> Result<Arc<ClientConfig>> {
+    let root_store = RootCertStore::empty();
+
+    // For testing, we'll accept any certificate
+    // In production, you should load proper root certificates
+
+    let mut config = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    // Set custom certificate verifier to accept self-signed certificates
+    config
+        .dangerous()
+        .set_certificate_verifier(Arc::new(NoCertificateVerification));
+
+    Ok(Arc::new(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // meow-rs vendoring change: `*Config::builder()` below auto-detects the
+    // process CryptoProvider, which panics when both `ring` and `aws-lc-rs` are
+    // compiled in (aws-lc-rs arrives transitively via reqwest in the workspace
+    // build). Install ring explicitly first, matching meow's own integration
+    // tests. Idempotent — ignores the Err when a default is already set.
+    fn install_ring() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    #[test]
+    fn test_create_client_config() {
+        install_ring();
+        let config = create_client_config().unwrap();
+        // Config should be created successfully
+        assert!(Arc::strong_count(&config) >= 1);
+    }
+
+    #[test]
+    fn test_generate_key_pair() {
+        // Should now succeed
+        let (cert, key) = generate_key_pair().unwrap();
+        assert!(!cert.as_ref().is_empty());
+        match &key {
+            PrivateKeyDer::Pkcs8(data) => assert!(!data.secret_pkcs8_der().is_empty()),
+            PrivateKeyDer::Pkcs1(data) => assert!(!data.secret_pkcs1_der().is_empty()),
+            PrivateKeyDer::Sec1(data) => assert!(!data.secret_sec1_der().is_empty()),
+            _ => panic!("Unexpected key type"),
+        }
+    }
+
+    #[test]
+    fn test_generate_key_pair_with_name() {
+        let (cert, key) = generate_key_pair_with_name(Some("example.com")).unwrap();
+        assert!(!cert.as_ref().is_empty());
+        match &key {
+            PrivateKeyDer::Pkcs8(data) => assert!(!data.secret_pkcs8_der().is_empty()),
+            PrivateKeyDer::Pkcs1(data) => assert!(!data.secret_pkcs1_der().is_empty()),
+            PrivateKeyDer::Sec1(data) => assert!(!data.secret_sec1_der().is_empty()),
+            _ => panic!("Unexpected key type"),
+        }
+    }
+
+    #[test]
+    fn test_create_server_config() {
+        install_ring();
+        // Should now succeed
+        let config = create_server_config().unwrap();
+        assert!(Arc::strong_count(&config) >= 1);
+    }
+}

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -19,11 +19,11 @@ vless-vision = ["vless"]
 # optional http/tls obfs (reused from the SS simple-obfs module),
 # UDP-over-TCP, and an opt-in v4/v5 reuse pool (CommandConnectV2).
 snell = ["dep:argon2", "dep:aes-gcm"]
-# Opt-in anytls outbound (uses the `anytls-rs` crate). Adds ~one extra TLS
-# provider to the binary because the upstream crate pins default rustls
-# features — accept the bloat in exchange for not re-implementing the
-# wire protocol. Off by default.
-anytls = ["dep:anytls-rs"]
+# Opt-in anytls outbound (uses the vendored `meow-anytls` crate, lib name
+# `anytls_rs`). Adds ~one extra TLS provider to the binary because the vendored
+# crate keeps the fork's default rustls features — accept the bloat in exchange
+# for not re-implementing the wire protocol. Off by default.
+anytls = ["dep:meow-anytls"]
 # Hysteria2 outbound implemented in-tree on top of Quinn.
 hysteria2 = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:blake2"]
 # Native client for the `ech-tls-tunnel` SIP003 plugin
@@ -36,7 +36,7 @@ meow-common = { workspace = true }
 meow-dns = { workspace = true }
 meow-transport = { workspace = true }
 tokio = { workspace = true }
-anytls-rs = { workspace = true, optional = true }
+meow-anytls = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 h3 = { workspace = true, optional = true }
 h3-quinn = { workspace = true, optional = true }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing meow-rs
 
-meow-rs ships as **11 crates** published together to [crates.io](https://crates.io)
+meow-rs ships as **12 crates** published together to [crates.io](https://crates.io)
 at a single workspace version. This is the checklist for cutting a release.
 
 > [!IMPORTANT]
@@ -16,7 +16,8 @@ at a single workspace version. This is the checklist for cutting a release.
 2. Add it to the repo as the **`CARGO_REGISTRY_TOKEN`** Actions secret
    (`Settings → Secrets and variables → Actions`). The
    [`publish.yml`](../.github/workflows/publish.yml) workflow reads it.
-3. Confirm you own all 11 crate names on crates.io (you do, as of `0.15.0`).
+3. Confirm you own all 12 crate names on crates.io (you own 11 as of `0.15.0`;
+   `meow-anytls` is new in this release and must be claimable under your account).
 
 ## The crates & publish order
 
@@ -26,9 +27,9 @@ dependencies — including **dev-dependencies**, which crates.io validates at pu
 time (e.g. `meow-tunnel` dev-depends on `meow-config`, so config goes first):
 
 ```
-meow-common  meow-trie  meow-transport      (leaves, no internal deps)
+meow-common  meow-trie  meow-anytls  meow-transport   (leaves, no internal deps)
 meow-rules   meow-dns                        (→ common, trie)
-meow-proxy                                   (→ common, dns, transport)
+meow-proxy                                   (→ common, dns, transport, anytls)
 meow-config                                  (→ common, trie, dns, rules, proxy)
 meow-tunnel                                  (→ …, + dev-dep on config)
 meow-listener  meow-api                      (→ tunnel, config)
@@ -60,7 +61,7 @@ meow-app                                     (→ everything)
    git push origin v0.15.1
    ```
    The tag push triggers [`publish.yml`](../.github/workflows/publish.yml), which
-   verifies the tag matches the workspace version and publishes all 11 crates in
+   verifies the tag matches the workspace version and publishes all 12 crates in
    order. (The workflow is idempotent — a re-run skips versions already on the
    registry, so a partial release can resume.)
 


### PR DESCRIPTION
Fixes #262 by **vendoring the anytls fork directly into the repo** instead of depending on it from crates.io/git.

Supersedes #264 (the `[patch.crates-io]` approach) — vendoring also fixes **downstream** consumers who pull `meow-proxy` from crates.io with `anytls` enabled, which `[patch]` could not.

## Problem
`meow-proxy`'s anytls adapter calls `anytls_rs::Stream::close()` (the fd/stream-leak fix for #201 item 4, madeye/anytls-rs#1). crates.io `anytls-rs@0.5.4` is **jxo-me's upstream** crate, which has no `close()` — that method only exists in the **madeye fork**, merged *after* the fork's own `v0.5.4` tag. So neither the registry crate nor that tag compiles, and any `--features anytls` build fails (`E0599`); `clippy --all-features` was red in CI.

## Fix
New workspace member `crates/meow-anytls` containing the fork's library source, pinned at the merge commit with `close()` (`e6134889`).

- **Package renamed** `meow-anytls` (avoids a crates.io name collision with upstream `anytls-rs`); **lib name stays `anytls_rs`**, so `meow-proxy`'s `use anytls_rs::…` code is unchanged — only the optional dep + feature gate are rewired.
- **MIT-licensed** (LICENSE kept) and **edition 2024**, declared explicitly rather than inherited from the GPL-3.0 / edition-2021 workspace.
- **Library source only** — upstream bins, benches, tests, scripts omitted.
- **rustls/tokio-rustls/rcgen pinned to `ring`** to match the rest of the workspace. meow installs ring as the process default at startup and the adapter builds TLS with an explicit ring provider, so this crate's `builder()`-based helpers are off the runtime path.
- Two upstream `util::tls` unit tests call `builder()` without installing a provider — that panics in the workspace build because aws-lc-rs is also present transitively (via reqwest). Install ring first in those two tests, matching meow's existing integration tests.
- **Release plumbing**: `publish.yml` + `RELEASING.md` publish `meow-anytls` before `meow-proxy` (12 published crates); `CLAUDE.md` crate table updated (13 workspace members).

> Note: `meow-anytls` is a new crate name on crates.io. The first release after this lands must be able to claim it under the project's account (called out in `RELEASING.md`).

## Verification — all green
- ✅ `cargo build -p meow-proxy --features anytls` (the #262 repro)
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo clippy --all-targets --no-default-features -- -D warnings`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` ← was failing before
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- ✅ `cargo test --lib`
- ✅ `cargo test -p meow-proxy --features anytls --test anytls_integration --test anytls_leak` (exercises the real adapter + the `close()` leak fix)
- ✅ `cargo publish -p meow-anytls --dry-run` (packages + verifies for crates.io)

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)