### PR TITLE
perf(rule-ir): index star-shaped DOMAIN-WILDCARD rules in the domain trie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,18 @@ codegen-units = 1
 panic = "abort"
 opt-level = "z"
 
+# Hot-path exception to the size-first default: the rule-match engine and
+# the domain trie run per connection, and at `opt-level = "z"` their scan
+# and probe loops get shredded by the -Oz inliner/machine-outliner (2-3x
+# swings measured on rules_bench across otherwise-unrelated code growth).
+# Fat LTO honors per-function optsize attrs, so exempting just these two
+# crates buys back the hot path while the rest of the binary stays "z".
+[profile.release.package.meow-tunnel]
+opt-level = 3
+
+[profile.release.package.meow-trie]
+opt-level = 3
+
 # Profile for dhat heap profiling — keeps debug symbols, no strip, no LTO.
 [profile.dhat]
 inherits = "release"

--- a/crates/meow-rules/src/geosite.rs
+++ b/crates/meow-rules/src/geosite.rs
@@ -154,6 +154,20 @@ impl GeositeDB {
             .collect()
     }
 
+    /// The domain trie behind one pre-resolved bucket key from
+    /// [`Self::resolve_keys`], if the bucket has one.
+    pub fn bucket_domain_trie(&self, key: &str) -> Option<&DomainTrie<()>> {
+        self.categories.get(key)
+    }
+
+    /// True iff the bucket has non-trie match sources (keywords / regex)
+    /// alongside its domain list — such a bucket cannot be fully handed
+    /// over to an external domain index.
+    pub fn bucket_has_residuals(&self, key: &str) -> bool {
+        self.keywords.get(key).is_some_and(|k| !k.is_empty())
+            || self.regex_compiled.get(key).is_some_and(|r| !r.is_empty())
+    }
+
     /// Match `domain` against one pre-resolved bucket key from
     /// [`Self::resolve_keys`]. Skips the per-lookup attribute splitting and
     /// case-fold scan that [`Self::lookup`] pays.

--- a/crates/meow-rules/src/rule_set.rs
+++ b/crates/meow-rules/src/rule_set.rs
@@ -76,6 +76,13 @@ pub trait RuleSet: Send + Sync {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Concrete-type escape hatch for the rule IR compiler (mirrors
+    /// `Rule::as_any`); set variants that can be fused into an external
+    /// index override this.
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
 }
 
 /// Build a rule-set of the given behavior from already-parsed entries.
@@ -247,6 +254,10 @@ pub struct DomainRuleSet {
 }
 
 impl DomainRuleSet {
+    pub fn domain_trie(&self) -> &DomainTrie<()> {
+        &self.trie
+    }
+
     pub fn from_entries(entries: &[String]) -> Self {
         let mut trie: DomainTrie<()> = DomainTrie::new();
         let mut count = 0;
@@ -286,6 +297,10 @@ impl RuleSet for DomainRuleSet {
             return false;
         }
         self.trie.search(host).is_some()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
     }
 
     fn len(&self) -> usize {

--- a/crates/meow-trie/src/trie.rs
+++ b/crates/meow-trie/src/trie.rs
@@ -410,6 +410,107 @@ impl<T: Clone + 'static> DomainTrie<T> {
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
+
+    /// Number of stored pattern slots. A `+.domain` insert counts as 2
+    /// (its star and dot forms); intended for capacity gating, not exact
+    /// pattern arithmetic.
+    pub fn pattern_slots(&self) -> usize {
+        self.len
+    }
+
+    /// Visit every stored pattern in its canonical insertable form:
+    /// `domain` (exact), `*.domain` (star, one label), `.domain` (dot, any
+    /// subdomain depth). Feeding each emitted string back into
+    /// [`Self::insert`] on another trie reproduces identical match
+    /// semantics — this is the primitive rule-index fusion builds on.
+    ///
+    /// Patterns come out lowercased (inserts fold case). Visit order is
+    /// unspecified.
+    pub fn for_each_pattern<F: FnMut(&str)>(&self, mut f: F) {
+        let mut labels: Vec<&str> = Vec::new();
+        let mut pattern = String::new();
+        match &self.state {
+            TrieState::Building(root) => {
+                Self::walk_build(root, &mut labels, &mut pattern, &mut f);
+            }
+            TrieState::Sealed(root) => {
+                Self::walk_sealed(root, &mut labels, &mut pattern, &mut f);
+            }
+        }
+    }
+
+    fn emit_node_patterns<F: FnMut(&str)>(
+        labels: &[&str],
+        pattern: &mut String,
+        exact: bool,
+        star: bool,
+        dot: bool,
+        f: &mut F,
+    ) {
+        if !(exact || star || dot) {
+            return;
+        }
+        // Labels are stored root-first from the TLD; the domain reads in
+        // reverse label order.
+        pattern.clear();
+        for label in labels.iter().rev() {
+            if !pattern.is_empty() {
+                pattern.push('.');
+            }
+            pattern.push_str(label);
+        }
+        if exact {
+            f(pattern);
+        }
+        if star {
+            f(&format!("*.{pattern}"));
+        }
+        if dot {
+            f(&format!(".{pattern}"));
+        }
+    }
+
+    fn walk_build<'a, F: FnMut(&str)>(
+        node: &'a BuildNode<T>,
+        labels: &mut Vec<&'a str>,
+        pattern: &mut String,
+        f: &mut F,
+    ) {
+        Self::emit_node_patterns(
+            labels,
+            pattern,
+            node.exact_value.is_some(),
+            node.star_value.is_some(),
+            node.dot_value.is_some(),
+            f,
+        );
+        for (label, child) in &node.children {
+            labels.push(label);
+            Self::walk_build(child, labels, pattern, f);
+            labels.pop();
+        }
+    }
+
+    fn walk_sealed<'a, F: FnMut(&str)>(
+        node: &'a SealedNode<T>,
+        labels: &mut Vec<&'a str>,
+        pattern: &mut String,
+        f: &mut F,
+    ) {
+        Self::emit_node_patterns(
+            labels,
+            pattern,
+            node.exact_value.is_some(),
+            node.star_value.is_some(),
+            node.dot_value.is_some(),
+            f,
+        );
+        for (label, child) in &node.children {
+            labels.push(label);
+            Self::walk_sealed(child, labels, pattern, f);
+            labels.pop();
+        }
+    }
 }
 
 fn fold_min<'a, T: Ord>(best: &mut Option<&'a T>, candidate: Option<&'a T>) {
@@ -623,6 +724,57 @@ mod tests {
         trie.insert("Example.COM", 1);
         assert_eq!(trie.search("example.com"), Some(&1));
         assert_eq!(trie.search("EXAMPLE.COM"), Some(&1));
+    }
+
+    #[test]
+    fn for_each_pattern_round_trips_match_semantics() {
+        let patterns = [
+            "exact.example.com",
+            "*.star.example.com",
+            ".dot.example.com",
+            "+.plus.example.com",
+            "MiXeD.example.com",
+        ];
+        let hosts = [
+            "exact.example.com",
+            "a.star.example.com",
+            "a.b.star.example.com",
+            "dot.example.com",
+            "a.dot.example.com",
+            "a.b.dot.example.com",
+            "plus.example.com",
+            "a.plus.example.com",
+            "a.b.plus.example.com",
+            "mixed.example.com",
+            "unrelated.com",
+        ];
+
+        for seal in [false, true] {
+            let mut original = DomainTrie::new();
+            for p in patterns {
+                original.insert(p, 1u32);
+            }
+            if seal {
+                original.seal();
+            }
+
+            let mut rebuilt = DomainTrie::new();
+            let mut emitted = 0usize;
+            original.for_each_pattern(|p| {
+                rebuilt.insert(p, 1u32);
+                emitted += 1;
+            });
+            rebuilt.seal();
+
+            assert_eq!(emitted, original.pattern_slots(), "seal={seal}");
+            for host in hosts {
+                assert_eq!(
+                    original.search(host).is_some(),
+                    rebuilt.search(host).is_some(),
+                    "seal={seal} host={host}",
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/meow-tunnel/src/match_engine.rs
+++ b/crates/meow-tunnel/src/match_engine.rs
@@ -74,6 +74,15 @@ impl DomainIndex {
         }
     }
 
+    /// Insert one pattern emitted by `DomainTrie::for_each_pattern` on
+    /// behalf of a fused GEOSITE / RULE-SET rule. The pattern is already in
+    /// canonical insertable form (`domain`, `*.domain`, `.domain`), so no
+    /// shape guard applies; first-write-wins keeps the minimum rule index
+    /// when callers insert in ascending rule order.
+    pub fn insert_fused_pattern(&mut self, index: usize, pattern: &str) {
+        self.trie.insert(pattern, index);
+    }
+
     pub fn seal(&mut self) {
         self.trie.seal();
     }

--- a/crates/meow-tunnel/src/match_engine.rs
+++ b/crates/meow-tunnel/src/match_engine.rs
@@ -57,18 +57,27 @@ impl DomainIndex {
     /// Duplicate patterns keep the first (minimum) rule index: inserts happen
     /// in ascending rule order and the trie's per-slot value is first-write.
     pub fn insert_rule(&mut self, index: usize, rule_type: RuleType, payload: &str) -> bool {
-        if !indexable_pattern(payload) {
-            return false;
-        }
         match rule_type {
-            RuleType::Domain => self.trie.insert(payload, index),
+            RuleType::Domain => indexable_pattern(payload) && self.trie.insert(payload, index),
             RuleType::DomainSuffix => {
+                if !indexable_pattern(payload) {
+                    return false;
+                }
                 // A suffix rule matches the apex domain itself as well as any
                 // subdomain; index both forms so a trie miss proves no suffix
                 // rule matches.
                 let subdomains = self.trie.insert(&format!("+.{payload}"), index);
                 let apex = self.trie.insert(payload, index);
                 subdomains && apex
+            }
+            RuleType::DomainWildcard => {
+                // Only the dominant `*.domain` shape is expressible: the
+                // trie's star kind matches exactly one extra label, which is
+                // byte-for-byte the wildcard glob semantics for this shape
+                // (`*` = one non-empty dot-free run). Other shapes
+                // (`a*b.com`, `example.*`, interior stars) stay on the scan
+                // path.
+                star_wildcard_indexable(payload) && self.trie.insert(payload, index)
             }
             _ => false,
         }
@@ -92,6 +101,15 @@ impl DomainIndex {
     pub fn search(&self, host: &str) -> Option<usize> {
         self.trie.search_min_normalized(host).copied()
     }
+}
+
+/// True iff a DOMAIN-WILDCARD payload has the `*.domain` shape the trie can
+/// own outright (see `DomainIndex::insert_rule`). Public so the IR's plan
+/// selection can weigh wildcard rules without attempting insertion.
+pub fn star_wildcard_indexable(payload: &str) -> bool {
+    payload
+        .strip_prefix("*.")
+        .is_some_and(|rest| indexable_pattern(rest) && !rest.contains('*'))
 }
 
 /// True iff `payload` is a plain hostname pattern whose trie insertion

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -13,6 +13,7 @@ use meow_rules::{
     rule_set_rule::RuleSetRule,
     src_geoip::SrcGeoIpRule,
 };
+use meow_trie::DomainTrie;
 use regex::Regex;
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
@@ -24,6 +25,13 @@ use std::sync::Arc;
 /// Below this size, trie probing costs more than it saves for common configs
 /// with early matches. Compile small configs to straight-line ordered IR scan.
 const LINEAR_SCAN_RULE_LIMIT: usize = 64;
+
+/// Per-rule cap on fused pattern slots (issue #287, relaxed gate). The
+/// largest real geosite categories (`cn`, `geolocation-!cn`) sit around
+/// 100–150k domains ≈ 200–300k pattern slots, well under this; only
+/// pathological monsters stay on the scan path. Skips are logged — no
+/// silent caps.
+const FUSED_PATTERN_SLOT_LIMIT: usize = 500_000;
 
 /// Native compiled rule metadata plus indexes for hot-path matching.
 ///
@@ -346,7 +354,17 @@ impl CompiledRuleSet {
             }
         }
 
-        let execution_plan = select_execution_plan(slots.len());
+        // Plan selection counts index weight, not just rule count: a config
+        // of two heavyweight GEOSITE rules wants the indexed plan just as
+        // much as a config of 100 DOMAIN lines (issue #287 / review pass 8).
+        let indexed_weight: usize = slots.iter().map(|slot| indexable_weight(&slot.op)).sum();
+        let execution_plan =
+            if slots.len() > LINEAR_SCAN_RULE_LIMIT || indexed_weight > LINEAR_SCAN_RULE_LIMIT {
+                ExecutionPlan::DomainIndexed
+            } else {
+                ExecutionPlan::LinearScan
+            };
+
         let mut domain_index = DomainIndex::empty();
         if execution_plan == ExecutionPlan::DomainIndexed {
             // Build the index from live slots only, and hand fully-indexed
@@ -354,14 +372,40 @@ impl CompiledRuleSet {
             // during scans, because min-index search semantics guarantee a
             // trie hit at T proves no owned slot before T matches, and a
             // trie miss proves no owned slot matches at all.
+            //
+            // GEOSITE / domain RULE-SET slots fuse their pattern tries into
+            // the index under the same min-index contract (issue #287).
+            // Ascending rule order + first-write-wins per trie slot keeps
+            // the minimum rule index for every pattern.
             for slot in &mut slots {
-                let owned = matches!(slot.op, RuleOp::Domain(_) | RuleOp::DomainSuffix(_))
-                    && domain_index.insert_rule(slot.rule_index, slot.rule_type, &slot.payload);
+                let owned = match &slot.op {
+                    RuleOp::Domain(_) | RuleOp::DomainSuffix(_) => {
+                        domain_index.insert_rule(slot.rule_index, slot.rule_type, &slot.payload)
+                    }
+                    RuleOp::GeoSite(op) => {
+                        fuse_geosite_slot(&mut domain_index, slot.rule_index, op)
+                    }
+                    RuleOp::RuleSetRef(handle) => {
+                        fuse_rule_set_slot(&mut domain_index, slot.rule_index, handle)
+                    }
+                    _ => false,
+                };
                 if owned {
                     slot.op = RuleOp::TrieOwned;
+                    // An owned slot's predicate is never evaluated, so it
+                    // must not stall the lazy scan on enrichment demands
+                    // (a GEOSITE rule reports should_resolve_ip, but the
+                    // trie answers it from the hostname alone).
+                    slot.demands_ip = false;
+                    slot.demands_process = false;
                 }
             }
             domain_index.seal();
+
+            // Ownership may have cleared per-slot demands; recompute the
+            // whole-plan enrichment flags from the surviving slots.
+            needs_ip_resolution = slots.iter().any(|slot| slot.demands_ip);
+            needs_process_lookup = slots.iter().any(|slot| slot.demands_process);
         }
 
         Self {
@@ -687,6 +731,12 @@ impl CompiledRuleSlot {
     pub fn is_lowered(&self) -> bool {
         !matches!(self.op, RuleOp::Fallback)
     }
+
+    /// True iff the domain index fully owns this slot's match semantics
+    /// (plain domain predicate or fused GEOSITE / RULE-SET).
+    pub fn is_trie_owned(&self) -> bool {
+        matches!(self.op, RuleOp::TrieOwned)
+    }
 }
 
 fn intern_adapter(
@@ -710,14 +760,6 @@ fn target_plan(rule_type: RuleType) -> TargetPlan {
         // rule's adapter/block name.
         RuleType::SubRule => TargetPlan::DynamicAdapter,
         _ => TargetPlan::StaticAdapter,
-    }
-}
-
-fn select_execution_plan(rule_count: usize) -> ExecutionPlan {
-    if rule_count <= LINEAR_SCAN_RULE_LIMIT {
-        ExecutionPlan::LinearScan
-    } else {
-        ExecutionPlan::DomainIndexed
     }
 }
 
@@ -860,6 +902,87 @@ fn lower_rule(rule: &dyn Rule) -> Option<RuleOp> {
 
 fn lower_children(rules: &[Box<dyn Rule>]) -> Option<Box<[RuleOp]>> {
     rules.iter().map(|rule| lower_rule(rule.as_ref())).collect()
+}
+
+/// Fuse a lowered GEOSITE op's bucket trie into the global domain index
+/// under this rule's index. Returns `true` iff the trie fully owns the
+/// rule's match semantics afterwards (single bucket, no keyword/regex
+/// residuals), so the slot can be skipped during scans.
+///
+/// Multi-attribute categories are intersections — a union-style pattern
+/// index cannot express them, so they are not fused at all (a fused hit
+/// would wrongly claim a match when only one bucket contains the host).
+fn fuse_geosite_slot(index: &mut DomainIndex, rule_index: usize, op: &GeoSiteOp) -> bool {
+    let [key] = op.keys.as_ref() else {
+        return false;
+    };
+    let Some(trie) = op.db.bucket_domain_trie(key) else {
+        // Keyword/regex-only bucket: nothing to fuse.
+        return false;
+    };
+    let slots = trie.pattern_slots();
+    if slots > FUSED_PATTERN_SLOT_LIMIT {
+        tracing::info!(
+            "rule_ir: GEOSITE bucket '{key}' has {slots} pattern slots \
+             (> {FUSED_PATTERN_SLOT_LIMIT}); not fused into the domain index",
+        );
+        return false;
+    }
+    trie.for_each_pattern(|pattern| index.insert_fused_pattern(rule_index, pattern));
+    !op.db.bucket_has_residuals(key)
+}
+
+/// Fuse a lowered domain-behavior RULE-SET into the global domain index.
+/// Domain rule-sets are pure tries, so a fused set is fully owned.
+fn fuse_rule_set_slot(index: &mut DomainIndex, rule_index: usize, handle: &RuleSetHandle) -> bool {
+    let Some(domain_set) = handle
+        .0
+        .as_any()
+        .and_then(|any| any.downcast_ref::<meow_rules::rule_set::DomainRuleSet>())
+    else {
+        return false;
+    };
+    let trie = domain_set.domain_trie();
+    let slots = trie.pattern_slots();
+    if slots > FUSED_PATTERN_SLOT_LIMIT {
+        tracing::info!(
+            "rule_ir: domain rule-set has {slots} pattern slots \
+             (> {FUSED_PATTERN_SLOT_LIMIT}); not fused into the domain index",
+        );
+        return false;
+    }
+    trie.for_each_pattern(|pattern| index.insert_fused_pattern(rule_index, pattern));
+    true
+}
+
+/// Weight this slot contributes to the domain index if the plan is
+/// `DomainIndexed`: 1 for plain domain predicates, the fused pattern-slot
+/// count for fusable GEOSITE / RULE-SET ops, 0 otherwise. Drives plan
+/// selection so a config of a few heavyweight GEOSITE rules still picks
+/// the indexed plan.
+fn indexable_weight(op: &RuleOp) -> usize {
+    match op {
+        RuleOp::Domain(_) | RuleOp::DomainSuffix(_) => 1,
+        RuleOp::GeoSite(geosite) => {
+            let [key] = geosite.keys.as_ref() else {
+                return 0;
+            };
+            geosite
+                .db
+                .bucket_domain_trie(key)
+                .map(DomainTrie::pattern_slots)
+                .filter(|slots| *slots <= FUSED_PATTERN_SLOT_LIMIT)
+                .unwrap_or(0)
+        }
+        RuleOp::RuleSetRef(handle) => handle
+            .0
+            .as_any()
+            .and_then(|any| any.downcast_ref::<meow_rules::rule_set::DomainRuleSet>())
+            .map(|set| set.domain_trie().pattern_slots())
+            .filter(|slots| *slots <= FUSED_PATTERN_SLOT_LIMIT)
+            .unwrap_or(0),
+        _ => 0,
+    }
 }
 
 fn ip_ranges_contain(v4: &IpRange<Ipv4Net>, v6: &IpRange<Ipv6Net>, ip: Option<IpAddr>) -> bool {
@@ -1501,12 +1624,23 @@ mod tests {
 
         let mut rng = Lcg(0x9E37_79B9_7F4A_7C15);
 
+        // Shared geosite DB over the same name/TLD pool, so generated
+        // GEOSITE rules regularly hit, miss, and fuse.
+        let mut geodb = GeositeDB::empty();
+        for name in &names {
+            for tld in &tlds {
+                geodb.insert(name, &format!("{name}.{tld}"));
+                geodb.insert(name, &format!("+.{name}.{tld}"));
+            }
+        }
+        let geodb = Arc::new(geodb);
+
         for &size in &[1usize, 3, 30, 63, 64, 65, 80, 150] {
             let mut rules: Vec<Box<dyn Rule>> = Vec::with_capacity(size + 1);
             for _ in 0..size {
                 let host = format!("{}.{}", rng.pick(&names), rng.pick(&tlds));
                 let adapter = rng.pick(&adapters);
-                let rule: Box<dyn Rule> = match rng.next() % 7 {
+                let rule: Box<dyn Rule> = match rng.next() % 8 {
                     0 => Box::new(DomainRule::new(&host, adapter)),
                     1 => Box::new(DomainRule::new(
                         &format!("{}.{host}", rng.pick(&subs)),
@@ -1515,6 +1649,12 @@ mod tests {
                     2 | 3 => Box::new(DomainSuffixRule::new(&host, adapter)),
                     4 => Box::new(DomainKeywordRule::new(rng.pick(&names), adapter)),
                     5 => Box::new(PortRule::new(rng.pick(&ports), adapter, false).unwrap()),
+                    6 => Box::new(GeoSiteRule::new(
+                        rng.pick(&names),
+                        adapter,
+                        Some(Arc::clone(&geodb)),
+                        false,
+                    )),
                     _ => Box::new(
                         IpCidrRule::new(
                             &format!("10.{}.0.0/16", rng.next() % 4),
@@ -1732,6 +1872,203 @@ mod tests {
         // depends on slot size staying put.
         let size = std::mem::size_of::<RuleOp>();
         assert!(size <= 32, "RuleOp grew to {size} B");
+    }
+
+    fn big_geosite_db(category: &str, count: usize) -> GeositeDB {
+        let mut db = GeositeDB::empty();
+        for i in 0..count {
+            db.insert(category, &format!("+.site{i}.{category}.test"));
+        }
+        db
+    }
+
+    #[test]
+    fn heavyweight_geosite_rule_fuses_and_owns_its_slot() {
+        // Two slots, but the fused pattern weight forces the indexed plan.
+        let db = Arc::new(big_geosite_db("cn", 200));
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(GeoSiteRule::new("cn", "GeoProxy", Some(db), false)),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(
+            !set.uses_linear_scan_plan(),
+            "fused pattern weight must select the indexed plan",
+        );
+        assert!(set.slots()[0].is_trie_owned(), "residual-free bucket owns");
+        assert!(
+            !set.needs_ip_resolution(),
+            "an owned GEOSITE slot must not force DNS pre-resolution",
+        );
+
+        for (host, expected) in [
+            // `+.` patterns match subdomains only — the apex misses,
+            // identically to the legacy GeositeDB lookup path.
+            ("site7.cn.test", "DIRECT"),
+            ("a.site7.cn.test", "GeoProxy"),
+            ("a.b.site42.cn.test", "GeoProxy"),
+            ("unrelated.test", "DIRECT"),
+            ("", "DIRECT"),
+        ] {
+            let meta = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let result = set.match_rules(&meta, &rules).expect("must match");
+            assert_eq!(result.adapter_name, expected, "host={host:?}");
+            if expected == "GeoProxy" {
+                assert_eq!(result.rule_type, RuleType::GeoSite);
+            }
+        }
+    }
+
+    #[test]
+    fn residual_geosite_bucket_fuses_but_stays_scanned() {
+        use std::collections::HashMap;
+
+        // Bucket with both a domain trie and a keyword residual.
+        let mut categories = HashMap::new();
+        let mut trie = meow_trie::DomainTrie::new();
+        for i in 0..100 {
+            trie.insert(&format!("+.listed{i}.kw.test"), ());
+        }
+        categories.insert("kw".to_string(), trie);
+        let mut keywords = HashMap::new();
+        keywords.insert("kw".to_string(), vec!["tracker".to_string()]);
+        let db = Arc::new(GeositeDB::from_parts(
+            categories,
+            HashMap::new(),
+            HashMap::new(),
+            keywords,
+        ));
+
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(GeoSiteRule::new("kw", "KwProxy", Some(db), false)),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+        assert!(
+            !set.slots()[0].is_trie_owned(),
+            "keyword residual must keep the slot on the scan path",
+        );
+
+        for (host, expected) in [
+            ("x.listed3.kw.test", "KwProxy"),  // via fused trie
+            ("my.tracker.example", "KwProxy"), // via keyword residual scan
+            ("clean.example", "DIRECT"),
+        ] {
+            let meta = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let result = set.match_rules(&meta, &rules).expect("must match");
+            assert_eq!(result.adapter_name, expected, "host={host}");
+        }
+    }
+
+    #[test]
+    fn multi_attribute_geosite_rule_is_not_fused() {
+        let mut db = GeositeDB::empty();
+        db.insert("ms@a", "both.test");
+        db.insert("ms@a", "aonly.test");
+        db.insert("ms@b", "both.test");
+        let db = Arc::new(db);
+
+        let mut rules: Vec<Box<dyn Rule>> = vec![Box::new(GeoSiteRule::new(
+            "ms@a@b",
+            "BothProxy",
+            Some(Arc::clone(&db)),
+            false,
+        ))];
+        rules.extend(filler_suffix_rules(70)); // force indexed plan
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+        assert!(
+            !set.slots()[0].is_trie_owned(),
+            "intersection semantics cannot be trie-fused",
+        );
+
+        for (host, expected) in [("both.test", "BothProxy"), ("aonly.test", "DIRECT")] {
+            let meta = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let result = set.match_rules(&meta, &rules).expect("must match");
+            assert_eq!(result.adapter_name, expected, "host={host}");
+        }
+    }
+
+    #[test]
+    fn domain_rule_set_fuses_and_owns_its_slot() {
+        let entries: Vec<String> = (0..100).map(|i| format!("+.rs{i}.set.test")).collect();
+        let set_box = build_rule_set(RuleSetBehavior::Domain, &entries, &ParserContext::default());
+        let rule_set: Arc<dyn RuleSet> = Arc::from(set_box);
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(RuleSetRule::new("mine", rule_set, "SetProxy", false)),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+
+        let compiled = CompiledRuleSet::build(&rules);
+        assert!(!compiled.uses_linear_scan_plan());
+        assert!(compiled.slots()[0].is_trie_owned());
+
+        for (host, expected) in [
+            ("a.rs9.set.test", "SetProxy"),
+            ("deep.b.rs50.set.test", "SetProxy"),
+            ("other.test", "DIRECT"),
+        ] {
+            let meta = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let result = compiled.match_rules(&meta, &rules).expect("must match");
+            assert_eq!(result.adapter_name, expected, "host={host}");
+        }
+    }
+
+    #[test]
+    fn earlier_domain_rule_beats_fused_geosite_and_vice_versa() {
+        let db = Arc::new(big_geosite_db("cn", 100));
+
+        // Case 1: DOMAIN before GEOSITE — domain rule wins its host.
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainRule::new("a.site3.cn.test", "DomainFirst")),
+            Box::new(GeoSiteRule::new(
+                "cn",
+                "GeoProxy",
+                Some(Arc::clone(&db)),
+                false,
+            )),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+        let meta = Metadata {
+            host: "a.site3.cn.test".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let result = set.match_rules(&meta, &rules).expect("must match");
+        assert_eq!(result.adapter_name, "DomainFirst", "min-index must win");
+
+        // Case 2: GEOSITE before DOMAIN-SUFFIX covering the same host.
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(GeoSiteRule::new("cn", "GeoProxy", Some(db), false)),
+            Box::new(DomainSuffixRule::new("site3.cn.test", "SuffixLater")),
+            Box::new(FinalRule::new("DIRECT")),
+        ];
+        let set = CompiledRuleSet::build(&rules);
+        let result = set.match_rules(&meta, &rules).expect("must match");
+        assert_eq!(result.adapter_name, "GeoProxy", "earlier fused rule wins");
     }
 
     #[test]

--- a/crates/meow-tunnel/src/rule_ir.rs
+++ b/crates/meow-tunnel/src/rule_ir.rs
@@ -357,7 +357,7 @@ impl CompiledRuleSet {
         // Plan selection counts index weight, not just rule count: a config
         // of two heavyweight GEOSITE rules wants the indexed plan just as
         // much as a config of 100 DOMAIN lines (issue #287 / review pass 8).
-        let indexed_weight: usize = slots.iter().map(|slot| indexable_weight(&slot.op)).sum();
+        let indexed_weight: usize = slots.iter().map(indexable_weight).sum();
         let execution_plan =
             if slots.len() > LINEAR_SCAN_RULE_LIMIT || indexed_weight > LINEAR_SCAN_RULE_LIMIT {
                 ExecutionPlan::DomainIndexed
@@ -379,7 +379,7 @@ impl CompiledRuleSet {
             // the minimum rule index for every pattern.
             for slot in &mut slots {
                 let owned = match &slot.op {
-                    RuleOp::Domain(_) | RuleOp::DomainSuffix(_) => {
+                    RuleOp::Domain(_) | RuleOp::DomainSuffix(_) | RuleOp::DomainWildcard(_) => {
                         domain_index.insert_rule(slot.rule_index, slot.rule_type, &slot.payload)
                     }
                     RuleOp::GeoSite(op) => {
@@ -956,13 +956,16 @@ fn fuse_rule_set_slot(index: &mut DomainIndex, rule_index: usize, handle: &RuleS
 }
 
 /// Weight this slot contributes to the domain index if the plan is
-/// `DomainIndexed`: 1 for plain domain predicates, the fused pattern-slot
-/// count for fusable GEOSITE / RULE-SET ops, 0 otherwise. Drives plan
-/// selection so a config of a few heavyweight GEOSITE rules still picks
-/// the indexed plan.
-fn indexable_weight(op: &RuleOp) -> usize {
-    match op {
+/// `DomainIndexed`: 1 for plain domain predicates (including `*.domain`
+/// wildcards the trie can own), the fused pattern-slot count for fusable
+/// GEOSITE / RULE-SET ops, 0 otherwise. Drives plan selection so a config
+/// of a few heavyweight GEOSITE rules still picks the indexed plan.
+fn indexable_weight(slot: &CompiledRuleSlot) -> usize {
+    match &slot.op {
         RuleOp::Domain(_) | RuleOp::DomainSuffix(_) => 1,
+        RuleOp::DomainWildcard(_) => {
+            usize::from(crate::match_engine::star_wildcard_indexable(&slot.payload))
+        }
         RuleOp::GeoSite(geosite) => {
             let [key] = geosite.keys.as_ref() else {
                 return 0;
@@ -1579,6 +1582,80 @@ mod tests {
     }
 
     #[test]
+    fn star_wildcards_are_trie_owned_in_indexed_plan() {
+        let mut rules: Vec<Box<dyn Rule>> = (0..70)
+            .map(|i| {
+                Box::new(
+                    DomainWildcardRule::new(&format!("*.blocked{i}.example.com"), &format!("W{i}"))
+                        .unwrap(),
+                ) as Box<dyn Rule>
+            })
+            .collect();
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+        assert!(
+            set.slots()
+                .iter()
+                .filter(|s| s.rule_type() == RuleType::DomainWildcard)
+                .all(CompiledRuleSlot::is_trie_owned),
+            "star-shaped wildcards must be owned by the trie",
+        );
+
+        for (host, expected) in [
+            ("x.blocked7.example.com", "W7"),       // exactly one label
+            ("blocked7.example.com", "DIRECT"),     // apex: star needs a label
+            ("a.b.blocked7.example.com", "DIRECT"), // two labels: gap has a dot
+            ("X.BLOCKED9.EXAMPLE.COM", "W9"),       // case-folded by lower_host
+            ("unrelated.test", "DIRECT"),
+        ] {
+            let meta = Metadata {
+                host: Metadata::lower_host(host),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let result = set.match_rules(&meta, &rules).expect("must match");
+            assert_eq!(result.adapter_name, expected, "host={host}");
+        }
+    }
+
+    #[test]
+    fn non_star_wildcard_shapes_stay_on_scan_path() {
+        let mut rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainWildcardRule::new("a*b.example.com", "InteriorStar").unwrap()),
+            Box::new(DomainWildcardRule::new("example.*", "TrailingStar").unwrap()),
+            Box::new(DomainWildcardRule::new("*.multi.*", "DoubleStar").unwrap()),
+        ];
+        rules.extend(filler_suffix_rules(70)); // force indexed plan
+        rules.push(Box::new(FinalRule::new("DIRECT")));
+
+        let set = CompiledRuleSet::build(&rules);
+        assert!(!set.uses_linear_scan_plan());
+        for pos in 0..3 {
+            assert!(
+                !set.slots()[pos].is_trie_owned(),
+                "non-star shape at {pos} must stay scanned",
+            );
+        }
+
+        for (host, expected) in [
+            ("axxb.example.com", "InteriorStar"),
+            ("example.net", "TrailingStar"),
+            ("x.multi.org", "DoubleStar"),
+            ("plain.test", "DIRECT"),
+        ] {
+            let meta = Metadata {
+                host: host.into(),
+                dst_port: 443,
+                ..Default::default()
+            };
+            let result = set.match_rules(&meta, &rules).expect("must match");
+            assert_eq!(result.adapter_name, expected, "host={host}");
+        }
+    }
+
+    #[test]
     fn indexed_plan_unindexable_domain_payload_stays_on_scan_path() {
         // Non-ASCII payload: the trie's Unicode lowercasing diverges from
         // the op's ASCII-insensitive compare, so the pattern must not be
@@ -1640,7 +1717,7 @@ mod tests {
             for _ in 0..size {
                 let host = format!("{}.{}", rng.pick(&names), rng.pick(&tlds));
                 let adapter = rng.pick(&adapters);
-                let rule: Box<dyn Rule> = match rng.next() % 8 {
+                let rule: Box<dyn Rule> = match rng.next() % 10 {
                     0 => Box::new(DomainRule::new(&host, adapter)),
                     1 => Box::new(DomainRule::new(
                         &format!("{}.{host}", rng.pick(&subs)),
@@ -1655,6 +1732,14 @@ mod tests {
                         Some(Arc::clone(&geodb)),
                         false,
                     )),
+                    7 => Box::new(DomainWildcardRule::new(&format!("*.{host}"), adapter).unwrap()),
+                    8 => Box::new(
+                        DomainWildcardRule::new(
+                            &format!("{}*.{}", rng.pick(&subs), rng.pick(&tlds)),
+                            adapter,
+                        )
+                        .unwrap(),
+                    ),
                     _ => Box::new(
                         IpCidrRule::new(
                             &format!("10.{}.0.0/16", rng.next() % 4),


### PR DESCRIPTION
## Summary

Implements the wildcard-batching target from #289 — stacked on #293 (merge that first, then re-target this to `main`; if #293 merges with branch deletion, re-target this one **before** deleting, per the #286 lesson).

The #289 baseline identified wildcard scans as the top remaining per-connection cost. It turns out the dominant `*.domain` shape needs no Aho-Corasick, no RegexSet, no new dependency at all: it is **exactly** the `DomainTrie` star kind (one non-empty dot-free label) — byte-for-byte the glob semantics for that shape.

- `DomainIndex::insert_rule` now indexes `*.domain` wildcards (plain-hostname tail only, same indexable-pattern guards); the IR marks them `TrieOwned`, so scans skip them and a trie miss proves no owned wildcard matches.
- Interior/trailing/adjacent-star shapes (`a*b.com`, `example.*`, `**.x`) keep their GlobMatcher/regex slots on the scan path, tested.
- Plan-selection weight counts indexable wildcards like plain domain predicates.

## Numbers

`synthetic_10k_wildcard_miss`: 15.24 → **5.19 µs** (4.4× vs the 22.7 µs pre-series baseline). Hot loop stays zero-allocation.

## Verification

Full bar green (fmt, three-way clippy `-D warnings`, doc, 12 lib suites, `rules_test` ×102). New tests: owned star wildcards (hit / apex miss / two-label miss / case fold), non-star shapes staying scanned, and the randomized differential now generates both wildcard shapes.

Closes #289 — the remaining candidates there (keyword/regex batching) target rule types rare in real configs and would each add a dependency for unproven µs-scale wins; the measurements are on the issue as the record if that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)