### PR TITLE
chore(audit): ignore RUSTSEC-2024-0436 (paste unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,9 @@
 # cargo-audit configuration.
 #
-# Three advisories are ignored — all pulled transitively via the `anytls-rs`
-# fork's `trust-dns-resolver 0.23` dep, none applicable to this workspace:
+# Four advisories are ignored, none applicable to this workspace.
+#
+# Three are pulled transitively via the `anytls-rs` fork's
+# `trust-dns-resolver 0.23` dep:
 #
 # * RUSTSEC-2024-0421 (`idna` 0.4 — privilege escalation via URL hostname
 #   comparison). Our use is DNS resolution, not URL/origin comparison.
@@ -9,10 +11,21 @@
 #   pending upstream `anytls-rs` migration.
 # * RUSTSEC-2025-0134 (`rustls-pemfile` rolled into `rustls-pki-types`). Same,
 #   pending upstream `anytls-rs` migration.
+#
+# One is pulled transitively via the TUN inbound's Linux netlink stack
+# (`tun-rs`/`route_manager` → `netlink-packet-core`):
+#
+# * RUSTSEC-2024-0436 (`paste` — unmaintained, no vulnerability). Build-time
+#   proc-macro only, compiled solely for Linux targets behind the opt-in
+#   `listener-tun` feature. The latest `netlink-packet-core` (0.8.1, and its
+#   git main as of 2026-07) still depends on `paste`, so there is no upstream
+#   fix to take. Re-evaluate when rust-netlink migrates (e.g. to `pastey`).
+#   Tracked in issue #349.
 
 [advisories]
 ignore = [
     "RUSTSEC-2024-0421",
     "RUSTSEC-2025-0017",
     "RUSTSEC-2025-0134",
+    "RUSTSEC-2024-0436",
 ]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,10 +7,12 @@ on:
   push:
     paths:
       - "Cargo.lock"
+      - ".cargo/audit.toml"
       - ".github/workflows/audit.yml"
   pull_request:
     paths:
       - "Cargo.lock"
+      - ".cargo/audit.toml"
       - ".github/workflows/audit.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Resolves #349 by adding `RUSTSEC-2024-0436` to the `.cargo/audit.toml` ignore list, following the same pattern (and documentation style) as the three existing `anytls-rs`-transitive ignores.

Also fixes a CI gap found while validating this: the audit workflow didn't trigger on `.cargo/audit.toml` changes, so a PR editing the ignore list couldn't validate itself. `.cargo/audit.toml` is now in the workflow's push/PR path filters.

## Why ignore rather than fix

- The advisory is **unmaintained-only** — there is no vulnerability in `paste`.
- `paste` is a **build-time proc-macro**; it ships no runtime code.
- It enters the tree transitively: `tun-rs`/`route_manager` → `netlink-packet-core` → `paste`, compiled **only for Linux targets** and only behind the opt-in `listener-tun` feature (`cargo tree -i paste` finds nothing without `--target all`).
- There is **no upstream fix to take**: the latest `netlink-packet-core` (0.8.1) and its git `main` (checked 2026-07) both still depend on `paste ^1`.

The config comment notes to re-evaluate when rust-netlink migrates (e.g. to `pastey`).

## Verification

- `cargo audit` exits 0 locally with the advisory reported as an allowed warning.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` all pass (config-only change).
- The Security Audit workflow now runs on this PR itself (it previously wouldn't have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)