### PR TITLE
fix(tunnel): replace arc-swap with RwLock<Arc<RouteTable>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,15 +148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,7 +2694,6 @@ dependencies = [
 name = "meow-tunnel"
 version = "0.17.0"
 dependencies = [
- "arc-swap",
  "async-trait",
  "criterion",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,6 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 parking_lot = "0.12"
 
 # Wait-free read / atomic swap for hot-path rule-set + proxy-provider refreshes
-arc-swap = "1"
 
 # BoringSSL (pulled in by meow-transport's boring-tls feature)
 boring      = { version = "5.0.2" }

--- a/crates/meow-tunnel/Cargo.toml
+++ b/crates/meow-tunnel/Cargo.toml
@@ -22,7 +22,6 @@ dashmap = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 parking_lot = { workspace = true }
-arc-swap = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }
 smol_str = { workspace = true }

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -2,7 +2,6 @@ use crate::match_engine::{self, DomainIndex};
 use crate::rule_ir::{CompiledMatchResult, CompiledRuleSet, LazyMatchOutcome};
 use crate::statistics::Statistics;
 use crate::udp::{self, NatTable};
-use arc_swap::ArcSwap;
 use meow_common::{Metadata, Proxy, ProxyAdapter, Rule, TunnelMode};
 use meow_dns::Resolver;
 use meow_proxy::DirectAdapter;
@@ -13,12 +12,20 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::{debug, info};
 
-/// Bundled rules + domain index + proxies map, atomically swapped on config
-/// reload via `ArcSwap`. Reads on the connection-setup hot path are lock-free
-/// — previously each `resolve_proxy` call acquired three `parking_lot::RwLock`
-/// guards (rules, domain_index, proxies). The atomic swap also guarantees
-/// rules + proxies are observed as a consistent snapshot, so a connection
-/// can no longer match a rule that points at a proxy not yet inserted.
+/// Bundled rules + domain index + proxies map, swapped as one `Arc` on
+/// config reload. Reads on the connection-setup hot path take a single
+/// short `RwLock` read (an `Arc` refcount bump) — previously each
+/// `resolve_proxy` call acquired three `parking_lot::RwLock` guards (rules,
+/// domain_index, proxies). Swapping the whole table also guarantees rules +
+/// proxies are observed as a consistent snapshot, so a connection can no
+/// longer match a rule that points at a proxy not yet inserted.
+///
+/// The slot is a `parking_lot::RwLock<Arc<RouteTable>>` rather than
+/// `arc_swap::ArcSwap`: `arc-swap`'s atomic-ordering correctness on
+/// weak-memory targets (ARM) has no formal proof and reproducible UAF /
+/// data-race reports exist upstream, so we prefer the well-understood lock
+/// (issue #327). Route reload is rare and the read critical section is a
+/// clone, so this is nowhere near a bottleneck.
 ///
 /// `rules` and `domain_index` are themselves `Arc`-wrapped so a partial
 /// update (e.g. `update_proxies` keeping the rules) is a refcount bump
@@ -43,8 +50,10 @@ impl RouteTable {
 
 pub struct TunnelInner {
     pub mode: RwLock<TunnelMode>,
-    /// Atomically-swapped route table (rules + domain index + proxies).
-    pub route: ArcSwap<RouteTable>,
+    /// Current route table (rules + domain index + proxies), replaced
+    /// wholesale on config reload. Readers clone the `Arc` and drop the
+    /// guard immediately; never hold the guard across an `.await`.
+    pub route: RwLock<Arc<RouteTable>>,
     pub resolver: Arc<Resolver>,
     /// Fallback DIRECT adapter used when no user-defined rule matches or
     /// when Direct/Global mode bypasses the proxies map. Pre-built with the
@@ -62,6 +71,12 @@ pub struct TunnelInner {
 }
 
 impl TunnelInner {
+    /// Snapshot the current route table: one short read lock + `Arc` clone.
+    /// The returned `Arc` is safe to hold across `.await` points.
+    pub fn route(&self) -> Arc<RouteTable> {
+        Arc::clone(&self.route.read())
+    }
+
     /// Rewrite a fake-IP destination back to its real hostname before rule
     /// matching. Mirrors upstream `preHandleMetadata` in
     /// `tunnel/tunnel.go`. Always called from `handle_tcp` / `handle_udp`
@@ -137,7 +152,7 @@ impl TunnelInner {
                 SmolStr::default(),
             )),
             TunnelMode::Global => {
-                let route = self.route.load();
+                let route = self.route();
                 if let Some(proxy) = route.proxies.get("GLOBAL") {
                     Some((
                         Arc::clone(proxy) as Arc<dyn ProxyAdapter>,
@@ -153,9 +168,9 @@ impl TunnelInner {
                 }
             }
             TunnelMode::Rule => {
-                // One ArcSwap load — rules + index + proxies all read from a
-                // consistent snapshot. Replaces three RwLock acquisitions.
-                let route = self.route.load();
+                // One route-table snapshot — rules + index + proxies all read
+                // from a consistent table. Replaces three RwLock acquisitions.
+                let route = self.route();
                 let needs_proc = self.needs_process_lookup.load(Ordering::Relaxed);
                 let enriched = if needs_proc {
                     match_engine::maybe_enrich_with_process(metadata)
@@ -190,9 +205,9 @@ impl TunnelInner {
             return self.resolve_proxy(metadata);
         }
 
-        // `load_full` (refcount bump) instead of `load`: the enrichment arm
-        // holds the snapshot across an `.await`.
-        let route = self.route.load_full();
+        // Owned `Arc` snapshot: the enrichment arm holds it across an
+        // `.await`, which a lock guard must never do.
+        let route = self.route();
         match route
             .compiled_rules
             .match_rules_lazy(metadata, route.rules.as_ref())
@@ -287,7 +302,7 @@ impl Tunnel {
         Self {
             inner: Arc::new(TunnelInner {
                 mode: RwLock::new(TunnelMode::Rule),
-                route: ArcSwap::from_pointee(RouteTable::empty()),
+                route: RwLock::new(Arc::new(RouteTable::empty())),
                 resolver,
                 direct,
                 nat_table: udp::new_nat_table(),
@@ -323,14 +338,18 @@ impl Tunnel {
         // Build a new route table on top of the current proxies map. The
         // current proxies are cloned (Arc bumps for adapter handles, one
         // HashMap clone) — paid only on config-reload, not the hot path.
-        let current = self.inner.route.load();
-        let new_route = RouteTable {
-            rules: Arc::new(rules),
-            domain_index: Arc::new(new_index),
-            compiled_rules: Arc::new(compiled_rules),
-            proxies: current.proxies.clone(),
-        };
-        self.inner.route.store(Arc::new(new_route));
+        // The write lock is held across the read-modify-write so a
+        // concurrent `update_proxies` cannot be lost.
+        {
+            let mut route = self.inner.route.write();
+            let new_route = RouteTable {
+                rules: Arc::new(rules),
+                domain_index: Arc::new(new_index),
+                compiled_rules: Arc::new(compiled_rules),
+                proxies: route.proxies.clone(),
+            };
+            *route = Arc::new(new_route);
+        }
         self.inner
             .needs_ip_resolution
             .store(needs_ip, Ordering::Relaxed);
@@ -344,15 +363,19 @@ impl Tunnel {
     }
 
     pub fn update_proxies(&self, proxies: HashMap<SmolStr, Arc<dyn Proxy>>) {
-        // Preserve the current rules + index via Arc refcount bumps.
-        let current = self.inner.route.load();
-        let new_route = RouteTable {
-            rules: Arc::clone(&current.rules),
-            domain_index: Arc::clone(&current.domain_index),
-            compiled_rules: Arc::clone(&current.compiled_rules),
-            proxies,
-        };
-        self.inner.route.store(Arc::new(new_route));
+        // Preserve the current rules + index via Arc refcount bumps. Held
+        // as a single write section so a concurrent `update_rules` cannot
+        // be lost.
+        {
+            let mut route = self.inner.route.write();
+            let new_route = RouteTable {
+                rules: Arc::clone(&route.rules),
+                domain_index: Arc::clone(&route.domain_index),
+                compiled_rules: Arc::clone(&route.compiled_rules),
+                proxies,
+            };
+            *route = Arc::new(new_route);
+        }
         info!("Proxies updated");
     }
 
@@ -366,15 +389,16 @@ impl Tunnel {
 
     /// Snapshot of the current route table (rules + domain index + proxies).
     ///
-    /// One atomic load + refcount bump; callers iterate `snapshot.proxies`
-    /// / `snapshot.rules` in place. Replaces the old `proxies()` accessor,
-    /// which cloned the whole proxy map on every call (audit #182).
+    /// One short read lock + refcount bump; callers iterate
+    /// `snapshot.proxies` / `snapshot.rules` in place. Replaces the old
+    /// `proxies()` accessor, which cloned the whole proxy map on every call
+    /// (audit #182).
     pub fn route_snapshot(&self) -> Arc<RouteTable> {
-        self.inner.route.load_full()
+        self.inner.route()
     }
 
     pub fn proxy(&self, name: &str) -> Option<Arc<dyn Proxy>> {
-        self.inner.route.load().proxies.get(name).cloned()
+        self.inner.route.read().proxies.get(name).cloned()
     }
 
     /// Spawn background tasks owned by the tunnel (currently just the UDP NAT

--- a/crates/meow-tunnel/tests/reload_churn_leak_test.rs
+++ b/crates/meow-tunnel/tests/reload_churn_leak_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Long-running proxies reload their rule/proxy tables repeatedly (subscription
 //! auto-refresh, REST `PUT /configs`, provider refresh). Each reload builds a
-//! fresh `RouteTable` and atomically swaps it in via `ArcSwap`; the previous
+//! fresh `RouteTable` and swaps it into the `RwLock<Arc<_>>` slot; the previous
 //! table must be released once no in-flight connection references it. A reload
 //! path that pins old `RouteTable`s (rules Vec + domain index) would grow the
 //! heap monotonically across reload cycles — a slow leak that only shows up
@@ -145,6 +145,6 @@ fn config_reload_does_not_leak_old_route_tables() {
     assert!(
         slope < MAX_SLOPE,
         "config reload retained {slope:.4} live allocs per reload over {RELOADS} reloads — \
-         old RouteTable (rules + domain index) is not being released by the ArcSwap swap"
+         old RouteTable (rules + domain index) is not being released by the route swap"
     );
 }

--- a/docs/specs/api-config-reload.md
+++ b/docs/specs/api-config-reload.md
@@ -209,7 +209,16 @@ an unstructured string like `"N connections dropped"` — the count must be
 machine-readable.
 
 **AppState mutability**: `AppState` is currently `Arc`-shared and immutable.
-Reload requires atomic swap of the tunnel. Use `arc_swap::ArcSwap<Tunnel>`:
+Reload requires atomic swap of the tunnel.
+
+> **Superseded by [#327](https://github.com/madeye/meow-rs/issues/327)** —
+> `arc-swap` was dropped from the workspace over unproven memory-ordering
+> correctness on weak-memory ARM. Use
+> `parking_lot::RwLock<Arc<Tunnel>>` instead: handlers do
+> `Arc::clone(&state.tunnel.read())` (guard dropped immediately, `Arc` safe
+> to hold across `.await`). The original design below is kept for the record.
+
+Use `arc_swap::ArcSwap<Tunnel>`:
 
 ```rust
 // AppState

--- a/docs/specs/rule-provider-upgrade-test-plan.md
+++ b/docs/specs/rule-provider-upgrade-test-plan.md
@@ -59,6 +59,12 @@ copies exist. Test G1 (structural guard) enforces this.
 
 ### P3 — ArcSwap not Arc<RwLock<Arc<>>>
 
+> **Superseded by [#327](https://github.com/madeye/meow-rs/issues/327)** —
+> `arc-swap` was dropped from the workspace over unproven memory-ordering
+> correctness on weak-memory ARM. The refresh slot should instead be
+> `parking_lot::RwLock<Arc<RuleSet>>` with guard-drop-before-await reads;
+> test F3's "no RwLock" grep no longer applies.
+
 The refresh path must use `arc_swap::ArcSwap`. Test F3 guards that no
 `RwLock` wraps the rule set on the read path. The double-Arc+RwLock pattern
 forces a lock acquisition on every rule match; `ArcSwap::load_full()` is

--- a/docs/specs/rule-provider-upgrade.md
+++ b/docs/specs/rule-provider-upgrade.md
@@ -145,6 +145,15 @@ blindly from this spec; the upstream source is the authoritative format spec.
 
 ### Atomic refresh
 
+> **Superseded by [#327](https://github.com/madeye/meow-rs/issues/327)** —
+> `arc-swap` was dropped from the workspace: its atomic-ordering correctness
+> on weak-memory targets (ARM) has no formal proof and upstream has
+> reproducible UAF/data-race reports
+> ([arc-swap#200](https://github.com/vorner/arc-swap/issues/200)). Use
+> `parking_lot::RwLock<Arc<RuleSet>>` where the read path clones the `Arc`
+> and drops the guard immediately (see `meow-tunnel/src/tunnel.rs`
+> `TunnelInner::route`). The original rationale below is kept for the record.
+
 Use `ArcSwap<RuleSet>` (not `Arc<RwLock<Arc<RuleSet>>>`). The double-Arc+RwLock
 pattern forces every rule match to acquire a read lock on a read-mostly structure,
 and the `try_read().unwrap_or_else(stale)` fallback was dead code (there is no


### PR DESCRIPTION
## Summary

Fixes #327 — drop `arc-swap` in favor of `parking_lot::RwLock<Arc<RouteTable>>`.

As @xmh0511 noted, `arc-swap` has no formal proof of its atomic memory-ordering correctness, and use-after-free / data-race issues were reproduced on weak-memory ARM (vorner/arc-swap#200). Since ARM (Raspberry Pi gateways, Apple Silicon) is a first-class deployment target for this project, correctness wins over the wait-free read.

## Changes

- `TunnelInner::route` is now `parking_lot::RwLock<Arc<RouteTable>>`. A new `TunnelInner::route()` helper takes a momentary read lock, clones the `Arc`, and drops the guard — the returned snapshot is safe to hold across `.await` (used by `resolve_proxy_lazy`).
- `update_rules` / `update_proxies` hold the write lock across their read-modify-write. This actually **fixes a pre-existing lost-update race**: the old `load()` → build → `store()` sequence could drop a concurrent proxies/rules update. The expensive index/IR builds in `update_rules` stay outside the critical section.
- `arc-swap` removed from the workspace and crate manifests (it was only used here; nothing pulls it transitively, so it's gone from `Cargo.lock`).
- Specs that prescribed `ArcSwap` for future work (`rule-provider-upgrade`, `api-config-reload`, and the rule-provider test plan's P3/F3 guard-rail) get superseded-by-#327 notes pointing at the RwLock pattern. Historical ADRs left untouched.

## Performance notes

- Hot path (`resolve_proxy`): one uncontended `parking_lot` read lock + `Arc` refcount bump, alongside the existing `mode` read lock. No allocation added (ADR-0008 hot-path invariants unaffected; no ADR-0011 tracked types touched).
- Route reload is rare (config reload / subscription refresh), so writer contention is negligible.

## Testing

- `cargo fmt --all -- --check`
- Three-way `cargo clippy --all-targets -- -D warnings` (default / no-default-features / all-features)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` — 64 passed
- `cargo test -p meow-tunnel --test reload_churn_leak_test --release` — the reload-churn allocator test that exercises this exact swap path, passes (old tables still released, ~0 retained-alloc slope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)