### PR TITLE
fix(tproxy): emit ip6 daddr for IPv6 bypass IPs in nftables ruleset

### DIFF
--- a/crates/meow-listener/src/tproxy/firewall.rs
+++ b/crates/meow-listener/src/tproxy/firewall.rs
@@ -184,7 +184,19 @@ pub(crate) fn build_nft_ruleset(
 ) -> String {
     let mut bypass_rules = String::new();
     for ip in bypass_ips {
-        writeln!(bypass_rules, "    ip daddr {ip} accept").expect("write to String");
+        // In an `inet` table the L3 protocol must be selected explicitly:
+        // `ip daddr` only parses IPv4 literals and `ip6 daddr` only IPv6.
+        // Emitting `ip daddr <v6>` is a parse error that makes `nft -f -`
+        // reject the *entire* ruleset, so the tproxy listener fails to start
+        // whenever a proxy host resolves to an IPv6 address.
+        match ip {
+            IpAddr::V4(v4) => {
+                writeln!(bypass_rules, "    ip daddr {v4} accept").expect("write to String");
+            }
+            IpAddr::V6(v6) => {
+                writeln!(bypass_rules, "    ip6 daddr {v6} accept").expect("write to String");
+            }
+        }
     }
     let mark_rule = match routing_mark {
         Some(mark) => format!("    meta mark 0x{mark:x} accept\n"),
@@ -356,7 +368,13 @@ mod tests {
         ];
         let rs = build_nft_ruleset("t", 1, None, &bypass);
         assert!(rs.contains("ip daddr 1.2.3.4 accept"));
-        assert!(rs.contains("ip daddr 2001:db8::1 accept"));
+        // IPv6 bypass IPs must use `ip6 daddr` — `ip daddr <v6>` is a parse
+        // error that aborts the whole `nft -f -` load.
+        assert!(rs.contains("ip6 daddr 2001:db8::1 accept"));
+        assert!(
+            !rs.contains("ip daddr 2001:db8::1"),
+            "IPv6 address must not follow `ip daddr`:\n{rs}"
+        );
     }
 
     // ─── pf (macOS) ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Linux-side issue found auditing the tproxy path after #268

Following up on the macOS `pfioc_natlook` fix (#268), I checked the Linux transparent-proxy path for analogous ABI/syntax bugs. The `orig_dest` getsockopt code is clean (standard libc types, correct `SO_ORIGINAL_DST`/`IP6T_SO_ORIGINAL_DST` constants), but `build_nft_ruleset` has a real bug.

### The bug
Firewall-bypass IPs were all emitted as `ip daddr {ip}`, including IPv6:

```rust
for ip in bypass_ips {
    writeln!(bypass_rules, "    ip daddr {ip} accept")...
}
```

In an nftables `inet` table the L3 protocol must be selected explicitly — `ip daddr` only parses **IPv4** literals, `ip6 daddr` only IPv6. So `ip daddr 2001:db8::1` is a **parse error** that makes `nft -f -` reject the *entire* ruleset. `FirewallGuard::setup` then returns `Err`, and `TProxyListener::run` propagates it — **the listener never starts**.

### Why it's reachable
`collect_proxy_server_ips` calls `to_socket_addrs()` on proxy hostnames. On a dual-stack host that returns AAAA (IPv6) records, so an IPv6 address lands in `bypass_ips` for any hostname-based proxy — the common case. The loopback bypasses just above already split `ip daddr 127.0.0.0/8` from `ip6 daddr ::1`, confirming the distinction was simply not applied to the dynamic bypass IPs. The existing unit test even asserted the broken `ip daddr 2001:db8::1` output.

### The fix
Match on `IpAddr::V4`/`V6` and emit `ip daddr` / `ip6 daddr` respectively. Updated the test and added a guard that no IPv6 literal ever follows `ip daddr`.

### Verification
- `cargo test -p meow-listener --lib firewall` → 8 passed.
- `cargo fmt --all -- --check` + three-way `clippy --all-targets -D warnings` (default / all-features / no-default-features) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)