### PR TITLE
perf(rule-ir): compilation clean-up passes + min-index domain trie

### DIFF
--- a/crates/meow-common/src/rule.rs
+++ b/crates/meow-common/src/rule.rs
@@ -129,6 +129,15 @@ pub trait Rule: Send + Sync {
         false
     }
 
+    /// True iff this rule can be proven at build time to never match any
+    /// metadata (e.g. a GEOSITE rule whose database was never loaded). The
+    /// answer must be constant for the lifetime of the rule object: the rule
+    /// IR compiler prunes such rules from its scan plan entirely, so a rule
+    /// whose matchability can change at runtime must return `false`.
+    fn never_matches(&self) -> bool {
+        false
+    }
+
     /// Match against metadata and, on match, return the routing target.
     ///
     /// Default: `Some(self.adapter())` when `match_metadata`

--- a/crates/meow-rules/src/geosite_rule.rs
+++ b/crates/meow-rules/src/geosite_rule.rs
@@ -71,6 +71,12 @@ impl Rule for GeoSiteRule {
     fn should_resolve_ip(&self) -> bool {
         !self.no_resolve
     }
+
+    fn never_matches(&self) -> bool {
+        // The DB is loaded once at startup and never mutated afterwards, so
+        // a missing DB (or empty category name) is a permanent no-match.
+        self.db.is_none() || self.category.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/crates/meow-trie/src/trie.rs
+++ b/crates/meow-trie/src/trie.rs
@@ -169,6 +169,31 @@ impl<T: Clone + 'static> DomainTrie<T> {
         self.search_inner(domain_lower.trim_end_matches('.'))
     }
 
+    /// Search with a pre-lowercased domain, returning the **minimum** value
+    /// among all patterns matching the query — not the most-specific one.
+    ///
+    /// [`Self::search_normalized`] answers "which pattern is the best match"
+    /// (exact beats wildcard, deeper beats shallower). First-match-wins rule
+    /// engines need a different question answered: "what is the smallest rule
+    /// index whose pattern matches this host". This walks the same path but
+    /// folds the minimum over every matching exact/star/dot value.
+    pub fn search_min_normalized(&self, domain_lower: &str) -> Option<&T>
+    where
+        T: Ord,
+    {
+        if self.len == 0 {
+            return None;
+        }
+        let query = domain_lower.trim_end_matches('.');
+        if query.is_empty() {
+            return None;
+        }
+        match &self.state {
+            TrieState::Building(root) => Self::search_min_build(root, query),
+            TrieState::Sealed(root) => Self::search_min_sealed(root, query),
+        }
+    }
+
     fn search_inner(&self, query: &str) -> Option<&T> {
         if query.is_empty() {
             return None;
@@ -323,8 +348,76 @@ impl<T: Clone + 'static> DomainTrie<T> {
         best
     }
 
+    fn search_min_build<'a>(root: &'a BuildNode<T>, query: &str) -> Option<&'a T>
+    where
+        T: Ord,
+    {
+        let n = query.bytes().filter(|&b| b == b'.').count() + 1;
+        let mut node = root;
+        let mut best: Option<&T> = None;
+
+        for (d, label) in query.rsplit('.').enumerate() {
+            match node.children.get(label) {
+                None => break,
+                Some(child) => {
+                    node = child;
+                    let remaining = n - d - 1;
+                    if remaining == 0 {
+                        fold_min(&mut best, node.exact_value.as_ref());
+                    } else {
+                        if remaining == 1 {
+                            fold_min(&mut best, node.star_value.as_ref());
+                        }
+                        fold_min(&mut best, node.dot_value.as_ref());
+                    }
+                }
+            }
+        }
+        best
+    }
+
+    fn search_min_sealed<'a>(root: &'a SealedNode<T>, query: &str) -> Option<&'a T>
+    where
+        T: Ord,
+    {
+        let n = query.bytes().filter(|&b| b == b'.').count() + 1;
+        let mut node = root;
+        let mut best: Option<&T> = None;
+
+        for (d, label) in query.rsplit('.').enumerate() {
+            let found = node
+                .children
+                .binary_search_by(|(k, _)| k.as_bytes().cmp(label.as_bytes()));
+            match found {
+                Err(_) => break,
+                Ok(idx) => {
+                    node = &node.children[idx].1;
+                    let remaining = n - d - 1;
+                    if remaining == 0 {
+                        fold_min(&mut best, node.exact_value.as_ref());
+                    } else {
+                        if remaining == 1 {
+                            fold_min(&mut best, node.star_value.as_ref());
+                        }
+                        fold_min(&mut best, node.dot_value.as_ref());
+                    }
+                }
+            }
+        }
+        best
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len == 0
+    }
+}
+
+fn fold_min<'a, T: Ord>(best: &mut Option<&'a T>, candidate: Option<&'a T>) {
+    if let Some(candidate) = candidate {
+        match best {
+            Some(current) if *current <= candidate => {}
+            _ => *best = Some(candidate),
+        }
     }
 }
 
@@ -530,6 +623,44 @@ mod tests {
         trie.insert("Example.COM", 1);
         assert_eq!(trie.search("example.com"), Some(&1));
         assert_eq!(trie.search("EXAMPLE.COM"), Some(&1));
+    }
+
+    #[test]
+    fn search_min_folds_across_all_matching_patterns() {
+        let mut trie = DomainTrie::new();
+        trie.insert("+.a.com", 1);
+        trie.insert("+.b.a.com", 3);
+        trie.insert("x.b.a.com", 7);
+
+        // Most-specific search prefers the exact/deepest pattern...
+        assert_eq!(trie.search_normalized("x.b.a.com"), Some(&7));
+        // ...min search folds the minimum over every matching pattern.
+        assert_eq!(trie.search_min_normalized("x.b.a.com"), Some(&1));
+        assert_eq!(trie.search_min_normalized("y.b.a.com"), Some(&1));
+        assert_eq!(trie.search_min_normalized("deep.y.b.a.com"), Some(&1));
+        assert_eq!(trie.search_min_normalized("unrelated.com"), None);
+
+        // Sealed trie must agree with the building trie.
+        trie.seal();
+        assert_eq!(trie.search_min_normalized("x.b.a.com"), Some(&1));
+        assert_eq!(trie.search_min_normalized("deep.y.b.a.com"), Some(&1));
+        assert_eq!(trie.search_min_normalized("unrelated.com"), None);
+    }
+
+    #[test]
+    fn search_min_sees_star_dot_and_exact_values() {
+        let mut trie = DomainTrie::new();
+        trie.insert("exact.example.com", 9);
+        trie.insert("*.example.com", 4);
+        trie.insert(".example.com", 6);
+        trie.seal();
+
+        // exact(9) vs star(4, one label) vs dot(6): min of the matching set.
+        assert_eq!(trie.search_min_normalized("exact.example.com"), Some(&4));
+        // Two labels below: star no longer applies, dot(6) does.
+        assert_eq!(trie.search_min_normalized("a.b.example.com"), Some(&6));
+        // Apex: only an exact pattern could match, none present.
+        assert_eq!(trie.search_min_normalized("example.com"), None);
     }
 
     #[test]

--- a/crates/meow-tunnel/src/match_engine.rs
+++ b/crates/meow-tunnel/src/match_engine.rs
@@ -1,6 +1,5 @@
 use meow_common::{find_process, Metadata, Rule, RuleMatchHelper, RuleType};
 use meow_trie::DomainTrie;
-use std::collections::HashSet;
 use std::net::SocketAddr;
 use tracing::trace;
 
@@ -15,9 +14,16 @@ pub struct MatchResult<'a> {
 
 /// Index of DOMAIN and DOMAIN-SUFFIX rules keyed by the trie.
 ///
-/// Stores only the earliest matching rule index for each pattern. The adapter
-/// and payload are borrowed from the rule slice after lookup, which keeps the
-/// index compact and avoids per-match result allocation.
+/// [`Self::search`] returns the **minimum rule index across every pattern
+/// matching the host** (min-index semantics), not the most-specific pattern.
+/// Under first-match-wins ordering this means a trie hit at `T` proves that
+/// no DOMAIN/DOMAIN-SUFFIX rule earlier than `T` matches the host — and a
+/// trie miss proves none matches at all. Suffix rules are indexed under both
+/// `+.pattern` (subdomains) and the bare pattern (the apex domain itself), so
+/// those proofs hold for every host a suffix rule can match.
+///
+/// The adapter and payload are borrowed from the rule slice after lookup,
+/// which keeps the index compact and avoids per-match result allocation.
 pub struct DomainIndex {
     trie: DomainTrie<usize>,
 }
@@ -29,50 +35,65 @@ impl DomainIndex {
         }
     }
 
-    /// Build an index from the rule list, recording the first (minimum-index)
-    /// occurrence of each domain pattern.
+    /// Build a sealed index from the rule list.
     pub fn build(rules: &[Box<dyn Rule>]) -> Self {
-        use std::borrow::Cow;
-        let mut trie: DomainTrie<usize> = DomainTrie::new();
-        let mut seen: HashSet<String> = HashSet::new();
+        let mut index = Self::empty();
         for (idx, rule) in rules.iter().enumerate() {
-            match rule.rule_type() {
-                RuleType::Domain | RuleType::DomainSuffix => {
-                    // Patterns are normally already lowercase; only allocate
-                    // for the rare mixed-case entry, and check `seen` before
-                    // taking an owned copy — duplicates cost no allocation.
-                    let payload = rule.payload();
-                    let lowered: Cow<'_, str> = if payload.chars().any(char::is_uppercase) {
-                        Cow::Owned(payload.to_lowercase())
-                    } else {
-                        Cow::Borrowed(payload)
-                    };
-                    if seen.contains(lowered.as_ref()) {
-                        continue;
-                    }
-                    let pattern = lowered.into_owned();
-                    // For Domain: exact match pattern; trie handles it directly.
-                    // For DomainSuffix: use "+." prefix so trie matches subdomains.
-                    if rule.rule_type() == RuleType::DomainSuffix {
-                        let trie_key = format!("+.{pattern}");
-                        trie.insert(&trie_key, idx);
-                    } else {
-                        trie.insert(&pattern, idx);
-                    }
-                    seen.insert(pattern);
-                }
-                _ => {}
-            }
+            index.insert_rule(idx, rule.rule_type(), rule.payload());
         }
-        trie.seal();
-        Self { trie }
+        index.seal();
+        index
+    }
+
+    /// Index one rule's pattern. Returns `true` iff the pattern was fully
+    /// indexed — meaning the trie completely owns this rule's match
+    /// semantics, so callers may skip the rule during linear scans.
+    ///
+    /// Only DOMAIN and DOMAIN-SUFFIX rules with plain hostname payloads are
+    /// indexable. Degenerate payloads (empty, leading `.`/`*`/`+`, empty
+    /// labels, non-ASCII) would change meaning under the trie's wildcard
+    /// syntax, so they return `false` and stay on the scan path.
+    ///
+    /// Duplicate patterns keep the first (minimum) rule index: inserts happen
+    /// in ascending rule order and the trie's per-slot value is first-write.
+    pub fn insert_rule(&mut self, index: usize, rule_type: RuleType, payload: &str) -> bool {
+        if !indexable_pattern(payload) {
+            return false;
+        }
+        match rule_type {
+            RuleType::Domain => self.trie.insert(payload, index),
+            RuleType::DomainSuffix => {
+                // A suffix rule matches the apex domain itself as well as any
+                // subdomain; index both forms so a trie miss proves no suffix
+                // rule matches.
+                let subdomains = self.trie.insert(&format!("+.{payload}"), index);
+                let apex = self.trie.insert(payload, index);
+                subdomains && apex
+            }
+            _ => false,
+        }
+    }
+
+    pub fn seal(&mut self) {
+        self.trie.seal();
     }
 
     /// Probe the trie for a production-normalized hostname. Returns the
-    /// matching DOMAIN/DOMAIN-SUFFIX rule index, or `None`.
+    /// minimum matching DOMAIN/DOMAIN-SUFFIX rule index, or `None`.
     pub fn search(&self, host: &str) -> Option<usize> {
-        self.trie.search_normalized(host).copied()
+        self.trie.search_min_normalized(host).copied()
     }
+}
+
+/// True iff `payload` is a plain hostname pattern whose trie insertion
+/// matches exactly the hosts the corresponding DOMAIN / DOMAIN-SUFFIX
+/// predicate matches.
+fn indexable_pattern(payload: &str) -> bool {
+    !payload.is_empty()
+        && payload.is_ascii()
+        && !payload.starts_with(['.', '*', '+'])
+        && !payload.ends_with('.')
+        && !payload.contains("..")
 }
 
 /// Match metadata against rules using the domain index for early-exit.
@@ -101,12 +122,13 @@ pub fn match_rules<'rules>(
         index.search(host)
     };
 
-    // Determine the scan ceiling: if trie found a hit at index T, we only
-    // need to check rules[0..T] for an earlier match.  The trie returns the
-    // most-specific match (exact > wildcard), NOT the minimum-index rule across
-    // all patterns that match this host.  A broader rule at index < T (e.g.
-    // DOMAIN-SUFFIX "example.com" at idx 0 before DOMAIN "sub.example.com" at
-    // idx 1) can still match, so we cannot skip domain rules in the prefix scan.
+    // Determine the scan ceiling: on a trie hit at index T, only rules[0..T]
+    // can contain an earlier match. `DomainIndex::search` returns the
+    // minimum rule index across ALL patterns matching this host (min-index
+    // semantics), so no domain rule below T matches — the prefix scan only
+    // exists to catch earlier non-domain rules. It still evaluates domain
+    // rules for simplicity (they are provably non-matching but harmless);
+    // the compiled IR path skips them outright.
     let scan_end = trie_hit.unwrap_or(rules.len());
 
     for rule in &rules[..scan_end] {

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -84,7 +84,10 @@ enum RuleOp {
     DomainKeyword(String),
     DomainRegex(Box<RegexMatcher>),
     DomainWildcard(Box<WildcardMatcher>),
-    IpCidr { net: IpNet, src: bool },
+    IpCidr {
+        net: IpNet,
+        src: bool,
+    },
     SrcPort(PortMatcher),
     DstPort(PortMatcher),
     InPort(PortMatcher),
@@ -97,6 +100,11 @@ enum RuleOp {
     InType(InTypeMask),
     InUser(String),
     Match,
+    /// A DOMAIN / DOMAIN-SUFFIX predicate fully owned by the domain index:
+    /// the trie's min-index search proves whether it matches, so scans skip
+    /// the slot without evaluating anything. The slot itself stays alive as
+    /// the match-result carrier for trie hits.
+    TrieOwned,
     Fallback,
 }
 
@@ -220,10 +228,22 @@ impl CompiledRuleSet {
         }
 
         let execution_plan = select_execution_plan(slots.len());
-        let domain_index = match execution_plan {
-            ExecutionPlan::LinearScan => DomainIndex::empty(),
-            ExecutionPlan::DomainIndexed => DomainIndex::build(rules),
-        };
+        let mut domain_index = DomainIndex::empty();
+        if execution_plan == ExecutionPlan::DomainIndexed {
+            // Build the index from live slots only, and hand fully-indexed
+            // patterns over to the trie: an owned slot is never evaluated
+            // during scans, because min-index search semantics guarantee a
+            // trie hit at T proves no owned slot before T matches, and a
+            // trie miss proves no owned slot matches at all.
+            for slot in &mut slots {
+                let owned = matches!(slot.op, RuleOp::Domain(_) | RuleOp::DomainSuffix(_))
+                    && domain_index.insert_rule(slot.rule_index, slot.rule_type, &slot.payload);
+                if owned {
+                    slot.op = RuleOp::TrieOwned;
+                }
+            }
+            domain_index.seal();
+        }
 
         Self {
             slots,
@@ -342,6 +362,9 @@ impl CompiledRuleSet {
     ) -> Option<CompiledMatchResult<'a>> {
         for slot in &self.slots[range] {
             match &slot.op {
+                // Owned by the domain index: the trie already proved this
+                // slot does not match anywhere a scan range is consulted.
+                RuleOp::TrieOwned => {}
                 RuleOp::Fallback => {
                     let rule = rules.get(slot.rule_index)?.as_ref();
                     match slot.target_plan {
@@ -560,7 +583,7 @@ fn matches_op(op: &RuleOp, input: &MatchInput<'_>) -> bool {
         RuleOp::InType(mask) => in_type_matches(*mask, input.metadata.conn_type),
         RuleOp::InUser(user) => input.metadata.in_user.as_deref() == Some(user.as_str()),
         RuleOp::Match => true,
-        RuleOp::Fallback => false,
+        RuleOp::TrieOwned | RuleOp::Fallback => false,
     }
 }
 
@@ -947,6 +970,232 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+
+    /// Naive first-match-wins reference: the semantics every compilation
+    /// pass must preserve.
+    fn naive_match<'a>(
+        metadata: &Metadata,
+        rules: &'a [Box<dyn Rule>],
+    ) -> Option<(&'a str, RuleType, &'a str)> {
+        let helper = RuleMatchHelper;
+        rules.iter().find_map(|rule| {
+            rule.match_and_resolve(metadata, &helper)
+                .map(|adapter| (adapter, rule.rule_type(), rule.payload()))
+        })
+    }
+
+    fn filler_suffix_rules(count: usize) -> Vec<Box<dyn Rule>> {
+        (0..count)
+            .map(|i| {
+                Box::new(DomainSuffixRule::new(
+                    &format!("s{i}.example"),
+                    &format!("P{i}"),
+                )) as Box<dyn Rule>
+            })
+            .collect()
+    }
+
+    #[test]
+    fn indexed_plan_owns_domain_slots_and_matches_suffix_apex() {
+        let mut rules = filler_suffix_rules(70);
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+        assert!(
+            set.slots()
+                .iter()
+                .filter(|s| s.rule_type() == RuleType::DomainSuffix)
+                .all(CompiledRuleSlot::is_lowered),
+            "suffix slots must be trie-owned, not fallback",
+        );
+
+        for (host, expected) in [
+            ("s7.example", "P7"),   // apex self-match must hit via trie
+            ("x.s7.example", "P7"), // subdomain
+            ("a.b.s42.example", "P42"),
+            ("unrelated.test", "DIRECT"),
+        ] {
+            let meta = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let result = set.match_rules(&meta, &rules).expect("must match");
+            assert_eq!(result.adapter_name, expected, "host={host}");
+        }
+    }
+
+    #[test]
+    fn indexed_plan_min_index_beats_more_specific_pattern() {
+        let mut rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainSuffixRule::new("example.com", "Broad")),
+            Box::new(DomainRule::new("sub.example.com", "Specific")),
+        ];
+        rules.extend(filler_suffix_rules(65));
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+
+        let meta = Metadata {
+            host: "sub.example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set.match_rules(&meta, &rules).expect("must match");
+        assert_eq!(
+            result.adapter_name, "Broad",
+            "min-index trie semantics: earliest matching domain rule wins",
+        );
+    }
+
+    #[test]
+    fn indexed_plan_earlier_non_domain_rule_beats_trie_hit() {
+        let mut rules: Vec<Box<dyn Rule>> =
+            vec![Box::new(PortRule::new("443", "PortFirst", false).unwrap())];
+        rules.extend(filler_suffix_rules(70));
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+
+        let hit_443 = Metadata {
+            host: "s9.example".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set.match_rules(&hit_443, &rules).expect("must match");
+        assert_eq!(result.adapter_name, "PortFirst");
+
+        let hit_80 = Metadata {
+            host: "s9.example".into(),
+            dst_port: 80,
+            ..Default::default()
+        };
+        let result = set.match_rules(&hit_80, &rules).expect("must match");
+        assert_eq!(result.adapter_name, "P9");
+    }
+
+    #[test]
+    fn indexed_plan_unindexable_domain_payload_stays_on_scan_path() {
+        // Non-ASCII payload: the trie's Unicode lowercasing diverges from
+        // the op's ASCII-insensitive compare, so the pattern must not be
+        // trie-owned — it stays a scanned slot and still matches literally.
+        let mut rules = filler_suffix_rules(70);
+        rules.push(Box::new(DomainRule::new("bücher.com", "Umlaut")));
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+
+        let meta = Metadata {
+            host: "bücher.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set.match_rules(&meta, &rules).expect("must match");
+        assert_eq!(result.adapter_name, "Umlaut");
+    }
+
+    #[test]
+    fn randomized_configs_match_naive_first_match_reference() {
+        // Deterministic LCG so failures reproduce; no external deps.
+        struct Lcg(u64);
+        impl Lcg {
+            fn next(&mut self) -> u64 {
+                self.0 = self
+                    .0
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                self.0 >> 33
+            }
+            fn pick<T: Copy>(&mut self, items: &[T]) -> T {
+                items[(self.next() as usize) % items.len()]
+            }
+        }
+
+        let names = ["alpha", "beta", "gamma", "delta", "epsilon"];
+        let tlds = ["com", "net", "org"];
+        let subs = ["www", "api", "cdn"];
+        let adapters = ["A", "B", "C", "DIRECT"];
+        let ports = ["80", "443", "8080", "1000-2000"];
+
+        let mut rng = Lcg(0x9E37_79B9_7F4A_7C15);
+
+        for &size in &[1usize, 3, 30, 63, 64, 65, 80, 150] {
+            let mut rules: Vec<Box<dyn Rule>> = Vec::with_capacity(size + 1);
+            for _ in 0..size {
+                let host = format!("{}.{}", rng.pick(&names), rng.pick(&tlds));
+                let adapter = rng.pick(&adapters);
+                let rule: Box<dyn Rule> = match rng.next() % 7 {
+                    0 => Box::new(DomainRule::new(&host, adapter)),
+                    1 => Box::new(DomainRule::new(
+                        &format!("{}.{host}", rng.pick(&subs)),
+                        adapter,
+                    )),
+                    2 | 3 => Box::new(DomainSuffixRule::new(&host, adapter)),
+                    4 => Box::new(DomainKeywordRule::new(rng.pick(&names), adapter)),
+                    5 => Box::new(PortRule::new(rng.pick(&ports), adapter, false).unwrap()),
+                    _ => Box::new(
+                        IpCidrRule::new(
+                            &format!("10.{}.0.0/16", rng.next() % 4),
+                            adapter,
+                            false,
+                            true,
+                        )
+                        .unwrap(),
+                    ),
+                };
+                rules.push(rule);
+                // Occasionally drop in an early FINAL to exercise dead-rule
+                // elimination against the reference.
+                if rng.next().is_multiple_of(23) {
+                    rules.push(Box::new(FinalRule::new("EARLY-FINAL")));
+                }
+            }
+            rules.push(Box::new(FinalRule::new("DIRECT")));
+
+            let set = CompiledRuleSet::build(&rules);
+
+            for _ in 0..60 {
+                let host = match rng.next() % 4 {
+                    0 => format!("{}.{}", rng.pick(&names), rng.pick(&tlds)),
+                    1 => format!(
+                        "{}.{}.{}",
+                        rng.pick(&subs),
+                        rng.pick(&names),
+                        rng.pick(&tlds)
+                    ),
+                    2 => format!("x.y.{}.{}", rng.pick(&names), rng.pick(&tlds)),
+                    _ => "unmatched.invalid".to_string(),
+                };
+                let metadata = Metadata {
+                    host: host.into(),
+                    dst_port: rng.pick(&[80u16, 443, 8080, 1500, 9999]),
+                    dst_ip: match rng.next() % 3 {
+                        0 => None,
+                        _ => Some(
+                            format!("10.{}.{}.{}", rng.next() % 4, rng.next() % 256, 1)
+                                .parse::<IpAddr>()
+                                .unwrap(),
+                        ),
+                    },
+                    ..Default::default()
+                };
+
+                let expected = naive_match(&metadata, &rules);
+                let actual = set
+                    .match_rules(&metadata, &rules)
+                    .map(|m| (m.adapter_name, m.rule_type, m.rule_payload));
+                assert_eq!(
+                    actual, expected,
+                    "size={size} host={} port={} ip={:?}",
+                    metadata.host, metadata.dst_port, metadata.dst_ip,
+                );
+            }
+        }
+    }
 
     #[test]
     fn dead_rules_after_final_are_eliminated() {

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -3,7 +3,7 @@ use ipnet::IpNet;
 use meow_common::{ConnType, Metadata, Network, Rule, RuleMatchHelper, RuleType};
 use regex::Regex;
 use smol_str::SmolStr;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::Path;
 
@@ -18,8 +18,27 @@ const LINEAR_SCAN_RULE_LIMIT: usize = 64;
 /// public `Rule` trait. Stable result metadata is captured once at build time
 /// so successful matches avoid repeat `rule_type` / `payload` / top-level
 /// `adapter` virtual calls.
+///
+/// Compilation runs three semantics-preserving clean-up passes over the rule
+/// list (all rely on first-match-wins ordering):
+///
+/// 1. **Dead-rule elimination** — nothing after the first unconditional
+///    `MATCH`/`FINAL` rule is reachable, so no slot is emitted for it and it
+///    does not contribute to `needs_ip_resolution` / `needs_process_lookup`.
+/// 2. **Duplicate elimination** — a later rule that lowers to an identical
+///    native predicate can never win against its first occurrence.
+/// 3. **Constant-false pruning** — rules that provably never match (a rule
+///    reporting [`Rule::never_matches`], or a `UID` rule on a platform
+///    without socket-UID lookup) are dropped from the scan plan.
+///
+/// Slots therefore form a subsequence of the source rules: each slot keeps
+/// its original `rule_index` (for fallback dispatch and diagnostics), and
+/// index-based lookups map rule index → slot position by binary search.
 pub struct CompiledRuleSet {
     slots: Vec<CompiledRuleSlot>,
+    /// Length of the rule slice this plan was compiled from. Slots may be
+    /// fewer after clean-up passes; this ties the plan back to its source.
+    source_rule_count: usize,
     adapter_names: Vec<SmolStr>,
     adapter_lookup: HashMap<SmolStr, usize>,
     domain_index: DomainIndex,
@@ -134,6 +153,7 @@ impl CompiledRuleSet {
     pub fn empty() -> Self {
         Self {
             slots: Vec::new(),
+            source_rule_count: 0,
             adapter_names: Vec::new(),
             adapter_lookup: HashMap::new(),
             domain_index: DomainIndex::empty(),
@@ -149,27 +169,57 @@ impl CompiledRuleSet {
         let mut adapter_lookup = HashMap::new();
         let mut needs_ip_resolution = false;
         let mut needs_process_lookup = false;
+        let mut seen_ops: HashSet<(RuleType, String)> = HashSet::new();
 
         for (rule_index, rule) in rules.iter().enumerate() {
             let rule_type = rule.rule_type();
-            let adapter_name = SmolStr::from(rule.adapter());
-            let adapter_index =
-                intern_adapter(&mut adapter_names, &mut adapter_lookup, adapter_name);
+            let payload = rule.payload();
+            let op = compile_op(rule_type, payload).unwrap_or(RuleOp::Fallback);
+
+            // Constant-false pruning: drop rules that can never match, so
+            // they neither occupy scan slots nor force metadata enrichment
+            // (a dead GEOSITE rule must not force DNS pre-resolution).
+            if rule.never_matches() || op_never_matches(&op) {
+                continue;
+            }
+
+            // Duplicate elimination, lowered predicates only: the op is a
+            // pure function of (rule_type, payload), so a later identical
+            // predicate can never win under first-match-wins — regardless of
+            // its adapter. Fallback rules carry private state and are never
+            // deduplicated.
+            if !matches!(op, RuleOp::Fallback)
+                && !seen_ops.insert((rule_type, dedup_key(rule_type, payload)))
+            {
+                continue;
+            }
 
             needs_ip_resolution |= rule.should_resolve_ip();
             needs_process_lookup |= rule.should_find_process();
+
+            let adapter_name = SmolStr::from(rule.adapter());
+            let adapter_index =
+                intern_adapter(&mut adapter_names, &mut adapter_lookup, adapter_name);
+            let terminator = matches!(op, RuleOp::Match);
 
             slots.push(CompiledRuleSlot {
                 rule_index,
                 rule_type,
                 adapter_index,
-                payload: SmolStr::from(rule.payload()),
+                payload: SmolStr::from(payload),
                 target_plan: target_plan(rule_type),
-                op: compile_op(rule_type, rule.payload()).unwrap_or(RuleOp::Fallback),
+                op,
             });
+
+            // Dead-rule elimination: an unconditional MATCH/FINAL ends the
+            // reachable prefix. (`RuleType::Match` always lowers to a static
+            // adapter, so the terminator is genuinely unconditional.)
+            if terminator {
+                break;
+            }
         }
 
-        let execution_plan = select_execution_plan(rules.len());
+        let execution_plan = select_execution_plan(slots.len());
         let domain_index = match execution_plan {
             ExecutionPlan::LinearScan => DomainIndex::empty(),
             ExecutionPlan::DomainIndexed => DomainIndex::build(rules),
@@ -177,6 +227,7 @@ impl CompiledRuleSet {
 
         Self {
             slots,
+            source_rule_count: rules.len(),
             adapter_names,
             adapter_lookup,
             domain_index,
@@ -198,7 +249,7 @@ impl CompiledRuleSet {
         rules: &'a [Box<dyn Rule>],
     ) -> Option<CompiledMatchResult<'a>> {
         debug_assert_eq!(
-            self.slots.len(),
+            self.source_rule_count,
             rules.len(),
             "CompiledRuleSet must be evaluated with the rule slice it was built from",
         );
@@ -215,16 +266,32 @@ impl CompiledRuleSet {
             self.domain_index.search(input.host)
         };
 
-        // Preserve DomainIndex early-exit behavior:
-        // if a trie hit occurs at T, scan only [0..T] for an earlier match,
-        // then return T. On trie miss, scan the full rule list.
-        let scan_end = trie_hit.unwrap_or(self.slots.len());
+        // Preserve DomainIndex early-exit behavior: on a trie hit at rule
+        // index T, scan only slots before T for an earlier match, then return
+        // T. On trie miss, scan everything. The trie stores *rule* indices;
+        // clean-up passes may have pruned slots, so map to a slot position by
+        // binary search (slots are ordered by rule_index). A hit whose slot
+        // was pruned degrades to a plain ordered scan, which stays correct:
+        // the trie only ever points at a pattern's first occurrence, and a
+        // hit past a MATCH terminator is preempted by the terminator slot.
+        let (scan_end, hit_slot) = match trie_hit {
+            Some(rule_idx) => {
+                let pos = self.slots.partition_point(|s| s.rule_index < rule_idx);
+                let slot = self
+                    .slots
+                    .get(pos)
+                    .filter(|slot| slot.rule_index == rule_idx);
+                (pos, slot)
+            }
+            None => (self.slots.len(), None),
+        };
+
         if let Some(matched) = self.scan_range(0..scan_end, &input, rules, &helper) {
             return Some(matched);
         }
 
-        if let Some(trie_idx) = trie_hit {
-            return self.slots.get(trie_idx).map(|slot| self.static_match(slot));
+        if let Some(slot) = hit_slot {
+            return Some(self.static_match(slot));
         }
 
         self.scan_range(scan_end..self.slots.len(), &input, rules, &helper)
@@ -259,7 +326,7 @@ impl CompiledRuleSet {
     }
 
     pub fn is_compatible_with(&self, rules: &[Box<dyn Rule>]) -> bool {
-        self.slots.len() == rules.len()
+        self.source_rule_count == rules.len()
     }
 
     pub fn uses_linear_scan_plan(&self) -> bool {
@@ -392,6 +459,29 @@ fn select_execution_plan(rule_count: usize) -> ExecutionPlan {
     } else {
         ExecutionPlan::DomainIndexed
     }
+}
+
+/// Dedup key for a lowered predicate. Domain-family matchers compare hosts
+/// case-insensitively, so their payloads are folded before comparison; all
+/// other lowered payloads dedup on the exact text (a missed dedup is only a
+/// lost optimization, never a correctness issue).
+fn dedup_key(rule_type: RuleType, payload: &str) -> String {
+    match rule_type {
+        RuleType::Domain
+        | RuleType::DomainSuffix
+        | RuleType::DomainKeyword
+        | RuleType::DomainWildcard
+        | RuleType::ProcessName => payload.to_ascii_lowercase(),
+        _ => payload.to_string(),
+    }
+}
+
+/// Ops that are compile-time-provably false on this platform.
+fn op_never_matches(op: &RuleOp) -> bool {
+    // Socket-UID lookup only exists on Linux; `uid_matches` is a constant
+    // `false` everywhere else, so the slot would burn a scan step per
+    // connection without ever matching.
+    matches!(op, RuleOp::Uid(_)) && cfg!(not(target_os = "linux"))
 }
 
 fn compile_op(rule_type: RuleType, payload: &str) -> Option<RuleOp> {
@@ -857,6 +947,97 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+
+    #[test]
+    fn dead_rules_after_final_are_eliminated() {
+        let mut db = GeositeDB::empty();
+        db.insert("cn", "cn.example");
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainSuffixRule::new("example.com", "Proxy")),
+            Box::new(FinalRule::new("DIRECT")),
+            // Unreachable: would otherwise force DNS pre-resolution.
+            Box::new(GeoSiteRule::new("cn", "Direct", Some(Arc::new(db)), false)),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+
+        assert_eq!(set.len(), 2, "rules after FINAL must not emit slots");
+        assert!(!set.needs_ip_resolution());
+        assert!(set.is_compatible_with(&rules));
+
+        let meta = Metadata {
+            host: "other.example".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set.match_rules(&meta, &rules).expect("FINAL must match");
+        assert_eq!(result.adapter_name, "DIRECT");
+        assert_eq!(result.rule_type, RuleType::Match);
+    }
+
+    #[test]
+    fn duplicate_lowered_rules_are_eliminated() {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainRule::new("dup.example.com", "First")),
+            Box::new(DomainRule::new("DUP.EXAMPLE.COM", "Second")),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+
+        assert_eq!(set.len(), 2, "identical later predicate must be dropped");
+
+        let meta = Metadata {
+            host: "dup.example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set.match_rules(&meta, &rules).expect("domain must match");
+        assert_eq!(result.adapter_name, "First", "first occurrence wins");
+    }
+
+    #[test]
+    fn never_match_geosite_rule_is_pruned() {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            // No DB loaded: provably never matches, but without pruning its
+            // `should_resolve_ip()` would force pre-resolution for every
+            // connection.
+            Box::new(GeoSiteRule::new("cn", "Direct", None, false)),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+
+        assert_eq!(set.len(), 1);
+        assert!(!set.needs_ip_resolution());
+
+        let meta = Metadata {
+            host: "cn.example".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set.match_rules(&meta, &rules).expect("FINAL must match");
+        assert_eq!(result.adapter_name, "DIRECT");
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn uid_rule_is_pruned_on_platforms_without_socket_uid() {
+        use meow_rules::uid::UidRule;
+
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(UidRule::new("1000", "UidProxy").unwrap()),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+
+        assert_eq!(set.len(), 1, "UID op is constant-false off Linux");
+        let result = set
+            .match_rules(&Metadata::default(), &rules)
+            .expect("FINAL must match");
+        assert_eq!(result.adapter_name, "DIRECT");
+    }
 
     #[test]
     fn small_rule_sets_use_linear_scan_plan() {

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -242,10 +242,14 @@ impl Tunnel {
     }
 
     pub fn update_rules(&self, rules: Vec<Box<dyn Rule>>) {
-        let needs_ip = rules.iter().any(|r| r.should_resolve_ip());
-        let needs_proc = rules.iter().any(|r| r.should_find_process());
         let new_index = DomainIndex::build(&rules);
         let compiled_rules = CompiledRuleSet::build(&rules);
+        // Take the enrichment flags from the compiled plan rather than the
+        // raw rule list: rules pruned by the IR clean-up passes (dead after
+        // MATCH, provable never-match) must not force per-connection DNS
+        // pre-resolution or process lookup.
+        let needs_ip = compiled_rules.needs_ip_resolution();
+        let needs_proc = compiled_rules.needs_process_lookup();
         // Build a new route table on top of the current proxies map. The
         // current proxies are cloned (Arc bumps for adapter handles, one
         // HashMap clone) — paid only on config-reload, not the hot path.


### PR DESCRIPTION
## Summary

First two optimization passes for the rule IR compiler, from the rule-engine review. Both preserve first-match-wins semantics exactly; a new seeded randomized differential test enforces this against a naive reference.

### Commit 1 — clean-up passes

`CompiledRuleSet::build` now runs three passes:

1. **Dead-rule elimination** — no slots after the first unconditional `MATCH`/`FINAL`; unreachable rules no longer OR into `needs_ip_resolution` / `needs_process_lookup`.
2. **Duplicate elimination** — later rules lowering to an identical native predicate emit no slot.
3. **Constant-false pruning** — new `Rule::never_matches()` hook (GEOSITE with no DB loaded) and `UID` ops off-Linux are dropped from the plan.

Slots become a subsequence of the source rules (trie hits map rule index → slot position by binary search). `Tunnel::update_rules` sources enrichment flags from the compiled plan, so a dead GEOSITE/GEOIP rule no longer forces per-connection DNS pre-resolution. Also fixes `is_compatible_with` passing on any same-length rule swap.

### Commit 2 — min-index domain trie

- `DomainTrie::search_min_normalized`: folds the **minimum value across all matching patterns** (first-match-wins needs "earliest matching rule", not "most-specific pattern").
- Suffix rules are indexed under `+.pattern` **and** the bare apex, so `DOMAIN-SUFFIX,example.com` hits the trie for `example.com` itself.
- With those two properties, a trie hit/miss *proves* whether any earlier domain rule matches — so the IR hands indexed patterns to the trie (`RuleOp::TrieOwned`) and skips them in every scan. This is the historical `skip_domain` idea (ADR-0002 Class A) made correct.
- Fixes a latent index bug: `DOMAIN,x.com` shadowing `DOMAIN-SUFFIX,x.com` kept the suffix pattern out of the trie; and guards unindexable payloads (wildcard-prefixed, non-ASCII, empty labels) onto the scan path.

### Verification

- `cargo fmt --check`, three-way clippy `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib` (12 suites), `cargo test --test rules_test` (102) — all green.
- New: trie min-fold tests, indexed-plan apex/min-index/precedence/unindexable tests, randomized differential (8 sizes crossing the 64-rule plan threshold × 60 probes each).
- `rule_ir_footprint` (release): hot loop stays **zero-allocation**; `CompiledRuleSet` build footprint ~2.4 KiB live on the 19-rule fixture.

ADR-0011 note: `Metadata`/`ConnectionInfo`/`UdpSession`/`CacheEntry` untouched. `CompiledRuleSlot` gains no fields (`RuleOp` gains a unit variant; enum size unchanged, dominated by existing variants).

### Follow-ups (next PRs in this series)

- Lazy field materialization (demand analysis: no DNS pre-resolve/process lookup for connections matched before the first demanding slot)
- GEOSITE/RULE-SET native lowering + trie fusion into the global index
- Same-kind batching (Aho-Corasick keywords, RegexSet, IpRange runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)