### PR TITLE
chore(release): 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64",
  "futures",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -226,16 +226,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.18.0" }
-meow-trie = { path = "crates/meow-trie", version = "0.18.0" }
+meow-common = { path = "crates/meow-common", version = "0.19.0" }
+meow-trie = { path = "crates/meow-trie", version = "0.19.0" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.18.0" }
-meow-dns = { path = "crates/meow-dns", version = "0.18.0", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.18.0" }
-meow-transport = { path = "crates/meow-transport", version = "0.18.0" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.18.0", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.18.0" }
-meow-listener = { path = "crates/meow-listener", version = "0.18.0", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.18.0" }
-meow-config = { path = "crates/meow-config", version = "0.18.0", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.19.0" }
+meow-dns = { path = "crates/meow-dns", version = "0.19.0", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.19.0" }
+meow-transport = { path = "crates/meow-transport", version = "0.19.0" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.19.0", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.19.0" }
+meow-listener = { path = "crates/meow-listener", version = "0.19.0", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.19.0" }
+meow-config = { path = "crates/meow-config", version = "0.19.0", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,7 +12,7 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
@@ -26,7 +26,7 @@ name = "anytls_rs"
 path = "src/lib.rs"
 
 [dependencies]
-meow-common = { path = "../meow-common", version = "0.18.0" }
+meow-common = { path = "../meow-common", version = "0.19.0" }
 tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",


### PR DESCRIPTION
Bump the workspace version and internal dependency pins from 0.18.0 to 0.19.0 ahead of tagging v0.19.0.

Highlights since v0.18.0:
- feat(dns): propagate real answer TTLs and add reverse-cache snapshot/restore (#351)
- feat(dns): support #PROXY fragments on nameserver-policy entries (#350)
- fix(tunnel): interleave relay directions fairly per buffer cycle (#347)
- fix(listener): query pf DIOCNATLOOK with PF_OUT to recover rdr original dst (#353)
- fix(listener): exempt ephemeral-port destinations from macOS pf rdr (#355)
- fix(tun): support runtime TUN start/stop via config reload (#360)
- fix(api): clamp /connections push interval to a 100ms floor (#359)
- fix(dns): eager-bind DnsServer socket, Weak worker refs, panic-guarded workers (#362)

Local regression bar passed: fmt, three-way clippy (default / no-default-features / all-features) with -D warnings, rustdoc -D warnings, cargo test --lib.