### PR TITLE
perf(dns): stop preallocating capacity-sized LRU tables at startup

### DIFF
--- a/crates/meow-dns/src/cache.rs
+++ b/crates/meow-dns/src/cache.rs
@@ -24,7 +24,6 @@ use smallvec::SmallVec;
 use smol_str::SmolStr;
 use std::borrow::Cow;
 use std::net::IpAddr;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -73,6 +72,15 @@ pub struct DnsCache {
     /// Bounded per-shard LRU — entries past capacity are evicted in
     /// least-recently-used order.
     reverse: [Mutex<LruCache<IpAddr, ReverseEntry>>; SHARDS],
+    /// Per-shard capacity caps. The shards are constructed with
+    /// `LruCache::unbounded()` and the cap is enforced manually on insert:
+    /// `LruCache::new(cap)` preallocates the full `cap`-slot hash table per
+    /// shard at construction (16 × 48 KiB ≈ 770 KiB idle RSS at the default
+    /// 4096-entry forward cap), charging every process for tables that only
+    /// fill under sustained DNS load. Lazy tables grow to the same bucket
+    /// count only once the entries actually exist.
+    fwd_shard_cap: usize,
+    rev_shard_cap: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -106,21 +114,20 @@ fn shard_ip(ip: IpAddr) -> usize {
     }
 }
 
-fn per_shard_cap(total: usize, min: usize) -> NonZeroUsize {
-    let per = (total / SHARDS).max(min);
-    NonZeroUsize::new(per).unwrap_or_else(|| NonZeroUsize::new(min).expect("min > 0"))
+fn per_shard_cap(total: usize, min: usize) -> usize {
+    (total / SHARDS).max(min)
 }
 
 impl DnsCache {
     pub fn new(capacity: usize) -> Self {
-        let fwd_cap = per_shard_cap(capacity.max(SHARDS), 8);
-        let rev_cap = per_shard_cap(
-            capacity.saturating_mul(REVERSE_CAP_MULTIPLIER).max(SHARDS),
-            16,
-        );
         Self {
-            cache: std::array::from_fn(|_| Mutex::new(LruCache::new(fwd_cap))),
-            reverse: std::array::from_fn(|_| Mutex::new(LruCache::new(rev_cap))),
+            cache: std::array::from_fn(|_| Mutex::new(LruCache::unbounded())),
+            reverse: std::array::from_fn(|_| Mutex::new(LruCache::unbounded())),
+            fwd_shard_cap: per_shard_cap(capacity.max(SHARDS), 8),
+            rev_shard_cap: per_shard_cap(
+                capacity.saturating_mul(REVERSE_CAP_MULTIPLIER).max(SHARDS),
+                16,
+            ),
         }
     }
 
@@ -179,6 +186,11 @@ impl DnsCache {
                     expire_at: reverse_expire_at,
                 },
             );
+            // Manual cap enforcement (shards are unbounded — see struct docs).
+            // One put per lock hold, so a single eviction restores the cap.
+            if reverse.len() > self.rev_shard_cap {
+                reverse.pop_lru();
+            }
         }
 
         let entry = CacheEntry {
@@ -186,7 +198,11 @@ impl DnsCache {
             expire_at,
             source: source.map(Arc::from),
         };
-        self.cache[shard_str(&domain)].lock().put(key, entry);
+        let mut cache = self.cache[shard_str(&domain)].lock();
+        cache.put(key, entry);
+        if cache.len() > self.fwd_shard_cap {
+            cache.pop_lru();
+        }
     }
 
     /// Reverse lookup: given an IP, return the domain that resolved to it.
@@ -256,6 +272,9 @@ impl DnsCache {
                 expire_at,
             },
         );
+        if reverse.len() > self.rev_shard_cap {
+            reverse.pop_lru();
+        }
     }
 }
 
@@ -436,6 +455,24 @@ mod tests {
         let c = DnsCache::new(1);
         c.put("tiny.example", &[ipv4(1, 1, 1, 1)], Duration::from_secs(30));
         assert!(c.get("tiny.example").is_some());
+    }
+
+    #[test]
+    fn reverse_capacity_evicts_lru() {
+        // capacity 16 → rev per-shard cap = max(16*4/16, 16) = 16, so the
+        // reverse table must never exceed 16 shards × 16 = 256 entries even
+        // though the shards are constructed unbounded.
+        let c = DnsCache::new(16);
+        for i in 0..2000u32 {
+            let ip = ipv4(10, (i >> 8) as u8, (i & 0xff) as u8, 1);
+            let key = format!("r{i}.example");
+            c.put(&key, &[ip], Duration::from_secs(30));
+        }
+        assert!(
+            c.reverse_len() <= 256,
+            "reverse_len {} exceeded global shard cap",
+            c.reverse_len()
+        );
     }
 
     #[test]

--- a/crates/meow-dns/src/fakeip.rs
+++ b/crates/meow-dns/src/fakeip.rs
@@ -33,7 +33,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -83,15 +82,20 @@ pub struct MemoryStore {
 struct MemoryInner {
     by_host: LruCache<SmolStr, IpAddr>,
     by_ip: LruCache<IpAddr, SmolStr>,
+    /// Pool capacity, enforced manually in `put`. The LRUs are constructed
+    /// unbounded because `LruCache::new(cap)` preallocates the full hash
+    /// table up front — for the default /16 fake-ip range that is two
+    /// ~65k-slot tables charged at startup even if no query ever arrives.
+    cap: usize,
 }
 
 impl MemoryStore {
     pub fn new(size: usize) -> Self {
-        let cap = NonZeroUsize::new(size.max(1)).unwrap();
         Self {
             inner: Mutex::new(MemoryInner {
-                by_host: LruCache::new(cap),
-                by_ip: LruCache::new(cap),
+                by_host: LruCache::unbounded(),
+                by_ip: LruCache::unbounded(),
+                cap: size.max(1),
             }),
         }
     }
@@ -115,6 +119,19 @@ impl Store for MemoryStore {
         let mut inner = self.inner.lock();
         inner.by_host.put(SmolStr::from(host), ip);
         inner.by_ip.put(ip, SmolStr::from(host));
+        // Manual cap enforcement (LRUs are unbounded — see `MemoryInner::cap`).
+        // Evict the LRU pair from both directions so the two maps stay
+        // consistent — bounded LRUs would evict each side independently.
+        if inner.by_ip.len() > inner.cap {
+            if let Some((_, evicted_host)) = inner.by_ip.pop_lru() {
+                inner.by_host.pop(&evicted_host);
+            }
+        }
+        if inner.by_host.len() > inner.cap {
+            if let Some((_, evicted_ip)) = inner.by_host.pop_lru() {
+                inner.by_ip.pop(&evicted_ip);
+            }
+        }
     }
     fn del_by_ip(&self, ip: IpAddr) {
         let mut inner = self.inner.lock();
@@ -698,6 +715,30 @@ mod tests {
     fn make_pool_v4() -> Pool {
         let net = IpNet::from_str("198.18.0.0/16").unwrap();
         Pool::new(net, Arc::new(MemoryStore::new(1024))).unwrap()
+    }
+
+    #[test]
+    fn memory_store_caps_at_size_with_paired_eviction() {
+        let s = MemoryStore::new(4);
+        for i in 0..10u8 {
+            let key = format!("h{i}.example");
+            s.put(&key, IpAddr::V4(Ipv4Addr::new(10, 0, 0, i)));
+        }
+        // Oldest entries evicted from BOTH directions...
+        assert!(s.get_by_host("h0.example").is_none());
+        assert!(s
+            .get_by_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)))
+            .is_none());
+        // ...newest present in both.
+        assert_eq!(
+            s.get_by_host("h9.example"),
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)))
+        );
+        assert_eq!(
+            s.get_by_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)))
+                .as_deref(),
+            Some("h9.example")
+        );
     }
 
     #[test]

--- a/crates/meow-dns/tests/lazy_construction_alloc_test.rs
+++ b/crates/meow-dns/tests/lazy_construction_alloc_test.rs
@@ -1,0 +1,56 @@
+//! Regression test for the 2026-07 idle-RSS finding: constructing the DNS
+//! cache and the fake-IP memory store must NOT preallocate capacity-sized
+//! hash tables. `lru::LruCache::new(cap)` eagerly allocates the full table;
+//! before the fix `DnsCache::new(4096)` alone charged ~930 KiB of heap to
+//! every process at startup (16 forward + 16 reverse shard tables), and
+//! `MemoryStore::new(65532)` (default /16 fake-ip range) two ~65k-slot
+//! tables. Both now construct unbounded LRUs and enforce their caps on
+//! insert, so construction allocates only per-shard sentinel nodes.
+
+use meow_dns::{DnsCache, MemoryStore};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingAlloc;
+
+static ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_BYTES.fetch_add(layout.size(), Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static A: CountingAlloc = CountingAlloc;
+
+/// Single test (not one per type) so the process-global counter can't see
+/// allocations from a concurrently running sibling test thread.
+#[test]
+fn construction_does_not_preallocate_capacity_sized_tables() {
+    let before = ALLOC_BYTES.load(Ordering::SeqCst);
+    let cache = DnsCache::new(4096);
+    let cache_bytes = ALLOC_BYTES.load(Ordering::SeqCst) - before;
+    // 32 unbounded shards allocate two LRU sentinel nodes each plus the
+    // mutex-wrapped arrays — a few KiB. Pre-fix: ~930 KiB.
+    assert!(
+        cache_bytes < 16 * 1024,
+        "DnsCache::new(4096) allocated {cache_bytes} B at construction"
+    );
+
+    let before = ALLOC_BYTES.load(Ordering::SeqCst);
+    let store = MemoryStore::new(65_532); // default 198.18.0.0/16 pool size
+    let store_bytes = ALLOC_BYTES.load(Ordering::SeqCst) - before;
+    assert!(
+        store_bytes < 4 * 1024,
+        "MemoryStore::new(65532) allocated {store_bytes} B at construction"
+    );
+
+    drop(cache);
+    drop(store);
+}

--- a/docs/benchmarks/baseline-2026-07-15.json
+++ b/docs/benchmarks/baseline-2026-07-15.json
@@ -1,0 +1,43 @@
+{
+ "rust": {
+  "target": "rust",
+  "binary_size_bytes": 8673008,
+  "rss_idle_bytes": 10420224,
+  "rss_load_bytes": 15253504,
+  "throughput": [
+   {
+    "label": "4 KB x 10000",
+    "total_bytes": 81920000,
+    "elapsed_secs": 0.291702,
+    "gbps": 2.246676402630081
+   },
+   {
+    "label": "1 MB x 10",
+    "total_bytes": 20971520,
+    "elapsed_secs": 0.009704914999999998,
+    "gbps": 17.287339456347638
+   },
+   {
+    "label": "64 MB x 1",
+    "total_bytes": 134217728,
+    "elapsed_secs": 0.061565333,
+    "gbps": 17.44068896695483
+   }
+  ],
+  "latency": {
+   "iterations": 1000,
+   "p50_us": 105.958,
+   "p95_us": 143.75,
+   "p99_us": 458.459,
+   "min_us": 89.917,
+   "max_us": 1099.875
+  },
+  "conn_rate": {
+   "duration_secs": 10.0,
+   "total_connections": 7025,
+   "connections_per_sec": 702.5
+  },
+  "dns": null
+ },
+ "go": null
+}

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -18,6 +18,7 @@ refactor/cleanup-2026-05 work (M1 + M2).
 | [rule-engine-findings.md](rule-engine-findings.md) | Rule engine profiling notes |
 | [rule-ir-pi-2026-07.md](rule-ir-pi-2026-07.md) | Rule-IR series (#285–#297) on-device benchmark: Raspberry Pi 4 gateway, real 7,528-rule config — 1.8–2.9× match latency, −11.5% live slots, IR build 37.6→96.1 ms |
 | [baseline-2026-04-18.json](baseline-2026-04-18.json) | Raw dhat JSON snapshot at M2 open |
+| [baseline-2026-07-15.json](baseline-2026-07-15.json) | Refreshed dev-laptop harness baseline (median of 3 runs, post DNS-cache prealloc fix); supersedes 2026-04-18 for `bench/compare.py` — see [methodology.md](methodology.md) §Developer baseline refresh |
 
 ## M2 delta summary
 

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -39,6 +39,42 @@ Conn rate   :  762 conns/s (10 s, concurrency=32)
 
 Full JSON: `baseline-2026-04-18.json`
 
+## Developer baseline refresh (2026-07-15)
+
+Machine: same Apple Silicon developer laptop, macOS 25.5.0 (Darwin 25.5.0).
+**Still not the M2 reference host.** Median of 3 full harness runs (defaults:
+`--duration 10`, `--concurrency 64`, `--latency-iterations 1000`), 75 s gaps
+between runs for ephemeral-port recycling.
+
+Refreshed because the 2026-04-18 snapshot was no longer reproducible even by
+its own binary: an interleaved same-machine A/B (3 runs each) of the April
+commit's binary vs HEAD showed the April binary itself scoring 703–705 conns/s
+(recorded: 762, taken at `--concurrency 32`) and 13.2–14.1 MB load RSS
+(recorded: 12.3 MB), i.e. the old numbers reflect harness arguments and
+machine state that no longer exist. The one code-level regression that A/B
+did confirm — ~1 MB idle RSS from eager LRU-table preallocation in
+`DnsCache::new` / fake-ip `MemoryStore::new` — was fixed before this baseline
+was recorded (see `perf(dns): stop preallocating capacity-sized LRU tables`).
+
+```
+Binary size : 8.3 MB (stripped, release LTO)
+RSS idle    : 9.9 MB
+RSS load    : 14.5 MB (peak during conn-rate test, concurrency=64)
+Throughput  : 17.4 Gbps (64 MB single transfer, loopback)
+Latency p50 : 106 µs    (connect + 1 B echo, 1000 iters)
+Latency p99 : 458 µs
+Conn rate   : 702 conns/s (10 s, concurrency=64; client/OS-bound on
+              loopback — Go mihomo measures 703/s on the same harness)
+```
+
+Caveats for `bench/compare.py` against this file: single-run latency variance
+on a developer laptop exceeds the 5% threshold (p50 spread 106–116 µs across
+the three baseline runs themselves), and load RSS is a peak sample. Treat
+single-run failures in those two metrics as a signal to re-run per the
+three-run protocol, not as a regression by themselves.
+
+Full JSON: `baseline-2026-07-15.json`
+
 ## Workloads (from ADR-0006 §1)
 
 | # | Workload | Tool | Steady-state |


### PR DESCRIPTION
## Summary

Perf-regression run against `baseline-2026-04-18.json` flagged idle RSS +11.8%. A same-machine interleaved A/B (April-commit binary vs HEAD, 3 runs each) confirmed a real, consistent **+1.0 MB idle RSS** delta; `malloc_history` attribution pinned it to `lru::LruCache::new(cap)` eagerly preallocating the full `cap`-slot hash table:

- `DnsCache::new(4096)`: 16 forward + 16 reverse shard tables (~930 KiB virtual, ~420 KiB dirty) charged to **every** process at startup, DNS traffic or not. The reverse table's ×4 capacity multiplier + 16-way sharding (both added since April) turned what used to be one lazy `DashMap` into the dominant startup allocation.
- fake-ip `MemoryStore::new(pool_size)`: same pattern, two ~65k-slot tables for the default /16 range.

## Fix

Construct these LRUs `unbounded()` and enforce the caps manually on insert (evict-after-put; identical visible semantics). For fake-ip the manual path evicts the LRU **pair** from both directions — an improvement over the previous independent per-side eviction, which could desynchronize `by_host`/`by_ip`.

Measured idle RSS (config-bench.yaml): **10,464 KB → 10,016 KB**; `MALLOC_SMALL` dirty 1120 KB → 704 KB. Remaining delta vs April (9,360 KB) is accumulated feature growth, not cache prealloc.

## Baseline refresh

Second commit records `baseline-2026-07-15.json` (median of 3 runs, post-fix) because the April snapshot is unreproducible even by its own binary (it was taken at `--concurrency 32` vs today's default 64; the April binary itself now scores 703/s and 13.2–14.1 MB load RSS against its recorded 762/s and 12.3 MB). Rationale + laptop-variance caveats documented in `methodology.md`.

## Not regressions (investigated, environment/noise)

- **conn-rate −7.9%**: April binary scores the same today (703–705/s); Go mihomo hits the identical 703/s ceiling — client/OS-bound on loopback.
- **throughput / latency flags**: single-run laptop variance exceeds the 5% threshold (13 samples/side: medians within 5%).

## Gates

- ADR-0008 alloc-count reproducers: pass (before and after)
- ADR-0011: `CacheEntry`/`ReverseEntry`/per-slot layouts untouched
- New regression tests: counting-allocator construction guard (`lazy_construction_alloc_test`), reverse-cap eviction, fake-ip paired eviction
- fmt + 3-way clippy `-D warnings` + doc + 916 lib tests: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)