### PR TITLE
fix(vmess): correct AEAD wire format for server interoperability (#270)

### DIFF
--- a/crates/meow-proxy/src/vmess/body.rs
+++ b/crates/meow-proxy/src/vmess/body.rs
@@ -172,6 +172,11 @@ impl BodyCipher {
         plaintext: &[u8],
     ) -> std::io::Result<()> {
         if matches!(self.write, RecordCipher::None) {
+            // OPT_STANDARD advertises chunk streaming even when the security
+            // type is none, so the payload still carries the 2-byte size.
+            let len = u16::try_from(plaintext.len())
+                .map_err(|_| std::io::Error::other("vmess plaintext record too large"))?;
+            writer.write_all(&len.to_be_bytes()).await?;
             writer.write_all(plaintext).await?;
             return writer.flush().await;
         }
@@ -190,12 +195,14 @@ impl BodyCipher {
         reader: &mut R,
     ) -> std::io::Result<Vec<u8>> {
         if matches!(self.read, RecordCipher::None) {
-            let mut buf = vec![0u8; 4096];
-            let n = reader.read(&mut buf).await?;
-            if n == 0 {
+            let mut len_buf = [0u8; 2];
+            reader.read_exact(&mut len_buf).await?;
+            let len = u16::from_be_bytes(len_buf) as usize;
+            if len == 0 {
                 return Err(std::io::ErrorKind::UnexpectedEof.into());
             }
-            buf.truncate(n);
+            let mut buf = vec![0u8; len];
+            reader.read_exact(&mut buf).await?;
             return Ok(buf);
         }
 
@@ -290,14 +297,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn none_is_passthrough() {
+    async fn none_still_uses_chunk_framing() {
         let (req_key, req_iv) = test_keys();
         let mut cipher = BodyCipher::new(Security::None, &req_key, &req_iv, 0x42);
         let plaintext = b"raw bytes no framing";
 
         let mut wire = Vec::new();
         cipher.write_record(&mut wire, plaintext).await.unwrap();
-        assert_eq!(wire, plaintext, "security:none must not add framing");
+        assert_eq!(
+            &wire[..2],
+            &(plaintext.len() as u16).to_be_bytes(),
+            "security:none keeps the chunk length advertised by OPT_STANDARD"
+        );
+        assert_eq!(&wire[2..], plaintext);
+
+        let mut cursor = std::io::Cursor::new(wire);
+        assert_eq!(cipher.read_record(&mut cursor).await.unwrap(), plaintext);
     }
 
     #[tokio::test]

--- a/crates/meow-proxy/src/vmess/body.rs
+++ b/crates/meow-proxy/src/vmess/body.rs
@@ -4,79 +4,56 @@ use chacha20poly1305::ChaCha20Poly1305;
 use md5::{Digest, Md5};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-use super::header::Security;
-use super::kdf::{kdf12, kdf16};
+use super::header::{response_body_keys, Security};
 
 /// Maximum plaintext per body record (matching upstream 16 KiB - 16 tag).
 const MAX_PLAINTEXT: usize = 16384 - 16;
 
-/// Body keys/IVs derived from the per-connection req_key and req_iv.
+/// Body keys/IVs derived from the per-connection req_key and req_iv. The IVs
+/// are the full 16-byte seeds; each record nonce is `count(2 BE) || iv[2..12]`.
 struct DerivedKeys {
     write_key: Vec<u8>,
-    write_iv: [u8; 12],
+    write_iv: [u8; 16],
     read_key: Vec<u8>,
-    read_iv: [u8; 12],
+    read_iv: [u8; 16],
+}
+
+/// Expand a 16-byte AEAD seed key into the actual cipher key for `security`.
+///
+/// - AES-128-GCM: the 16-byte key is used directly.
+/// - ChaCha20-Poly1305: 32-byte key `MD5(k) || MD5(MD5(k))`.
+///
+/// upstream: `transport/vmess/conn.go` (`sendRequest`, per-security branch).
+fn expand_body_key(security: Security, key16: &[u8; 16]) -> Vec<u8> {
+    match security {
+        Security::Aes128Gcm => key16.to_vec(),
+        Security::ChaCha20Poly1305 => {
+            let md5_1: [u8; 16] = Md5::digest(key16).into();
+            let md5_2: [u8; 16] = Md5::digest(md5_1).into();
+            let mut k = Vec::with_capacity(32);
+            k.extend_from_slice(&md5_1);
+            k.extend_from_slice(&md5_2);
+            k
+        }
+        Security::None => Vec::new(),
+    }
 }
 
 fn derive_keys(security: Security, req_key: &[u8; 16], req_iv: &[u8; 16]) -> DerivedKeys {
-    let mut key_iv = [0u8; 32];
-    key_iv[..16].copy_from_slice(req_key);
-    key_iv[16..].copy_from_slice(req_iv);
+    // Request (write) direction uses the raw per-connection key/iv directly —
+    // there is NO "VMess Body AEAD Key" KDF in the wire protocol.
+    let write_key = expand_body_key(security, req_key);
+    let write_iv = *req_iv;
 
-    let (write_key, write_iv) = match security {
-        Security::Aes128Gcm => {
-            let k = kdf16(&key_iv, &[b"VMess Body AEAD Key"]);
-            let iv = kdf12(&key_iv, &[b"VMess Body AEAD IV"]);
-            (k.to_vec(), iv)
-        }
-        Security::ChaCha20Poly1305 => {
-            let mut hasher = Md5::new();
-            hasher.update(req_key);
-            let md5_1: [u8; 16] = hasher.finalize().into();
-            let mut hasher2 = Md5::new();
-            hasher2.update(md5_1);
-            let md5_2: [u8; 16] = hasher2.finalize().into();
-            let mut k = Vec::with_capacity(32);
-            k.extend_from_slice(&md5_1);
-            k.extend_from_slice(&md5_2);
-            let iv = kdf12(&key_iv, &[b"VMess Body AEAD IV"]);
-            (k, iv)
-        }
-        Security::None => (Vec::new(), [0u8; 12]),
-    };
-
-    // Response keys: swap req_key/req_iv
-    let mut resp_key_iv = [0u8; 32];
-    resp_key_iv[..16].copy_from_slice(req_iv);
-    resp_key_iv[16..].copy_from_slice(req_key);
-
-    let (read_key, read_iv) = match security {
-        Security::Aes128Gcm => {
-            let k = kdf16(&resp_key_iv, &[b"VMess Body AEAD Key"]);
-            let iv = kdf12(&resp_key_iv, &[b"VMess Body AEAD IV"]);
-            (k.to_vec(), iv)
-        }
-        Security::ChaCha20Poly1305 => {
-            let mut hasher = Md5::new();
-            hasher.update(req_iv);
-            let md5_1: [u8; 16] = hasher.finalize().into();
-            let mut hasher2 = Md5::new();
-            hasher2.update(md5_1);
-            let md5_2: [u8; 16] = hasher2.finalize().into();
-            let mut k = Vec::with_capacity(32);
-            k.extend_from_slice(&md5_1);
-            k.extend_from_slice(&md5_2);
-            let iv = kdf12(&resp_key_iv, &[b"VMess Body AEAD IV"]);
-            (k, iv)
-        }
-        Security::None => (Vec::new(), [0u8; 12]),
-    };
+    // Response (read) direction keys come from SHA-256 of the request key/iv.
+    let (resp_key, resp_iv) = response_body_keys(req_key, req_iv);
+    let read_key = expand_body_key(security, &resp_key);
 
     DerivedKeys {
         write_key,
         write_iv,
         read_key,
-        read_iv,
+        read_iv: resp_iv,
     }
 }
 
@@ -128,20 +105,31 @@ impl RecordCipher {
     }
 }
 
+/// Build a 16-byte-seed record nonce: `count(2 BE) || iv[2..12]`. The first
+/// two IV bytes are discarded (overwritten by the counter), matching mihomo
+/// `aead.go` — a scheme that XORs the counter into the full IV only agrees
+/// when `iv[0]==iv[1]==0`, so its records fail to authenticate on real servers.
+fn record_nonce(iv: &[u8; 16], counter: u16) -> [u8; 12] {
+    let mut nonce = [0u8; 12];
+    nonce[..2].copy_from_slice(&counter.to_be_bytes());
+    nonce[2..].copy_from_slice(&iv[2..12]);
+    nonce
+}
+
 /// Per-connection body cipher state for both directions.
 pub struct BodyCipher {
     write: RecordCipher,
-    write_iv: [u8; 12],
+    write_iv: [u8; 16],
     read: RecordCipher,
-    read_iv: [u8; 12],
+    read_iv: [u8; 16],
     write_counter: u16,
     read_counter: u16,
 }
 
 impl BodyCipher {
     pub fn new(security: Security, req_key: &[u8; 16], req_iv: &[u8; 16], resp_v: u8) -> Self {
-        // XOR of resp_v into the response IV seed is handled upstream of the
-        // body layer; the parameter is kept for signature stability.
+        // resp_v gates the response *header* validation (in header.rs), not the
+        // body IV; the parameter is kept for call-site signature stability.
         let _ = resp_v;
         let keys = derive_keys(security, req_key, req_iv);
 
@@ -156,7 +144,7 @@ impl BodyCipher {
     }
 
     /// Test hook: make the read direction decrypt what the write direction
-    /// encrypts (real connections derive read keys from swapped req material).
+    /// encrypts (real connections derive read keys from SHA-256 of req material).
     #[cfg(test)]
     fn mirror_write_to_read(&mut self) {
         self.read = self.write.clone();
@@ -165,19 +153,13 @@ impl BodyCipher {
     }
 
     fn write_nonce(&mut self) -> [u8; 12] {
-        let mut nonce = self.write_iv;
-        let counter_be = self.write_counter.to_be_bytes();
-        nonce[0] ^= counter_be[0];
-        nonce[1] ^= counter_be[1];
+        let nonce = record_nonce(&self.write_iv, self.write_counter);
         self.write_counter = self.write_counter.wrapping_add(1);
         nonce
     }
 
     fn read_nonce(&mut self) -> [u8; 12] {
-        let mut nonce = self.read_iv;
-        let counter_be = self.read_counter.to_be_bytes();
-        nonce[0] ^= counter_be[0];
-        nonce[1] ^= counter_be[1];
+        let nonce = record_nonce(&self.read_iv, self.read_counter);
         self.read_counter = self.read_counter.wrapping_add(1);
         nonce
     }
@@ -360,16 +342,69 @@ mod tests {
     }
 
     #[test]
-    fn aes_key_uses_kdf_not_md5() {
+    fn aes_write_key_is_raw_req_key() {
+        // upstream: AES-128-GCM request body key = reqBodyKey verbatim (no KDF).
         let (req_key, req_iv) = test_keys();
         let keys = derive_keys(Security::Aes128Gcm, &req_key, &req_iv);
-        assert_eq!(keys.write_key.len(), 16, "aes key must be 16 bytes (KDF)");
-        // Verify it matches the KDF derivation
-        let mut key_iv = [0u8; 32];
-        key_iv[..16].copy_from_slice(&req_key);
-        key_iv[16..].copy_from_slice(&req_iv);
-        let expected = kdf16(&key_iv, &[b"VMess Body AEAD Key"]);
-        assert_eq!(keys.write_key.as_slice(), &expected);
+        assert_eq!(keys.write_key.as_slice(), &req_key);
+        assert_eq!(keys.write_iv, req_iv);
+    }
+
+    #[test]
+    fn aes_read_key_is_sha256_of_req_key() {
+        // upstream: respBodyKey = SHA256(reqBodyKey)[..16], respBodyIV = SHA256(reqBodyIV)[..16].
+        use sha2::{Digest, Sha256};
+        let (req_key, req_iv) = test_keys();
+        let keys = derive_keys(Security::Aes128Gcm, &req_key, &req_iv);
+        let bk: [u8; 32] = Sha256::digest(req_key).into();
+        let bi: [u8; 32] = Sha256::digest(req_iv).into();
+        assert_eq!(keys.read_key.as_slice(), &bk[..16]);
+        assert_eq!(&keys.read_iv, &bi[..16]);
+    }
+
+    #[test]
+    fn record_nonce_overwrites_first_two_iv_bytes() {
+        // nonce = count(2 BE) || iv[2..12]; iv[0]/iv[1] discarded.
+        let iv = [
+            0xAA, 0xBB, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+            0x0E, 0x0F,
+        ];
+        let n = super::record_nonce(&iv, 0x1234);
+        assert_eq!(n[0], 0x12);
+        assert_eq!(n[1], 0x34);
+        assert_eq!(&n[2..], &iv[2..12]);
+    }
+
+    /// End-to-end read-direction interop: a hand-rolled "server" encrypts a
+    /// response record with the response keys (SHA-256 of req material) and
+    /// the client's `read_record` must decrypt it. This fails if the read
+    /// derivation or the nonce construction diverges from the wire spec —
+    /// unlike the mirror-based round-trip which hides both.
+    #[tokio::test]
+    async fn read_record_decrypts_independently_encoded_response() {
+        use aes_gcm::aead::Aead;
+        use sha2::{Digest, Sha256};
+
+        let (req_key, req_iv) = test_keys();
+        let bk: [u8; 32] = Sha256::digest(req_key).into();
+        let bi: [u8; 32] = Sha256::digest(req_iv).into();
+        let resp_key: [u8; 16] = bk[..16].try_into().unwrap();
+        let resp_iv: [u8; 16] = bi[..16].try_into().unwrap();
+
+        // Server seals record 0 with nonce = count(0) || resp_iv[2..12].
+        let plaintext = b"response payload from server";
+        let nonce = super::record_nonce(&resp_iv, 0);
+        let cipher = Aes128Gcm::new_from_slice(&resp_key).unwrap();
+        let ct = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext.as_ref())
+            .unwrap();
+        let mut wire = (ct.len() as u16).to_be_bytes().to_vec();
+        wire.extend_from_slice(&ct);
+
+        let mut client = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, 0x42);
+        let mut cursor = std::io::Cursor::new(wire);
+        let decrypted = client.read_record(&mut cursor).await.unwrap();
+        assert_eq!(decrypted, plaintext);
     }
 
     #[tokio::test]

--- a/crates/meow-proxy/src/vmess/body.rs
+++ b/crates/meow-proxy/src/vmess/body.rs
@@ -239,155 +239,62 @@ mod tests {
         (req_key, req_iv)
     }
 
-    #[tokio::test]
-    async fn aes_128_gcm_record_round_trip() {
+    async fn body_modes_round_trip_with_protocol_framing() {
         let (req_key, req_iv) = test_keys();
-        let mut writer_cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, 0x42);
-        let plaintext = b"hello vmess aes-128-gcm body";
+        let plaintext = b"hello vmess body";
 
-        let mut wire = Vec::new();
-        writer_cipher
-            .write_record(&mut wire, plaintext)
-            .await
-            .unwrap();
+        for (security, overhead) in [
+            (Security::Aes128Gcm, 16),
+            (Security::ChaCha20Poly1305, 16),
+            (Security::None, 0),
+        ] {
+            let mut writer = BodyCipher::new(security, &req_key, &req_iv, 0x42);
+            let mut wire = Vec::new();
+            writer.write_record(&mut wire, plaintext).await.unwrap();
 
-        // Wire must be: 2-byte length + ciphertext(plaintext_len + 16 tag)
-        let expected_ct_len = plaintext.len() + 16;
-        let wire_len = u16::from_be_bytes([wire[0], wire[1]]) as usize;
-        assert_eq!(
-            wire_len, expected_ct_len,
-            "record length must include the 16-byte tag"
-        );
-        assert_eq!(wire.len(), 2 + expected_ct_len);
+            let framed_len = u16::from_be_bytes([wire[0], wire[1]]) as usize;
+            assert_eq!(framed_len, plaintext.len() + overhead);
+            assert_eq!(wire.len(), 2 + framed_len);
 
-        // Now read it back — use WRITE keys since we're decrypting what we wrote
-        // (read_cipher uses response keys derived from swapped req_iv/req_key)
-        // For self-round-trip, we need a cipher with matching keys.
-        let mut read_cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, 0x42);
-        read_cipher.mirror_write_to_read();
-
-        let mut cursor = std::io::Cursor::new(wire);
-        let decrypted = read_cipher.read_record(&mut cursor).await.unwrap();
-        assert_eq!(decrypted, plaintext);
+            let mut reader = BodyCipher::new(security, &req_key, &req_iv, 0x42);
+            reader.mirror_write_to_read();
+            let mut cursor = std::io::Cursor::new(wire);
+            assert_eq!(reader.read_record(&mut cursor).await.unwrap(), plaintext);
+        }
     }
 
-    #[tokio::test]
-    async fn chacha20_poly1305_record_round_trip() {
-        let (req_key, req_iv) = test_keys();
-        let mut writer_cipher =
-            BodyCipher::new(Security::ChaCha20Poly1305, &req_key, &req_iv, 0x42);
-        let plaintext = b"hello vmess chacha20 body";
-
-        let mut wire = Vec::new();
-        writer_cipher
-            .write_record(&mut wire, plaintext)
-            .await
-            .unwrap();
-
-        let expected_ct_len = plaintext.len() + 16;
-        let wire_len = u16::from_be_bytes([wire[0], wire[1]]) as usize;
-        assert_eq!(wire_len, expected_ct_len);
-
-        let mut read_cipher = BodyCipher::new(Security::ChaCha20Poly1305, &req_key, &req_iv, 0x42);
-        read_cipher.mirror_write_to_read();
-
-        let mut cursor = std::io::Cursor::new(wire);
-        let decrypted = read_cipher.read_record(&mut cursor).await.unwrap();
-        assert_eq!(decrypted, plaintext);
-    }
-
-    #[tokio::test]
-    async fn none_still_uses_chunk_framing() {
-        let (req_key, req_iv) = test_keys();
-        let mut cipher = BodyCipher::new(Security::None, &req_key, &req_iv, 0x42);
-        let plaintext = b"raw bytes no framing";
-
-        let mut wire = Vec::new();
-        cipher.write_record(&mut wire, plaintext).await.unwrap();
-        assert_eq!(
-            &wire[..2],
-            &(plaintext.len() as u16).to_be_bytes(),
-            "security:none keeps the chunk length advertised by OPT_STANDARD"
-        );
-        assert_eq!(&wire[2..], plaintext);
-
-        let mut cursor = std::io::Cursor::new(wire);
-        assert_eq!(cipher.read_record(&mut cursor).await.unwrap(), plaintext);
-    }
-
-    #[tokio::test]
-    async fn nonce_counter_increments_per_record() {
-        let (req_key, req_iv) = test_keys();
-        let mut cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, 0x42);
-        let data = b"x";
-
-        let mut wire1 = Vec::new();
-        cipher.write_record(&mut wire1, data).await.unwrap();
-        let mut wire2 = Vec::new();
-        cipher.write_record(&mut wire2, data).await.unwrap();
-        let mut wire3 = Vec::new();
-        cipher.write_record(&mut wire3, data).await.unwrap();
-
-        // Same plaintext with different nonces must produce different ciphertext
-        assert_ne!(wire1, wire2);
-        assert_ne!(wire2, wire3);
-        assert_ne!(wire1, wire3);
-    }
-
-    #[test]
-    fn chacha_key_uses_md5_cascade_not_kdf() {
-        let (req_key, req_iv) = test_keys();
-        let keys = derive_keys(Security::ChaCha20Poly1305, &req_key, &req_iv);
-        // ChaCha20 body_key = MD5(req_key) || MD5(MD5(req_key)) — 32 bytes
-        assert_eq!(
-            keys.write_key.len(),
-            32,
-            "chacha key must be 32 bytes (double MD5)"
-        );
-
-        let mut hasher = Md5::new();
-        hasher.update(req_key);
-        let md5_1: [u8; 16] = hasher.finalize().into();
-        let mut hasher2 = Md5::new();
-        hasher2.update(md5_1);
-        let md5_2: [u8; 16] = hasher2.finalize().into();
-
-        assert_eq!(&keys.write_key[..16], &md5_1);
-        assert_eq!(&keys.write_key[16..], &md5_2);
-    }
-
-    #[test]
-    fn aes_write_key_is_raw_req_key() {
-        // upstream: AES-128-GCM request body key = reqBodyKey verbatim (no KDF).
-        let (req_key, req_iv) = test_keys();
-        let keys = derive_keys(Security::Aes128Gcm, &req_key, &req_iv);
-        assert_eq!(keys.write_key.as_slice(), &req_key);
-        assert_eq!(keys.write_iv, req_iv);
-    }
-
-    #[test]
-    fn aes_read_key_is_sha256_of_req_key() {
-        // upstream: respBodyKey = SHA256(reqBodyKey)[..16], respBodyIV = SHA256(reqBodyIV)[..16].
+    fn body_key_derivation_matches_protocol() {
         use sha2::{Digest, Sha256};
+
         let (req_key, req_iv) = test_keys();
-        let keys = derive_keys(Security::Aes128Gcm, &req_key, &req_iv);
+        let aes = derive_keys(Security::Aes128Gcm, &req_key, &req_iv);
+        assert_eq!(aes.write_key.as_slice(), &req_key);
+        assert_eq!(aes.write_iv, req_iv);
         let bk: [u8; 32] = Sha256::digest(req_key).into();
         let bi: [u8; 32] = Sha256::digest(req_iv).into();
-        assert_eq!(keys.read_key.as_slice(), &bk[..16]);
-        assert_eq!(&keys.read_iv, &bi[..16]);
+        assert_eq!(aes.read_key.as_slice(), &bk[..16]);
+        assert_eq!(&aes.read_iv, &bi[..16]);
+
+        let chacha = derive_keys(Security::ChaCha20Poly1305, &req_key, &req_iv);
+        let md5_1: [u8; 16] = Md5::digest(req_key).into();
+        let md5_2: [u8; 16] = Md5::digest(md5_1).into();
+        assert_eq!(chacha.write_key, [md5_1, md5_2].concat());
     }
 
-    #[test]
-    fn record_nonce_overwrites_first_two_iv_bytes() {
-        // nonce = count(2 BE) || iv[2..12]; iv[0]/iv[1] discarded.
+    fn record_nonce_overwrites_iv_prefix_and_increments() {
         let iv = [
             0xAA, 0xBB, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
             0x0E, 0x0F,
         ];
-        let n = super::record_nonce(&iv, 0x1234);
-        assert_eq!(n[0], 0x12);
-        assert_eq!(n[1], 0x34);
-        assert_eq!(&n[2..], &iv[2..12]);
+        assert_eq!(
+            record_nonce(&iv, 0x1234),
+            [0x12, 0x34, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        );
+
+        let (req_key, _) = test_keys();
+        let mut cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &iv, 0x42);
+        assert_eq!(cipher.write_nonce()[..2], [0, 0]);
+        assert_eq!(cipher.write_nonce()[..2], [0, 1]);
     }
 
     /// End-to-end read-direction interop: a hand-rolled "server" encrypts a
@@ -395,7 +302,6 @@ mod tests {
     /// the client's `read_record` must decrypt it. This fails if the read
     /// derivation or the nonce construction diverges from the wire spec —
     /// unlike the mirror-based round-trip which hides both.
-    #[tokio::test]
     async fn read_record_decrypts_independently_encoded_response() {
         use aes_gcm::aead::Aead;
         use sha2::{Digest, Sha256};
@@ -423,20 +329,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn record_length_includes_tag() {
-        let (req_key, req_iv) = test_keys();
-        let mut cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, 0x42);
-        let plaintext = vec![0xAB; 100];
-
-        let mut wire = Vec::new();
-        cipher.write_record(&mut wire, &plaintext).await.unwrap();
-
-        let wire_len = u16::from_be_bytes([wire[0], wire[1]]) as usize;
-        // upstream: len = plaintext_len + 16 (tag), NOT just plaintext_len
-        assert_eq!(
-            wire_len,
-            100 + 16,
-            "record length must be plaintext + 16 (tag)"
-        );
+    async fn body_wire_format_matches_protocol() {
+        body_modes_round_trip_with_protocol_framing().await;
+        body_key_derivation_matches_protocol();
+        record_nonce_overwrites_iv_prefix_and_increments();
+        read_record_decrypts_independently_encoded_response().await;
     }
 }

--- a/crates/meow-proxy/src/vmess/conn.rs
+++ b/crates/meow-proxy/src/vmess/conn.rs
@@ -21,21 +21,23 @@ pub fn spawn_vmess_relay(
 
     tokio::spawn(async move {
         let (mut rd, mut wr) = tokio::io::split(stream);
-
-        // Consume and validate the AEAD-sealed response header. The response
-        // body keys are SHA-256 of the request body key/iv.
-        let (resp_body_key, resp_body_iv) = response_body_keys(&req_key, &req_iv);
-        if let Err(e) =
-            read_aead_response_header(&mut rd, &resp_body_key, &resp_body_iv, resp_v).await
-        {
-            tracing::warn!("vmess: response header decode failed: {e}");
-            return;
-        }
-
         let (mut proxy_rd, mut proxy_wr) = tokio::io::split(proxy);
 
-        // Upstream: stream → decrypt → proxy_wr
+        // Upstream: consume the response header, then stream → decrypt →
+        // proxy_wr. This runs concurrently with the write side: a conformant
+        // server commonly waits for request data before sending its response
+        // header, so awaiting the header before forwarding the request would
+        // deadlock every request/response protocol.
         let read_task = tokio::spawn(async move {
+            let (resp_body_key, resp_body_iv) = response_body_keys(&req_key, &req_iv);
+            if let Err(e) =
+                read_aead_response_header(&mut rd, &resp_body_key, &resp_body_iv, resp_v).await
+            {
+                tracing::warn!("vmess: response header decode failed: {e}");
+                let _ = proxy_wr.shutdown().await;
+                return;
+            }
+
             while let Ok(plaintext) = read_cipher.read_record(&mut rd).await {
                 if proxy_wr.write_all(&plaintext).await.is_err() {
                     break;
@@ -64,4 +66,77 @@ pub fn spawn_vmess_relay(
     });
 
     client
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vmess::header::Security;
+    use crate::vmess::kdf::{kdf12, kdf16};
+    use aes_gcm::aead::Aead;
+    use aes_gcm::{Aes128Gcm, KeyInit, Nonce};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn seal_response_header(req_key: &[u8; 16], req_iv: &[u8; 16], resp_v: u8) -> Vec<u8> {
+        let (resp_key, resp_iv) = response_body_keys(req_key, req_iv);
+        let header = [resp_v, 0, 0, 0];
+
+        let len_key = kdf16(&resp_key, &[b"AEAD Resp Header Len Key"]);
+        let len_iv = kdf12(&resp_iv, &[b"AEAD Resp Header Len IV"]);
+        let len_ct = Aes128Gcm::new_from_slice(&len_key)
+            .unwrap()
+            .encrypt(
+                Nonce::from_slice(&len_iv),
+                (header.len() as u16).to_be_bytes().as_ref(),
+            )
+            .unwrap();
+
+        let header_key = kdf16(&resp_key, &[b"AEAD Resp Header Key"]);
+        let header_iv = kdf12(&resp_iv, &[b"AEAD Resp Header IV"]);
+        let header_ct = Aes128Gcm::new_from_slice(&header_key)
+            .unwrap()
+            .encrypt(Nonce::from_slice(&header_iv), header.as_ref())
+            .unwrap();
+
+        [len_ct, header_ct].concat()
+    }
+
+    #[tokio::test]
+    async fn forwards_request_body_before_response_header_arrives() {
+        let req_key = [0x11; 16];
+        let req_iv = [0x22; 16];
+        let resp_v = 0x5a;
+        let (transport, mut server) = tokio::io::duplex(4096);
+        let read_cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, resp_v);
+        let write_cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, resp_v);
+        let mut app = spawn_vmess_relay(
+            Box::new(transport),
+            read_cipher,
+            write_cipher,
+            req_key,
+            req_iv,
+            resp_v,
+        );
+
+        app.write_all(b"GET / HTTP/1.1\r\n\r\n").await.unwrap();
+
+        // A real server does not send the response header until it has read
+        // the request. The relay must therefore forward a body record first.
+        let mut len = [0u8; 2];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            server.read_exact(&mut len),
+        )
+        .await
+        .expect("request body was blocked behind response-header read")
+        .unwrap();
+        let mut ciphertext = vec![0u8; u16::from_be_bytes(len) as usize];
+        server.read_exact(&mut ciphertext).await.unwrap();
+        assert_eq!(ciphertext.len(), b"GET / HTTP/1.1\r\n\r\n".len() + 16);
+
+        server
+            .write_all(&seal_response_header(&req_key, &req_iv, resp_v))
+            .await
+            .unwrap();
+    }
 }

--- a/crates/meow-proxy/src/vmess/conn.rs
+++ b/crates/meow-proxy/src/vmess/conn.rs
@@ -1,16 +1,20 @@
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 
 use super::body::BodyCipher;
+use super::header::{read_aead_response_header, response_body_keys};
 
 /// Spawn a VMess relay task that handles AEAD body record framing.
 ///
 /// Returns a `DuplexStream` that the caller reads/writes plain bytes on.
-/// The background task encrypts writes into body records and decrypts
-/// reads from body records on the underlying stream.
+/// The background task first consumes the AEAD-sealed response header
+/// (validating the per-connection `resp_v` byte), then encrypts writes into
+/// body records and decrypts reads from body records on the underlying stream.
 pub fn spawn_vmess_relay(
     stream: Box<dyn meow_transport::Stream>,
     mut read_cipher: BodyCipher,
     mut write_cipher: BodyCipher,
+    req_key: [u8; 16],
+    req_iv: [u8; 16],
     resp_v: u8,
 ) -> DuplexStream {
     let (client, proxy) = tokio::io::duplex(32768);
@@ -18,13 +22,13 @@ pub fn spawn_vmess_relay(
     tokio::spawn(async move {
         let (mut rd, mut wr) = tokio::io::split(stream);
 
-        // Read and validate the 4-byte response header
-        let mut hdr = [0u8; 4];
-        if rd.read_exact(&mut hdr).await.is_err() {
-            return;
-        }
-        if hdr[0] != resp_v {
-            tracing::warn!("vmess: response validation byte mismatch");
+        // Consume and validate the AEAD-sealed response header. The response
+        // body keys are SHA-256 of the request body key/iv.
+        let (resp_body_key, resp_body_iv) = response_body_keys(&req_key, &req_iv);
+        if let Err(e) =
+            read_aead_response_header(&mut rd, &resp_body_key, &resp_body_iv, resp_v).await
+        {
+            tracing::warn!("vmess: response header decode failed: {e}");
             return;
         }
 

--- a/crates/meow-proxy/src/vmess/header.rs
+++ b/crates/meow-proxy/src/vmess/header.rs
@@ -4,7 +4,9 @@ use aes_gcm::aead::Aead;
 use aes_gcm::{Aes128Gcm, Nonce};
 use md5::{Digest, Md5};
 use rand::RngCore;
+use sha2::Sha256;
 use std::net::IpAddr;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use meow_common::Metadata;
 
@@ -110,14 +112,16 @@ pub fn seal_request_header(
         &[b"VMess Header AEAD Nonce", &auth_id, &conn_nonce],
     );
 
-    // 4) Derive length encryption keys
+    // 4) Derive length encryption keys. The salts use an underscore
+    //    (`Key_Length` / `Nonce_Length`) in v2ray/xray/mihomo — a space here
+    //    mis-derives the key and the server fails to open the header.
     let length_key = kdf16(
         cmd_key,
-        &[b"VMess Header AEAD Key Length", &auth_id, &conn_nonce],
+        &[b"VMess Header AEAD Key_Length", &auth_id, &conn_nonce],
     );
     let length_iv = kdf12(
         cmd_key,
-        &[b"VMess Header AEAD Nonce Length", &auth_id, &conn_nonce],
+        &[b"VMess Header AEAD Nonce_Length", &auth_id, &conn_nonce],
     );
 
     // 5) Encrypt the header
@@ -127,8 +131,10 @@ pub fn seal_request_header(
         .encrypt(Nonce::from_slice(&header_iv), plaintext.as_ref())
         .map_err(|e| format!("vmess: header encrypt: {e}"))?;
 
-    // 6) Encrypt the length (2 bytes, big-endian)
-    let header_len = encrypted_header.len() as u16;
+    // 6) Encrypt the length. The length field is the PLAINTEXT header length
+    //    (the server reads L then reads L+16 for the tag); using the
+    //    ciphertext length here would make the server over-read by 16 bytes.
+    let header_len = plaintext.len() as u16;
     let length_cipher = Aes128Gcm::new_from_slice(&length_key)
         .map_err(|e| format!("vmess: length cipher init: {e}"))?;
     let encrypted_length = length_cipher
@@ -138,11 +144,13 @@ pub fn seal_request_header(
         )
         .map_err(|e| format!("vmess: length encrypt: {e}"))?;
 
-    // 7) Assemble: auth_id(16) || conn_nonce(8) || encrypted_length(18) || encrypted_header(N+16)
-    let mut out = Vec::with_capacity(16 + 8 + encrypted_length.len() + encrypted_header.len());
+    // 7) Assemble in the exact upstream order:
+    //    auth_id(16) || encrypted_length(2+16) || conn_nonce(8) || encrypted_header(N+16)
+    //    (v2ray SealVMessAEADHeader). conn_nonce sits AFTER the length block.
+    let mut out = Vec::with_capacity(16 + encrypted_length.len() + 8 + encrypted_header.len());
     out.extend_from_slice(&auth_id);
-    out.extend_from_slice(&conn_nonce);
     out.extend_from_slice(&encrypted_length);
+    out.extend_from_slice(&conn_nonce);
     out.extend_from_slice(&encrypted_header);
 
     Ok(SealedHeader {
@@ -151,6 +159,68 @@ pub fn seal_request_header(
         req_iv,
         resp_v,
     })
+}
+
+/// Response body key/iv for AEAD VMess, derived from the request body
+/// key/iv: `respBodyKey = SHA256(req_key)[..16]`, `respBodyIV = SHA256(req_iv)[..16]`.
+///
+/// upstream: `transport/vmess/conn.go` (`sendRequest`, AEAD branch)
+pub fn response_body_keys(req_key: &[u8; 16], req_iv: &[u8; 16]) -> ([u8; 16], [u8; 16]) {
+    let bk: [u8; 32] = Sha256::digest(req_key).into();
+    let bi: [u8; 32] = Sha256::digest(req_iv).into();
+    let mut resp_key = [0u8; 16];
+    let mut resp_iv = [0u8; 16];
+    resp_key.copy_from_slice(&bk[..16]);
+    resp_iv.copy_from_slice(&bi[..16]);
+    (resp_key, resp_iv)
+}
+
+/// Read and validate the AEAD-sealed VMess response header from `rd`, leaving
+/// the reader positioned at the first response body record.
+///
+/// Wire layout (all AES-128-GCM, single-shot): `encrypted_length(2+16)` sealed
+/// with (`AEAD Resp Header Len Key`/`IV`), then `encrypted_header(L+16)` sealed
+/// with (`AEAD Resp Header Key`/`IV`). The header's first byte must equal the
+/// per-connection response-verification byte (`resp_v`).
+///
+/// upstream: `transport/vmess/conn.go` (`recvResponse`)
+pub async fn read_aead_response_header<R: AsyncRead + Unpin>(
+    rd: &mut R,
+    resp_body_key: &[u8; 16],
+    resp_body_iv: &[u8; 16],
+    resp_v: u8,
+) -> std::io::Result<()> {
+    let invalid = |msg: &'static str| std::io::Error::new(std::io::ErrorKind::InvalidData, msg);
+
+    // Length block.
+    let len_key = kdf16(resp_body_key, &[b"AEAD Resp Header Len Key"]);
+    let len_iv = kdf12(resp_body_iv, &[b"AEAD Resp Header Len IV"]);
+    let mut len_ct = [0u8; 18];
+    rd.read_exact(&mut len_ct).await?;
+    let len_cipher =
+        Aes128Gcm::new_from_slice(&len_key).map_err(|_| invalid("vmess: resp len cipher init"))?;
+    let len_pt = len_cipher
+        .decrypt(Nonce::from_slice(&len_iv), len_ct.as_ref())
+        .map_err(|_| invalid("vmess: response length AEAD open failed"))?;
+    if len_pt.len() != 2 {
+        return Err(invalid("vmess: response length not 2 bytes"));
+    }
+    let hdr_len = u16::from_be_bytes([len_pt[0], len_pt[1]]) as usize;
+
+    // Header block (L plaintext + 16 tag).
+    let hdr_key = kdf16(resp_body_key, &[b"AEAD Resp Header Key"]);
+    let hdr_iv = kdf12(resp_body_iv, &[b"AEAD Resp Header IV"]);
+    let mut hdr_ct = vec![0u8; hdr_len + 16];
+    rd.read_exact(&mut hdr_ct).await?;
+    let hdr_cipher =
+        Aes128Gcm::new_from_slice(&hdr_key).map_err(|_| invalid("vmess: resp hdr cipher init"))?;
+    let hdr = hdr_cipher
+        .decrypt(Nonce::from_slice(&hdr_iv), hdr_ct.as_ref())
+        .map_err(|_| invalid("vmess: response header AEAD open failed"))?;
+    if hdr.first() != Some(&resp_v) {
+        return Err(invalid("vmess: response header verification byte mismatch"));
+    }
+    Ok(())
 }
 
 fn build_auth_id(cmd_key: &[u8; 16], rng: &mut impl RngCore) -> [u8; 16] {
@@ -403,6 +473,147 @@ mod tests {
         assert!(sealed.bytes.len() >= 16 + 8 + 18 + 16, "header too short");
         assert_ne!(sealed.req_key, [0u8; 16], "req_key must be random");
         assert_ne!(sealed.req_iv, [0u8; 16], "req_iv must be random");
+    }
+
+    /// Independently open a sealed request header the way a conformant server
+    /// (v2ray `OpenVMessAEADHeader`) does, re-deriving every key from the wire
+    /// bytes. This catches the seal-order, plaintext-length, and length-salt
+    /// bugs that a self-consistent seal/open pair would hide.
+    fn server_open_request_header(cmd_key: &[u8; 16], wire: &[u8]) -> Result<Vec<u8>, String> {
+        use aes_gcm::aead::Aead;
+        let auth_id = &wire[0..16];
+        let encrypted_length = &wire[16..34]; // 2 + 16 tag
+        let conn_nonce = &wire[34..42]; // 8 bytes AFTER the length block
+        let encrypted_payload = &wire[42..];
+
+        let length_key = kdf16(
+            cmd_key,
+            &[b"VMess Header AEAD Key_Length", auth_id, conn_nonce],
+        );
+        let length_iv = kdf12(
+            cmd_key,
+            &[b"VMess Header AEAD Nonce_Length", auth_id, conn_nonce],
+        );
+        let len_cipher = Aes128Gcm::new_from_slice(&length_key).map_err(|e| e.to_string())?;
+        let len_pt = len_cipher
+            .decrypt(Nonce::from_slice(&length_iv), encrypted_length)
+            .map_err(|_| "length AEAD open failed".to_string())?;
+        let l = u16::from_be_bytes([len_pt[0], len_pt[1]]) as usize;
+        if encrypted_payload.len() != l + 16 {
+            return Err(format!(
+                "payload len {} != L+16 ({})",
+                encrypted_payload.len(),
+                l + 16
+            ));
+        }
+
+        let header_key = kdf16(cmd_key, &[b"VMess Header AEAD Key", auth_id, conn_nonce]);
+        let header_iv = kdf12(cmd_key, &[b"VMess Header AEAD Nonce", auth_id, conn_nonce]);
+        let hdr_cipher = Aes128Gcm::new_from_slice(&header_key).map_err(|e| e.to_string())?;
+        let plaintext = hdr_cipher
+            .decrypt(Nonce::from_slice(&header_iv), encrypted_payload)
+            .map_err(|_| "payload AEAD open failed".to_string())?;
+        if plaintext.len() != l {
+            return Err(format!("plaintext len {} != L {}", plaintext.len(), l));
+        }
+        Ok(plaintext)
+    }
+
+    #[test]
+    fn sealed_header_is_server_openable() {
+        let uuid: [u8; 16] = [
+            0xb8, 0x31, 0x38, 0x1d, 0x63, 0x24, 0x4d, 0x53, 0xad, 0x4f, 0x8c, 0xda, 0x48, 0xb3,
+            0x08, 0x11,
+        ];
+        let ck = cmd_key(&uuid);
+        let meta = Metadata {
+            host: "example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let sealed = seal_request_header(&ck, Security::Aes128Gcm, &meta, false).unwrap();
+        let pt = server_open_request_header(&ck, &sealed.bytes)
+            .expect("a conformant server must be able to open the sealed header");
+
+        // Plaintext layout: version(1) | req_iv(16) | req_key(16) | resp_v(1) | ...
+        assert_eq!(pt[0], 0x01, "version byte");
+        assert_eq!(
+            &pt[1..17],
+            &sealed.req_iv,
+            "req_iv round-trips through wire"
+        );
+        assert_eq!(
+            &pt[17..33],
+            &sealed.req_key,
+            "req_key round-trips through wire"
+        );
+        assert_eq!(pt[33], sealed.resp_v, "resp_v round-trips through wire");
+
+        // FNV-1a trailer must cover everything before it.
+        let body = &pt[..pt.len() - 4];
+        let want = fnv1a32(body);
+        let got = u32::from_be_bytes([
+            pt[pt.len() - 4],
+            pt[pt.len() - 3],
+            pt[pt.len() - 2],
+            pt[pt.len() - 1],
+        ]);
+        assert_eq!(got, want, "server-visible FNV-1a must validate");
+    }
+
+    #[tokio::test]
+    async fn response_header_round_trips() {
+        use aes_gcm::aead::Aead;
+        let req_key = [0x11u8; 16];
+        let req_iv = [0x22u8; 16];
+        let resp_v = 0x5A;
+        let (rk, ri) = response_body_keys(&req_key, &req_iv);
+
+        // Server seals a minimal 4-byte response header [resp_v, opt=0, cmdlen=0, 0].
+        let hdr_pt = [resp_v, 0x00, 0x00, 0x00];
+        let len_key = kdf16(&rk, &[b"AEAD Resp Header Len Key"]);
+        let len_iv = kdf12(&ri, &[b"AEAD Resp Header Len IV"]);
+        let len_ct = Aes128Gcm::new_from_slice(&len_key)
+            .unwrap()
+            .encrypt(
+                Nonce::from_slice(&len_iv),
+                (hdr_pt.len() as u16).to_be_bytes().as_ref(),
+            )
+            .unwrap();
+        let hdr_key = kdf16(&rk, &[b"AEAD Resp Header Key"]);
+        let hdr_iv = kdf12(&ri, &[b"AEAD Resp Header IV"]);
+        let hdr_ct = Aes128Gcm::new_from_slice(&hdr_key)
+            .unwrap()
+            .encrypt(Nonce::from_slice(&hdr_iv), hdr_pt.as_ref())
+            .unwrap();
+
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&len_ct);
+        wire.extend_from_slice(&hdr_ct);
+        wire.extend_from_slice(b"body-records-follow");
+
+        let mut cursor = std::io::Cursor::new(wire);
+        read_aead_response_header(&mut cursor, &rk, &ri, resp_v)
+            .await
+            .expect("client must open the server's response header");
+
+        // Reader is positioned exactly at the body bytes.
+        let mut rest = Vec::new();
+        cursor.read_to_end(&mut rest).await.unwrap();
+        assert_eq!(rest, b"body-records-follow");
+
+        // A wrong resp_v must be rejected.
+        let mut cursor2 = std::io::Cursor::new({
+            let mut w = Vec::new();
+            w.extend_from_slice(&len_ct);
+            w.extend_from_slice(&hdr_ct);
+            w
+        });
+        assert!(
+            read_aead_response_header(&mut cursor2, &rk, &ri, resp_v ^ 0xFF)
+                .await
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/meow-proxy/src/vmess/header.rs
+++ b/crates/meow-proxy/src/vmess/header.rs
@@ -1,6 +1,6 @@
 use aes::cipher::{BlockEncrypt, KeyInit};
 use aes::Aes128;
-use aes_gcm::aead::Aead;
+use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::{Aes128Gcm, Nonce};
 use md5::{Digest, Md5};
 use rand::RngCore;
@@ -128,7 +128,13 @@ pub fn seal_request_header(
     let cipher = Aes128Gcm::new_from_slice(&header_key)
         .map_err(|e| format!("vmess: header cipher init: {e}"))?;
     let encrypted_header = cipher
-        .encrypt(Nonce::from_slice(&header_iv), plaintext.as_ref())
+        .encrypt(
+            Nonce::from_slice(&header_iv),
+            Payload {
+                msg: &plaintext,
+                aad: &auth_id,
+            },
+        )
         .map_err(|e| format!("vmess: header encrypt: {e}"))?;
 
     // 6) Encrypt the length. The length field is the PLAINTEXT header length
@@ -140,7 +146,10 @@ pub fn seal_request_header(
     let encrypted_length = length_cipher
         .encrypt(
             Nonce::from_slice(&length_iv),
-            header_len.to_be_bytes().as_ref(),
+            Payload {
+                msg: &header_len.to_be_bytes(),
+                aad: &auth_id,
+            },
         )
         .map_err(|e| format!("vmess: length encrypt: {e}"))?;
 
@@ -480,7 +489,7 @@ mod tests {
     /// bytes. This catches the seal-order, plaintext-length, and length-salt
     /// bugs that a self-consistent seal/open pair would hide.
     fn server_open_request_header(cmd_key: &[u8; 16], wire: &[u8]) -> Result<Vec<u8>, String> {
-        use aes_gcm::aead::Aead;
+        use aes_gcm::aead::{Aead, Payload};
         let auth_id = &wire[0..16];
         let encrypted_length = &wire[16..34]; // 2 + 16 tag
         let conn_nonce = &wire[34..42]; // 8 bytes AFTER the length block
@@ -496,7 +505,13 @@ mod tests {
         );
         let len_cipher = Aes128Gcm::new_from_slice(&length_key).map_err(|e| e.to_string())?;
         let len_pt = len_cipher
-            .decrypt(Nonce::from_slice(&length_iv), encrypted_length)
+            .decrypt(
+                Nonce::from_slice(&length_iv),
+                Payload {
+                    msg: encrypted_length,
+                    aad: auth_id,
+                },
+            )
             .map_err(|_| "length AEAD open failed".to_string())?;
         let l = u16::from_be_bytes([len_pt[0], len_pt[1]]) as usize;
         if encrypted_payload.len() != l + 16 {
@@ -511,7 +526,13 @@ mod tests {
         let header_iv = kdf12(cmd_key, &[b"VMess Header AEAD Nonce", auth_id, conn_nonce]);
         let hdr_cipher = Aes128Gcm::new_from_slice(&header_key).map_err(|e| e.to_string())?;
         let plaintext = hdr_cipher
-            .decrypt(Nonce::from_slice(&header_iv), encrypted_payload)
+            .decrypt(
+                Nonce::from_slice(&header_iv),
+                Payload {
+                    msg: encrypted_payload,
+                    aad: auth_id,
+                },
+            )
             .map_err(|_| "payload AEAD open failed".to_string())?;
         if plaintext.len() != l {
             return Err(format!("plaintext len {} != L {}", plaintext.len(), l));

--- a/crates/meow-proxy/src/vmess/header.rs
+++ b/crates/meow-proxy/src/vmess/header.rs
@@ -336,152 +336,78 @@ fn fnv1a32(data: &[u8]) -> u32 {
 mod tests {
     use super::*;
 
-    #[test]
-    fn cmd_key_is_deterministic() {
+    fn protocol_constants_and_hashes_match_reference() {
         let uuid: [u8; 16] = [
             0xb8, 0x31, 0x38, 0x1d, 0x63, 0x24, 0x4d, 0x53, 0xad, 0x4f, 0x8c, 0xda, 0x48, 0xb3,
             0x08, 0x11,
         ];
-        let k1 = cmd_key(&uuid);
-        let k2 = cmd_key(&uuid);
-        assert_eq!(k1, k2);
-        assert_ne!(k1, [0u8; 16]);
-    }
-
-    #[test]
-    fn fnv1a_known_value() {
+        assert_eq!(cmd_key(&uuid), cmd_key(&uuid));
+        assert_ne!(cmd_key(&uuid), [0u8; 16]);
         assert_eq!(fnv1a32(b""), 0x811c_9dc5);
         assert_eq!(fnv1a32(b"a"), 0xe40c_292c);
-    }
-
-    #[test]
-    fn address_encode_ipv4() {
-        let meta = Metadata {
-            dst_ip: Some(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1))),
-            dst_port: 443,
-            ..Default::default()
-        };
-        let mut buf = Vec::new();
-        encode_address(&mut buf, &meta).unwrap();
-        assert_eq!(buf, vec![0x01, 127, 0, 0, 1]);
-    }
-
-    #[test]
-    fn address_encode_domain() {
-        let meta = Metadata {
-            host: "example.com".into(),
-            dst_port: 80,
-            ..Default::default()
-        };
-        let mut buf = Vec::new();
-        encode_address(&mut buf, &meta).unwrap();
-        assert_eq!(buf[0], 0x02);
-        assert_eq!(buf[1], 11);
-        assert_eq!(&buf[2..], b"example.com");
-    }
-
-    #[test]
-    fn address_encode_domain_too_long() {
-        let long = "a".repeat(256);
-        let meta = Metadata {
-            host: long.into(),
-            dst_port: 80,
-            ..Default::default()
-        };
-        let mut buf = Vec::new();
-        assert!(encode_address(&mut buf, &meta).is_err());
-    }
-
-    #[test]
-    fn security_nibble_values() {
         assert_eq!(Security::Aes128Gcm.to_nibble(), 0x03);
         assert_eq!(Security::ChaCha20Poly1305.to_nibble(), 0x04);
         assert_eq!(Security::None.to_nibble(), 0x05);
+        assert!(matches!(
+            auto_security(),
+            Security::Aes128Gcm | Security::ChaCha20Poly1305
+        ));
     }
 
-    #[test]
-    fn address_encode_ipv6() {
-        let meta = Metadata {
+    fn address_encoding_covers_all_wire_variants_and_boundaries() {
+        fn encoded(meta: &Metadata) -> Vec<u8> {
+            let mut buf = Vec::new();
+            encode_address(&mut buf, meta).unwrap();
+            buf
+        }
+
+        assert_eq!(
+            encoded(&Metadata {
+                dst_ip: Some(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1))),
+                ..Default::default()
+            }),
+            vec![ADDR_IPV4, 127, 0, 0, 1]
+        );
+
+        let ipv6 = encoded(&Metadata {
             dst_ip: Some(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
-            dst_port: 443,
             ..Default::default()
-        };
-        let mut buf = Vec::new();
-        encode_address(&mut buf, &meta).unwrap();
-        assert_eq!(buf[0], ADDR_IPV6);
-        assert_eq!(buf.len(), 1 + 16);
-    }
+        });
+        assert_eq!(ipv6[0], ADDR_IPV6);
+        assert_eq!(ipv6.len(), 17);
 
-    #[test]
-    fn address_encode_domain_max_255_ok() {
-        let domain = "a".repeat(255);
-        let meta = Metadata {
-            host: domain.into(),
-            dst_port: 80,
-            ..Default::default()
-        };
-        let mut buf = Vec::new();
-        encode_address(&mut buf, &meta).unwrap();
-        assert_eq!(buf[0], ADDR_DOMAIN);
-        assert_eq!(buf[1], 255);
-        assert_eq!(buf.len(), 2 + 255);
-    }
-
-    #[test]
-    fn address_encode_no_destination_errors() {
-        let meta = Metadata {
-            dst_port: 80,
-            ..Default::default()
-        };
-        let mut buf = Vec::new();
-        assert!(encode_address(&mut buf, &meta).is_err());
-    }
-
-    #[test]
-    fn address_encode_domain_idn_not_punycoded() {
-        // upstream: passes raw UTF-8, no punycode conversion
-        let meta = Metadata {
-            host: "例え.jp".into(),
-            dst_port: 80,
-            ..Default::default()
-        };
-        let mut buf = Vec::new();
-        encode_address(&mut buf, &meta).unwrap();
-        assert_eq!(buf[0], ADDR_DOMAIN);
-        assert_eq!(&buf[2..], "例え.jp".as_bytes());
-    }
-
-    #[test]
-    fn address_domain_prefers_host_over_ip() {
-        let meta = Metadata {
+        let domain = encoded(&Metadata {
             host: "example.com".into(),
             dst_ip: Some(IpAddr::V4(std::net::Ipv4Addr::new(1, 2, 3, 4))),
-            dst_port: 443,
             ..Default::default()
-        };
-        let mut buf = Vec::new();
-        encode_address(&mut buf, &meta).unwrap();
-        assert_eq!(buf[0], ADDR_DOMAIN, "domain must take priority over IP");
+        });
+        assert_eq!(&domain, b"\x02\x0bexample.com");
+
+        let idn = encoded(&Metadata {
+            host: "例え.jp".into(),
+            ..Default::default()
+        });
+        assert_eq!(&idn[2..], "例え.jp".as_bytes());
+
+        let max_domain = encoded(&Metadata {
+            host: "a".repeat(255).into(),
+            ..Default::default()
+        });
+        assert_eq!(max_domain[1], 255);
+        assert_eq!(max_domain.len(), 257);
     }
 
-    #[test]
-    fn seal_request_header_produces_valid_structure() {
-        let uuid: [u8; 16] = [
-            0xb8, 0x31, 0x38, 0x1d, 0x63, 0x24, 0x4d, 0x53, 0xad, 0x4f, 0x8c, 0xda, 0x48, 0xb3,
-            0x08, 0x11,
-        ];
-        let ck = cmd_key(&uuid);
-        let meta = Metadata {
-            host: "example.com".into(),
-            dst_port: 443,
-            ..Default::default()
-        };
-        let sealed = seal_request_header(&ck, Security::Aes128Gcm, &meta, false).unwrap();
-
-        // auth_id(16) + conn_nonce(8) + encrypted_length(2+16=18) + encrypted_header(N+16)
-        assert!(sealed.bytes.len() >= 16 + 8 + 18 + 16, "header too short");
-        assert_ne!(sealed.req_key, [0u8; 16], "req_key must be random");
-        assert_ne!(sealed.req_iv, [0u8; 16], "req_iv must be random");
+    fn address_encoding_rejects_missing_or_oversized_destination() {
+        let mut buf = Vec::new();
+        assert!(encode_address(&mut buf, &Metadata::default()).is_err());
+        assert!(encode_address(
+            &mut buf,
+            &Metadata {
+                host: "a".repeat(256).into(),
+                ..Default::default()
+            }
+        )
+        .is_err());
     }
 
     /// Independently open a sealed request header the way a conformant server
@@ -540,8 +466,7 @@ mod tests {
         Ok(plaintext)
     }
 
-    #[test]
-    fn sealed_header_is_server_openable() {
+    fn sealed_headers_are_unique_and_server_openable() {
         let uuid: [u8; 16] = [
             0xb8, 0x31, 0x38, 0x1d, 0x63, 0x24, 0x4d, 0x53, 0xad, 0x4f, 0x8c, 0xda, 0x48, 0xb3,
             0x08, 0x11,
@@ -553,6 +478,13 @@ mod tests {
             ..Default::default()
         };
         let sealed = seal_request_header(&ck, Security::Aes128Gcm, &meta, false).unwrap();
+        let second = seal_request_header(&ck, Security::Aes128Gcm, &meta, false).unwrap();
+        assert_ne!(sealed.bytes, second.bytes);
+        assert_ne!(sealed.req_key, second.req_key);
+        assert!(sealed.bytes.len() >= 16 + 18 + 8 + 16);
+        assert_ne!(sealed.req_key, [0; 16]);
+        assert_ne!(sealed.req_iv, [0; 16]);
+
         let pt = server_open_request_header(&ck, &sealed.bytes)
             .expect("a conformant server must be able to open the sealed header");
 
@@ -582,7 +514,6 @@ mod tests {
         assert_eq!(got, want, "server-visible FNV-1a must validate");
     }
 
-    #[tokio::test]
     async fn response_header_round_trips() {
         use aes_gcm::aead::Aead;
         let req_key = [0x11u8; 16];
@@ -637,29 +568,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn seal_request_header_unique_per_call() {
-        let uuid: [u8; 16] = [0x01; 16];
-        let ck = cmd_key(&uuid);
-        let meta = Metadata {
-            host: "test.com".into(),
-            dst_port: 80,
-            ..Default::default()
-        };
-        let h1 = seal_request_header(&ck, Security::Aes128Gcm, &meta, false).unwrap();
-        let h2 = seal_request_header(&ck, Security::Aes128Gcm, &meta, false).unwrap();
-        assert_ne!(h1.bytes, h2.bytes, "each header must use fresh randomness");
-        assert_ne!(h1.req_key, h2.req_key);
-    }
-
-    #[test]
-    fn header_plaintext_port_before_addr_type() {
+    fn plaintext_layout_and_checksum_match_protocol() {
         let meta = Metadata {
             host: "example.com".into(),
             dst_port: 443,
             ..Default::default()
         };
-        let mut rng = rand::rng();
+        let mut rng = FakeRng(0);
         let req_key = [0u8; 16];
         let req_iv = [0u8; 16];
         let pt = build_header_plaintext(
@@ -682,26 +597,7 @@ mod tests {
             ADDR_DOMAIN,
             "addr_type must follow port"
         );
-    }
 
-    #[test]
-    fn header_plaintext_ends_with_fnv1a() {
-        let meta = Metadata {
-            dst_ip: Some(IpAddr::V4(std::net::Ipv4Addr::new(1, 2, 3, 4))),
-            dst_port: 80,
-            ..Default::default()
-        };
-        let mut rng = FakeRng(0);
-        let pt = build_header_plaintext(
-            &[0u8; 16],
-            &[0u8; 16],
-            0x42,
-            Security::Aes128Gcm,
-            &meta,
-            false,
-            &mut rng,
-        )
-        .unwrap();
         let body = &pt[..pt.len() - 4];
         let expected_hash = fnv1a32(body);
         let actual_hash = u32::from_be_bytes([
@@ -716,13 +612,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn auto_security_returns_valid_cipher() {
-        let s = super::auto_security();
-        assert!(
-            s == Security::Aes128Gcm || s == Security::ChaCha20Poly1305,
-            "auto must pick aes or chacha"
-        );
+    #[tokio::test]
+    async fn header_wire_format_matches_protocol() {
+        protocol_constants_and_hashes_match_reference();
+        address_encoding_covers_all_wire_variants_and_boundaries();
+        address_encoding_rejects_missing_or_oversized_destination();
+        plaintext_layout_and_checksum_match_protocol();
+        sealed_headers_are_unique_and_server_openable();
+        response_header_round_trips().await;
     }
 
     struct FakeRng(u64);

--- a/crates/meow-proxy/src/vmess/kdf.rs
+++ b/crates/meow-proxy/src/vmess/kdf.rs
@@ -80,52 +80,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn kdf_produces_deterministic_output() {
-        let k1 = kdf(b"test-key", &[b"label1"]);
-        let k2 = kdf(b"test-key", &[b"label1"]);
-        assert_eq!(k1, k2);
-    }
-
-    #[test]
-    fn kdf_different_paths_differ() {
-        let k1 = kdf(b"test-key", &[b"label1"]);
-        let k2 = kdf(b"test-key", &[b"label2"]);
-        assert_ne!(k1, k2);
-    }
-
-    #[test]
-    fn kdf_multi_segment_path() {
-        let k1 = kdf(b"key", &[b"a", b"b"]);
-        let k2 = kdf(b"key", &[b"a"]);
-        assert_ne!(k1, k2);
-    }
-
-    /// Cross-implementation vector from v2ray-core `proxy/vmess/aead/kdf_test.go`
-    /// (`TestKDFValue`). Any regression to the old HMAC-cascade construction
-    /// changes this output and breaks interop with every conformant server.
-    #[test]
-    fn kdf_matches_v2ray_reference_vector() {
-        let out = kdf(
-            b"Demo Key for KDF Value Test",
-            &[
-                b"Demo Path for KDF Value Test",
-                b"Demo Path for KDF Value Test2",
-                b"Demo Path for KDF Value Test3",
-            ],
+    fn kdf_matches_single_and_multi_segment_reference_vectors() {
+        assert_eq!(
+            kdf(b"key", &[b"label"]),
+            hex_literal_32("c9cebf77e859ffcbe78619d4e503b0df707f1d7ac98a189c418763940880e3eb")
         );
-        let expected =
-            hex_literal_32("53e9d7e1bd7bd25022b71ead07d8a596efc8a845c7888652fd684b4903dc8892");
-        assert_eq!(out, expected);
-    }
-
-    /// A single-segment path is a plain HMAC-SHA256 keyed by the segment over
-    /// an HMAC-SHA256 keyed by the fixed salt — pinned independently.
-    #[test]
-    fn kdf_single_segment_vector() {
-        let out = kdf(b"key", &[b"label"]);
-        let expected =
-            hex_literal_32("c9cebf77e859ffcbe78619d4e503b0df707f1d7ac98a189c418763940880e3eb");
-        assert_eq!(out, expected);
+        assert_eq!(
+            kdf(
+                b"Demo Key for KDF Value Test",
+                &[
+                    b"Demo Path for KDF Value Test",
+                    b"Demo Path for KDF Value Test2",
+                    b"Demo Path for KDF Value Test3",
+                ],
+            ),
+            hex_literal_32("53e9d7e1bd7bd25022b71ead07d8a596efc8a845c7888652fd684b4903dc8892")
+        );
     }
 
     fn hex_literal_32(s: &str) -> [u8; 32] {

--- a/crates/meow-proxy/src/vmess/kdf.rs
+++ b/crates/meow-proxy/src/vmess/kdf.rs
@@ -1,25 +1,64 @@
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 
-type HmacSha256 = Hmac<Sha256>;
+/// SHA-256 block size, in bytes.
+const BLOCK: usize = 64;
 
-/// VMess KDF — HMAC-SHA256 cascade keyed by label and path segments.
+fn sha256(data: &[u8]) -> [u8; 32] {
+    Sha256::digest(data).into()
+}
+
+/// Recursively-nested HMAC-SHA256 as used by the VMess AEAD KDF.
 ///
-/// upstream: transport/vmess/aead/encrypt.go::KDF
-pub fn kdf(key: &[u8], path: &[&[u8]]) -> [u8; 32] {
-    let mut current_key = {
-        let mut mac =
-            HmacSha256::new_from_slice(b"VMess AEAD KDF").expect("HMAC accepts any key length");
-        mac.update(key);
-        mac.finalize().into_bytes()
+/// `keys[0]` is the innermost HMAC key and `keys[last]` the outermost; `msg`
+/// is fed to the outermost HMAC. With a single key this is a plain
+/// HMAC-SHA256; each additional key wraps another HMAC whose underlying hash
+/// primitive is the *inner HMAC* (not raw SHA-256). This mirrors v2ray
+/// `proxy/vmess/aead` `KDF` / `hMacCreator` exactly — a cascade (feeding each
+/// digest as the next HMAC key) produces entirely different output and does
+/// not interoperate.
+fn nested_hmac(keys: &[&[u8]], msg: &[u8]) -> [u8; 32] {
+    let Some((k, inner_keys)) = keys.split_last() else {
+        return sha256(msg);
     };
-    for seg in path {
-        let mut mac =
-            HmacSha256::new_from_slice(&current_key).expect("HMAC accepts any key length");
-        mac.update(seg);
-        current_key = mac.finalize().into_bytes();
+
+    // Normalize the outermost key to the block size. Keys longer than the
+    // block are first hashed by the parent hash; VMess never hits this (all
+    // salts/derived inputs are < 64 bytes) but it keeps the primitive correct.
+    let mut key_block = [0u8; BLOCK];
+    if k.len() > BLOCK {
+        key_block[..32].copy_from_slice(&nested_hmac(inner_keys, k));
+    } else {
+        key_block[..k.len()].copy_from_slice(k);
     }
-    current_key.into()
+
+    let mut ipad = [0u8; BLOCK];
+    let mut opad = [0u8; BLOCK];
+    for i in 0..BLOCK {
+        ipad[i] = key_block[i] ^ 0x36;
+        opad[i] = key_block[i] ^ 0x5c;
+    }
+
+    let mut inner_msg = Vec::with_capacity(BLOCK + msg.len());
+    inner_msg.extend_from_slice(&ipad);
+    inner_msg.extend_from_slice(msg);
+    let inner_digest = nested_hmac(inner_keys, &inner_msg);
+
+    let mut outer_msg = Vec::with_capacity(BLOCK + 32);
+    outer_msg.extend_from_slice(&opad);
+    outer_msg.extend_from_slice(&inner_digest);
+    nested_hmac(inner_keys, &outer_msg)
+}
+
+/// VMess AEAD KDF — recursively-nested HMAC-SHA256 keyed by the fixed
+/// `"VMess AEAD KDF"` salt (innermost) and each `path` segment, with `key`
+/// fed as the message to the outermost HMAC.
+///
+/// upstream: `proxy/vmess/aead/kdf.go` (`KDF`)
+pub fn kdf(key: &[u8], path: &[&[u8]]) -> [u8; 32] {
+    let mut keys: Vec<&[u8]> = Vec::with_capacity(1 + path.len());
+    keys.push(b"VMess AEAD KDF");
+    keys.extend_from_slice(path);
+    nested_hmac(&keys, key)
 }
 
 pub fn kdf16(key: &[u8], path: &[&[u8]]) -> [u8; 16] {
@@ -59,5 +98,44 @@ mod tests {
         let k1 = kdf(b"key", &[b"a", b"b"]);
         let k2 = kdf(b"key", &[b"a"]);
         assert_ne!(k1, k2);
+    }
+
+    /// Cross-implementation vector from v2ray-core `proxy/vmess/aead/kdf_test.go`
+    /// (`TestKDFValue`). Any regression to the old HMAC-cascade construction
+    /// changes this output and breaks interop with every conformant server.
+    #[test]
+    fn kdf_matches_v2ray_reference_vector() {
+        let out = kdf(
+            b"Demo Key for KDF Value Test",
+            &[
+                b"Demo Path for KDF Value Test",
+                b"Demo Path for KDF Value Test2",
+                b"Demo Path for KDF Value Test3",
+            ],
+        );
+        let expected =
+            hex_literal_32("53e9d7e1bd7bd25022b71ead07d8a596efc8a845c7888652fd684b4903dc8892");
+        assert_eq!(out, expected);
+    }
+
+    /// A single-segment path is a plain HMAC-SHA256 keyed by the segment over
+    /// an HMAC-SHA256 keyed by the fixed salt — pinned independently.
+    #[test]
+    fn kdf_single_segment_vector() {
+        let out = kdf(b"key", &[b"label"]);
+        let expected =
+            hex_literal_32("c9cebf77e859ffcbe78619d4e503b0df707f1d7ac98a189c418763940880e3eb");
+        assert_eq!(out, expected);
+    }
+
+    fn hex_literal_32(s: &str) -> [u8; 32] {
+        let bytes = s.as_bytes();
+        let mut out = [0u8; 32];
+        for (i, chunk) in bytes.chunks(2).enumerate() {
+            let hi = (chunk[0] as char).to_digit(16).unwrap() as u8;
+            let lo = (chunk[1] as char).to_digit(16).unwrap() as u8;
+            out[i] = (hi << 4) | lo;
+        }
+        out
     }
 }

--- a/crates/meow-proxy/src/vmess/mod.rs
+++ b/crates/meow-proxy/src/vmess/mod.rs
@@ -110,7 +110,14 @@ impl ProxyAdapter for VmessAdapter {
             sealed.resp_v,
         );
 
-        let duplex = conn::spawn_vmess_relay(stream, read_cipher, write_cipher, sealed.resp_v);
+        let duplex = conn::spawn_vmess_relay(
+            stream,
+            read_cipher,
+            write_cipher,
+            sealed.req_key,
+            sealed.req_iv,
+            sealed.resp_v,
+        );
         Ok(Box::new(crate::stream_conn::StreamConn(Box::new(duplex))))
     }
 


### PR DESCRIPTION
## Summary

Fixes #270 — the default-on VMess outbound could not interoperate with any conformant server. Several independent AEAD wire-format defects each broke the handshake; self-consistent unit tests passed only because both ends ran the same wrong code. Every item was verified against the **mihomo `transport/vmess`** and **v2ray `proxy/vmess/aead`** reference (fetched during this work).

The audit in the issue listed 4 defects; fixing them end-to-end surfaced **3 more** wire-format bugs in the same code paths, all fixed here.

## Defects fixed

| # | File | Bug | Fix |
|---|------|-----|-----|
| 1 | `kdf.rs` | KDF was an HMAC **cascade** (prev digest → next key) | Recursively-**nested** HMAC-SHA256 (`hMacCreator`): each segment keys an HMAC whose hash primitive is the parent HMAC; `key` is the message to the outermost, written once |
| 2 | `body.rs` | Record nonce **XORed** counter into full IV | `nonce = count(2 BE) ‖ iv[2..12]` (overwrite; iv[0]/iv[1] discarded) |
| 3 | `conn.rs`/`header.rs` | Response header read as 4 **plaintext** bytes; response keys non-standard | AEAD-decode response header (`AEAD Resp Header Len Key/IV`, `AEAD Resp Header Key/IV`); `respBodyKey/IV = SHA256(reqBodyKey/IV)[..16]`; validate `header[0]==resp_v` |
| 4 | `header.rs` | Length salts used a **space** | `VMess Header AEAD Key_Length` / `Nonce_Length` (underscore) |
| **5** | `header.rs` | Length field was **ciphertext** length | Must be **plaintext** length (server reads L, then L+16 for tag) |
| **6** | `header.rs` | Seal order had `conn_nonce`/length **swapped** | `auth_id ‖ enc_length ‖ conn_nonce ‖ enc_header` (v2ray `SealVMessAEADHeader`) |
| **7** | `body.rs` | **Request** body key was `kdf16(req_key‖req_iv, "VMess Body AEAD Key")` — a salt that doesn't exist in the protocol | AES-128-GCM uses `reqBodyKey`/`reqBodyIV` **directly**; ChaCha20 uses `MD5(k)‖MD5(MD5(k))` |

## Tests (interop-oriented, replacing self-consistent ones)

- **`kdf_matches_v2ray_reference_vector`** — pins the KDF to v2ray's `kdf_test.go` vector (`Demo Key…` → `53e9d7e1…`), generated and double-checked with two independent HMAC implementations.
- **`sealed_header_is_server_openable`** — an independent server-side `OpenVMessAEADHeader` routine decodes the sealed request straight off the wire (re-deriving every key), catching the order/length/salt bugs.
- **`response_header_round_trips`** — hand-rolled server seal → client `read_aead_response_header` decode, incl. wrong-`resp_v` rejection and body-position check.
- **`read_record_decrypts_independently_encoded_response`** — a response body record encrypted with SHA-256-derived keys is decrypted by the client read path.

## Verification

Full regression bar run locally: `cargo fmt --check`, three-way clippy (`default` / `--no-default-features` / `--all-features`) with `-D warnings`, `cargo doc` with `-D warnings`, `cargo test --lib` (all crates; 309 in meow-proxy).

No changes to `Metadata`/`ConnectionInfo`/`UdpSession`/`CacheEntry` layouts; no relay-path (`relay.rs`/`tcp.rs`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)