### PR TITLE
fix(tproxy): correct macOS pfioc_natlook struct layout (84 vs 76 bytes)

### DIFF
--- a/crates/meow-listener/src/tproxy/orig_dest.rs
+++ b/crates/meow-listener/src/tproxy/orig_dest.rs
@@ -56,8 +56,38 @@ mod macos {
         }
     }
 
-    /// Mirrors `struct pfioc_natlook` from <net/pfvar.h>.
-    /// The exact layout is ABI-sensitive; fields are ordered to match the kernel struct.
+    /// Port/SPI union matching `union pf_state_xport` from <net/pfvar.h>:
+    ///
+    /// ```c
+    /// union pf_state_xport { u_int16_t port; u_int16_t call_id; u_int32_t spi; };
+    /// ```
+    ///
+    /// It is 4 bytes — aligned to the `u32 spi` member. Representing ports as a
+    /// bare `u16` (2 bytes) shrinks `pfioc_natlook` to 76 bytes instead of 84,
+    /// so the size the kernel reads/writes (encoded in the `DIOCNATLOOK` ioctl
+    /// number) no longer matches the buffer we pass — an ABI mismatch that
+    /// corrupts the natlook result and reads/writes out of bounds.
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    union PfStateXport {
+        port: u16, // network byte order
+        _call_id: u16,
+        _spi: u32,
+    }
+
+    impl Default for PfStateXport {
+        fn default() -> Self {
+            PfStateXport { _spi: 0 }
+        }
+    }
+
+    /// Mirrors `struct pfioc_natlook` from <net/pfvar.h> (84 bytes, verified
+    /// against macOS 14 / xnu headers). The exact layout is ABI-sensitive; the
+    /// port fields are 4-byte `pf_state_xport` unions, not bare `u16`s.
+    ///
+    /// Field offsets: saddr@0, daddr@16, rsaddr@32, rdaddr@48, sxport@64,
+    /// dxport@68, rsxport@72, rdxport@76, af@80, proto@81, proto_variant@82,
+    /// direction@83.
     #[repr(C)]
     #[derive(Default)]
     struct PfiocNatlook {
@@ -65,15 +95,19 @@ mod macos {
         daddr: PfAddr,
         rsaddr: PfAddr,
         rdaddr: PfAddr,
-        sxport: [u8; 2], // source port (network byte order)
-        dxport: [u8; 2], // dest port (network byte order)
-        rsxport: [u8; 2],
-        rdxport: [u8; 2],
+        sxport: PfStateXport, // source port (network byte order)
+        dxport: PfStateXport, // dest port (network byte order)
+        rsxport: PfStateXport,
+        rdxport: PfStateXport,
         af: u8,    // address family
         proto: u8, // protocol (IPPROTO_TCP)
         proto_variant: u8,
         direction: u8, // PF_IN or PF_OUT
     }
+
+    // The kernel encodes this size into the DIOCNATLOOK ioctl number, so it
+    // must be exactly 84 bytes or the ioctl is rejected / corrupts memory.
+    const _: () = assert!(mem::size_of::<PfiocNatlook>() == 84);
 
     pub fn get_original_dst(stream: &TcpStream, listen_addr: SocketAddr) -> io::Result<SocketAddr> {
         let peer = stream.peer_addr().map_err(io::Error::other)?;
@@ -119,7 +153,9 @@ mod macos {
         nl.saddr.v4 = libc::in_addr {
             s_addr: u32::from(peer_ip).to_be(),
         };
-        nl.sxport = peer_port.to_be_bytes();
+        nl.sxport = PfStateXport {
+            port: peer_port.to_be(),
+        };
 
         // Destination: the listen address (after redirection)
         let listen_ip = match listen_addr.ip() {
@@ -129,7 +165,9 @@ mod macos {
         nl.daddr.v4 = libc::in_addr {
             s_addr: u32::from(listen_ip).to_be(),
         };
-        nl.dxport = listen_port.to_be_bytes();
+        nl.dxport = PfStateXport {
+            port: listen_port.to_be(),
+        };
 
         let ret =
             unsafe { libc::ioctl(pf_fd.as_raw_fd(), DIOCNATLOOK, &mut nl as *mut PfiocNatlook) };
@@ -143,9 +181,61 @@ mod macos {
             let s_addr = nl.rdaddr.v4.s_addr;
             Ipv4Addr::from(u32::from_be(s_addr))
         };
-        let orig_port = u16::from_be_bytes(nl.rdxport);
+        // Safety: we only ever write the `port` variant into the xport unions.
+        let orig_port = u16::from_be(unsafe { nl.rdxport.port });
 
         Ok(SocketAddr::new(IpAddr::V4(orig_ip), orig_port))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn struct_sizes_match_kernel() {
+            assert_eq!(mem::size_of::<PfStateXport>(), 4);
+            assert_eq!(mem::size_of::<PfiocNatlook>(), 84);
+        }
+
+        #[test]
+        fn field_offsets_match_kernel() {
+            // Verified against macOS 14 xnu <net/pfvar.h>.
+            assert_eq!(mem::offset_of!(PfiocNatlook, saddr), 0);
+            assert_eq!(mem::offset_of!(PfiocNatlook, daddr), 16);
+            assert_eq!(mem::offset_of!(PfiocNatlook, rsaddr), 32);
+            assert_eq!(mem::offset_of!(PfiocNatlook, rdaddr), 48);
+            assert_eq!(mem::offset_of!(PfiocNatlook, sxport), 64);
+            assert_eq!(mem::offset_of!(PfiocNatlook, dxport), 68);
+            assert_eq!(mem::offset_of!(PfiocNatlook, rsxport), 72);
+            assert_eq!(mem::offset_of!(PfiocNatlook, rdxport), 76);
+            assert_eq!(mem::offset_of!(PfiocNatlook, af), 80);
+            assert_eq!(mem::offset_of!(PfiocNatlook, proto), 81);
+            assert_eq!(mem::offset_of!(PfiocNatlook, proto_variant), 82);
+            assert_eq!(mem::offset_of!(PfiocNatlook, direction), 83);
+        }
+
+        #[test]
+        fn ioctl_number_matches_struct_size() {
+            // DIOCNATLOOK = _IOWR('D', 23, struct pfioc_natlook).
+            // The struct size (84) is encoded in bits 16..29 of the number,
+            // so the hardcoded constant must agree with size_of::<PfiocNatlook>.
+            let expected: libc::c_ulong = 0xC000_0000
+                | ((mem::size_of::<PfiocNatlook>() as libc::c_ulong) << 16)
+                | (u64::from(b'D') << 8)
+                | 23;
+            assert_eq!(DIOCNATLOOK, expected);
+            assert_eq!(DIOCNATLOOK, 0xC054_4417);
+            // The pre-fix 76-byte struct produced this rejected number.
+            assert_ne!(DIOCNATLOOK, 0xC04C_4417);
+        }
+
+        #[test]
+        fn port_union_round_trip() {
+            let xport = PfStateXport {
+                port: 443u16.to_be(),
+            };
+            assert_eq!(u16::from_be(unsafe { xport.port }), 443);
+        }
     }
 }
 


### PR DESCRIPTION
## Same issue as [madeye/trans_proxy#2](https://github.com/madeye/trans_proxy/pull/2)

While reviewing trans_proxy#2 I checked meow-rs's equivalent macOS pf code (`crates/meow-listener/src/tproxy/orig_dest.rs`) and it has the **same `pfioc_natlook` layout bug**.

### The bug
The port fields were declared as bare 2-byte values:

```rust
sxport: [u8; 2],
dxport: [u8; 2],
rsxport: [u8; 2],
rdxport: [u8; 2],
```

But the kernel's `union pf_state_xport` is **4 bytes** — it carries a `u32 spi` alongside the `u16 port`, so the union aligns to 4:

```c
union pf_state_xport { u_int16_t port; u_int16_t call_id; u_int32_t spi; };
```

With 2-byte ports the struct is **76 bytes instead of 84** (confirmed locally).

`DIOCNATLOOK` is hardcoded to `0xC0544417`, the value `_IOWR('D', 23, struct pfioc_natlook)` derives from an **84-byte** struct. Passing a 76-byte buffer to that ioctl means:

- The kernel copies 84 bytes in/out of a 76-byte stack buffer → **8-byte out-of-bounds** read/write.
- Every field from `sxport` onward is at the wrong offset — including `rdxport` (the original port we read back) and the `af`/`proto`/`direction` **inputs**, so the lookup can't function.

macOS tproxy is experimental and CI is Linux-only, so this was latent (no test ever exercised the struct layout — exactly the gap trans_proxy#2 calls out).

### The fix (mirrors trans_proxy#2)
- Add a 4-byte `PfStateXport` union for the xport fields.
- Compile-time `assert!(size_of::<PfiocNatlook>() == 84)`.
- Unit tests: struct size, all field offsets, the ioctl number (derived from `size_of`, equals `0xC0544417`, and **not** the old 76-byte `0xC04C4417`), and port round-trip.

### Verification (on macOS, where this code is active)
- `cargo test -p meow-listener --lib orig_dest` → 4 passed.
- `cargo fmt --all -- --check` + three-way `clippy --all-targets -D warnings` (default / all-features / no-default-features) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)