### PR TITLE
fix(test): isolate alloc-count gates from cross-thread harness noise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Rules tests
         run: cargo test --test rules_test -- --nocapture
 
+      # ADR-0008 allocation-count gates. Release build: the thresholds are
+      # calibrated against release codegen. The provider-backed pressure
+      # test self-skips when geodata files are absent (as on CI runners);
+      # the remaining gates run everywhere.
+      - name: Allocation-count gates (ADR-0008)
+        run: cargo test -p meow-tunnel --test alloc_count_test --release -- --nocapture
+
       - name: Shadowsocks integration tests (incl. simple-obfs)
         env:
           # Force-fail (instead of silently SKIP) if ssserver / obfs-local /

--- a/crates/meow-tunnel/tests/alloc_count_test.rs
+++ b/crates/meow-tunnel/tests/alloc_count_test.rs
@@ -7,7 +7,7 @@ use smol_str::SmolStr;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 struct CountingAlloc;
 
@@ -29,6 +29,34 @@ unsafe impl GlobalAlloc for CountingAlloc {
 
 #[global_allocator]
 static A: CountingAlloc = CountingAlloc;
+
+/// Serialize the measuring tests, recovering from poisoning so a failed
+/// assertion in one test surfaces as that test's failure instead of
+/// cascading `PoisonError`s into the rest.
+///
+/// The counters are process-global: anything a concurrent thread allocates
+/// lands in the measuring test's window. Every test must therefore acquire
+/// this lock BEFORE any allocating work — fixtures included — not just
+/// before its measured section. The libtest harness itself still allocates
+/// outside any lock we can take (test-thread spawn preambles, the previous
+/// test's result reporting), so after acquiring, wait for the allocation
+/// counter to go quiet: parked threads don't allocate, and the harness
+/// settles within a few milliseconds.
+fn serial() -> MutexGuard<'static, ()> {
+    let guard = ALLOC_TEST_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    let mut last = ALLOC_COUNT.load(Ordering::SeqCst);
+    for _ in 0..250 {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let now = ALLOC_COUNT.load(Ordering::SeqCst);
+        if now == last {
+            break;
+        }
+        last = now;
+    }
+    guard
+}
 
 fn reset_counts() -> (usize, usize) {
     let a = ALLOC_COUNT.swap(0, Ordering::SeqCst);
@@ -122,7 +150,7 @@ fn test_metadata() -> Metadata {
 
 #[test]
 fn rule_match_zero_alloc_on_hot_path() {
-    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
+    let _guard = serial();
     let long_adapter = "ProxyNameThatExceedsSmolStrInlineCapacity";
     let long_domain = "very-long-subdomain-name-that-exceeds-inline-capacity.example.com";
     let rules: Vec<Box<dyn Rule>> = vec![
@@ -160,9 +188,18 @@ fn rule_match_zero_alloc_on_hot_path() {
     );
 }
 
-#[tokio::test]
-async fn rule_engine_pressure_zero_alloc_free_on_critical_path() {
+#[test]
+fn rule_engine_pressure_zero_alloc_free_on_critical_path() {
     const ITERS: usize = 50_000;
+
+    // Take the serialization lock before building any fixture: loading the
+    // provider-backed config allocates heavily, and doing that on a
+    // concurrent test thread pollutes whichever test is measuring the
+    // process-global counters at that moment (observed as
+    // track_connection_alloc_count "failing" at 8+ allocs/conn once the
+    // geodata files exist locally). A manual runtime instead of
+    // #[tokio::test] keeps the runtime construction inside the lock too.
+    let _guard = serial();
 
     let required_providers = [
         "/Users/mlv/.config/meow/Country.mmdb",
@@ -176,8 +213,14 @@ async fn rule_engine_pressure_zero_alloc_free_on_critical_path() {
         return;
     }
 
-    let config = load_config_from_str(include_str!("fixtures/memleak_ech_pressure_config.yaml"))
-        .await
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread runtime must build");
+    let config = runtime
+        .block_on(load_config_from_str(include_str!(
+            "fixtures/memleak_ech_pressure_config.yaml"
+        )))
         .expect("memleak ECH pressure config must load with geodata providers");
     let rules = config.rules;
     let index = DomainIndex::build(&rules);
@@ -224,7 +267,6 @@ async fn rule_engine_pressure_zero_alloc_free_on_critical_path() {
         "其他"
     );
 
-    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
     reset_counts();
     for _ in 0..ITERS {
         let domain = match_rules(
@@ -271,7 +313,7 @@ async fn rule_engine_pressure_zero_alloc_free_on_critical_path() {
 
 #[test]
 fn track_connection_alloc_count() {
-    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
+    let _guard = serial();
     let stats = Statistics::new();
     let meta = test_metadata();
 
@@ -322,7 +364,7 @@ fn track_connection_alloc_count() {
 
 #[test]
 fn metadata_remote_address_zero_alloc() {
-    let _guard = ALLOC_TEST_LOCK.lock().unwrap();
+    let _guard = serial();
     let meta = test_metadata();
 
     reset_counts();


### PR DESCRIPTION
## Symptom

`cargo test -p meow-tunnel --test alloc_count_test` fails 3 of 4 tests on a machine with geodata files in `~/.config/meow`:

- `track_connection_alloc_count`: 8.41 allocs/conn vs the ≤4 cap
- `rule_match_zero_alloc_on_hot_path` / `rule_engine_pressure_zero_alloc_free_on_critical_path`: `PoisonError` at the lock

## Root cause — no product regression

All four gates pass cleanly in isolation (`track_connection` is at ~2.5 allocs/conn; both rule-engine paths are exactly 0-alloc). The counters are process-global, but:

1. The provider-backed pressure test built its heavyweight fixture (config load with geosite.dat + Country.mmdb) **before** taking `ALLOC_TEST_LOCK`, on a concurrent libtest thread — polluting whichever test was measuring at that moment. This only bites once the geodata files exist locally, which is why it appeared "recently" and why bisecting is a trap (a first attempt fingered #291 spuriously).
2. The panicking test poisons the shared lock → bogus `PoisonError` cascades.
3. Even with fixtures locked, libtest itself allocates outside any lock we can take: test-thread spawn preambles and the previous test's result-reporting epilogue — observed as exactly 4 stray allocs landing in `rule_match`'s `== 0` window in ~2/5 runs.

## Fix

- Pressure test acquires the lock **before any fixture work**; a manual current-thread runtime replaces `#[tokio::test]` so runtime construction is inside the lock too
- New `serial()` helper: recovers from poisoning (one failure surfaces as one failing test) and **quiesces** — after acquiring, waits until the allocation counter stops moving (10 ms windows, bounded), absorbing harness noise
- CI never ran `alloc_count_test` (not in `test.yml`) — the ADR-0008 gate could rot silently. Added it, release profile; the provider-backed test self-skips on runners without geodata

## Verification

Before: 3/5 full-suite runs failed. After: 10/10 green in release, 3/3 in debug, fmt/clippy×3/doc/`cargo test --lib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)