### PR TITLE
fix(listener): query pf DIOCNATLOOK with PF_OUT to recover rdr original dst

### DIFF
--- a/crates/meow-listener/src/tproxy/orig_dest.rs
+++ b/crates/meow-listener/src/tproxy/orig_dest.rs
@@ -40,6 +40,13 @@ mod macos {
     // pf address type
     const PF_ADDR_IPV4: u8 = 2; // AF_INET
 
+    // Lookup direction, from <net/pfvar.h>: PF_INOUT = 0, PF_IN = 1, PF_OUT = 2.
+    // An `rdr` state's pre-translation destination is keyed under PF_OUT —
+    // querying with PF_IN hits the wrong state tree and returns ENOENT for
+    // every connection (issue #248). Squid's pf interception and OpenBSD's
+    // ftp-proxy both use PF_OUT for this lookup.
+    const PF_OUT: u8 = 2;
+
     /// pf address union — we only handle IPv4 for now.
     #[repr(C)]
     #[derive(Copy, Clone)]
@@ -145,7 +152,7 @@ mod macos {
         let mut nl = PfiocNatlook {
             af: PF_ADDR_IPV4,
             proto: libc::IPPROTO_TCP as u8,
-            direction: 1, // PF_IN
+            direction: PF_OUT,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Summary

Fixes the root cause of #248 §1 (original destination not recovered on macOS tproxy): the `DIOCNATLOOK` ioctl was issued with `direction = PF_IN`, but an `rdr` state's pre-translation destination is keyed under the **outbound** direction (`PF_OUT = 2` in xnu's `<net/pfvar.h>`). With `PF_IN` the lookup keys the wrong state tree and returns `ENOENT` for every redirected connection — matching the reported symptom (listener logs nothing, handshake times out, `meow_logged_original_dst` check fails).

## Precedent

Both battle-tested pf transparent-proxy implementations populate the natlook exactly as we do (saddr = client peer, daddr = redirected-to listen addr) and query with `PF_OUT`:

- Squid `src/ip/Intercept.cc`: `nl.direction = PF_OUT;` before `ioctl(pffd, DIOCNATLOOK, &nl)` (verified against current master)
- OpenBSD `ftp-proxy` `server_lookup()`: `pnl.direction = PF_OUT;`

The struct layout itself (84-byte `pfioc_natlook`, 4-byte `pf_state_xport` unions) was already verified against xnu offsets in #268 and is covered by compile-time and unit assertions — only the direction constant was wrong.

## Scope / verification status

- Compiled and linted on macOS (this path is macOS-only and doesn't build on Linux CI): `cargo fmt --check`, three-way `clippy -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib` all pass.
- Runtime verification against the `scripts/verify-tproxy-setup.sh` / `verify-tproxy-test.sh` rig needs a macOS VM (pf rule changes are too invasive for a dev workstation); the `meow_logged_original_dst` check is the acceptance signal.
- #248 §2 (`rdr` only on `lo0`, so only loopback traffic is intercepted) is **not** addressed here and the issue should stay open.

Addresses #248 (partial — §1 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)