### PR TITLE
feat(dns): propagate real answer TTLs and add reverse-cache snapshot/restore

### DIFF
--- a/crates/meow-dns/src/cache.rs
+++ b/crates/meow-dns/src/cache.rs
@@ -91,6 +91,21 @@ pub struct DnsCacheSnapshotEntry {
     pub source: Option<String>,
 }
 
+/// One live reverse (IP → host) mapping, as captured by
+/// [`DnsCache::reverse_snapshot`] and re-inserted by
+/// [`DnsCache::restore_reverse`]. `remaining` is the entry's lifetime left at
+/// snapshot time; the pair exists so an embedding process can persist the
+/// reverse table across an engine restart (redir-host mode loses IP → host
+/// recovery for every connection dialed from a pre-restart DNS answer
+/// otherwise). Wall-clock anchoring of `remaining` across the restart gap is
+/// the caller's job — `Instant` doesn't survive a process.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReverseSnapshotEntry {
+    pub ip: IpAddr,
+    pub domain: String,
+    pub remaining: Duration,
+}
+
 /// FNV-1a 32-bit hash over the bytes of `s`. Inline so it can be used on
 /// `&str` or `&[u8]` without allocation. The cache only needs the result for
 /// shard selection — quality matters less than speed.
@@ -132,13 +147,24 @@ impl DnsCache {
     }
 
     pub fn get(&self, domain: &str) -> Option<IpList> {
+        self.get_with_ttl(domain).map(|(ips, _)| ips)
+    }
+
+    /// Like [`Self::get`], but also returns the entry's remaining lifetime, so
+    /// answers served from cache can carry the upstream's real TTL (decayed by
+    /// time already spent in cache) instead of a synthetic constant.
+    pub fn get_with_ttl(&self, domain: &str) -> Option<(IpList, Duration)> {
         let domain = normalize_domain(domain);
         let shard = &self.cache[shard_str(&domain)];
         let mut cache = shard.lock();
         let mut expired = false;
         if let Some(entry) = cache.get(domain.as_ref()) {
-            if entry.expire_at > Instant::now() {
-                return Some(SmallVec::from_slice(&entry.ips));
+            let now = Instant::now();
+            if entry.expire_at > now {
+                return Some((
+                    SmallVec::from_slice(&entry.ips),
+                    entry.expire_at.saturating_duration_since(now),
+                ));
             }
             // Expired — flag for eviction; can't pop while `entry` borrows.
             expired = true;
@@ -257,6 +283,60 @@ impl DnsCache {
         }
         entries.sort_by(|a, b| a.name.cmp(&b.name));
         entries
+    }
+
+    /// Capture every live reverse (IP → host) entry with its remaining
+    /// lifetime. Expired entries are evicted on the way through, mirroring
+    /// [`Self::snapshot`]. Output is sorted by IP so identical table states
+    /// serialize identically — callers persisting to disk can cheaply skip
+    /// rewrites when nothing changed.
+    pub fn reverse_snapshot(&self) -> Vec<ReverseSnapshotEntry> {
+        let now = Instant::now();
+        let mut entries = Vec::new();
+        for shard in &self.reverse {
+            let mut reverse = shard.lock();
+            let expired: Vec<IpAddr> = reverse
+                .iter()
+                .filter(|(_, entry)| entry.expire_at <= now)
+                .map(|(ip, _)| *ip)
+                .collect();
+            for ip in expired {
+                reverse.pop(&ip);
+            }
+            entries.extend(reverse.iter().map(|(ip, entry)| ReverseSnapshotEntry {
+                ip: *ip,
+                domain: entry.domain.to_string(),
+                remaining: entry.expire_at.saturating_duration_since(now),
+            }));
+        }
+        entries.sort_by_key(|e| e.ip);
+        entries
+    }
+
+    /// Re-insert reverse entries captured by [`Self::reverse_snapshot`] in a
+    /// previous run. Entries whose `remaining` has decayed to zero are
+    /// skipped; per-shard capacity is enforced as on the normal insert path.
+    /// Existing entries for the same IP are overwritten — call this before
+    /// live traffic populates the table (fresh answers would be clobbered by
+    /// stale persisted ones otherwise).
+    pub fn restore_reverse(&self, entries: impl IntoIterator<Item = ReverseSnapshotEntry>) {
+        let now = Instant::now();
+        for e in entries {
+            if e.remaining.is_zero() {
+                continue;
+            }
+            let mut reverse = self.reverse[shard_ip(e.ip)].lock();
+            reverse.put(
+                e.ip,
+                ReverseEntry {
+                    domain: Arc::from(e.domain.as_str()),
+                    expire_at: now + e.remaining,
+                },
+            );
+            if reverse.len() > self.rev_shard_cap {
+                reverse.pop_lru();
+            }
+        }
     }
 
     /// Insert a reverse entry with an explicit expiry. Test-only: lets unit
@@ -402,6 +482,92 @@ mod tests {
             c.reverse_lookup(ip).as_deref(),
             Some("short.example"),
             "reverse mapping must outlive the short forward TTL"
+        );
+    }
+
+    #[test]
+    fn get_with_ttl_returns_decaying_remaining() {
+        let c = DnsCache::new(64);
+        c.put("ttl.example", &[ipv4(1, 2, 3, 4)], Duration::from_secs(300));
+        let (ips, remaining) = c.get_with_ttl("ttl.example").expect("cache hit");
+        assert_eq!(ips.as_slice(), &[ipv4(1, 2, 3, 4)]);
+        assert!(remaining <= Duration::from_secs(300));
+        assert!(
+            remaining > Duration::from_secs(295),
+            "remaining {remaining:?} decayed implausibly fast"
+        );
+        assert!(c.get_with_ttl("miss.example").is_none());
+    }
+
+    #[test]
+    fn reverse_snapshot_restore_round_trips() {
+        let c = DnsCache::new(64);
+        c.put(
+            "snap.example",
+            &[ipv4(192, 0, 2, 10), ipv4(192, 0, 2, 11)],
+            Duration::from_secs(30),
+        );
+        let snap = c.reverse_snapshot();
+        assert_eq!(snap.len(), 2);
+        assert!(snap.iter().all(|e| e.domain == "snap.example"));
+        assert!(snap
+            .iter()
+            .all(|e| e.remaining > Duration::ZERO && e.remaining <= REVERSE_TTL_FLOOR));
+        // Sorted by IP for stable serialization.
+        assert!(snap.windows(2).all(|w| w[0].ip <= w[1].ip));
+
+        // "Restart": restore into a fresh cache, reverse lookups work again.
+        let fresh = DnsCache::new(64);
+        fresh.restore_reverse(snap);
+        assert_eq!(
+            fresh.reverse_lookup(ipv4(192, 0, 2, 10)).as_deref(),
+            Some("snap.example")
+        );
+        assert_eq!(
+            fresh.reverse_lookup(ipv4(192, 0, 2, 11)).as_deref(),
+            Some("snap.example")
+        );
+        assert_eq!(fresh.reverse_len(), 2);
+    }
+
+    #[test]
+    fn reverse_snapshot_evicts_and_omits_expired() {
+        let c = DnsCache::new(64);
+        let past = Instant::now() - Duration::from_secs(1);
+        c.put_reverse_with_expiry(ipv4(10, 0, 0, 9), "dead.example", past);
+        c.put(
+            "live.example",
+            &[ipv4(10, 0, 0, 10)],
+            Duration::from_secs(30),
+        );
+        let snap = c.reverse_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].domain, "live.example");
+        // The expired entry was evicted as a side-effect.
+        assert_eq!(c.reverse_len(), 1);
+    }
+
+    #[test]
+    fn restore_reverse_skips_zero_remaining_and_enforces_cap() {
+        let c = DnsCache::new(16); // rev per-shard cap = 16 → global ≤ 256
+        let mut entries = vec![ReverseSnapshotEntry {
+            ip: ipv4(10, 1, 0, 0),
+            domain: "expired.example".into(),
+            remaining: Duration::ZERO,
+        }];
+        for i in 0..2000u32 {
+            entries.push(ReverseSnapshotEntry {
+                ip: ipv4(10, (i >> 8) as u8, (i & 0xff) as u8, 1),
+                domain: format!("r{i}.example"),
+                remaining: Duration::from_secs(60),
+            });
+        }
+        c.restore_reverse(entries);
+        assert!(c.reverse_lookup(ipv4(10, 1, 0, 0)).is_none());
+        assert!(
+            c.reverse_len() <= 256,
+            "reverse_len {} exceeded global shard cap",
+            c.reverse_len()
         );
     }
 

--- a/crates/meow-dns/src/lib.rs
+++ b/crates/meow-dns/src/lib.rs
@@ -6,7 +6,7 @@ pub mod resolver;
 pub mod server;
 pub mod upstream;
 
-pub use cache::{DnsCache, DnsCacheSnapshotEntry};
+pub use cache::{DnsCache, DnsCacheSnapshotEntry, ReverseSnapshotEntry};
 pub use client::{set_socket_factory, ClientError, DnsClient, SocketFactory};
 pub use fakeip::{FileStore, MemoryStore, Pool, PoolError, Skipper, SkipperMode, Store};
 pub use host_resolver_hook::ResolverHostHook;

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -200,6 +200,12 @@ impl Drop for InflightGuard<'_> {
 /// wrap evictions.
 pub const DEFAULT_FAKE_IP_TTL: Duration = Duration::from_secs(1);
 
+/// TTL stamped on answers that have no upstream TTL to honor: hosts-trie
+/// mappings, and the (rare) fresh-lookup path where the just-written cache
+/// entry got evicted before it could be re-read. Matches the DNS server's
+/// pre-TTL-propagation default so hosts answers behave exactly as before.
+pub const HOSTS_ANSWER_TTL: Duration = Duration::from_secs(60);
+
 fn clamp_ttl(raw: Duration) -> Duration {
     const MIN_TTL: Duration = Duration::from_secs(10);
     const MAX_TTL: Duration = Duration::from_secs(3600);
@@ -817,9 +823,19 @@ impl Resolver {
     }
 
     pub async fn lookup_ipv4(&self, host: &str) -> Option<IpAddr> {
+        self.lookup_ipv4_with_ttl(host).await.map(|(ip, _)| ip)
+    }
+
+    /// Like [`Self::lookup_ipv4`], but also returns the TTL the answer should
+    /// carry: the fake-IP TTL for synthesised addresses, the entry's remaining
+    /// lifetime for cache hits, and the upstream's (clamped) TTL for fresh
+    /// lookups. Hosts-trie hits get [`HOSTS_ANSWER_TTL`] — static mappings
+    /// have no upstream TTL to honor.
+    pub async fn lookup_ipv4_with_ttl(&self, host: &str) -> Option<(IpAddr, Duration)> {
         if self.use_hosts {
             if let Some(ips) = self.hosts.search(host) {
-                return ips.iter().find(|ip| ip.is_ipv4()).copied();
+                let ip = ips.iter().find(|ip| ip.is_ipv4()).copied()?;
+                return Some((ip, HOSTS_ANSWER_TTL));
             }
         }
         // Fake-IP mode: synthesise from the v4 pool unless the skipper says
@@ -828,21 +844,24 @@ impl Resolver {
         if self.mode == DnsMode::FakeIp {
             if let Some(pool) = &self.fakeip_v4 {
                 if !self.skipper_bypasses(host) {
-                    return Some(pool.lookup(host));
+                    return Some((pool.lookup(host), self.fakeip_ttl));
                 }
             }
         }
-        if let Some(ips) = self.cache.get(host) {
-            return ips.iter().find(|ip| ip.is_ipv4()).copied();
-        }
-        let ips = self.lookup_actual_all(host).await?;
-        ips.into_iter().find(std::net::IpAddr::is_ipv4)
+        self.lookup_real_with_ttl(host, std::net::IpAddr::is_ipv4)
+            .await
     }
 
     pub async fn lookup_ipv6(&self, host: &str) -> Option<IpAddr> {
+        self.lookup_ipv6_with_ttl(host).await.map(|(ip, _)| ip)
+    }
+
+    /// AAAA counterpart of [`Self::lookup_ipv4_with_ttl`] — same TTL contract.
+    pub async fn lookup_ipv6_with_ttl(&self, host: &str) -> Option<(IpAddr, Duration)> {
         if self.use_hosts {
             if let Some(ips) = self.hosts.search(host) {
-                return ips.iter().find(|ip| ip.is_ipv6()).copied();
+                let ip = ips.iter().find(|ip| ip.is_ipv6()).copied()?;
+                return Some((ip, HOSTS_ANSWER_TTL));
             }
         }
         // Fake-IP mode for AAAA: synthesise from the v6 pool if configured.
@@ -852,18 +871,39 @@ impl Resolver {
         if self.mode == DnsMode::FakeIp {
             if let Some(pool) = &self.fakeip_v6 {
                 if !self.skipper_bypasses(host) {
-                    return Some(pool.lookup(host));
+                    return Some((pool.lookup(host), self.fakeip_ttl));
                 }
             } else if self.fakeip_v4.is_some() && !self.skipper_bypasses(host) {
                 // v4-only fake-ip config: suppress AAAA so clients fall back.
                 return None;
             }
         }
-        if let Some(ips) = self.cache.get(host) {
-            return ips.iter().find(|ip| ip.is_ipv6()).copied();
+        self.lookup_real_with_ttl(host, std::net::IpAddr::is_ipv6)
+            .await
+    }
+
+    /// Cache-then-upstream address lookup carrying the answer TTL. Cache hits
+    /// report the entry's remaining lifetime; upstream lookups re-read the
+    /// cache entry `do_lookup` just wrote, so the answer reflects the same
+    /// (clamped) TTL the cache will honor. The re-read can only miss on a
+    /// zero-capacity cache or an eviction race — fall back to the upstream
+    /// answer with [`HOSTS_ANSWER_TTL`] rather than dropping it.
+    async fn lookup_real_with_ttl(
+        &self,
+        host: &str,
+        family: fn(&IpAddr) -> bool,
+    ) -> Option<(IpAddr, Duration)> {
+        if let Some((ips, remaining)) = self.cache.get_with_ttl(host) {
+            let ip = ips.iter().find(|ip| family(ip)).copied()?;
+            return Some((ip, remaining));
         }
         let ips = self.lookup_actual_all(host).await?;
-        ips.into_iter().find(std::net::IpAddr::is_ipv6)
+        let ip = ips.into_iter().find(family)?;
+        let ttl = self
+            .cache
+            .get_with_ttl(host)
+            .map_or(HOSTS_ANSWER_TTL, |(_, remaining)| remaining);
+        Some((ip, ttl))
     }
 
     fn skipper_bypasses(&self, host: &str) -> bool {
@@ -999,6 +1039,26 @@ impl Resolver {
             return Some(result.ips);
         }
         None
+    }
+
+    /// Capture the live reverse (IP → host) table with remaining lifetimes,
+    /// for persistence across an engine restart. Fake-IP pool mappings are
+    /// not included — the pools have their own [`crate::fakeip::Store`]
+    /// persistence.
+    pub fn reverse_cache_snapshot(&self) -> Vec<crate::cache::ReverseSnapshotEntry> {
+        self.cache.reverse_snapshot()
+    }
+
+    /// Restore reverse (IP → host) entries captured by
+    /// [`Self::reverse_cache_snapshot`] in a previous run. Call at startup,
+    /// before traffic: in redir-host (Mapping) mode this is what lets
+    /// connections dialed from pre-restart DNS answers still recover their
+    /// hostname for rule matching.
+    pub fn restore_reverse_cache(
+        &self,
+        entries: impl IntoIterator<Item = crate::cache::ReverseSnapshotEntry>,
+    ) {
+        self.cache.restore_reverse(entries);
     }
 
     pub fn reverse_lookup(&self, ip: IpAddr) -> Option<SmolStr> {
@@ -1329,6 +1389,75 @@ mod tests {
         assert!(
             aaaa.is_some_and(|ip| ip.is_ipv6() && dual.is_fake_ip(ip)),
             "AAAA must return a v6 fake IP when a v6 pool is configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_with_ttl_reports_remaining_cache_lifetime() {
+        let resolver = Resolver::new(vec![], vec![], DnsMode::Mapping, DomainTrie::new(), true);
+        let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        resolver
+            .cache
+            .put("cached.test", &[real], Duration::from_secs(300));
+        let (ip, ttl) = resolver
+            .lookup_ipv4_with_ttl("cached.test")
+            .await
+            .expect("cache hit");
+        assert_eq!(ip, real);
+        assert!(ttl <= Duration::from_secs(300));
+        assert!(
+            ttl > Duration::from_secs(295),
+            "ttl {ttl:?} should be the remaining lifetime, not a constant"
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_with_ttl_uses_hosts_ttl_for_static_mappings() {
+        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let pinned = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        hosts.insert("pinned.test", vec![pinned]);
+        let resolver = Resolver::new(vec![], vec![], DnsMode::Mapping, hosts, true);
+        assert_eq!(
+            resolver.lookup_ipv4_with_ttl("pinned.test").await,
+            Some((pinned, HOSTS_ANSWER_TTL))
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_with_ttl_reports_fake_ip_ttl_for_synthesised_answers() {
+        use crate::fakeip::MemoryStore;
+        let mut resolver = Resolver::new(vec![], vec![], DnsMode::FakeIp, DomainTrie::new(), true);
+        resolver.set_fakeip_v4(Arc::new(
+            Pool::new(
+                "198.18.0.0/16".parse().unwrap(),
+                Arc::new(MemoryStore::new(1024)),
+            )
+            .unwrap(),
+        ));
+        let (ip, ttl) = resolver
+            .lookup_ipv4_with_ttl("example.com")
+            .await
+            .expect("fake-IP synthesis");
+        assert!(resolver.is_fake_ip(ip));
+        assert_eq!(ttl, DEFAULT_FAKE_IP_TTL);
+    }
+
+    #[test]
+    fn reverse_cache_snapshot_restore_round_trips_via_resolver() {
+        let resolver = Resolver::new(vec![], vec![], DnsMode::Mapping, DomainTrie::new(), true);
+        let ip = IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34));
+        resolver
+            .cache
+            .put("persist.test", &[ip], Duration::from_secs(60));
+        let snap = resolver.reverse_cache_snapshot();
+        assert_eq!(snap.len(), 1);
+
+        let restarted = Resolver::new(vec![], vec![], DnsMode::Mapping, DomainTrie::new(), true);
+        assert!(restarted.reverse_lookup(ip).is_none());
+        restarted.restore_reverse_cache(snap);
+        assert_eq!(
+            restarted.reverse_lookup(ip).as_deref(),
+            Some("persist.test")
         );
     }
 

--- a/crates/meow-dns/src/server.rs
+++ b/crates/meow-dns/src/server.rs
@@ -125,23 +125,25 @@ impl DnsServer {
         }
 
         // Resolve using our resolver (cache + upstream + fake-IP synthesis).
+        // The resolver reports the TTL each answer should carry: the short
+        // fake-IP TTL for synthesised addresses (clients must re-query after
+        // pool eviction), and the upstream's real TTL — decayed by time spent
+        // in cache — for everything else, so redir-host / normal-mode clients
+        // expire their own caches on the upstream's schedule instead of a
+        // synthetic constant.
         let ip = if qtype == 1 {
-            resolver.lookup_ipv4(&domain).await
+            resolver.lookup_ipv4_with_ttl(&domain).await
         } else {
-            resolver.lookup_ipv6(&domain).await
+            resolver.lookup_ipv6_with_ttl(&domain).await
         };
 
-        // Synthesised fake-IP responses get a short TTL so clients re-query
-        // after pool eviction. Real upstream answers keep the default.
-        let ttl =
-            if resolver.mode() == DnsMode::FakeIp && ip.is_some_and(|i| resolver.is_fake_ip(i)) {
-                resolver.fake_ip_ttl().as_secs().clamp(1, u32::MAX as u64) as u32
-            } else {
-                DEFAULT_ANSWER_TTL_SECS
-            };
-
         Ok(match ip {
-            Some(addr) => Self::build_response(id, data, qtype, addr, ttl),
+            Some((addr, ttl)) => {
+                // Sub-second remainders round up to 1 — a 0-TTL answer means
+                // "never cache", which is stricter than the entry deserves.
+                let ttl_secs = ttl.as_secs().clamp(1, u64::from(u32::MAX)) as u32;
+                Self::build_response(id, data, qtype, addr, ttl_secs)
+            }
             // Fake-IP mode AAAA when only v4 pool is configured: return
             // NOERROR-empty so clients fall back to IPv4 cleanly. NXDOMAIN
             // would tell them "no such host" — wrong signal.


### PR DESCRIPTION
Two redir-host (Mapping) mode improvements, both motivated by the iOS NE embedding:

## 1. Answers carry the real TTL

`DnsServer` stamped every non-fake-IP A/AAAA answer with a fixed `DEFAULT_ANSWER_TTL_SECS = 60`, discarding the upstream's TTL. New `Resolver::lookup_ipv4_with_ttl` / `lookup_ipv6_with_ttl` (backed by `DnsCache::get_with_ttl`) report the TTL each answer should carry:

- cache hit → the entry's **remaining** lifetime (decays as the entry ages);
- fresh lookup → the upstream's TTL as stored (still clamped 10–3600s by `clamp_ttl` on insert);
- fake-IP synthesis → the fake-IP TTL (unchanged behavior, now decided in one place);
- hosts-trie mapping → `HOSTS_ANSWER_TTL = 60s` (static entries have no upstream TTL; matches previous behavior).

Sub-second remainders round up to 1s rather than emitting a "never cache" 0-TTL answer. The old `lookup_ipv4/6` remain as thin wrappers, so no call-site churn.

## 2. Reverse (IP → host) table snapshot/restore

`DnsCache::reverse_snapshot()` captures every live reverse entry with its remaining lifetime (evicting expired ones on the way, sorted by IP for stable serialization); `restore_reverse()` re-inserts them respecting per-shard caps. Mirrored on `Resolver` as `reverse_cache_snapshot` / `restore_reverse_cache`.

This lets an embedding process persist the redir-host reverse table across an engine restart. Without it, every connection dialed from a pre-restart DNS answer loses IP → host recovery and silently degrades to IP-only rule matching. Wall-clock anchoring across the restart gap is the caller's job (`Instant` doesn't survive a process); the meow-ios FFI will persist absolute expiry timestamps.

## Testing

- `cargo test -p meow-dns` (full, incl. integration suites) — green
- `cargo test --lib` (workspace) — green
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p meow-dns --no-deps` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)