### PR TITLE
dns: preserve encrypted upstream labels

### DIFF
--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -107,6 +107,7 @@ pub struct DnsClient {
     transport: Transport,
     timeout: Duration,
     proxy: Option<DnsProxy>,
+    label: Option<Arc<str>>,
 }
 
 enum Transport {
@@ -141,6 +142,7 @@ impl DnsClient {
             transport: Transport::Udp { addr },
             timeout: DEFAULT_QUERY_TIMEOUT,
             proxy: None,
+            label: None,
         }
     }
 
@@ -150,6 +152,7 @@ impl DnsClient {
             transport: Transport::Tcp { addr },
             timeout: DEFAULT_QUERY_TIMEOUT,
             proxy: None,
+            label: None,
         }
     }
 
@@ -159,6 +162,7 @@ impl DnsClient {
             transport: Transport::RCode { code },
             timeout: DEFAULT_QUERY_TIMEOUT,
             proxy: None,
+            label: None,
         }
     }
 
@@ -173,6 +177,7 @@ impl DnsClient {
             },
             timeout: DEFAULT_QUERY_TIMEOUT,
             proxy: None,
+            label: None,
         }
     }
 
@@ -188,6 +193,7 @@ impl DnsClient {
             },
             timeout: DEFAULT_QUERY_TIMEOUT,
             proxy: None,
+            label: None,
         }
     }
 
@@ -210,29 +216,47 @@ impl DnsClient {
         self
     }
 
+    /// Override the API/UI label used to report this upstream in DNS results.
+    pub fn with_upstream_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(Arc::from(label.into()));
+        self
+    }
+
     /// Human-readable upstream identifier for API/UI surfaces.
     pub fn upstream_label(&self) -> String {
-        let mut label = match &self.transport {
-            Transport::Udp { addr } | Transport::Tcp { addr } => socket_label(*addr, 53),
-            Transport::RCode { code } => format!("rcode:{code:?}"),
-            #[cfg(feature = "encrypted")]
-            Transport::Dot { addr, sni, .. } => {
-                if sni.is_empty() {
-                    socket_label(*addr, 853)
-                } else {
-                    sni.to_string()
+        let mut label = if let Some(label) = &self.label {
+            label.to_string()
+        } else {
+            match &self.transport {
+                Transport::Udp { addr } | Transport::Tcp { addr } => socket_label(*addr, 53),
+                Transport::RCode { code } => format!("rcode:{code:?}"),
+                #[cfg(feature = "encrypted")]
+                Transport::Dot { addr, sni, .. } => {
+                    if sni.is_empty() {
+                        format!("tls://{}", socket_label(*addr, 853))
+                    } else if addr.port() == 853 {
+                        format!("tls://{sni}")
+                    } else {
+                        format!("tls://{sni}:{}", addr.port())
+                    }
                 }
-            }
-            #[cfg(feature = "encrypted")]
-            Transport::Doh {
-                addr, sni, path, ..
-            } => {
-                if sni.is_empty() {
-                    socket_label(*addr, 443)
-                } else if path.as_ref() == "/dns-query" {
-                    sni.to_string()
-                } else {
-                    format!("{sni}{path}")
+                #[cfg(feature = "encrypted")]
+                Transport::Doh {
+                    addr, sni, path, ..
+                } => {
+                    if sni.is_empty() {
+                        format!("https://{}", socket_label(*addr, 443))
+                    } else if path.as_ref() == "/dns-query" {
+                        if addr.port() == 443 {
+                            format!("https://{sni}")
+                        } else {
+                            format!("https://{sni}:{}", addr.port())
+                        }
+                    } else if addr.port() == 443 {
+                        format!("https://{sni}{path}")
+                    } else {
+                        format!("https://{sni}:{}{path}", addr.port())
+                    }
                 }
             }
         };
@@ -574,5 +598,26 @@ mod tests {
         assert_eq!(resp.metadata.response_code, ResponseCode::NoError);
         assert!(resp.answers.is_empty());
         assert_eq!(resp.queries.len(), 1);
+    }
+
+    #[cfg(feature = "encrypted")]
+    #[test]
+    fn encrypted_upstream_labels_include_scheme() {
+        let dot = DnsClient::dot("8.8.8.8:853".parse().unwrap(), "dns.google");
+        assert_eq!(dot.upstream_label(), "tls://dns.google");
+
+        let doh = DnsClient::doh(
+            "1.1.1.1:443".parse().unwrap(),
+            "cloudflare-dns.com",
+            "/dns-query",
+        );
+        assert_eq!(doh.upstream_label(), "https://cloudflare-dns.com");
+    }
+
+    #[test]
+    fn explicit_upstream_label_overrides_default_label() {
+        let client = DnsClient::udp("8.8.8.8:53".parse().unwrap())
+            .with_upstream_label("tls://dns.google:853");
+        assert_eq!(client.upstream_label(), "tls://dns.google:853");
     }
 }

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -295,6 +295,45 @@ struct PoolLookupResult {
     source: String,
 }
 
+fn encrypted_upstream_label(url: &NameServerUrl) -> Option<String> {
+    match url {
+        NameServerUrl::Tls { addr, port, sni } => {
+            let mut label = format!("tls://{}", authority_label(addr, *port, 853));
+            if sni != &addr.to_string() {
+                label.push('#');
+                label.push_str(sni);
+            }
+            Some(label)
+        }
+        NameServerUrl::Https {
+            addr,
+            port,
+            path,
+            sni,
+        } => {
+            let mut label = format!("https://{}{}", authority_label(addr, *port, 443), path);
+            if sni != &addr.to_string() {
+                label.push('#');
+                label.push_str(sni);
+            }
+            Some(label)
+        }
+        _ => None,
+    }
+}
+
+fn authority_label(addr: &HostOrIp, port: u16, default_port: u16) -> String {
+    let host = match addr {
+        HostOrIp::Ip(IpAddr::V6(ip)) => format!("[{ip}]"),
+        _ => addr.to_string(),
+    };
+    if port == default_port {
+        host
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
 async fn query_pool(clients: &[Arc<DnsClient>], host: &str) -> Option<PoolLookupResult> {
     match clients.len() {
         0 => None,
@@ -706,6 +745,7 @@ impl Resolver {
                 return Arc::new(client);
             }
         };
+        let label = encrypted_upstream_label(url);
         let client = match url {
             NameServerUrl::Udp { .. } => DnsClient::udp(socket_addr),
             NameServerUrl::Tcp { .. } => DnsClient::tcp(socket_addr),
@@ -740,6 +780,10 @@ impl Resolver {
             NameServerUrl::RCode { .. } => {
                 unreachable!("rcode nameservers return before socket client construction")
             }
+        };
+        let client = match label {
+            Some(label) => client.with_upstream_label(label),
+            None => client,
         };
         let client = match proxy {
             Some(p) => client.with_proxy(p),
@@ -1099,6 +1143,43 @@ impl Resolver {
 mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn build_single_resolver_preserves_configured_dot_label() {
+        let url = NameServerUrl::parse("tls://dns.google:853").unwrap();
+        let mut resolved = HashMap::new();
+        resolved.insert(
+            "dns.google".to_string(),
+            IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+        );
+
+        let client = Resolver::build_single_resolver(&url, &resolved);
+
+        assert_eq!(client.upstream_label(), "tls://dns.google");
+    }
+
+    #[test]
+    fn build_single_resolver_preserves_configured_dot_sni_label() {
+        let url = NameServerUrl::parse("tls://8.8.8.8:853#dns.google").unwrap();
+        let resolved = HashMap::new();
+
+        let client = Resolver::build_single_resolver(&url, &resolved);
+
+        assert_eq!(client.upstream_label(), "tls://8.8.8.8#dns.google");
+    }
+
+    #[test]
+    fn build_single_resolver_preserves_configured_doh_label() {
+        let url = NameServerUrl::parse("https://1.1.1.1/dns-query#cloudflare-dns.com").unwrap();
+        let resolved = HashMap::new();
+
+        let client = Resolver::build_single_resolver(&url, &resolved);
+
+        assert_eq!(
+            client.upstream_label(),
+            "https://1.1.1.1/dns-query#cloudflare-dns.com"
+        );
+    }
 
     #[tokio::test]
     async fn resolve_ip_uses_hosts_file() {


### PR DESCRIPTION
## Summary
- preserve the configured upstream label for encrypted DNS resolvers used by DNS results
- include the `tls://` / `https://` scheme for DoT and DoH fallback labels instead of reporting only the hostname
- omit default encrypted DNS ports from display labels while preserving explicit non-default ports and SNI overrides

## Motivation
When querying through a config that uses DoT upstreams such as `tls://dns.google:853`, `/dns/results` reported `from_server` as `dns.google`. That made encrypted DNS look indistinguishable from a plain upstream. The resolver now keeps a display label derived from the configured nameserver URL and attaches it to the `DnsClient`.

## Tests
- `cargo fmt`
- `cargo test -p meow-dns --lib`
- `cargo test -p meow-api --test api_test dns_results_returns_searchable_cache_entries`
