### PR TITLE
fix outstanding correctness and security issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -2163,6 +2163,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "futures-util",
  "hickory-proto",
  "httparse",
  "ipnet",
@@ -3059,6 +3060,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3078,12 +3080,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -4290,6 +4294,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ opt-level = 1
 version = "0.16.0"
 edition = "2021"
 rust-version = "1.89"
-license = "GPL-3.0"
+license = "MIT"
 repository = "https://github.com/madeye/meow-rs"
 homepage = "https://madeye.github.io/meow-rs/"
 

--- a/README.md
+++ b/README.md
@@ -388,4 +388,4 @@ bash tests/test_tproxy_qemu.sh
 
 ## License
 
-GPL-3.0
+MIT

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -4,9 +4,8 @@
 # crates.io `anytls-rs@0.5.4` is jxo-me's UPSTREAM crate and lacks `close()`,
 # so meow-proxy could not build the `anytls` feature against the registry.
 #
-# This crate is MIT-licensed (see LICENSE) — distinct from the workspace's
-# GPL-3.0 — and uses Rust edition 2024, so package metadata is declared
-# explicitly here rather than inherited from `[workspace.package]`.
+# This crate uses Rust edition 2024, so package metadata is declared explicitly
+# here rather than inherited from `[workspace.package]`.
 #
 # The package is renamed (`meow-anytls`) to avoid a crates.io name collision
 # with the upstream `anytls-rs`, while the library name stays `anytls_rs` so

--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Mutex};
 use tower_http::cors::CorsLayer;
 use tracing::{debug, info, warn};
 
@@ -45,6 +45,10 @@ pub struct AppState {
     /// at `/ui`; when `None`, the built-in panel is served (issue #223).
     pub external_ui: Option<std::path::PathBuf>,
 }
+
+/// The API server owns one raw/runtime configuration, so all mutation
+/// endpoints share one commit lane. Reads remain independent.
+static CONFIG_MUTATION: Mutex<()> = Mutex::const_new(());
 
 impl AppState {
     fn auth_required(&self) -> bool {
@@ -589,14 +593,39 @@ async fn apply_raw_to_tunnel(
     mut raw: RawConfig,
     tunnel: &Tunnel,
 ) -> Result<(), (StatusCode, String)> {
+    let expected_groups: Vec<String> = raw
+        .proxy_groups
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|group| group.name.clone())
+        .collect();
     if let Some(ps) = raw.proxies.as_mut() {
         meow_config::ech_dns::preresolve_ech(ps).await;
     }
     let (proxies, rules) = rebuild_from_raw_with_resolver_async(raw, Arc::clone(tunnel.resolver()))
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    if let Some(missing) = expected_groups
+        .iter()
+        .find(|name| !proxies.contains_key(name.as_str()))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("proxy group '{missing}' failed validation"),
+        ));
+    }
     tunnel.update_proxies(proxies);
     tunnel.update_rules(rules);
+    Ok(())
+}
+
+async fn commit_raw_candidate(
+    state: &AppState,
+    candidate: RawConfig,
+) -> Result<(), (StatusCode, String)> {
+    apply_raw_to_tunnel(candidate.clone(), &state.tunnel).await?;
+    *state.raw_config.write() = candidate;
     Ok(())
 }
 
@@ -682,8 +711,9 @@ async fn add_subscription(
     let gc = fetched.proxy_groups.len();
     let rc = fetched.rules.len();
 
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
 
         if let Some(ref subs) = raw.subscriptions {
             if subs.iter().any(|s| s.name == body.name) {
@@ -707,13 +737,14 @@ async fn add_subscription(
         raw.proxy_groups = Some(fetched.proxy_groups);
         raw.rules = Some(fetched.rules);
 
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot.clone()).await?;
 
     // Auto-save so subscription data is cached on disk
-    let raw = state.raw_config.read().clone();
-    let _ = meow_config::save_raw_config_async(&state.config_path, &raw).await;
+    meow_config::save_raw_config_async(&state.config_path, &snapshot)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     Ok(Json(serde_json::json!({
         "message": "subscription added",
@@ -725,8 +756,9 @@ async fn delete_subscription(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
 
         if let Some(ref mut subs) = raw.subscriptions {
             let before = subs.len();
@@ -743,11 +775,12 @@ async fn delete_subscription(
         raw.proxy_groups = Some(Vec::new());
         raw.rules = Some(Vec::new());
 
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
-    let raw = state.raw_config.read().clone();
-    let _ = meow_config::save_raw_config_async(&state.config_path, &raw).await;
+    commit_raw_candidate(&state, snapshot.clone()).await?;
+    meow_config::save_raw_config_async(&state.config_path, &snapshot)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -777,8 +810,9 @@ async fn refresh_subscription(
     let gc = fetched.proxy_groups.len();
     let rc = fetched.rules.len();
 
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
 
         if let Some(ref mut subs) = raw.subscriptions {
             if let Some(sub) = subs.iter_mut().find(|s| s.name == name) {
@@ -790,13 +824,14 @@ async fn refresh_subscription(
         raw.proxy_groups = Some(fetched.proxy_groups);
         raw.rules = Some(fetched.rules);
 
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot.clone()).await?;
 
     // Auto-save so subscription data is cached on disk
-    let raw = state.raw_config.read().clone();
-    let _ = meow_config::save_raw_config_async(&state.config_path, &raw).await;
+    meow_config::save_raw_config_async(&state.config_path, &snapshot)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     Ok(Json(serde_json::json!({
         "message": "subscription refreshed",
@@ -862,8 +897,9 @@ async fn create_proxy_group(
     Json(body): Json<CreateProxyGroupRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let group_name = body.name.clone();
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
         if let Some(ref groups) = raw.proxy_groups {
             if groups.iter().any(|g| g.name == body.name) {
                 return Err((StatusCode::CONFLICT, "group name already exists".into()));
@@ -879,9 +915,9 @@ async fn create_proxy_group(
             ..Default::default()
         };
         raw.proxy_groups.get_or_insert_with(Vec::new).push(group);
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot).await?;
     Ok(Json(
         serde_json::json!({"message": "group created", "name": group_name}),
     ))
@@ -892,8 +928,9 @@ async fn update_proxy_group(
     Path(name): Path<String>,
     Json(body): Json<CreateProxyGroupRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
         let group = raw
             .proxy_groups
             .as_mut()
@@ -904,9 +941,9 @@ async fn update_proxy_group(
         group.url = body.url;
         group.interval = body.interval;
         group.tolerance = body.tolerance;
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -914,8 +951,9 @@ async fn delete_proxy_group(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
         if let Some(ref mut groups) = raw.proxy_groups {
             let before = groups.len();
             groups.retain(|g| g.name != name);
@@ -931,9 +969,9 @@ async fn delete_proxy_group(
                 parts.last().is_none_or(|target| target.trim() != name)
             });
         }
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -976,12 +1014,13 @@ async fn replace_rules(
     State(state): State<Arc<AppState>>,
     Json(body): Json<ReplaceRulesRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
         raw.rules = Some(body.rules);
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -995,16 +1034,17 @@ async fn update_rule_at_index(
     State(state): State<Arc<AppState>>,
     Json(body): Json<UpdateRuleRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
         let rules = raw.rules.get_or_insert_with(Vec::new);
         if body.index >= rules.len() {
             return Err((StatusCode::BAD_REQUEST, "index out of range".into()));
         }
         rules[body.index] = body.rule;
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1012,16 +1052,17 @@ async fn delete_rule(
     State(state): State<Arc<AppState>>,
     Path(index): Path<usize>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
         let rules = raw.rules.get_or_insert_with(Vec::new);
         if index >= rules.len() {
             return Err((StatusCode::BAD_REQUEST, "index out of range".into()));
         }
         rules.remove(index);
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1035,17 +1076,18 @@ async fn reorder_rules(
     State(state): State<Arc<AppState>>,
     Json(body): Json<ReorderRulesRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let _mutation = CONFIG_MUTATION.lock().await;
     let snapshot = {
-        let mut raw = state.raw_config.write();
+        let mut raw = state.raw_config.read().clone();
         let rules = raw.rules.get_or_insert_with(Vec::new);
         if body.from >= rules.len() || body.to >= rules.len() {
             return Err((StatusCode::BAD_REQUEST, "index out of range".into()));
         }
         let rule = rules.remove(body.from);
         rules.insert(body.to, rule);
-        raw.clone()
+        raw
     };
-    apply_raw_to_tunnel(snapshot, &state.tunnel).await?;
+    commit_raw_candidate(&state, snapshot).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1280,6 +1322,8 @@ async fn put_configs(
     if let Some(ps) = raw_config.proxies.as_mut() {
         meow_config::ech_dns::preresolve_ech(ps).await;
     }
+
+    let _mutation = CONFIG_MUTATION.lock().await;
 
     // Semantic rebuild (proxy/rule parsing)
     let resolver = Arc::clone(state.tunnel.resolver());

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -701,6 +701,32 @@ async fn create_proxy_group_selector() {
 }
 
 #[tokio::test]
+async fn rejected_proxy_group_does_not_mutate_raw_config() {
+    let state = test_state_default();
+    let app = create_router(Arc::clone(&state));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/proxy-groups")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"name":"Broken","type":"relay","proxies":["DIRECT"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert!(state
+        .raw_config
+        .read()
+        .proxy_groups
+        .as_ref()
+        .is_none_or(Vec::is_empty));
+}
+
+#[tokio::test]
 async fn create_proxy_group_duplicate_name() {
     let mut raw = test_raw_config();
     raw.proxy_groups = Some(vec![RawProxyGroup {

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -20,7 +20,10 @@ pub fn extract_specs(raw_groups: &[meow_config::raw::RawProxyGroup]) -> Vec<Heal
         .map(|g| HealthCheckSpec {
             group_name: g.name.clone(),
             url: g.url.as_deref().unwrap_or(DEFAULT_URL).to_string(),
-            interval_secs: g.interval.unwrap_or(DEFAULT_INTERVAL_SECS),
+            interval_secs: g
+                .interval
+                .filter(|interval| *interval > 0)
+                .unwrap_or(DEFAULT_INTERVAL_SECS),
             lazy: g.lazy.unwrap_or(false),
         })
         .collect()
@@ -90,5 +93,22 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
             "health-check: {} — {}/{} alive",
             spec.group_name, alive_count, total_count
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_interval_uses_safe_default() {
+        let group = meow_config::raw::RawProxyGroup {
+            name: "auto".into(),
+            group_type: "url-test".into(),
+            interval: Some(0),
+            ..Default::default()
+        };
+        let specs = extract_specs(&[group]);
+        assert_eq!(specs[0].interval_secs, DEFAULT_INTERVAL_SECS);
     }
 }

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -40,7 +40,8 @@ serde_yaml = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
+futures-util = { workspace = true }
 maxminddb = { workspace = true }
 ipnet = { workspace = true }
 base64 = { workspace = true }

--- a/crates/meow-config/src/dns_parser.rs
+++ b/crates/meow-config/src/dns_parser.rs
@@ -56,7 +56,7 @@ pub async fn parse_dns(
         _ => DnsMode::Normal,
     };
 
-    let listen_addr = dns.listen.as_deref().and_then(|s| s.parse().ok());
+    let listen_addr = crate::parse_optional_socket_addr("dns.listen", dns.listen.as_deref())?;
     let mut hosts = build_hosts_trie(raw.hosts.as_ref())?;
 
     if use_hosts && use_system_hosts {

--- a/crates/meow-config/src/internal_http.rs
+++ b/crates/meow-config/src/internal_http.rs
@@ -13,6 +13,7 @@
 //!     `reqwest::bytes()` semantics on every call site).
 
 use anyhow::{anyhow, bail, Result};
+use futures_util::StreamExt;
 use meow_common::adapter::Proxy;
 use meow_common::metadata::Metadata;
 use meow_common::{ConnType, Network};
@@ -25,7 +26,27 @@ use url::Url;
 const MAX_REDIRECTS: u8 = 5;
 const READ_TIMEOUT: Duration = Duration::from_secs(60);
 const USER_AGENT: &str = concat!("clash.meta/", env!("CARGO_PKG_VERSION"));
-const MAX_BODY_BYTES: usize = 256 * 1024 * 1024; // 256 MiB hard ceiling
+pub(crate) const MAX_BODY_BYTES: usize = 256 * 1024 * 1024; // 256 MiB hard ceiling
+
+pub(crate) async fn response_text_with_limit(resp: reqwest::Response) -> Result<String> {
+    if resp
+        .content_length()
+        .is_some_and(|length| length > MAX_BODY_BYTES as u64)
+    {
+        bail!("response exceeds max body size ({MAX_BODY_BYTES} bytes)");
+    }
+
+    let mut bytes = Vec::new();
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        if chunk.len() > MAX_BODY_BYTES.saturating_sub(bytes.len()) {
+            bail!("response exceeds max body size ({MAX_BODY_BYTES} bytes)");
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    String::from_utf8(bytes).map_err(|e| anyhow!("response body is not UTF-8: {e}"))
+}
 
 /// Fetch `url` via `proxy` and return the response body.
 ///
@@ -179,7 +200,52 @@ fn parse_response(buf: &[u8]) -> Result<Outcome> {
     if !(200..300).contains(&status) {
         bail!("HTTP {status}");
     }
-    Ok(Outcome::Body(buf[body_start..].to_vec()))
+    let chunked = resp.headers.iter().any(|header| {
+        header.name.eq_ignore_ascii_case("transfer-encoding")
+            && std::str::from_utf8(header.value).is_ok_and(|value| {
+                value
+                    .split(',')
+                    .any(|v| v.trim().eq_ignore_ascii_case("chunked"))
+            })
+    });
+    let body = if chunked {
+        decode_chunked(&buf[body_start..])?
+    } else {
+        buf[body_start..].to_vec()
+    };
+    Ok(Outcome::Body(body))
+}
+
+fn decode_chunked(mut input: &[u8]) -> Result<Vec<u8>> {
+    let mut body = Vec::new();
+    loop {
+        let line_end = input
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .ok_or_else(|| anyhow!("incomplete chunk-size line"))?;
+        let size_text = std::str::from_utf8(&input[..line_end])
+            .map_err(|e| anyhow!("non-UTF-8 chunk size: {e}"))?;
+        let size =
+            usize::from_str_radix(size_text.split(';').next().unwrap_or_default().trim(), 16)
+                .map_err(|e| anyhow!("invalid chunk size '{size_text}': {e}"))?;
+        input = &input[line_end + 2..];
+
+        if size == 0 {
+            // A zero chunk is followed by optional trailers and a final CRLF.
+            if input == b"\r\n" || input.windows(4).any(|w| w == b"\r\n\r\n") {
+                return Ok(body);
+            }
+            bail!("incomplete chunked response trailers");
+        }
+        if size > MAX_BODY_BYTES.saturating_sub(body.len()) {
+            bail!("response exceeds max body size ({MAX_BODY_BYTES} bytes)");
+        }
+        if input.len() < size + 2 || &input[size..size + 2] != b"\r\n" {
+            bail!("incomplete chunk data");
+        }
+        body.extend_from_slice(&input[..size]);
+        input = &input[size + 2..];
+    }
 }
 
 fn tls_connector() -> tokio_rustls::TlsConnector {
@@ -204,4 +270,24 @@ pub fn first_named_proxy(
     let entry = raw_proxies?.first()?;
     let name = entry.get("name")?.as_str()?;
     proxies.get(name).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_response_decodes_chunked_body_and_extensions() {
+        let response = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4;foo=bar\r\nWiki\r\n5\r\npedia\r\n0\r\nX-Trailer: yes\r\n\r\n";
+        match parse_response(response).unwrap() {
+            Outcome::Body(body) => assert_eq!(body, b"Wikipedia"),
+            Outcome::Redirect(_) => panic!("unexpected redirect"),
+        }
+    }
+
+    #[test]
+    fn parse_response_rejects_truncated_chunk() {
+        let response = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabc";
+        assert!(parse_response(response).is_err());
+    }
 }

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -43,6 +43,19 @@ where
     tokio::task::spawn_blocking(move || tracing::dispatcher::with_default(&dispatch, f)).await
 }
 
+pub(crate) fn parse_optional_socket_addr(
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<SocketAddr>, anyhow::Error> {
+    match value {
+        Some(value) if !value.is_empty() => value
+            .parse()
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("invalid {field} socket address '{value}': {e}")),
+        _ => Ok(None),
+    }
+}
+
 pub struct Config {
     pub general: GeneralConfig,
     pub dns: DnsConfig,
@@ -102,7 +115,7 @@ pub struct NamedListener {
     pub listen: String,
     pub tproxy_sni: bool,
     /// Cap on concurrent in-flight inbound connections for this listener.
-    /// `0` (default) disables the cap. Resolved from the per-listener
+    /// `0` explicitly disables the cap; the default is 256. Resolved from the per-listener
     /// `max-connections` field, falling back to the global `max-connections`.
     #[serde(default)]
     pub max_connections: usize,
@@ -1062,7 +1075,7 @@ fn build_named_listeners(
     let mut result: Vec<NamedListener> = Vec::new();
     let mut used_ports: HashMap<u16, String> = HashMap::new();
     let mut used_names: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let global_max_conns = raw.max_connections.unwrap_or(0);
+    let global_max_conns = raw.max_connections.unwrap_or(256);
 
     let mut add = |name: &str,
                    ltype: ListenerType,
@@ -1318,10 +1331,10 @@ async fn build_config(
             dir
         });
     let api = ApiConfig {
-        external_controller: raw
-            .external_controller
-            .as_deref()
-            .and_then(|s| s.parse().ok()),
+        external_controller: parse_optional_socket_addr(
+            "external-controller",
+            raw.external_controller.as_deref(),
+        )?,
         secret: raw.secret.clone(),
         external_ui,
         external_ui_url: raw
@@ -1772,6 +1785,26 @@ mod load_config_encoding_tests {
                 "BOM-prefixed UTF-8 must not trigger encoding error: {msg}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod socket_address_tests {
+    use super::parse_optional_socket_addr;
+
+    #[test]
+    fn configured_socket_addresses_are_validated() {
+        assert_eq!(
+            parse_optional_socket_addr("dns.listen", Some("127.0.0.1:53")).unwrap(),
+            Some("127.0.0.1:53".parse().unwrap())
+        );
+        assert!(parse_optional_socket_addr("dns.listen", Some("localhost")).is_err());
+        assert!(parse_optional_socket_addr("dns.listen", Some("127.0.0.1:70000")).is_err());
+        assert!(parse_optional_socket_addr("external-controller", Some("[::1]:9090")).is_ok());
+        assert_eq!(
+            parse_optional_socket_addr("dns.listen", None).unwrap(),
+            None
+        );
     }
 }
 

--- a/crates/meow-config/src/proxy_provider.rs
+++ b/crates/meow-config/src/proxy_provider.rs
@@ -132,7 +132,7 @@ impl ProxyProvider {
                 }
                 match req.send().await {
                     Ok(resp) if resp.status().is_success() => {
-                        match resp.text().await {
+                        match crate::internal_http::response_text_with_limit(resp).await {
                             Ok(text) => {
                                 // Cache to disk for offline fallback
                                 if let Some(parent) = cache_path.parent() {

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -127,7 +127,7 @@ pub struct RawConfig {
     pub skip_auth_prefixes: Option<Vec<String>>,
     pub geodata: Option<RawGeoDataConfig>,
     /// Global default cap on concurrent in-flight inbound connections per
-    /// listener. `0` (the default) disables the cap. Individual `listeners:`
+    /// listener. The default is 256; explicit `0` disables the cap. Individual `listeners:`
     /// entries can override this with their own `max-connections` field.
     pub max_connections: Option<usize>,
 }

--- a/crates/meow-config/src/subscription.rs
+++ b/crates/meow-config/src/subscription.rs
@@ -17,7 +17,7 @@ pub async fn fetch_subscription(url: &str) -> Result<SubscriptionData, anyhow::E
         .build()?;
     let resp = client.get(url).send().await?;
     let status = resp.status();
-    let text = resp.text().await?;
+    let text = crate::internal_http::response_text_with_limit(resp).await?;
     if !status.is_success() {
         return Err(anyhow::anyhow!(
             "HTTP {}: {}",

--- a/crates/meow-dns/src/cache.rs
+++ b/crates/meow-dns/src/cache.rs
@@ -22,6 +22,7 @@ use lru::LruCache;
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use smol_str::SmolStr;
+use std::borrow::Cow;
 use std::net::IpAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -124,10 +125,11 @@ impl DnsCache {
     }
 
     pub fn get(&self, domain: &str) -> Option<IpList> {
-        let shard = &self.cache[shard_str(domain)];
+        let domain = normalize_domain(domain);
+        let shard = &self.cache[shard_str(&domain)];
         let mut cache = shard.lock();
         let mut expired = false;
-        if let Some(entry) = cache.get(domain) {
+        if let Some(entry) = cache.get(domain.as_ref()) {
             if entry.expire_at > Instant::now() {
                 return Some(SmallVec::from_slice(&entry.ips));
             }
@@ -135,7 +137,7 @@ impl DnsCache {
             expired = true;
         }
         if expired {
-            cache.pop(domain);
+            cache.pop(domain.as_ref());
         }
         None
     }
@@ -161,11 +163,8 @@ impl DnsCache {
         // until the inbound connection that uses the IP can recover its host
         // for rule matching, even when the DNS TTL is short (10s clamp).
         let reverse_expire_at = now + ttl.max(REVERSE_TTL_FLOOR);
-        let key: Arc<str> = if domain.bytes().any(|b| b.is_ascii_uppercase()) {
-            Arc::from(domain.to_ascii_lowercase().as_str())
-        } else {
-            Arc::from(domain)
-        };
+        let domain = normalize_domain(domain);
+        let key: Arc<str> = Arc::from(domain.as_ref());
 
         // One reverse-shard lock per unique shard; common case is N=2-4 IPs
         // so we just take each shard's lock per insert. For larger N we
@@ -187,7 +186,7 @@ impl DnsCache {
             expire_at,
             source: source.map(Arc::from),
         };
-        self.cache[shard_str(domain)].lock().put(key, entry);
+        self.cache[shard_str(&domain)].lock().put(key, entry);
     }
 
     /// Reverse lookup: given an IP, return the domain that resolved to it.
@@ -263,6 +262,14 @@ impl DnsCache {
     }
 }
 
+fn normalize_domain(domain: &str) -> Cow<'_, str> {
+    if domain.bytes().any(|b| b.is_ascii_uppercase()) {
+        Cow::Owned(domain.to_ascii_lowercase())
+    } else {
+        Cow::Borrowed(domain)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,6 +304,16 @@ mod tests {
         c.put("a.example", &ips, Duration::from_secs(30));
         assert_eq!(c.get("a.example").as_deref(), Some(&ips[..]));
         assert!(c.get("nope.example").is_none());
+    }
+
+    #[test]
+    fn cache_keys_are_ascii_case_insensitive() {
+        let c = DnsCache::new(64);
+        let ip = ipv4(1, 2, 3, 4);
+        c.put("GitHub.COM", &[ip], Duration::from_secs(30));
+        assert_eq!(c.get("github.com").as_deref(), Some(&[ip][..]));
+        assert_eq!(c.get("GITHUB.com").as_deref(), Some(&[ip][..]));
+        assert_eq!(c.reverse_lookup(ip).as_deref(), Some("github.com"));
     }
 
     #[test]

--- a/crates/meow-dns/src/cache.rs
+++ b/crates/meow-dns/src/cache.rs
@@ -194,12 +194,9 @@ impl DnsCache {
         let shard = &self.reverse[shard_ip(ip)];
         let mut reverse = shard.lock();
         let now = Instant::now();
-        if let Some(entry) = reverse.get(&ip) {
-            if entry.expire_at > now {
-                return Some(SmolStr::from(entry.domain.as_ref()));
-            }
-        } else {
-            return None;
+        let entry = reverse.get(&ip)?;
+        if entry.expire_at > now {
+            return Some(SmolStr::from(entry.domain.as_ref()));
         }
         reverse.pop(&ip);
         None

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -597,10 +597,10 @@ impl Resolver {
         let main_urls: Vec<NameServerUrl> = main_urls.into_iter().map(|e| e.url).collect();
         let fallback_urls: Vec<NameServerUrl> = fallback_urls.into_iter().map(|e| e.url).collect();
         let default_ns: Vec<NameServerUrl> = default_ns.into_iter().map(|e| e.url).collect();
-        // Step 1: Validate default_ns — encrypted entries are only allowed
-        // when they use IP literals (no bootstrap loop).
+        // Step 1: default nameservers are themselves the bootstrap roots, so
+        // every entry must use an IP literal regardless of transport.
         for ns in &default_ns {
-            if !ns.is_plain() && ns.needs_bootstrap().is_some() {
+            if ns.needs_bootstrap().is_some() {
                 return Err(BootstrapError::DefaultNameserverNotPlain {
                     entry: ns.to_string(),
                 });
@@ -1426,6 +1426,28 @@ mod tests {
             matches!(err, BootstrapError::DefaultNameserverNotPlain { .. }),
             "expected DefaultNameserverNotPlain, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_rejects_plain_hostname_default_ns() {
+        let default_ns = vec![NameServerUrl::parse("dns.google").unwrap()];
+        let err = Resolver::new_with_bootstrap(
+            vec![NameServerUrl::parse("tls://cloudflare-dns.com").unwrap()],
+            vec![],
+            default_ns,
+            DnsMode::Normal,
+            DomainTrie::new(),
+            true,
+            None,
+            None,
+        )
+        .await
+        .err()
+        .expect("expected error");
+        assert!(matches!(
+            err,
+            BootstrapError::DefaultNameserverNotPlain { .. }
+        ));
     }
 
     // B5b: Tls IP-literal in default_ns → accepted (no bootstrap loop).

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -58,22 +58,31 @@ async fn handle_http_inner(
     const MAX_HEADERS: usize = 8192;
     let mut request_buf = Vec::with_capacity(4096);
     let mut chunk = [0u8; CHUNK];
-    let header_end = loop {
-        let n = stream.read(&mut chunk).await?;
-        if n == 0 {
-            return Err("connection closed before headers complete".into());
-        }
-        // Overlap the previous tail by 3 bytes so a marker straddling two
-        // reads (e.g. "\r\n\r" then "\n…") is still detected.
-        let search_start = request_buf.len().saturating_sub(3);
-        request_buf.extend_from_slice(&chunk[..n]);
-        if let Some(rel) = find_crlf_crlf(&request_buf[search_start..]) {
-            break search_start + rel + 4;
-        }
-        if request_buf.len() > MAX_HEADERS {
-            return Err("request headers too large".into());
+    let read_headers = async {
+        loop {
+            let n = stream.read(&mut chunk).await?;
+            if n == 0 {
+                return Err::<usize, Box<dyn std::error::Error + Send + Sync>>(
+                    "connection closed before headers complete".into(),
+                );
+            }
+            // Overlap the previous tail by 3 bytes so a marker straddling two
+            // reads (e.g. "\r\n\r" then "\n…") is still detected.
+            let search_start = request_buf.len().saturating_sub(3);
+            request_buf.extend_from_slice(&chunk[..n]);
+            if let Some(rel) = find_crlf_crlf(&request_buf[search_start..]) {
+                return Ok(search_start + rel + 4);
+            }
+            if request_buf.len() > MAX_HEADERS {
+                return Err::<usize, Box<dyn std::error::Error + Send + Sync>>(
+                    "request headers too large".into(),
+                );
+            }
         }
     };
+    let header_end = tokio::time::timeout(crate::mixed::DEFAULT_HANDSHAKE_TIMEOUT, read_headers)
+        .await
+        .map_err(|_| "HTTP proxy handshake timed out")??;
     let leftover: Vec<u8> = request_buf[header_end..].to_vec();
     request_buf.truncate(header_end);
 
@@ -163,7 +172,9 @@ async fn handle_http_inner(
 
         // Hand off to tunnel
         let inner = tunnel.inner();
-        let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy(&metadata) else {
+        inner.pre_handle_metadata(&mut metadata);
+        let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy_lazy(&mut metadata).await
+        else {
             return Err("no matching rule".into());
         };
 
@@ -247,7 +258,9 @@ async fn handle_http_inner(
         debug!("HTTP {} to {}:{}", method, host, port);
 
         let inner = tunnel.inner();
-        let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy(&metadata) else {
+        inner.pre_handle_metadata(&mut metadata);
+        let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy_lazy(&mut metadata).await
+        else {
             stream
                 .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
                 .await?;

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -80,7 +80,7 @@ async fn handle_http_inner(
             }
         }
     };
-    let header_end = tokio::time::timeout(crate::mixed::DEFAULT_HANDSHAKE_TIMEOUT, read_headers)
+    let header_end = tokio::time::timeout(crate::DEFAULT_HANDSHAKE_TIMEOUT, read_headers)
         .await
         .map_err(|_| "HTTP proxy handshake timed out")??;
     let leftover: Vec<u8> = request_buf[header_end..].to_vec();

--- a/crates/meow-listener/src/lib.rs
+++ b/crates/meow-listener/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod sniffer;
 
+pub const DEFAULT_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 #[cfg(feature = "listener-http")]
 pub mod http_proxy;
 #[cfg(feature = "listener-mixed")]

--- a/crates/meow-listener/src/mixed.rs
+++ b/crates/meow-listener/src/mixed.rs
@@ -5,7 +5,6 @@ use meow_common::AuthConfig;
 use meow_tunnel::Tunnel;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
@@ -17,7 +16,6 @@ use tracing::{debug, error, info, warn};
 /// VLESS+WS+TLS+ECH tunnel costs ~90 KB of userland memory, so a cap of 256
 /// holds RSS to ~50 MB on top of an ~18 MB idle baseline.
 pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
-pub const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub struct MixedListener {
     tunnel: Tunnel,
@@ -145,7 +143,7 @@ async fn handle_connection(
 ) {
     // Peek the first byte to determine protocol
     let mut peek = [0u8; 1];
-    match tokio::time::timeout(DEFAULT_HANDSHAKE_TIMEOUT, stream.peek(&mut peek)).await {
+    match tokio::time::timeout(crate::DEFAULT_HANDSHAKE_TIMEOUT, stream.peek(&mut peek)).await {
         Err(_) => {
             debug!("Protocol detection timed out for {src_addr}");
             return;

--- a/crates/meow-listener/src/mixed.rs
+++ b/crates/meow-listener/src/mixed.rs
@@ -5,18 +5,19 @@ use meow_common::AuthConfig;
 use meow_tunnel::Tunnel;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
 /// Default cap on in-flight inbound connections per listener.
-/// `0` means no cap — the listener accepts as many concurrent connections as
-/// the kernel and tokio runtime can hold. Set a positive value (via the
+/// `0` explicitly disables the cap. Set a positive value (via the
 /// `max-connections` config key, top-level or per-listener) to back-pressure
 /// the TCP listen queue and bound RSS under burst load: each live
 /// VLESS+WS+TLS+ECH tunnel costs ~90 KB of userland memory, so a cap of 256
 /// holds RSS to ~50 MB on top of an ~18 MB idle baseline.
-pub const DEFAULT_MAX_CONNECTIONS: usize = 0;
+pub const DEFAULT_MAX_CONNECTIONS: usize = 256;
+pub const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub struct MixedListener {
     tunnel: Tunnel,
@@ -144,10 +145,14 @@ async fn handle_connection(
 ) {
     // Peek the first byte to determine protocol
     let mut peek = [0u8; 1];
-    match stream.peek(&mut peek).await {
-        Ok(0) => return,
-        Ok(_) => {}
-        Err(e) => {
+    match tokio::time::timeout(DEFAULT_HANDSHAKE_TIMEOUT, stream.peek(&mut peek)).await {
+        Err(_) => {
+            debug!("Protocol detection timed out for {src_addr}");
+            return;
+        }
+        Ok(Ok(0)) => return,
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
             debug!("Peek error: {}", e);
             return;
         }

--- a/crates/meow-listener/src/socks5.rs
+++ b/crates/meow-listener/src/socks5.rs
@@ -40,12 +40,22 @@ pub async fn handle_socks5(
     .await
     {
         Ok(PostHandshake::Done) => {}
-        Ok(PostHandshake::UdpAssociate) => {
+        Ok(PostHandshake::UdpAssociate {
+            requested_ip,
+            requested_port,
+        }) => {
             // The handshake (auth + request) is consumed; the control conn is
             // now ours for the association's lifetime.
-            if let Err(e) =
-                crate::socks5_udp::handle_udp_associate(tunnel, stream, src_addr, in_name, in_port)
-                    .await
+            if let Err(e) = crate::socks5_udp::handle_udp_associate(
+                tunnel,
+                stream,
+                src_addr,
+                requested_ip,
+                requested_port,
+                in_name,
+                in_port,
+            )
+            .await
             {
                 debug!("SOCKS5 UDP ASSOCIATE error from {}: {}", src_addr, e);
             }
@@ -59,7 +69,10 @@ pub async fn handle_socks5(
 /// the UDP relay.
 enum PostHandshake {
     Done,
-    UdpAssociate,
+    UdpAssociate {
+        requested_ip: Option<IpAddr>,
+        requested_port: u16,
+    },
 }
 
 async fn handle_socks5_inner(
@@ -71,15 +84,16 @@ async fn handle_socks5_inner(
     in_name: &str,
     in_port: u16,
 ) -> Result<PostHandshake, Box<dyn std::error::Error + Send + Sync>> {
+    let deadline = tokio::time::Instant::now() + crate::mixed::DEFAULT_HANDSHAKE_TIMEOUT;
     // 1. Version/method negotiation
     let mut header = [0u8; 2];
-    stream.read_exact(&mut header).await?;
+    read_exact_before(stream, &mut header, deadline).await?;
     if header[0] != SOCKS5_VERSION {
         return Err("invalid SOCKS version".into());
     }
     let nmethods = header[1] as usize;
     let mut methods_buf = [0u8; 255];
-    stream.read_exact(&mut methods_buf[..nmethods]).await?;
+    read_exact_before(stream, &mut methods_buf[..nmethods], deadline).await?;
     let methods = &methods_buf[..nmethods];
 
     let in_user: Option<String> = if let Some(auth) = auth
@@ -96,7 +110,7 @@ async fn handle_socks5_inner(
 
         // RFC 1929 sub-negotiation: [0x01, ulen, user..., plen, pass...]
         let mut sub_ver = [0u8; 1];
-        stream.read_exact(&mut sub_ver).await?;
+        read_exact_before(stream, &mut sub_ver, deadline).await?;
         if sub_ver[0] != 0x01 {
             return Err("invalid auth sub-negotiation version".into());
         }
@@ -104,13 +118,13 @@ async fn handle_socks5_inner(
         // copied to the heap after a successful verify (audit #182 — the
         // failure/empty path previously allocated two Strings regardless).
         let mut ulen = [0u8; 1];
-        stream.read_exact(&mut ulen).await?;
+        read_exact_before(stream, &mut ulen, deadline).await?;
         let mut user_buf = [0u8; 255];
-        stream.read_exact(&mut user_buf[..ulen[0] as usize]).await?;
+        read_exact_before(stream, &mut user_buf[..ulen[0] as usize], deadline).await?;
         let mut plen = [0u8; 1];
-        stream.read_exact(&mut plen).await?;
+        read_exact_before(stream, &mut plen, deadline).await?;
         let mut pass_buf = [0u8; 255];
-        stream.read_exact(&mut pass_buf[..plen[0] as usize]).await?;
+        read_exact_before(stream, &mut pass_buf[..plen[0] as usize], deadline).await?;
         let Ok(username) = std::str::from_utf8(&user_buf[..ulen[0] as usize]) else {
             stream.write_all(&[0x01, 0x01]).await?;
             return Err("invalid SOCKS5 username encoding".into());
@@ -139,7 +153,7 @@ async fn handle_socks5_inner(
 
     // 2. Request
     let mut req = [0u8; 4];
-    stream.read_exact(&mut req).await?;
+    read_exact_before(stream, &mut req, deadline).await?;
     if req[0] != SOCKS5_VERSION {
         return Err("invalid SOCKS version in request".into());
     }
@@ -147,13 +161,15 @@ async fn handle_socks5_inner(
     let cmd = req[1];
     let atyp = req[3];
 
-    // Parse address (for UDP ASSOCIATE this is the client's advertised source,
-    // which we ignore — the relay learns the real source from the first packet).
-    let (host, dst_ip, dst_port) = parse_socks5_address(stream, atyp).await?;
+    // Parse address (for UDP ASSOCIATE this is the client's advertised source).
+    let (host, dst_ip, dst_port) = parse_socks5_address(stream, atyp, deadline).await?;
 
     if cmd == CMD_UDP_ASSOCIATE {
         // Hand the control connection to the UDP relay; it writes its own reply.
-        return Ok(PostHandshake::UdpAssociate);
+        return Ok(PostHandshake::UdpAssociate {
+            requested_ip: dst_ip,
+            requested_port: dst_port,
+        });
     }
 
     if cmd != CMD_CONNECT {
@@ -263,25 +279,26 @@ async fn handle_socks5_inner(
 async fn parse_socks5_address(
     stream: &mut TcpStream,
     atyp: u8,
+    deadline: tokio::time::Instant,
 ) -> Result<(String, Option<IpAddr>, u16), Box<dyn std::error::Error + Send + Sync>> {
     match atyp {
         ATYP_IPV4 => {
             let mut addr = [0u8; 4];
-            stream.read_exact(&mut addr).await?;
+            read_exact_before(stream, &mut addr, deadline).await?;
             let mut port_buf = [0u8; 2];
-            stream.read_exact(&mut port_buf).await?;
+            read_exact_before(stream, &mut port_buf, deadline).await?;
             let ip = IpAddr::V4(Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]));
             let port = u16::from_be_bytes(port_buf);
             Ok((String::new(), Some(ip), port))
         }
         ATYP_DOMAIN => {
             let mut len = [0u8; 1];
-            stream.read_exact(&mut len).await?;
+            read_exact_before(stream, &mut len, deadline).await?;
             let dlen = len[0] as usize;
             let mut domain_buf = [0u8; 255];
-            stream.read_exact(&mut domain_buf[..dlen]).await?;
+            read_exact_before(stream, &mut domain_buf[..dlen], deadline).await?;
             let mut port_buf = [0u8; 2];
-            stream.read_exact(&mut port_buf).await?;
+            read_exact_before(stream, &mut port_buf, deadline).await?;
             let host = std::str::from_utf8(&domain_buf[..dlen])
                 .map_err(|_| "invalid domain name encoding")?
                 .to_string();
@@ -290,13 +307,24 @@ async fn parse_socks5_address(
         }
         ATYP_IPV6 => {
             let mut addr = [0u8; 16];
-            stream.read_exact(&mut addr).await?;
+            read_exact_before(stream, &mut addr, deadline).await?;
             let mut port_buf = [0u8; 2];
-            stream.read_exact(&mut port_buf).await?;
+            read_exact_before(stream, &mut port_buf, deadline).await?;
             let ip = IpAddr::V6(Ipv6Addr::from(addr));
             let port = u16::from_be_bytes(port_buf);
             Ok((String::new(), Some(ip), port))
         }
         _ => Err(format!("unsupported address type: {atyp}").into()),
     }
+}
+
+async fn read_exact_before(
+    stream: &mut TcpStream,
+    buf: &mut [u8],
+    deadline: tokio::time::Instant,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tokio::time::timeout_at(deadline, stream.read_exact(buf))
+        .await
+        .map_err(|_| "SOCKS5 handshake timed out")??;
+    Ok(())
 }

--- a/crates/meow-listener/src/socks5.rs
+++ b/crates/meow-listener/src/socks5.rs
@@ -84,7 +84,7 @@ async fn handle_socks5_inner(
     in_name: &str,
     in_port: u16,
 ) -> Result<PostHandshake, Box<dyn std::error::Error + Send + Sync>> {
-    let deadline = tokio::time::Instant::now() + crate::mixed::DEFAULT_HANDSHAKE_TIMEOUT;
+    let deadline = tokio::time::Instant::now() + crate::DEFAULT_HANDSHAKE_TIMEOUT;
     // 1. Version/method negotiation
     let mut header = [0u8; 2];
     read_exact_before(stream, &mut header, deadline).await?;

--- a/crates/meow-listener/src/socks5_udp.rs
+++ b/crates/meow-listener/src/socks5_udp.rs
@@ -16,7 +16,9 @@
 use std::collections::HashMap;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
 use meow_common::{ConnType, Metadata, Network, ProxyAdapter, ProxyPacketConn};
 use meow_tunnel::Tunnel;
@@ -32,12 +34,19 @@ const RESERVED: u8 = 0x00;
 const ATYP_IPV4: u8 = 0x01;
 const ATYP_DOMAIN: u8 = 0x03;
 const ATYP_IPV6: u8 = 0x04;
+const NAT_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Per-destination outbound session within one association.
 struct Session {
     conn: Arc<dyn ProxyPacketConn>,
+    last_activity_ms: Arc<AtomicU64>,
     /// Reply task (server→client); aborted when the session is dropped.
     reply_task: tokio::task::AbortHandle,
+}
+
+fn monotonic_ms() -> u64 {
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_millis() as u64
 }
 
 impl Drop for Session {
@@ -47,12 +56,15 @@ impl Drop for Session {
 }
 
 /// Handle a SOCKS5 UDP ASSOCIATE request. `control` is the TCP control
-/// connection (request already consumed by the caller); the advertised
-/// DST.ADDR/PORT is ignored per common practice (clients send `0.0.0.0:0`).
+/// connection (request already consumed by the caller). An advertised source
+/// endpoint is honored when compatible with the authenticated TCP peer;
+/// otherwise the first valid UDP datagram locks the association endpoint.
 pub async fn handle_udp_associate(
     tunnel: &Tunnel,
     mut control: TcpStream,
     src_addr: SocketAddr,
+    requested_ip: Option<IpAddr>,
+    requested_port: u16,
     in_name: &str,
     in_port: u16,
 ) -> io::Result<()> {
@@ -68,6 +80,14 @@ pub async fn handle_udp_associate(
     let mut nat: HashMap<SocketAddr, Session> = HashMap::new();
     let mut buf = vec![0u8; 65535];
     let mut ctrl_buf = [0u8; 16];
+    let requested_ip = requested_ip.filter(|ip| !ip.is_unspecified());
+    let mut client_endpoint = match (requested_ip, requested_port) {
+        (Some(ip), port) if ip == src_addr.ip() && port != 0 => Some(SocketAddr::new(ip, port)),
+        (None, port) if port != 0 => Some(SocketAddr::new(src_addr.ip(), port)),
+        _ => None,
+    };
+    let mut sweeper = tokio::time::interval(NAT_SWEEP_INTERVAL);
+    sweeper.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
         tokio::select! {
@@ -83,11 +103,37 @@ pub async fn handle_udp_associate(
                     Ok(v) => v,
                     Err(e) => { debug!("SOCKS5 UDP recv error: {e}"); continue; }
                 };
+                if client.ip() != src_addr.ip() {
+                    debug!("SOCKS5 UDP ignoring source {client}: TCP peer is {src_addr}");
+                    continue;
+                }
+                match client_endpoint {
+                    Some(expected) if client != expected => {
+                        debug!("SOCKS5 UDP ignoring source {client}: association is bound to {expected}");
+                        continue;
+                    }
+                    None => {
+                        // Do not let a malformed packet claim the association.
+                        if let Err(e) = parse_udp_request(&buf[..n]) {
+                            debug!("SOCKS5 UDP datagram from {client}: {e}");
+                            continue;
+                        }
+                        client_endpoint = Some(client);
+                    }
+                    Some(_) => {}
+                }
                 if let Err(e) =
                     handle_client_datagram(tunnel, &relay, &mut nat, &buf[..n], client, in_name, in_port).await
                 {
                     debug!("SOCKS5 UDP datagram from {client}: {e}");
                 }
+            }
+            _ = sweeper.tick() => {
+                let now = monotonic_ms();
+                let idle_ms = meow_tunnel::udp::DEFAULT_UDP_IDLE.as_millis() as u64;
+                nat.retain(|_, session| {
+                    now.saturating_sub(session.last_activity_ms.load(Ordering::Relaxed)) < idle_ms
+                });
             }
         }
     }
@@ -131,6 +177,9 @@ async fn handle_client_datagram(
     // a resolved dst_ip for its session bookkeeping regardless of what the
     // rules demand.
     inner.pre_resolve(&mut metadata).await;
+    if metadata.dst_ip.is_none() && !metadata.host.is_empty() {
+        metadata.dst_ip = inner.resolver.resolve_ip_real(&metadata.host).await;
+    }
 
     let Some(dst_ip) = metadata.dst_ip else {
         return Err(format!(
@@ -148,6 +197,9 @@ async fn handle_client_datagram(
             .write_packet(payload, &dst_addr)
             .await
             .map_err(|e| format!("udp write {dst_addr}: {e}"))?;
+        session
+            .last_activity_ms
+            .store(monotonic_ms(), Ordering::Relaxed);
         return Ok(());
     }
 
@@ -181,9 +233,11 @@ async fn handle_client_datagram(
 
     // Reply task: server→client. Wraps each datagram in the SOCKS5 UDP header
     // and sends it back to the client's UDP source address.
+    let last_activity_ms = Arc::new(AtomicU64::new(monotonic_ms()));
     let reply_task = {
         let relay = Arc::clone(relay);
         let conn = Arc::clone(&conn);
+        let last_activity_ms = Arc::clone(&last_activity_ms);
         tokio::spawn(async move {
             let mut rbuf = vec![0u8; 65535];
             while let Ok((m, src)) = conn.read_packet(&mut rbuf).await {
@@ -193,12 +247,20 @@ async fn handle_client_datagram(
                 if relay.send_to(&out, client).await.is_err() {
                     break;
                 }
+                last_activity_ms.store(monotonic_ms(), Ordering::Relaxed);
             }
         })
         .abort_handle()
     };
 
-    nat.insert(dst_addr, Session { conn, reply_task });
+    nat.insert(
+        dst_addr,
+        Session {
+            conn,
+            last_activity_ms,
+            reply_task,
+        },
+    );
     Ok(())
 }
 

--- a/crates/meow-proxy/src/health.rs
+++ b/crates/meow-proxy/src/health.rs
@@ -345,10 +345,8 @@ impl ParsedUrl {
     fn parse(url: &str) -> Option<Self> {
         let (https, rest) = if let Some(r) = url.strip_prefix("https://") {
             (true, r)
-        } else if let Some(r) = url.strip_prefix("http://") {
-            (false, r)
         } else {
-            return None;
+            (false, url.strip_prefix("http://")?)
         };
         let (authority, path) = match rest.find('/') {
             Some(i) => (&rest[..i], &rest[i..]),

--- a/crates/meow-rules/src/rule_set.rs
+++ b/crates/meow-rules/src/rule_set.rs
@@ -73,6 +73,12 @@ pub trait RuleSet: Send + Sync {
     fn behavior(&self) -> RuleSetBehavior;
     fn matches(&self, metadata: &Metadata, helper: &RuleMatchHelper) -> bool;
     fn len(&self) -> usize;
+    fn should_resolve_ip(&self) -> bool {
+        false
+    }
+    fn should_find_process(&self) -> bool {
+        false
+    }
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -363,6 +369,10 @@ impl RuleSet for IpCidrRuleSet {
     fn len(&self) -> usize {
         self.count
     }
+
+    fn should_resolve_ip(&self) -> bool {
+        true
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -409,6 +419,14 @@ impl RuleSet for ClassicalRuleSet {
 
     fn len(&self) -> usize {
         self.rules.len()
+    }
+
+    fn should_resolve_ip(&self) -> bool {
+        self.rules.iter().any(|rule| rule.should_resolve_ip())
+    }
+
+    fn should_find_process(&self) -> bool {
+        self.rules.iter().any(|rule| rule.should_find_process())
     }
 }
 
@@ -520,6 +538,20 @@ mod tests {
         assert!(set.matches(&meta_host("mail.google.com"), &helper()));
         assert!(set.matches(&meta_ip("10.1.2.3"), &helper()));
         assert!(!set.matches(&meta_host("example.org"), &helper()));
+    }
+
+    #[test]
+    fn classical_rule_set_propagates_metadata_demands() {
+        let ctx = ParserContext::empty();
+        let set = ClassicalRuleSet::from_entries(
+            &[
+                "IP-CIDR,10.0.0.0/8".to_string(),
+                "PROCESS-NAME,curl".to_string(),
+            ],
+            &ctx,
+        );
+        assert!(set.should_resolve_ip());
+        assert!(set.should_find_process());
     }
 
     #[test]

--- a/crates/meow-rules/src/rule_set_rule.rs
+++ b/crates/meow-rules/src/rule_set_rule.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType};
 
-use crate::rule_set::{RuleSet, RuleSetBehavior};
+use crate::rule_set::RuleSet;
 
 /// A `RULE-SET,<name>,<adapter>[,no-resolve]` rule — a thin wrapper that
 /// delegates matching to an `Arc<dyn RuleSet>` loaded by the rule-provider
@@ -47,8 +47,11 @@ impl Rule for RuleSetRule {
     }
 
     fn should_resolve_ip(&self) -> bool {
-        // Only ipcidr sets need DNS resolution for rule matching.
-        matches!(self.set.behavior(), RuleSetBehavior::IpCidr) && !self.no_resolve
+        self.set.should_resolve_ip() && !self.no_resolve
+    }
+
+    fn should_find_process(&self) -> bool {
+        self.set.should_find_process()
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/crates/meow-tunnel/src/relay.rs
+++ b/crates/meow-tunnel/src/relay.rs
@@ -56,6 +56,7 @@ struct HalfCopy<'buf> {
     pos: usize,
     cap: usize,
     amt: u64,
+    need_flush: bool,
 }
 
 impl<'buf> HalfCopy<'buf> {
@@ -66,6 +67,7 @@ impl<'buf> HalfCopy<'buf> {
             pos: 0,
             cap: 0,
             amt: 0,
+            need_flush: false,
         }
     }
 
@@ -94,7 +96,13 @@ impl<'buf> HalfCopy<'buf> {
                         }
                     }
                     Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                    Poll::Pending => return Poll::Pending,
+                    Poll::Pending => {
+                        if self.need_flush {
+                            ready!(writer.as_mut().poll_flush(cx))?;
+                            self.need_flush = false;
+                        }
+                        return Poll::Pending;
+                    }
                 }
             }
 
@@ -111,6 +119,7 @@ impl<'buf> HalfCopy<'buf> {
                     Poll::Ready(Ok(n)) => {
                         self.pos += n;
                         self.amt += n as u64;
+                        self.need_flush = true;
                     }
                     Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                     Poll::Pending => return Poll::Pending,

--- a/crates/meow-tunnel/src/udp.rs
+++ b/crates/meow-tunnel/src/udp.rs
@@ -126,6 +126,13 @@ pub async fn handle_udp(
     // the rules demand.
     tunnel.pre_resolve(&mut metadata).await;
 
+    // Rule-demand gating is only an optimization. UDP still requires a real
+    // address for its NAT key and outbound packet API, including after a
+    // fake-IP was rewritten back to a hostname under domain-only rules.
+    if metadata.dst_ip.is_none() && !metadata.host.is_empty() {
+        metadata.dst_ip = tunnel.resolver.resolve_ip_real(&metadata.host).await;
+    }
+
     // Build destination SocketAddr for the NAT key.
     // pre_resolve() populates dst_ip for any hostname; if it is still None
     // after that (resolution failure or unresolvable host), we cannot track


### PR DESCRIPTION
## Summary

- make API config mutations transactional and serialized so rejected or concurrent updates cannot diverge raw and runtime state
- harden inbound HTTP/SOCKS5 handling with bounded handshakes, correct metadata enrichment, and source-bound/idle-evicted SOCKS5 UDP sessions
- fix HTTP chunk decoding and response-size limits for subscription and provider downloads
- fix DNS cache normalization, bootstrap/config address validation, fake-IP UDP resolution, classical rule-set enrichment, and relay flushing
- update `anyhow` past RUSTSEC-2026-0190 and align project metadata/docs on the intended MIT license

## Impact

This removes several authentication-boundary, resource-exhaustion, stale-state, panic, cache-corruption, and routing-correctness failure modes reported in the open issue queue.

## Validation

- `cargo test --workspace --lib`
- `cargo test -p meow-api --test api_test` (95 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Docker, real-node, and externally dependent integration tests were not run.

Closes #271
Closes #272
Closes #273
Closes #274
Closes #275
Closes #276
Closes #280
Closes #281
Closes #282
Closes #302
Closes #303
Closes #304
Closes #305
Closes #306
Closes #307
Closes #311
Closes #312
