### PR TITLE
chore(release): 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "futures",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -226,16 +226,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.17.0" }
-meow-trie = { path = "crates/meow-trie", version = "0.17.0" }
+meow-common = { path = "crates/meow-common", version = "0.18.0" }
+meow-trie = { path = "crates/meow-trie", version = "0.18.0" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.17.0" }
-meow-dns = { path = "crates/meow-dns", version = "0.17.0", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.17.0" }
-meow-transport = { path = "crates/meow-transport", version = "0.17.0" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.17.0", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.17.0" }
-meow-listener = { path = "crates/meow-listener", version = "0.17.0", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.17.0" }
-meow-config = { path = "crates/meow-config", version = "0.17.0", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.18.0" }
+meow-dns = { path = "crates/meow-dns", version = "0.18.0", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.18.0" }
+meow-transport = { path = "crates/meow-transport", version = "0.18.0" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.18.0", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.18.0" }
+meow-listener = { path = "crates/meow-listener", version = "0.18.0", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.18.0" }
+meow-config = { path = "crates/meow-config", version = "0.18.0", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,7 +12,7 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
@@ -26,7 +26,7 @@ name = "anytls_rs"
 path = "src/lib.rs"
 
 [dependencies]
-meow-common = { path = "../meow-common", version = "0.17.0" }
+meow-common = { path = "../meow-common", version = "0.18.0" }
 tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",


### PR DESCRIPTION
Bump the workspace version and internal dependency pins from 0.17.0 to 0.18.0 ahead of tagging v0.18.0.

Highlights since v0.17.0:
- TUN inbound for Windows transparent proxy (#326, #332)
- Windows service support (#331)
- 17-target release matrix; 32-bit platforms without 64-bit atomics incl. MIPS (#343)
- Traffic accounting fixes (#339, #341)
- DNS LRU startup memory fix (#337)

Locally verified: `cargo fmt --all -- --check`, three-way clippy `-D warnings` (default / no-default-features / all-features), `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `cargo test --lib` — all green.

After merge: tag `v0.18.0` on main to trigger the release workflow (first real run of the 17-target matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)