### PR TITLE
fix(api): serialize DelayHistory time as RFC 3339 string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
  "socket2 0.5.10",
  "subtle",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Time (used directly by meow-api log timestamps; formatting feature enabled)
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/meow-common/Cargo.toml
+++ b/crates/meow-common/Cargo.toml
@@ -16,6 +16,7 @@ parking_lot = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true }
 bytes = { workspace = true }
 tracing = { workspace = true }
 httparse = { version = "1", default-features = false }

--- a/crates/meow-common/src/adapter.rs
+++ b/crates/meow-common/src/adapter.rs
@@ -11,8 +11,36 @@ use std::time::SystemTime;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelayHistory {
+    #[serde(with = "rfc3339_system_time")]
     pub time: SystemTime,
     pub delay: u16,
+}
+
+/// Wire format for [`DelayHistory::time`]: an RFC 3339 string, matching
+/// upstream Go mihomo where `history[].time` marshals via `time.Time`
+/// (`"2024-01-15T10:30:45Z"`). serde's default `SystemTime` representation
+/// is a `{secs_since_epoch, nanos_since_epoch}` object, which breaks API
+/// clients and dashboards that decode the upstream string shape — a probe
+/// recording history made `GET /proxies` undecodable for them.
+mod rfc3339_system_time {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::SystemTime;
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+
+    pub fn serialize<S: Serializer>(t: &SystemTime, serializer: S) -> Result<S::Ok, S::Error> {
+        let formatted = OffsetDateTime::from(*t)
+            .format(&Rfc3339)
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&formatted)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<SystemTime, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        OffsetDateTime::parse(&s, &Rfc3339)
+            .map(SystemTime::from)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -154,5 +182,36 @@ pub trait Proxy: ProxyAdapter {
     /// (selected/fastest/first-alive depending on group kind).
     fn current(&self) -> Option<String> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[test]
+    fn delay_history_time_serializes_as_rfc3339_string() {
+        let entry = DelayHistory {
+            time: UNIX_EPOCH + Duration::from_secs(1_751_527_000),
+            delay: 76,
+        };
+        let json = serde_json::to_value(&entry).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({"time": "2025-07-03T07:16:40Z", "delay": 76}),
+        );
+    }
+
+    #[test]
+    fn delay_history_round_trips_through_json() {
+        let entry = DelayHistory {
+            time: UNIX_EPOCH + Duration::from_secs(1_751_527_000),
+            delay: 321,
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        let back: DelayHistory = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.time, entry.time);
+        assert_eq!(back.delay, entry.delay);
     }
 }


### PR DESCRIPTION
serde's default `SystemTime` representation is a `{secs_since_epoch, nanos_since_epoch}` object, so as soon as any probe recorded history, `GET /proxies` emitted `history[].time` in a shape no clash-API client understands — upstream Go mihomo marshals it via `time.Time` as an RFC 3339 string. meow-ios decodes `time: String`, so the first delay test made the whole `/proxies` payload undecodable and the proxy-groups UI froze with no delays (madeye/meow-ios#255 follow-up).

- Emit RFC 3339 via the `time` crate (already a workspace dep for meow-api log timestamps; adds the `parsing` feature for the `Deserialize` side).
- Round-trip + exact-shape unit tests in `meow-common`.

Local verification: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` (whole workspace), `cargo test --lib` (all 10 suites green), `cargo test -p meow-common` and `cargo test -p meow-api` (119 tests incl. the delay-endpoint suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)