### PR TITLE
fix(listener): exempt ephemeral-port destinations from macOS pf rdr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ The workspace has 13 crates (see also [ADR-0009](docs/adr/0009-cleanup-scope.md)
 
 ### Transparent-proxy gateway
 
-The built-in TProxy listener firewall (`meow-listener/src/tproxy/firewall.rs`) is `output`-chain/REDIRECT-based and only covers the **host's own** traffic — it is *not* a forwarding LAN gateway. To proxy *other* devices' traffic you add prerouting rules + a DNS hijack yourself. Helper scripts automate this: `scripts/tproxy-gateway-linux.sh` (nftables) and `scripts/tproxy-gateway-macos.sh` (pf, experimental). Full setup, DNS-mode (fake-ip vs redir-host) trade-offs, and systemd wiring are in [docs/tproxy-gateway.md](docs/tproxy-gateway.md). Note: the top-level `tproxy-port` hard-binds `127.0.0.1`; a gateway must declare the listener via `listeners:` with a non-loopback `listen`.
+The built-in TProxy listener firewall (`meow-listener/src/tproxy/firewall.rs`) is `output`-chain/REDIRECT-based and only covers the **host's own** traffic — it is *not* a forwarding LAN gateway. To proxy *other* devices' traffic you add prerouting rules + a DNS hijack yourself. Helper scripts automate this: `scripts/tproxy-gateway-linux.sh` (nftables) and `scripts/tproxy-gateway-macos.sh` (pf, experimental). Full setup, DNS-mode (fake-ip vs redir-host) trade-offs, and systemd wiring are in [docs/tproxy-gateway.md](docs/tproxy-gateway.md). macOS *local* tproxy (managed pf anchor + manual `route-to lo0` for real outbound traffic, IPv4 TCP only) is documented in [docs/tproxy-macos.md](docs/tproxy-macos.md). Note: the top-level `tproxy-port` hard-binds `127.0.0.1`; a gateway must declare the listener via `listeners:` with a non-loopback `listen`.
 
 ### TUN inbound (Windows transparent proxy)
 

--- a/crates/meow-listener/src/tproxy/firewall.rs
+++ b/crates/meow-listener/src/tproxy/firewall.rs
@@ -72,11 +72,35 @@ struct PlatformGuard {
 ///
 /// Extracted as a pure function so the macOS-specific syntax can be unit
 /// tested without invoking `pfctl(8)`.
+///
+/// `ephemeral_first` is the low end of the client ephemeral port range
+/// (`net.inet.ip.portrange.first`); see the `no rdr` exemption below.
 #[cfg(any(target_os = "macos", test))]
-pub(crate) fn build_pf_ruleset(uid: u32, listen_port: u16, bypass_ips: &[IpAddr]) -> String {
+pub(crate) fn build_pf_ruleset(
+    uid: u32,
+    listen_port: u16,
+    ephemeral_first: u16,
+    bypass_ips: &[IpAddr],
+) -> String {
     // Translation first: redirect lo0 TCP to the local tproxy listener.
+    //
+    // Every lo0 packet traverses pf twice (out, then in). Without an
+    // exemption, the listener's own SYN-ACK — un-translated on the outbound
+    // pass — re-enters lo0 inbound, matches the broad `rdr` as a *new*
+    // connection, and is rewritten back into the listener: every intercepted
+    // handshake wedges in SYN_SENT (issue #354). `rdr` rules cannot match TCP
+    // flags, so the discriminator is the destination port: replies go to the
+    // client's ephemeral source port, fresh SYNs to service ports. Exempting
+    // ephemeral destination ports lets replies through; the trade-off is that
+    // destinations listening on ephemeral-range ports bypass the proxy (fail
+    // open) instead of wedging. Translation rules are first-match, so the
+    // `no rdr` must precede the `rdr`.
     let mut rules =
-        format!("rdr pass on lo0 proto tcp from any to any -> 127.0.0.1 port {listen_port}\n");
+        format!("no rdr on lo0 proto tcp from any to any port {ephemeral_first}:65535\n");
+    let _ = writeln!(
+        rules,
+        "rdr pass on lo0 proto tcp from any to any -> 127.0.0.1 port {listen_port}"
+    );
     // Then filtering bypasses (our own uid, loopback, upstream proxy servers).
     let _ = writeln!(
         rules,
@@ -87,6 +111,30 @@ pub(crate) fn build_pf_ruleset(uid: u32, listen_port: u16, bypass_ips: &[IpAddr]
         let _ = writeln!(rules, "pass out quick on lo0 proto tcp from any to {ip}");
     }
     rules
+}
+
+/// Low end of the kernel's ephemeral (local) port range, used by `connect()`
+/// when picking source ports — replies to intercepted connections always
+/// target a port at or above it. Falls back to the macOS default (49152) if
+/// the sysctl is unreadable or out of range.
+#[cfg(target_os = "macos")]
+fn ephemeral_port_first() -> u16 {
+    let mut value: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>();
+    let ret = unsafe {
+        libc::sysctlbyname(
+            c"net.inet.ip.portrange.first".as_ptr(),
+            std::ptr::from_mut(&mut value).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret == 0 && (1..=65535).contains(&value) {
+        value as u16
+    } else {
+        49152
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -104,7 +152,7 @@ impl PlatformGuard {
         let anchor = "com.apple/com.meow.tproxy".to_string();
         let uid = unsafe { libc::getuid() };
 
-        let rules = build_pf_ruleset(uid, listen_port, bypass_ips);
+        let rules = build_pf_ruleset(uid, listen_port, ephemeral_port_first(), bypass_ips);
 
         let tmp_path = format!("/tmp/meow_tproxy_{pid}.conf", pid = std::process::id());
         std::fs::write(&tmp_path, &rules)?;
@@ -390,7 +438,7 @@ mod tests {
 
     #[test]
     fn pf_ruleset_contains_uid_bypass_and_redirect() {
-        let rs = build_pf_ruleset(501, 7893, &[]);
+        let rs = build_pf_ruleset(501, 7893, 49152, &[]);
         assert!(
             rs.contains("pass out quick on lo0 proto tcp from any to any user 501"),
             "UID bypass missing:\n{rs}"
@@ -405,16 +453,41 @@ mod tests {
         // translation (`rdr`) — "Rules must be in order: …, translation,
         // filtering". The `rdr` must therefore come first, or the anchor fails
         // to load and the tproxy listener never starts (regression guard).
-        let rs = build_pf_ruleset(501, 7893, &[]);
+        let rs = build_pf_ruleset(501, 7893, 49152, &[]);
         let rdr_pos = rs.find("rdr pass").unwrap();
         let uid_pos = rs.find("user 501").unwrap();
         assert!(rdr_pos < uid_pos, "rdr must precede filter rules:\n{rs}");
     }
 
     #[test]
+    fn pf_replies_to_ephemeral_ports_are_exempt_from_rdr() {
+        // Issue #354: on lo0 every packet traverses pf twice, so without this
+        // exemption the listener's own SYN-ACK (destined to the client's
+        // ephemeral port) re-matches the broad `rdr` inbound and is redirected
+        // back into the listener — every intercepted handshake wedges.
+        let rs = build_pf_ruleset(501, 7893, 49152, &[]);
+        assert!(
+            rs.contains("no rdr on lo0 proto tcp from any to any port 49152:65535"),
+            "ephemeral-port rdr exemption missing:\n{rs}"
+        );
+        // Translation rules are first-match: the exemption must precede the rdr.
+        let no_rdr_pos = rs.find("no rdr").unwrap();
+        let rdr_pos = rs.find("rdr pass").unwrap();
+        assert!(no_rdr_pos < rdr_pos, "no rdr must precede rdr:\n{rs}");
+    }
+
+    #[test]
+    fn pf_ephemeral_range_is_parameterized() {
+        // The exemption must track the kernel's actual ephemeral range
+        // (net.inet.ip.portrange.first), not a hardcoded default.
+        let rs = build_pf_ruleset(501, 7893, 10000, &[]);
+        assert!(rs.contains("no rdr on lo0 proto tcp from any to any port 10000:65535"));
+    }
+
+    #[test]
     fn pf_bypass_ips_are_emitted() {
         let bypass = [IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))];
-        let rs = build_pf_ruleset(501, 7893, &bypass);
+        let rs = build_pf_ruleset(501, 7893, 49152, &bypass);
         assert!(rs.contains("pass out quick on lo0 proto tcp from any to 1.1.1.1"));
     }
 }

--- a/docs/tproxy-gateway.md
+++ b/docs/tproxy-gateway.md
@@ -368,4 +368,4 @@ rule — confirm the client's source IP appears:
   (`net.inet.ip.portrange.first`–65535, default 49152+) are not intercepted:
   the `rdr` exempts them so the listener's own replies — which target the
   client's ephemeral port and re-traverse `lo0` — aren't redirected back into
-  the listener (issue #354).
+  the listener (issue #354). Setup guide: [tproxy-macos.md](tproxy-macos.md).

--- a/docs/tproxy-gateway.md
+++ b/docs/tproxy-gateway.md
@@ -364,4 +364,8 @@ rule — confirm the client's source IP appears:
   tproxy listener.
 - **macOS:** the built-in firewall uses a `pf` anchor with UID-based loop
   avoidance and supports local interception only; this gateway recipe is
-  Linux/nftables-specific.
+  Linux/nftables-specific. Destinations listening on ephemeral-range ports
+  (`net.inet.ip.portrange.first`–65535, default 49152+) are not intercepted:
+  the `rdr` exempts them so the listener's own replies — which target the
+  client's ephemeral port and re-traverse `lo0` — aren't redirected back into
+  the listener (issue #354).

--- a/docs/tproxy-macos.md
+++ b/docs/tproxy-macos.md
@@ -1,0 +1,134 @@
+# Transparent proxy on macOS (pf) — experimental
+
+Proxy **this host's own outbound TCP traffic** on macOS without touching
+application proxy settings, using a `tproxy` listener and pf. For forwarding
+*other* devices' traffic see [tproxy-gateway.md](tproxy-gateway.md) (the macOS
+gateway script is experimental); for the strategic, more capable path on macOS
+(UDP, IPv6, IP-literal capture without pf) see [tun.md](tun.md).
+
+**Status: experimental.** Requires a build containing the `DIOCNATLOOK`
+direction fix (#353) and the lo0 reply-exemption fix (#355) — `main` since
+July 2026, first release after 0.18.0. Scope today: **IPv4 TCP only**, no UDP.
+
+## How it works
+
+Configuring `tproxy-port` makes meow (which must run as root — pf requires it)
+auto-load a pf anchor `com.apple/com.meow.tproxy` on startup and flush it on
+exit:
+
+```
+no rdr on lo0 proto tcp from any to any port 49152:65535   # let replies through (#354)
+rdr pass on lo0 proto tcp from any to any -> 127.0.0.1 port <tproxy-port>
+pass out quick on lo0 proto tcp from any to any user 0     # meow's own dials skip
+pass out quick on lo0 proto tcp from any to 127.0.0.0/8
+```
+
+Every TCP connection that traverses `lo0` is redirected into the listener,
+which recovers the pre-translation destination from pf's state table
+(`DIOCNATLOOK`) and routes it through your rules like any other connection.
+Loop avoidance is UID-based: connections made *by root* bypass interception,
+so meow (running as root) can dial out freely — run client apps as a normal
+user.
+
+The `no rdr` line exempts destination ports in the kernel's ephemeral range
+(`sysctl net.inet.ip.portrange.first`, default 49152+): on `lo0` every packet
+passes pf twice, and without the exemption the listener's own replies would be
+re-redirected into itself, wedging every handshake. Consequence: destinations
+listening on ephemeral-range ports are not intercepted (they connect directly).
+
+## Quick start
+
+```yaml
+# config.yaml
+mode: rule
+tproxy-port: 7893     # binds 127.0.0.1; meow manages the pf anchor
+proxies:
+  - { name: my-proxy, type: ss, server: ..., port: ..., cipher: ..., password: ... }
+rules:
+  - MATCH,my-proxy
+```
+
+```bash
+sudo ./meow -f config.yaml
+# → INFO pf anchor 'com.apple/com.meow.tproxy' loaded
+# → INFO TProxy listener 'tproxy' started on 127.0.0.1:7893
+```
+
+Out of the box this intercepts only traffic that already traverses `lo0`
+(connections to loopback-aliased addresses). That is enough for the
+[verification rig](../scripts/README.md) but not for real browsing — read on.
+
+`scripts/tproxy-local-macos.sh up|down|status` wraps the above and confirms
+the anchor came up.
+
+## Intercepting real outbound traffic (`route-to lo0`)
+
+The host's outbound connections to remote IPs leave via `en0` and never touch
+`lo0`, so meow's managed `rdr` cannot see them (issue #248 §2). To intercept
+them, add a pf rule that detours matching outbound packets through `lo0`.
+meow does **not** install this for you. Verified recipe (child anchors under
+`com.apple/*` are evaluated by the stock `/etc/pf.conf`):
+
+```bash
+# Example: proxy all TCP to 1.1.1.1. Widen the "to" spec to taste.
+echo '
+pass out quick on en0 proto tcp from any to 1.1.1.1 user root
+pass out quick on en0 route-to lo0 inet proto tcp from any to 1.1.1.1
+' | sudo pfctl -a com.apple/com.meow.routeto -f -
+```
+
+Rule 1 is mandatory: it lets meow's *own* (root) outbound dials to the same
+destinations escape the detour — without it every proxied connection loops
+straight back into the listener. Rule 2 steers everyone else's packets into
+`lo0`, where the managed `rdr` picks them up.
+
+Notes:
+
+- **Scope the `to` spec deliberately.** Start with specific IPs/tables and
+  widen once you trust your rules; a `to any` detour combined with a broken
+  ruleset can take the host's entire TCP egress down with it.
+- If meow runs as a dedicated non-root… it can't — pf needs root. The `user
+  root` escape therefore always matches meow. If you run *other* root
+  processes whose traffic you wanted proxied, they are bypassed too (same
+  trade-off as the managed anchor's UID loop avoidance).
+- The anchor does not survive reboot; re-load it at startup (LaunchDaemon) or
+  keep it in `/etc/pf.conf` via an `anchor`/`load anchor` pair.
+- Remove with `sudo pfctl -a com.apple/com.meow.routeto -F all`.
+
+End-to-end check (this exact recipe is verified on macOS 26 VMs): with the
+anchor loaded, `curl http://1.1.1.1/` from a non-root shell returns normally
+and meow logs
+
+```
+INFO meow_listener::tproxy: 192.168.x.x:49219 --> 1.1.1.1:80 match MATCH() using DIRECT
+```
+
+## Limitations
+
+| Limitation | Detail |
+|------------|--------|
+| IPv4 TCP only | `DIOCNATLOOK` recovery is IPv4; UDP is not intercepted (use [TUN](tun.md)) |
+| Ephemeral-port destinations bypass | dst ports ≥ `net.inet.ip.portrange.first` (default 49152) connect directly (#354) |
+| Manual `route-to` for real traffic | meow only manages the `lo0` rdr (#248 §2) |
+| Root-owned traffic bypasses | UID loop avoidance skips everything root sends |
+| Not reboot-persistent | both meow's anchor (by design) and your `route-to` anchor |
+
+## Troubleshooting
+
+```bash
+sudo pfctl -a com.apple/com.meow.tproxy -sn   # rdr + no-rdr present?
+sudo pfctl -a com.apple/com.meow.tproxy -sr   # uid/loopback bypasses present?
+sudo pfctl -ss | grep <tproxy-port>           # states being created?
+```
+
+A state stuck in `SYN_SENT:ESTABLISHED` alongside a second, reversed state
+means replies are being re-redirected — you are running a build without the
+#355 exemption. No states at all means the traffic never traversed `lo0`
+(missing `route-to`). meow accepting but logging nothing at `info` usually
+means original-destination recovery failed; re-run with `log-level: debug`
+(errors on the accept path are logged at debug).
+
+The scripted rig `scripts/verify-tproxy-setup.sh` / `verify-tproxy-test.sh`
+asserts the whole loopback path (listener, anchor, interception, recovery) on
+a disposable loopback alias — **it rewrites pf state; run it in a VM, not on
+a workstation you care about.**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,9 @@ root for the firewall (`nft` on Linux, `pfctl` on macOS).
 install — so the gateway scripts do.
 
 Full background (how meow's tproxy works, fake-ip vs redir-host, the non-loopback
-listener requirement) is in [`docs/tproxy-gateway.md`](../docs/tproxy-gateway.md).
+listener requirement) is in [`docs/tproxy-gateway.md`](../docs/tproxy-gateway.md);
+the macOS local-mode guide (pf anchor, `route-to lo0` recipe, limitations) is
+[`docs/tproxy-macos.md`](../docs/tproxy-macos.md).
 
 ---
 

--- a/scripts/tproxy-local-macos.sh
+++ b/scripts/tproxy-local-macos.sh
@@ -8,10 +8,9 @@
 # and confirms the anchor came up. To forward OTHER devices' traffic, use
 # tproxy-gateway-macos.sh instead.
 #
-# NOTE (see GitHub issue on macOS tproxy): macOS interception is currently
-# loopback-only and the redirected connection's handshake does not complete, so
-# this does not yet proxy real outbound traffic. The wrapper still demonstrates
-# that the listener + pf anchor are installed correctly.
+# NOTE: out of the box, interception covers only traffic that traverses lo0.
+# To proxy this host's real outbound traffic you additionally load a manual
+# `route-to lo0` anchor — recipe and limitations in docs/tproxy-macos.md.
 #
 # Usage:
 #   sudo ./tproxy-local-macos.sh up [--config FILE] [--meow PATH]


### PR DESCRIPTION
## Summary

Fixes #354: the managed pf anchor's broad `rdr pass on lo0 proto tcp from any to any` also matched the tproxy listener's own SYN-ACK replies as they re-entered lo0 inbound (loopback double-pass), redirecting them back into the listener. Every intercepted handshake wedged in `SYN_SENT`, which is why macOS tproxy failed out of the box even after the natlook fix (#353/#348).

## Approach

pf translation rules cannot match TCP flags, so the discriminator is the destination port: replies always target the client's **ephemeral** source port, while fresh SYNs target service ports. The ruleset now leads with

```
no rdr on lo0 proto tcp from any to any port <first>:65535
```

where `<first>` is read from `net.inet.ip.portrange.first` at setup (fallback 49152) — translation rules are first-match, so the exemption precedes the `rdr`.

**Trade-off**: destinations listening on ephemeral-range ports bypass the proxy (fail open) instead of wedging (fail closed, the status quo). Documented in `docs/tproxy-gateway.md`.

## Verification

- Full regression bar: fmt, three-way clippy `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib` — all green.
- New unit tests: exemption emitted, precedes the rdr, range parameterized (not hardcoded).
- Ruleset parse-validated with `pfctl -n`.
- **e2e in a macOS 26.4 tart VM with the stock `verify-tproxy-*` rig**: previously 3/4 (`meow_logged_original_dst` failing, handshake stuck in SYN_SENT, reversed rdr state in `pfctl -ss`); with this fix **4/4 out of the box**, meow logs `10.88.0.1:49157 --> 10.88.0.1:9999 match MATCH() using REJECT`.

Together with #353/#348 this makes macOS local tproxy functional end-to-end for the first time. #248 §2 (lo0-only scope) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)