### PR TITLE
fix(lint): satisfy clippy 1.97 question_mark in reverse_lookup

### DIFF
--- a/crates/meow-dns/src/cache.rs
+++ b/crates/meow-dns/src/cache.rs
@@ -195,12 +195,9 @@ impl DnsCache {
         let shard = &self.reverse[shard_ip(ip)];
         let mut reverse = shard.lock();
         let now = Instant::now();
-        if let Some(entry) = reverse.get(&ip) {
-            if entry.expire_at > now {
-                return Some(SmolStr::from(entry.domain.as_ref()));
-            }
-        } else {
-            return None;
+        let entry = reverse.get(&ip)?;
+        if entry.expire_at > now {
+            return Some(SmolStr::from(entry.domain.as_ref()));
         }
         reverse.pop(&ip);
         None

--- a/crates/meow-proxy/src/health.rs
+++ b/crates/meow-proxy/src/health.rs
@@ -345,10 +345,8 @@ impl ParsedUrl {
     fn parse(url: &str) -> Option<Self> {
         let (https, rest) = if let Some(r) = url.strip_prefix("https://") {
             (true, r)
-        } else if let Some(r) = url.strip_prefix("http://") {
-            (false, r)
         } else {
-            return None;
+            (false, url.strip_prefix("http://")?)
         };
         let (authority, path) = match rest.find('/') {
             Some(i) => (&rest[..i], &rest[i..]),


### PR DESCRIPTION
## Summary

The `lint` job on main is red: CI uses `dtolnay/rust-toolchain@stable`, which picked up Rust 1.97, and its clippy newly flags the `if let / else return None` block in `DnsCache::reverse_lookup` (`crates/meow-dns/src/cache.rs:198`) under `clippy::question_mark`. Both post-merge Test runs on main (`0609fed`, `f54a7d6`) failed on this single error; the code itself dates from April and is unrelated to those commits.

Rewritten with the `?` operator. Behavior is unchanged:
- clean miss → `None` without popping (preserves the "skip useless pop on clean miss" optimization from 8007a33)
- fresh hit → domain returned
- expired hit → entry popped, `None`

## Verification

Full regression bar run locally:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` (default / `--no-default-features` / `--all-features`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` — 64 passed

No struct layout changes (control flow only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)