### PR TITLE
chore(release): bump workspace to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "base64",
  "ipnet",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"
@@ -213,16 +213,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.15.1" }
-meow-trie = { path = "crates/meow-trie", version = "0.15.1" }
+meow-common = { path = "crates/meow-common", version = "0.16.0" }
+meow-trie = { path = "crates/meow-trie", version = "0.16.0" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.15.1" }
-meow-dns = { path = "crates/meow-dns", version = "0.15.1", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.15.1" }
-meow-transport = { path = "crates/meow-transport", version = "0.15.1" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.15.1", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.15.1" }
-meow-listener = { path = "crates/meow-listener", version = "0.15.1", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.15.1" }
-meow-config = { path = "crates/meow-config", version = "0.15.1", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.16.0" }
+meow-dns = { path = "crates/meow-dns", version = "0.16.0", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.16.0" }
+meow-transport = { path = "crates/meow-transport", version = "0.16.0" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.16.0", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.16.0" }
+meow-listener = { path = "crates/meow-listener", version = "0.16.0", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.16.0" }
+meow-config = { path = "crates/meow-config", version = "0.16.0", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -13,7 +13,7 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."


### PR DESCRIPTION
Version bump to cut the **0.16.0** release.

Minor bump (not patch) because this release adds a **new published crate** to the workspace, `meow-anytls`.

## What ships in 0.16.0
- **#265** — anytls fork vendored in-tree as `crates/meow-anytls` (closes #262)
- **#263** — quinn-proto + memmap2 security bumps, RUSTSEC-2026-0185/-0186 (closes #260, #261)
- **#258** — Pages docs

## This PR
- `[workspace.package]` version + all internal `[workspace.dependencies]` meow-* pins: `0.15.1` → `0.16.0`
- `crates/meow-anytls` explicit version (edition-2024/MIT, not workspace-inherited): `0.15.1` → `0.16.0`
- `cargo update -w` refreshed the lockfile

## Verification
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo test --lib`
- (full three-way clippy + all-features + anytls integration verified on the same code prior to the bump)

After merge, tagging `v0.16.0` triggers `publish.yml`, which publishes all 12 crates in dependency order. Note: `meow-anytls` is a **new crate name** on crates.io and will be claimed on this release's first publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)