### PR TITLE
fix(cli,api): stop silently ignoring mihomo compat flags; simplify delay lookup

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -280,7 +280,7 @@ struct ProxyInfo {
     /// Group-only: name of the currently active member.
     #[serde(skip_serializing_if = "Option::is_none")]
     now: Option<String>,
-    /// Last measured delay in ms, 0 if unknown.
+    /// Last measured delay in ms; omitted until a probe has succeeded.
     #[serde(skip_serializing_if = "Option::is_none")]
     delay: Option<u16>,
 }
@@ -296,10 +296,7 @@ impl ProxyInfo {
             current = ?current,
             "building ProxyInfo",
         );
-        let delay = {
-            let h = proxy.delay_history();
-            h.last().map(|d| d.delay).filter(|&d| d > 0)
-        };
+        let delay = Some(proxy.last_delay()).filter(|&d| d > 0);
         Self {
             name: proxy.name().to_string(),
             proxy_type: proxy.adapter_type().to_string(),

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -130,6 +130,25 @@ fn main() -> Result<()> {
     if args.age_secret_key.is_some() {
         anyhow::bail!("--age-secret-key is not yet supported");
     }
+    if args.ext_ctl_tls.is_some() {
+        anyhow::bail!("--ext-ctl-tls is not yet supported");
+    }
+    if args.ext_ctl_unix.is_some() {
+        anyhow::bail!("--ext-ctl-unix is not yet supported");
+    }
+    if args.ext_ctl_pipe.is_some() {
+        anyhow::bail!("--ext-ctl-pipe is not yet supported");
+    }
+
+    // Accepted for mihomo CLI compatibility but not implemented. Frontends may
+    // pass these blindly, so warn instead of bailing (tracing is not yet
+    // initialized here, hence eprintln).
+    if args.geodata_mode {
+        eprintln!("warning: --geodata-mode is not supported and will be ignored");
+    }
+    if args.ext_ctl_routing_mark.is_some() {
+        eprintln!("warning: --ext-ctl-routing-mark is not supported and will be ignored");
+    }
 
     // Handle subcommands before initializing logging/runtime
     if let Some(cmd) = &args.command {


### PR DESCRIPTION
Follow-up to the #313 review (second batch, after #325).

## Changes

**Dead CLI flags** (`crates/meow-app/src/main.rs`) — five flags added in #313 were parsed but never read. Split by consequence:
- `--ext-ctl-tls`, `--ext-ctl-unix`, `--ext-ctl-pipe` now hard-error like the other unsupported flags — silently ignoring them would run the external controller without the transport the user explicitly requested (especially TLS).
- `--geodata-mode` and `--ext-ctl-routing-mark` warn and continue — tuning knobs that frontends (clash-nyanpasu et al.) may pass unconditionally, so bailing would break the drop-in use case. Warning goes through `eprintln!` since tracing is not yet initialized at that point; a comment documents the split.

**Delay cleanups** (`crates/meow-api/src/routes.rs`):
- `ProxyInfo::from_proxy` uses the existing `Proxy::last_delay()` instead of cloning the full delay-history `Vec` to read its last entry (allocation-lint posture, ADR-0010 addendum A).
- The `delay` field doc no longer claims a `0` sentinel that serialization never emits — it's omitted until a probe has succeeded.

## Verification

- `cargo fmt --all -- --check`, three-way clippy (default / no-default-features / all-features) with `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib`, and `cargo test -p meow-api --test api_test` (95 passed) all green.
- Exercised the binary: `--ext-ctl-tls 127.0.0.1:9443` exits 1 with `Error: --ext-ctl-tls is not yet supported`; `--geodata-mode -t` prints the warning and proceeds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)