### PR TITLE
fix(proxy): VLESS/Snell UDP-over-TCP half-duplex stall (#278)

### DIFF
--- a/crates/meow-proxy/src/snell/protocol.rs
+++ b/crates/meow-proxy/src/snell/protocol.rs
@@ -140,6 +140,17 @@ impl<S: AsyncRead + AsyncWrite + Unpin> SnellInner<S> {
     }
 }
 
+/// Cross-poll state for [`Snell::poll_write_packet_frame`]. One instance per
+/// datagram write; the caller keeps it alive across `Poll::Pending` returns
+/// because the stream lock (and thus `&mut Snell`) is released between polls.
+#[derive(Default)]
+pub struct PacketFrameProgress {
+    /// v4: the frame has been staged into the writer's pending buffer.
+    staged: bool,
+    /// v3: bytes of `frame` already accepted by the AEAD stream.
+    written: usize,
+}
+
 /// AEAD-wrapped stream with snell request/response semantics.
 ///
 /// On the first `poll_read`, the wrapper consumes the server's status byte
@@ -231,6 +242,65 @@ impl<S> Snell<S> {
             }
         }
         Ok(buf.len())
+    }
+
+    /// Poll-based equivalent of [`Snell::write_packet_frame`] for callers
+    /// that must not hold a lock across an `.await` (issue #278): the UDP
+    /// packet conn locks the shared stream only for the duration of each
+    /// poll, so `progress` carries the write state between polls.
+    ///
+    /// v4 stages `frame` as a single AEAD packet frame and drains it; v3
+    /// writes through the regular AEAD stream. Both flush before returning
+    /// `Ready(Ok(()))`.
+    pub fn poll_write_packet_frame(
+        &mut self,
+        cx: &mut Context<'_>,
+        frame: &[u8],
+        progress: &mut PacketFrameProgress,
+    ) -> Poll<io::Result<()>>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        if frame.len() > MAX_PAYLOAD_LENGTH {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snell: packet frame too large",
+            )));
+        }
+        match &mut self.inner {
+            SnellInner::V3(conn) => {
+                while progress.written < frame.len() {
+                    match Pin::new(&mut *conn).poll_write(cx, &frame[progress.written..]) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Ready(Ok(0)) => {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::WriteZero,
+                                "snell v3: packet frame write returned 0",
+                            )));
+                        }
+                        Poll::Ready(Ok(n)) => progress.written += n,
+                    }
+                }
+                Pin::new(conn).poll_flush(cx)
+            }
+            SnellInner::V4(conn) => {
+                if !progress.staged {
+                    conn.stage_packet_frame(frame)?;
+                    progress.staged = true;
+                }
+                if conn.has_pending_write() {
+                    // poll_flush drains the staged frame and flushes the
+                    // underlying stream.
+                    match Pin::new(&mut *conn).poll_flush(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Ready(Ok(())) => {}
+                    }
+                }
+                Poll::Ready(Ok(()))
+            }
+        }
     }
 
     /// Read from the raw version-specific codec without the status-byte

--- a/crates/meow-proxy/src/snell/udp.rs
+++ b/crates/meow-proxy/src/snell/udp.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use meow_common::{MeowError, ProxyPacketConn, Result};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
 
 use super::protocol::{Snell, COMMAND_UDP_FORWARD};
@@ -49,19 +49,13 @@ fn build_request_frame(addr: &SocketAddr, payload: &[u8]) -> Vec<u8> {
 
 /// Parse a server-to-client snell UDP response frame, writing the payload
 /// into `out` and returning (bytes copied, source address).
-async fn read_response_frame<R: AsyncRead + Unpin>(
-    reader: &mut R,
-    out: &mut [u8],
-) -> io::Result<(usize, SocketAddr)> {
-    let mut frame = vec![0u8; super::v4::MAX_PAYLOAD_LENGTH];
-    let n = reader.read(&mut frame).await?;
-    if n < 1 {
+fn parse_response_frame(frame: &[u8], out: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+    if frame.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
             "snell udp: empty response frame",
         ));
     }
-    frame.truncate(n);
 
     let (addr, payload_start) = match frame[0] {
         0x04 => {
@@ -110,17 +104,29 @@ async fn read_response_frame<R: AsyncRead + Unpin>(
 }
 
 /// Per-connection snell UDP relay. Multiplexes datagrams over a single AEAD
-/// stream guarded by a `Mutex`. The lock is held only during one
-/// frame-sized read or write, so reads and writes serialise but never block
-/// each other for long.
+/// stream.
+///
+/// The AEAD codec keeps its read and write cipher states in one object over
+/// one TCP stream, so a `tokio::io::split`-style structural split is not
+/// possible. Instead the stream sits behind a synchronous mutex that is
+/// locked **per poll** (the same mechanism `tokio::io::split` uses
+/// internally): a `read_packet` parked waiting for a server datagram holds
+/// nothing between polls, so `write_packet` on the same conn proceeds freely
+/// (issue #278). The `read_gate`/`write_gate` async mutexes serialise whole
+/// datagrams within each direction so concurrent callers cannot interleave
+/// partial frames.
 pub struct SnellPacketConn<S> {
-    inner: Arc<Mutex<Snell<S>>>,
+    stream: Arc<parking_lot::Mutex<Snell<S>>>,
+    read_gate: Mutex<()>,
+    write_gate: Mutex<()>,
 }
 
 impl<S> SnellPacketConn<S> {
     pub fn new(snell: Snell<S>) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(snell)),
+            stream: Arc::new(parking_lot::Mutex::new(snell)),
+            read_gate: Mutex::new(()),
+            write_gate: Mutex::new(()),
         }
     }
 }
@@ -131,19 +137,34 @@ where
     S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
 {
     async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
-        let mut guard = self.inner.lock().await;
-        read_response_frame(&mut *guard, buf)
-            .await
-            .map_err(MeowError::Io)
+        let _serialized = self.read_gate.lock().await;
+        // One decoded AEAD frame per `poll_read` ready; the frame buffer is
+        // sized so a full frame always fits and never splits across reads.
+        let mut frame = vec![0u8; super::v4::MAX_PAYLOAD_LENGTH];
+        let n = std::future::poll_fn(|cx| {
+            let mut stream = self.stream.lock();
+            let mut rb = tokio::io::ReadBuf::new(&mut frame);
+            match std::pin::Pin::new(&mut *stream).poll_read(cx, &mut rb) {
+                std::task::Poll::Ready(Ok(())) => std::task::Poll::Ready(Ok(rb.filled().len())),
+                std::task::Poll::Ready(Err(e)) => std::task::Poll::Ready(Err(e)),
+                std::task::Poll::Pending => std::task::Poll::Pending,
+            }
+        })
+        .await
+        .map_err(MeowError::Io)?;
+        parse_response_frame(&frame[..n], buf).map_err(MeowError::Io)
     }
 
     async fn write_packet(&self, buf: &[u8], addr: &SocketAddr) -> Result<usize> {
+        let _serialized = self.write_gate.lock().await;
         let frame = build_request_frame(addr, buf);
-        let mut guard = self.inner.lock().await;
-        guard
-            .write_packet_frame(&frame)
-            .await
-            .map_err(MeowError::Io)?;
+        let mut progress = super::protocol::PacketFrameProgress::default();
+        std::future::poll_fn(|cx| {
+            let mut stream = self.stream.lock();
+            stream.poll_write_packet_frame(cx, &frame, &mut progress)
+        })
+        .await
+        .map_err(MeowError::Io)?;
         Ok(buf.len())
     }
 
@@ -160,6 +181,68 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::snell::protocol::RESPONSE_TUNNEL;
+    use crate::snell::v4::V4Conn;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::time::timeout;
+
+    /// Regression for issue #278: with a single async mutex held across the
+    /// blocking frame read, a parked `read_packet` starved `write_packet`
+    /// forever and any send-while-awaiting-reply flow stalled after the
+    /// first datagram. The write below must complete while a reader is
+    /// parked on an idle stream.
+    #[tokio::test]
+    async fn write_packet_proceeds_while_read_parked() {
+        let (a, b) = tokio::io::duplex(1 << 16);
+        let psk: Arc<[u8]> = Arc::from(b"test-psk".as_slice());
+        let conn = Arc::new(SnellPacketConn::new(Snell::new(a, Arc::clone(&psk))));
+        let mut peer = V4Conn::new(b, psk);
+
+        let dst: SocketAddr = "9.9.9.9:53".parse().unwrap();
+
+        // Park a reader while the stream is idle.
+        let reader_conn = Arc::clone(&conn);
+        let reader = tokio::spawn(async move {
+            let mut buf = [0u8; 2048];
+            reader_conn
+                .read_packet(&mut buf)
+                .await
+                .map(|(n, addr)| (buf[..n].to_vec(), addr))
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Old design: deadlocked here (reader held the stream lock).
+        timeout(Duration::from_secs(5), conn.write_packet(b"ping", &dst))
+            .await
+            .expect("write_packet must not deadlock while a read is parked")
+            .expect("write_packet");
+
+        // Peer: acknowledge the session, verify the client's request frame,
+        // then echo a response frame so the parked reader completes.
+        peer.write_all(&[RESPONSE_TUNNEL]).await.unwrap();
+        peer.flush().await.unwrap();
+        let mut buf = [0u8; 2048];
+        let n = timeout(Duration::from_secs(5), peer.read(&mut buf))
+            .await
+            .expect("peer read timed out")
+            .unwrap();
+        assert_eq!(&buf[..n], &build_request_frame(&dst, b"ping")[..]);
+
+        let mut resp = vec![0x04, 9, 9, 9, 9];
+        resp.extend_from_slice(&53u16.to_be_bytes());
+        resp.extend_from_slice(b"pong");
+        peer.write_all(&resp).await.unwrap();
+        peer.flush().await.unwrap();
+
+        let (payload, addr) = timeout(Duration::from_secs(5), reader)
+            .await
+            .expect("parked reader timed out")
+            .expect("reader task")
+            .expect("read_packet");
+        assert_eq!(payload, b"pong");
+        assert_eq!(addr, dst);
+    }
 
     #[test]
     fn request_frame_ipv4_layout() {

--- a/crates/meow-proxy/src/snell/v4.rs
+++ b/crates/meow-proxy/src/snell/v4.rs
@@ -365,10 +365,9 @@ impl<S: AsyncRead> V4Conn<S> {
 
 impl<S> V4Conn<S> {
     /// Stage a single frame carrying `buf` as a UDP datagram payload. The
-    /// caller is responsible for draining the stream (calling `poll_write`
-    /// with an empty buf is a no-op here; the higher-level
-    /// `SnellPacketConn::write_packet` uses a dedicated path that owns the
-    /// stream mutex and drives the drain to completion).
+    /// caller is responsible for draining the stream to completion (see
+    /// `Snell::poll_write_packet_frame`, which the higher-level
+    /// `SnellPacketConn::write_packet` drives with a per-poll stream lock).
     pub fn stage_packet_frame(&mut self, buf: &[u8]) -> io::Result<()> {
         if buf.len() > MAX_PAYLOAD_LENGTH {
             return Err(io::Error::new(

--- a/crates/meow-proxy/src/vless/conn.rs
+++ b/crates/meow-proxy/src/vless/conn.rs
@@ -9,7 +9,6 @@
 
 use std::io;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use bytes::{BufMut, BytesMut};
@@ -173,9 +172,15 @@ impl ProxyConn for VlessConn {}
 /// Each datagram is framed as `u16_be(length) + data`.  The VLESS request
 /// header (cmd=0x02) is sent on construction; the response header is consumed.
 ///
-/// Implements [`ProxyPacketConn`] with shared-reference access via `Mutex`.
+/// The stream is split into independent read/write halves, each behind its
+/// own `Mutex`, so a `read_packet` parked waiting for a server datagram never
+/// blocks `write_packet` on the same connection (issue #278). The tunnel
+/// drives the two directions from separate tasks; with a single stream-wide
+/// lock any flow needing interleaved sends while a recv is pending (QUIC,
+/// WireGuard, games) stalled after the first packet.
 pub struct VlessPacketConn {
-    inner: Arc<tokio::sync::Mutex<Box<dyn Stream>>>,
+    reader: tokio::sync::Mutex<tokio::io::ReadHalf<Box<dyn Stream>>>,
+    writer: tokio::sync::Mutex<tokio::io::WriteHalf<Box<dyn Stream>>>,
 }
 
 impl VlessPacketConn {
@@ -195,8 +200,10 @@ impl VlessPacketConn {
         // Read and discard the response header.
         decode_response(&mut stream).await?;
 
+        let (reader, writer) = tokio::io::split(stream);
         Ok(Self {
-            inner: Arc::new(tokio::sync::Mutex::new(stream)),
+            reader: tokio::sync::Mutex::new(reader),
+            writer: tokio::sync::Mutex::new(writer),
         })
     }
 }
@@ -205,20 +212,21 @@ impl VlessPacketConn {
 impl ProxyPacketConn for VlessPacketConn {
     /// Write a UDP packet as `u16_be(len) + data`.
     async fn write_packet(&self, buf: &[u8], _addr: &std::net::SocketAddr) -> Result<usize> {
-        let mut guard = self.inner.lock().await;
+        let mut writer = self.writer.lock().await;
         let mut frame = BytesMut::with_capacity(2 + buf.len());
         frame.put_u16(buf.len() as u16);
         frame.put_slice(buf);
-        guard.write_all(&frame).await.map_err(MeowError::Io)?;
+        writer.write_all(&frame).await.map_err(MeowError::Io)?;
+        writer.flush().await.map_err(MeowError::Io)?;
         Ok(buf.len())
     }
 
     /// Read a UDP packet: consume `u16_be(len)` then `len` bytes.
     async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, std::net::SocketAddr)> {
         use tokio::io::AsyncReadExt;
-        let mut guard = self.inner.lock().await;
+        let mut reader = self.reader.lock().await;
         let mut len_buf = [0u8; 2];
-        guard
+        reader
             .read_exact(&mut len_buf)
             .await
             .map_err(MeowError::Io)?;
@@ -230,7 +238,7 @@ impl ProxyPacketConn for VlessPacketConn {
                 buf.len()
             )));
         }
-        guard
+        reader
             .read_exact(&mut buf[..pkt_len])
             .await
             .map_err(MeowError::Io)?;
@@ -505,6 +513,72 @@ mod tests {
                 || msg.contains("Eof"),
             "error must give diagnostic, got: {msg}"
         );
+    }
+
+    // ─── Issue #278: parked read must not starve writes ───────────────────────
+
+    /// Regression for issue #278: with the whole stream behind one async
+    /// mutex, a `read_packet` parked waiting for a server datagram held the
+    /// lock and every `write_packet` deadlocked, stalling any flow that
+    /// interleaves sends with a pending recv (QUIC, WireGuard, games).
+    #[tokio::test]
+    async fn vless_packet_conn_write_proceeds_while_read_parked() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let (client, server) = duplex(4096);
+        // Mock server: consume the request header, ack, then echo one framed
+        // datagram once it arrives.
+        tokio::spawn(async move {
+            let mut s = server;
+            let mut hdr = vec![0u8; 26];
+            s.read_exact(&mut hdr).await.unwrap();
+            s.write_all(&[0x00, 0x00]).await.unwrap();
+            let mut len = [0u8; 2];
+            s.read_exact(&mut len).await.unwrap();
+            let n = u16::from_be_bytes(len) as usize;
+            let mut payload = vec![0u8; n];
+            s.read_exact(&mut payload).await.unwrap();
+            s.write_all(&len).await.unwrap();
+            s.write_all(&payload).await.unwrap();
+        });
+
+        let conn = Arc::new(
+            VlessPacketConn::new(
+                Box::new(client),
+                &TEST_UUID,
+                53,
+                &VlessAddr::Ipv4([8, 8, 8, 8]),
+            )
+            .await
+            .expect("VlessPacketConn::new"),
+        );
+
+        // Park a reader while no server datagram is available.
+        let reader_conn = Arc::clone(&conn);
+        let reader = tokio::spawn(async move {
+            let mut buf = [0u8; 64];
+            reader_conn
+                .read_packet(&mut buf)
+                .await
+                .map(|(n, _)| buf[..n].to_vec())
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Old design: deadlocked here (reader held the stream lock).
+        let dst = "8.8.8.8:53".parse().unwrap();
+        timeout(Duration::from_secs(5), conn.write_packet(b"ping", &dst))
+            .await
+            .expect("write_packet must not deadlock while a read is parked")
+            .expect("write_packet");
+
+        let echoed = timeout(Duration::from_secs(5), reader)
+            .await
+            .expect("parked reader timed out")
+            .expect("reader task")
+            .expect("read_packet");
+        assert_eq!(echoed, b"ping");
     }
 
     // ─── F7: UDP cmd byte is 0x02 ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #278 — `VlessPacketConn` and `SnellPacketConn` held one async `Mutex` across the blocking datagram read, so a parked `read_packet` starved `write_packet` forever. Flows needing interleaved sends while a recv is pending (QUIC, WireGuard, games) wedged after the first packet.

## Changes

**VLESS** (`crates/meow-proxy/src/vless/conn.rs`)
- `tokio::io::split` into independent `ReadHalf`/`WriteHalf`, each behind its own `Mutex` — the exact pattern `TrojanPacketConn` already uses.
- `write_packet` now flushes after `write_all` (parity with Trojan; datagrams must not sit in a buffered transport layer).

**Snell** (`crates/meow-proxy/src/snell/udp.rs`, `protocol.rs`, `v4.rs`)
- The AEAD codec holds both cipher directions in one object over one stream, so a structural split is impossible. The stream now sits behind a **synchronous mutex locked per poll** — the same mechanism `tokio::io::split` uses internally. A read parked on `Poll::Pending` holds nothing between polls, so writes proceed freely.
- New `Snell::poll_write_packet_frame` + `PacketFrameProgress` carry a datagram write across polls. This preserves the v4 **one-datagram-one-frame** invariant that a plain `AsyncWrite` half could not (v4 `poll_write` chunks by `next_payload_limit()`, which could split a datagram across AEAD frames).
- Per-direction async gates (`read_gate`/`write_gate`) serialize whole datagrams within each direction so concurrent same-direction callers can't interleave partial frames.
- `read_response_frame` refactored into a sync `parse_response_frame` (the frame read now happens under the per-poll lock).

## Tests

- `vless_packet_conn_write_proceeds_while_read_parked` and `snell::udp::write_packet_proceeds_while_read_parked`: park a reader on an idle stream, assert `write_packet` completes within a timeout, then finish the echo round-trip (payload + source addr). Both deadlock under the old design.

## Verification

Full regression bar run locally: `cargo fmt --check`, three-way clippy (`default` / `--no-default-features` / `--all-features`) with `-D warnings`, `cargo doc` with `-D warnings`, `cargo test --lib` (all crates).

No changes to `Metadata`/`ConnectionInfo`/`UdpSession`/`CacheEntry` layouts; no relay-path (`relay.rs`/`tcp.rs`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)