### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64",
  "ipnet",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -220,16 +220,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.16.0" }
-meow-trie = { path = "crates/meow-trie", version = "0.16.0" }
+meow-common = { path = "crates/meow-common", version = "0.17.0" }
+meow-trie = { path = "crates/meow-trie", version = "0.17.0" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.16.0" }
-meow-dns = { path = "crates/meow-dns", version = "0.16.0", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.16.0" }
-meow-transport = { path = "crates/meow-transport", version = "0.16.0" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.16.0", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.16.0" }
-meow-listener = { path = "crates/meow-listener", version = "0.16.0", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.16.0" }
-meow-config = { path = "crates/meow-config", version = "0.16.0", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.17.0" }
+meow-dns = { path = "crates/meow-dns", version = "0.17.0", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.17.0" }
+meow-transport = { path = "crates/meow-transport", version = "0.17.0" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.17.0", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.17.0" }
+meow-listener = { path = "crates/meow-listener", version = "0.17.0", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.17.0" }
+meow-config = { path = "crates/meow-config", version = "0.17.0", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,7 +12,7 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."


### PR DESCRIPTION
Bump the workspace version and internal dependency pins to 0.17.0 per [docs/RELEASING.md](docs/RELEASING.md). After merge, tagging `v0.17.0` triggers the crates.io publish and the binary release (now including Windows, per #329).

Highlights since v0.16.0:
- Windows platform support (#310) and Windows release binaries (#329)
- mihomo compatibility improvements (#313, #325, #328)
- VLESS post-quantum encryption `mlkem768x25519plus` (#317)
- Official OpenWrt arm ipks + LuCI app (#321)
- VMess AEAD wire-format fix for server interop (#320)
- Relay group / DIRECT hop fixes (#315), VLESS/Snell UoT starvation fix (#319)

🤖 Generated with [Claude Code](https://claude.com/claude-code)