### PR TITLE
fix(tunnel): publish traffic snapshot values atomically

### DIFF
--- a/crates/meow-tunnel/src/statistics.rs
+++ b/crates/meow-tunnel/src/statistics.rs
@@ -18,6 +18,7 @@
 
 use dashmap::DashMap;
 use meow_common::Metadata;
+use parking_lot::Mutex;
 use serde::Serialize;
 use smallvec::SmallVec;
 use smol_str::SmolStr;
@@ -117,13 +118,24 @@ pub struct ConnectionInfo {
     pub rule_payload: SmolStr,
 }
 
+/// Values exposed by the mihomo `/traffic` stream, captured together under
+/// one lock so a reader never mixes rates and totals from different sampling
+/// ticks (issue #338). Totals are as of the last `sample_traffic` tick, not
+/// live — [`Statistics::snapshot`] still reads the live atomics.
+#[derive(Default, Clone, Copy)]
+struct TrafficSnapshot {
+    upload_rate: i64,
+    download_rate: i64,
+    upload_total: i64,
+    download_total: i64,
+}
+
 pub struct Statistics {
     pub upload_total: AtomicI64,
     pub download_total: AtomicI64,
     upload_temp: AtomicI64,
     download_temp: AtomicI64,
-    upload_rate: AtomicI64,
-    download_rate: AtomicI64,
+    traffic: Mutex<TrafficSnapshot>,
     /// Keyed by `Uuid` (16 B Copy) — formerly `String`, which heap-allocated a
     /// 36-byte hyphenated representation per insert.  REST handlers parse the
     /// query path back into a `Uuid` at lookup time.
@@ -138,8 +150,7 @@ impl Statistics {
             download_total: AtomicI64::new(0),
             upload_temp: AtomicI64::new(0),
             download_temp: AtomicI64::new(0),
-            upload_rate: AtomicI64::new(0),
-            download_rate: AtomicI64::new(0),
+            traffic: Mutex::new(TrafficSnapshot::default()),
             connections: DashMap::new(),
             rule_match: Arc::new(RuleMatchCounters::new()),
         }
@@ -178,24 +189,33 @@ impl Statistics {
     }
 
     /// Roll the current one-second counters into the values exposed by the
-    /// mihomo `/traffic` stream.
+    /// mihomo `/traffic` stream. All four values are published under one lock
+    /// so `traffic_snapshot` readers see a mutually consistent set; the hot
+    /// path stays lock-free, and the once-per-second ticker plus `/traffic`
+    /// pollers are the only contenders.
     pub fn sample_traffic(&self) {
-        self.upload_rate.store(
-            self.upload_temp.swap(0, Ordering::Relaxed),
-            Ordering::Relaxed,
-        );
-        self.download_rate.store(
-            self.download_temp.swap(0, Ordering::Relaxed),
-            Ordering::Relaxed,
-        );
+        let upload_rate = self.upload_temp.swap(0, Ordering::Relaxed);
+        let download_rate = self.download_temp.swap(0, Ordering::Relaxed);
+        let upload_total = self.upload_total.load(Ordering::Relaxed);
+        let download_total = self.download_total.load(Ordering::Relaxed);
+        *self.traffic.lock() = TrafficSnapshot {
+            upload_rate,
+            download_rate,
+            upload_total,
+            download_total,
+        };
     }
 
+    /// `(upload_rate, download_rate, upload_total, download_total)` as of the
+    /// last `sample_traffic` tick. Totals lag the live counters by up to one
+    /// tick, in exchange for being consistent with the rates.
     pub fn traffic_snapshot(&self) -> (i64, i64, i64, i64) {
+        let snap = *self.traffic.lock();
         (
-            self.upload_rate.load(Ordering::Relaxed),
-            self.download_rate.load(Ordering::Relaxed),
-            self.upload_total.load(Ordering::Relaxed),
-            self.download_total.load(Ordering::Relaxed),
+            snap.upload_rate,
+            snap.download_rate,
+            snap.upload_total,
+            snap.download_total,
         )
     }
 

--- a/crates/meow-tunnel/tests/statistics_test.rs
+++ b/crates/meow-tunnel/tests/statistics_test.rs
@@ -49,6 +49,41 @@ fn test_upload_and_download_independent() {
 }
 
 #[test]
+fn test_traffic_snapshot_rolls_rates_per_sample() {
+    let stats = Statistics::new();
+    stats.add_upload(100);
+    stats.add_download(200);
+
+    // Nothing published until the sampler ticks.
+    assert_eq!(stats.traffic_snapshot(), (0, 0, 0, 0));
+
+    stats.sample_traffic();
+    assert_eq!(stats.traffic_snapshot(), (100, 200, 100, 200));
+
+    // Next window: rates reset to the new window's bytes, totals accumulate.
+    stats.add_upload(30);
+    stats.sample_traffic();
+    assert_eq!(stats.traffic_snapshot(), (30, 0, 130, 200));
+}
+
+#[test]
+fn test_traffic_snapshot_totals_consistent_with_rates() {
+    // Issue #338: all four values come from the same sampling tick — traffic
+    // written after the tick must not leak into the snapshot until the next
+    // sample, so rates and totals stay mutually consistent.
+    let stats = Statistics::new();
+    stats.add_upload(100);
+    stats.sample_traffic();
+
+    stats.add_upload(999);
+    stats.add_download(999);
+    assert_eq!(stats.traffic_snapshot(), (100, 0, 100, 0));
+
+    // Live totals (used by `/connections`) still see the new bytes.
+    assert_eq!(stats.snapshot(), (1099, 999));
+}
+
+#[test]
 fn test_track_connection() {
     let stats = Statistics::new();
     let metadata = Metadata::default();


### PR DESCRIPTION
Closes #338.

## Problem

`traffic_snapshot()` performed four independent relaxed loads across two atomics written by the relay hot path (`_total`) and two written by the 1s sampler (`_rate`). A reader could observe an upload rate from one sampling tick and a download rate from the previous one, and totals inconsistent with both — breaking any consumer that needs the four `/traffic` values to be mutually consistent (ratio calculations, per-second accounting).

## Fix

Adopts the Mutex approach proposed in the issue:

- `upload_rate` / `download_rate` atomics are replaced by a `parking_lot::Mutex<TrafficSnapshot>` holding all four `/traffic` values.
- `sample_traffic()` swaps the temp accumulators, loads the totals, and publishes the whole set under one lock.
- `traffic_snapshot()` reads the whole set under the same lock, so rates and totals always come from the same sampling tick.

## What is deliberately unchanged

- **Hot path stays lock-free**: `add_upload` / `add_download` are still two relaxed `fetch_add`s; the mutex is only touched by the once-per-second sampler and `/traffic` pollers, so contention is negligible.
- **`Statistics::snapshot()` (used by `/connections`) still reads the live totals** — only the `/traffic` view is tick-aligned. Totals in `/traffic` are now ≤1 tick stale, in exchange for consistency with the rates.
- **Layer-1 skew** (an in-flight `add_upload` not yet paired with its `add_download`) is inherent to per-direction accounting and remains, per the issue discussion.

## Tests

Two new integration tests in `statistics_test.rs`: one covering rate roll-over across sampling windows, one asserting that bytes written after a tick don't leak into the published snapshot until the next tick while live totals still advance.

Full regression bar run locally: `cargo fmt --check`, three-way clippy (`default` / `--no-default-features` / `--all-features`) with `-D warnings`, `cargo doc -D warnings`, `cargo test --lib` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)