### PR TITLE
fix(listener): parse HTTP headers as strict bytes

### DIFF
--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -483,7 +483,7 @@ fn parse_request_head(head: &[u8]) -> Result<RequestHead<'_>, &'static str> {
 fn validate_message_framing(headers: &[HeaderField<'_>]) -> Result<(), &'static str> {
     let mut content_length = None;
     let mut has_content_length = false;
-    let mut transfer_codings: Vec<&[u8]> = Vec::new();
+    let mut transfer_codings = Vec::new();
 
     for header in headers {
         if header.name.eq_ignore_ascii_case(b"content-length") {
@@ -505,13 +505,7 @@ fn validate_message_framing(headers: &[HeaderField<'_>]) -> Result<(), &'static 
                 content_length = Some(parsed);
             }
         } else if header.name.eq_ignore_ascii_case(b"transfer-encoding") {
-            for coding in header.value.split(|byte| *byte == b',') {
-                let coding = trim_ows(coding);
-                if coding.is_empty() || !coding.iter().copied().all(is_tchar) {
-                    return Err("invalid Transfer-Encoding");
-                }
-                transfer_codings.push(coding);
-            }
+            parse_transfer_codings(header.value, &mut transfer_codings)?;
         }
     }
 
@@ -521,17 +515,124 @@ fn validate_message_framing(headers: &[HeaderField<'_>]) -> Result<(), &'static 
     if !transfer_codings.is_empty() {
         let chunked_count = transfer_codings
             .iter()
-            .filter(|coding| coding.eq_ignore_ascii_case(b"chunked"))
+            .filter(|coding| coding.name.eq_ignore_ascii_case(b"chunked"))
             .count();
         if chunked_count != 1
-            || !transfer_codings
-                .last()
-                .is_some_and(|coding| coding.eq_ignore_ascii_case(b"chunked"))
+            || !transfer_codings.last().is_some_and(|coding| {
+                coding.name.eq_ignore_ascii_case(b"chunked") && !coding.has_parameters
+            })
         {
             return Err("invalid request Transfer-Encoding");
         }
     }
     Ok(())
+}
+
+#[derive(Debug)]
+struct TransferCoding<'a> {
+    name: &'a [u8],
+    has_parameters: bool,
+}
+
+/// Parse the RFC 9110 transfer-coding list without treating commas inside a
+/// quoted parameter value as list separators.
+fn parse_transfer_codings<'a>(
+    value: &'a [u8],
+    codings: &mut Vec<TransferCoding<'a>>,
+) -> Result<(), &'static str> {
+    let mut cursor = 0;
+    skip_ows(value, &mut cursor);
+
+    loop {
+        let name = parse_token(value, &mut cursor).ok_or("invalid Transfer-Encoding")?;
+        let mut has_parameters = false;
+
+        loop {
+            skip_ows(value, &mut cursor);
+            if value.get(cursor) != Some(&b';') {
+                break;
+            }
+            has_parameters = true;
+            cursor += 1;
+            skip_ows(value, &mut cursor);
+            parse_token(value, &mut cursor).ok_or("invalid Transfer-Encoding parameter")?;
+            skip_ows(value, &mut cursor);
+            if value.get(cursor) != Some(&b'=') {
+                return Err("invalid Transfer-Encoding parameter");
+            }
+            cursor += 1;
+            skip_ows(value, &mut cursor);
+            if value.get(cursor) == Some(&b'"') {
+                parse_quoted_string(value, &mut cursor)?;
+            } else {
+                parse_token(value, &mut cursor)
+                    .ok_or("invalid Transfer-Encoding parameter value")?;
+            }
+        }
+
+        codings.push(TransferCoding {
+            name,
+            has_parameters,
+        });
+        skip_ows(value, &mut cursor);
+        match value.get(cursor) {
+            None => return Ok(()),
+            Some(b',') => {
+                cursor += 1;
+                skip_ows(value, &mut cursor);
+                if cursor == value.len() {
+                    return Err("invalid Transfer-Encoding");
+                }
+            }
+            _ => return Err("invalid Transfer-Encoding"),
+        }
+    }
+}
+
+fn parse_token<'a>(value: &'a [u8], cursor: &mut usize) -> Option<&'a [u8]> {
+    let start = *cursor;
+    while value.get(*cursor).is_some_and(|byte| is_tchar(*byte)) {
+        *cursor += 1;
+    }
+    (*cursor != start).then_some(&value[start..*cursor])
+}
+
+fn parse_quoted_string(value: &[u8], cursor: &mut usize) -> Result<(), &'static str> {
+    debug_assert_eq!(value.get(*cursor), Some(&b'"'));
+    *cursor += 1;
+    loop {
+        match value.get(*cursor).copied() {
+            Some(b'"') => {
+                *cursor += 1;
+                return Ok(());
+            }
+            Some(b'\\') => {
+                *cursor += 1;
+                let escaped = value
+                    .get(*cursor)
+                    .copied()
+                    .ok_or("unterminated Transfer-Encoding quoted string")?;
+                if !matches!(escaped, b'\t' | b' '..=b'~' | 0x80..=0xff) {
+                    return Err("invalid Transfer-Encoding quoted pair");
+                }
+                *cursor += 1;
+            }
+            Some(b'\t' | b' ' | b'!' | b'#'..=b'[' | b']'..=b'~' | 0x80..=0xff) => {
+                *cursor += 1;
+            }
+            Some(_) => return Err("invalid Transfer-Encoding quoted string"),
+            None => return Err("unterminated Transfer-Encoding quoted string"),
+        }
+    }
+}
+
+fn skip_ows(value: &[u8], cursor: &mut usize) {
+    while value
+        .get(*cursor)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        *cursor += 1;
+    }
 }
 
 fn rewrite_plain_request(request: &RequestHead<'_>, path: &str) -> Vec<u8> {
@@ -753,6 +854,40 @@ mod tests {
             b"POST http://example.com/ HTTP/1.1\r\nContent-Length: 5, 5\r\nContent-Length: 5\r\n\r\n"
         )
         .is_ok());
+    }
+
+    #[test]
+    fn parser_accepts_parameterized_transfer_codings() {
+        assert!(parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nTransfer-Encoding: gzip; level=1, chunked\r\n\r\n"
+        )
+        .is_ok());
+        assert!(parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nTransfer-Encoding: custom ; note = \"a,b\\\"c\", chunked\r\n\r\n"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn parser_rejects_malformed_transfer_coding_parameters() {
+        for value in [
+            b"gzip; level, chunked".as_slice(),
+            b"gzip; level=, chunked",
+            b"gzip; note=\"unterminated, chunked",
+            b"gzip; note=\"bad\\",
+            b"gzip,,chunked",
+            b"gzip,",
+        ] {
+            let mut codings = Vec::new();
+            assert!(
+                parse_transfer_codings(value, &mut codings).is_err(),
+                "unexpectedly accepted {value:?}"
+            );
+        }
+        assert!(parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nTransfer-Encoding: chunked; extension=yes\r\n\r\n"
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -3,6 +3,7 @@ use base64::Engine;
 use meow_common::{AuthConfig, ConnType, Metadata, Network};
 use meow_tunnel::{copy_bidirectional_buf_tracked, ConnectionGuard, Tunnel, RELAY_BUF_SIZE};
 use smallvec::smallvec;
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -62,36 +63,68 @@ async fn handle_http_inner(
         loop {
             let n = stream.read(&mut chunk).await?;
             if n == 0 {
-                return Err::<usize, Box<dyn std::error::Error + Send + Sync>>(
-                    "connection closed before headers complete".into(),
-                );
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "connection closed before headers complete",
+                ));
             }
             // Overlap the previous tail by 3 bytes so a marker straddling two
             // reads (e.g. "\r\n\r" then "\n…") is still detected.
             let search_start = request_buf.len().saturating_sub(3);
             request_buf.extend_from_slice(&chunk[..n]);
-            if let Some(rel) = find_crlf_crlf(&request_buf[search_start..]) {
-                return Ok(search_start + rel + 4);
+            let header_end = find_crlf_crlf(&request_buf[search_start..])
+                .map(|relative| search_start + relative + 4);
+            let bytes_to_validate = header_end.unwrap_or(request_buf.len());
+            if has_bare_line_ending(&request_buf[..bytes_to_validate]) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "bare CR or LF in request headers",
+                ));
+            }
+            if let Some(header_end) = header_end {
+                if header_end > MAX_HEADERS {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "request headers too large",
+                    ));
+                }
+                return Ok(header_end);
             }
             if request_buf.len() > MAX_HEADERS {
-                return Err::<usize, Box<dyn std::error::Error + Send + Sync>>(
-                    "request headers too large".into(),
-                );
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "request headers too large",
+                ));
             }
         }
     };
-    let header_end = tokio::time::timeout(crate::DEFAULT_HANDSHAKE_TIMEOUT, read_headers)
-        .await
-        .map_err(|_| "HTTP proxy handshake timed out")??;
+    let header_end =
+        match tokio::time::timeout(crate::DEFAULT_HANDSHAKE_TIMEOUT, read_headers).await {
+            Err(_) => return Err("HTTP proxy handshake timed out".into()),
+            Ok(Err(error)) if error.kind() == io::ErrorKind::InvalidData => {
+                write_bad_request(stream).await?;
+                return Err(error.into());
+            }
+            Ok(Err(error)) => return Err(error.into()),
+            Ok(Ok(header_end)) => header_end,
+        };
     let leftover: Vec<u8> = request_buf[header_end..].to_vec();
     request_buf.truncate(header_end);
+
+    let request = match parse_request_head(&request_buf) {
+        Ok(request) => request,
+        Err(error) => {
+            write_bad_request(stream).await?;
+            return Err(error.into());
+        }
+    };
 
     // Auth check: verify Proxy-Authorization before dispatching.
     let in_user: Option<String> = if let Some(auth) = auth
         .filter(|a| !a.credentials.is_empty())
         .filter(|a| !a.should_skip(&src_addr.ip()))
     {
-        match parse_proxy_authorization(&request_buf) {
+        match parse_proxy_authorization(&request.headers) {
             None => {
                 stream
                     .write_all(
@@ -120,20 +153,8 @@ async fn handle_http_inner(
         None
     };
 
-    // Parse the request line from the buffer — no heap allocation.
-    let request_str = String::from_utf8_lossy(&request_buf);
-    let request_line = request_str.lines().next().ok_or("empty request")?;
-
-    let mut parts = [""; 3];
-    for (i, part) in request_line.split_whitespace().take(3).enumerate() {
-        parts[i] = part;
-    }
-    if parts[2].is_empty() {
-        return Err("invalid HTTP request line".into());
-    }
-
-    let method = parts[0];
-    let target = parts[1];
+    let method = request.method;
+    let target = request.target;
 
     if method.eq_ignore_ascii_case("CONNECT") {
         // HTTPS CONNECT
@@ -300,36 +321,15 @@ async fn handle_http_inner(
         match proxy.dial_tcp(&metadata).await {
             Ok(mut remote) => {
                 // Rewrite the request line: remove the absolute URI scheme+host,
-                // keep the path. Rebuild headers without Proxy-* headers.
+                // keep the path. Rebuild headers without Proxy-* headers while
+                // preserving all other field bytes exactly.
                 let path = extract_path_from_url(url);
-                // Capacity hint: the rewrite never grows beyond the original
-                // request (the absolute URI shrinks to a path; headers only
-                // ever drop).
-                let mut rewritten = String::with_capacity(request_str.len());
-                {
-                    use std::fmt::Write as _;
-                    let _ = write!(rewritten, "{} {} {}\r\n", method, path, parts[2]);
-                }
-                for line in request_str.lines().skip(1) {
-                    if line.is_empty() {
-                        break;
-                    }
-                    // Skip proxy-specific headers — case-insensitive compare
-                    // on the slice, no per-line lowercased copy.
-                    if starts_with_ignore_ascii_case(line, "proxy-connection")
-                        || starts_with_ignore_ascii_case(line, "proxy-authorization")
-                    {
-                        continue;
-                    }
-                    rewritten.push_str(line);
-                    rewritten.push_str("\r\n");
-                }
-                rewritten.push_str("\r\n");
+                let rewritten = rewrite_plain_request(&request, path);
 
                 // Send the rewritten request to remote, then any body bytes
                 // that arrived in the same TCP segment as the headers (POST
                 // payloads typically do).
-                remote.write_all(rewritten.as_bytes()).await?;
+                remote.write_all(&rewritten).await?;
                 let up = Arc::clone(_guard.counters());
                 let dn = Arc::clone(_guard.counters());
                 if !leftover.is_empty() {
@@ -385,6 +385,225 @@ fn find_crlf_crlf(buf: &[u8]) -> Option<usize> {
     buf.windows(4).position(|w| w == b"\r\n\r\n")
 }
 
+/// Return true once a CR or LF can no longer be part of a CRLF pair. A final
+/// CR is left undecided because its LF may arrive in the next socket read.
+fn has_bare_line_ending(buf: &[u8]) -> bool {
+    buf.iter().enumerate().any(|(index, byte)| match *byte {
+        b'\n' => index == 0 || buf[index - 1] != b'\r',
+        b'\r' => index + 1 < buf.len() && buf[index + 1] != b'\n',
+        _ => false,
+    })
+}
+
+#[derive(Debug)]
+struct HeaderField<'a> {
+    name: &'a [u8],
+    value: &'a [u8],
+    raw: &'a [u8],
+}
+
+#[derive(Debug)]
+struct RequestHead<'a> {
+    method: &'a str,
+    target: &'a str,
+    version: &'a str,
+    headers: Vec<HeaderField<'a>>,
+}
+
+fn parse_request_head(head: &[u8]) -> Result<RequestHead<'_>, &'static str> {
+    if !head.ends_with(b"\r\n\r\n") || has_bare_line_ending(head) {
+        return Err("invalid HTTP line ending");
+    }
+
+    let mut lines = Vec::new();
+    let mut remaining = &head[..head.len() - 4];
+    loop {
+        if let Some(end) = remaining.windows(2).position(|window| window == b"\r\n") {
+            lines.push(&remaining[..end]);
+            remaining = &remaining[end + 2..];
+        } else {
+            lines.push(remaining);
+            break;
+        }
+    }
+    let (request_line, header_lines) = lines.split_first().ok_or("empty HTTP request")?;
+    let request_line =
+        std::str::from_utf8(request_line).map_err(|_| "non-ASCII HTTP request line")?;
+    if !request_line.is_ascii() {
+        return Err("non-ASCII HTTP request line");
+    }
+    let mut parts = request_line.split(' ');
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    let version = parts.next().unwrap_or_default();
+    if method.is_empty()
+        || target.is_empty()
+        || version.is_empty()
+        || parts.next().is_some()
+        || !method.as_bytes().iter().copied().all(is_tchar)
+        || !target.bytes().all(|byte| (0x21..=0x7e).contains(&byte))
+        || !matches!(version, "HTTP/1.0" | "HTTP/1.1")
+    {
+        return Err("invalid HTTP request line");
+    }
+
+    let mut headers = Vec::with_capacity(header_lines.len());
+    for &line in header_lines {
+        let colon = line
+            .iter()
+            .position(|byte| *byte == b':')
+            .ok_or("HTTP header missing colon")?;
+        let (name, value_with_colon) = line.split_at(colon);
+        if name.is_empty() || !name.iter().copied().all(is_tchar) {
+            return Err("invalid HTTP header name");
+        }
+        let value = &value_with_colon[1..];
+        if !value
+            .iter()
+            .all(|byte| *byte == b'\t' || (*byte >= 0x20 && *byte != 0x7f))
+        {
+            return Err("invalid HTTP header value");
+        }
+        headers.push(HeaderField {
+            name,
+            value,
+            raw: line,
+        });
+    }
+    validate_message_framing(&headers)?;
+
+    Ok(RequestHead {
+        method,
+        target,
+        version,
+        headers,
+    })
+}
+
+fn validate_message_framing(headers: &[HeaderField<'_>]) -> Result<(), &'static str> {
+    let mut content_length = None;
+    let mut has_content_length = false;
+    let mut transfer_codings: Vec<&[u8]> = Vec::new();
+
+    for header in headers {
+        if header.name.eq_ignore_ascii_case(b"content-length") {
+            has_content_length = true;
+            for value in header.value.split(|byte| *byte == b',') {
+                let value = trim_ows(value);
+                if value.is_empty() {
+                    return Err("invalid Content-Length");
+                }
+                let parsed = value.iter().try_fold(0u64, |length, byte| {
+                    byte.is_ascii_digit()
+                        .then(|| length.checked_mul(10)?.checked_add(u64::from(*byte - b'0')))
+                        .flatten()
+                });
+                let parsed = parsed.ok_or("invalid Content-Length")?;
+                if content_length.is_some_and(|length| length != parsed) {
+                    return Err("conflicting Content-Length values");
+                }
+                content_length = Some(parsed);
+            }
+        } else if header.name.eq_ignore_ascii_case(b"transfer-encoding") {
+            for coding in header.value.split(|byte| *byte == b',') {
+                let coding = trim_ows(coding);
+                if coding.is_empty() || !coding.iter().copied().all(is_tchar) {
+                    return Err("invalid Transfer-Encoding");
+                }
+                transfer_codings.push(coding);
+            }
+        }
+    }
+
+    if has_content_length && !transfer_codings.is_empty() {
+        return Err("Transfer-Encoding with Content-Length is ambiguous");
+    }
+    if !transfer_codings.is_empty() {
+        let chunked_count = transfer_codings
+            .iter()
+            .filter(|coding| coding.eq_ignore_ascii_case(b"chunked"))
+            .count();
+        if chunked_count != 1
+            || !transfer_codings
+                .last()
+                .is_some_and(|coding| coding.eq_ignore_ascii_case(b"chunked"))
+        {
+            return Err("invalid request Transfer-Encoding");
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_plain_request(request: &RequestHead<'_>, path: &str) -> Vec<u8> {
+    let mut rewritten = Vec::with_capacity(
+        request.method.len() + path.len() + request.version.len() + 4 + request.headers.len() * 2,
+    );
+    rewritten.extend_from_slice(request.method.as_bytes());
+    rewritten.push(b' ');
+    rewritten.extend_from_slice(path.as_bytes());
+    rewritten.push(b' ');
+    rewritten.extend_from_slice(request.version.as_bytes());
+    rewritten.extend_from_slice(b"\r\n");
+    for header in &request.headers {
+        if header.name.eq_ignore_ascii_case(b"proxy-connection")
+            || header.name.eq_ignore_ascii_case(b"proxy-authorization")
+        {
+            continue;
+        }
+        rewritten.extend_from_slice(header.raw);
+        rewritten.extend_from_slice(b"\r\n");
+    }
+    rewritten.extend_from_slice(b"\r\n");
+    rewritten
+}
+
+fn trim_ows(mut value: &[u8]) -> &[u8] {
+    while value
+        .first()
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        value = &value[1..];
+    }
+    while value
+        .last()
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        value = &value[..value.len() - 1];
+    }
+    value
+}
+
+fn is_tchar(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b'!' | b'#'
+                | b'$'
+                | b'%'
+                | b'&'
+                | b'\''
+                | b'*'
+                | b'+'
+                | b'-'
+                | b'.'
+                | b'^'
+                | b'_'
+                | b'`'
+                | b'|'
+                | b'~'
+        )
+}
+
+async fn write_bad_request(stream: &mut TcpStream) -> io::Result<()> {
+    stream
+        .write_all(
+            b"HTTP/1.1 400 Bad Request\r\n\
+              Connection: close\r\n\
+              Content-Length: 0\r\n\r\n",
+        )
+        .await
+}
+
 /// Parse an HTTP host token as an IP literal, returning `Some(ip)` when it is
 /// one. Strips the surrounding brackets of an IPv6 literal (`[2606:..]`) so it
 /// parses; returns `None` for hostnames, which are resolved later by the
@@ -431,27 +650,19 @@ fn extract_path_from_url(url: &str) -> &str {
         .map_or("/", |i| &without_scheme[i..])
 }
 
-/// Case-insensitive ASCII prefix test without allocating a lowercased copy.
-/// Byte-wise so a multi-byte UTF-8 char at the boundary can't panic a slice.
-fn starts_with_ignore_ascii_case(line: &str, prefix: &str) -> bool {
-    line.len() >= prefix.len()
-        && line.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
-}
-
-/// Parse `Proxy-Authorization: Basic <base64>` from raw request headers.
+/// Parse `Proxy-Authorization: Basic <base64>` from parsed request headers.
 /// Returns `(username, password)` on success.
-fn parse_proxy_authorization(headers: &[u8]) -> Option<(String, String)> {
-    const PROXY_AUTH_PREFIX: &str = "proxy-authorization:";
-
-    let headers_str = std::str::from_utf8(headers).ok()?;
-    for line in headers_str.lines() {
-        if !starts_with_ignore_ascii_case(line, PROXY_AUTH_PREFIX) {
+fn parse_proxy_authorization(headers: &[HeaderField<'_>]) -> Option<(String, String)> {
+    for header in headers {
+        if !header.name.eq_ignore_ascii_case(b"proxy-authorization") {
             continue;
         }
-        let value = line[PROXY_AUTH_PREFIX.len()..].trim();
-        let encoded = value
-            .strip_prefix("Basic ")
-            .or_else(|| value.strip_prefix("basic "))?;
+        let value = trim_ows(header.value);
+        let separator = value.iter().position(|byte| matches!(byte, b' ' | b'\t'))?;
+        if !value[..separator].eq_ignore_ascii_case(b"basic") {
+            return None;
+        }
+        let encoded = std::str::from_utf8(trim_ows(&value[separator..])).ok()?;
         let decoded = base64::engine::general_purpose::STANDARD
             .decode(encoded)
             .ok()?;
@@ -496,12 +707,59 @@ mod tests {
     }
 
     #[test]
-    fn parse_proxy_authorization_ignores_non_ascii_header_without_panic() {
-        let headers = concat!(
-            "GET http://example.com/ HTTP/1.1\r\n",
-            "aaaaaaaaaaaaaaaaaaaé: value\r\n",
-            "\r\n"
+    fn strict_parser_rejects_bare_lf_and_bare_cr() {
+        assert!(parse_request_head(
+            b"GET http://example.com/ HTTP/1.1\r\nX-A: 1\nContent-Length: 0\r\n\r\n"
+        )
+        .is_err());
+        assert!(parse_request_head(
+            b"GET http://example.com/ HTTP/1.1\r\nX-A: 1\rContent-Length: 0\r\n\r\n"
+        )
+        .is_err());
+        assert!(parse_request_head(
+            b"GET http://example.com/ HTTP/1.1\r\nX-A: 1\n\nX-Dropped: yes\r\n\r\n"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rewrite_preserves_obs_text_and_only_drops_proxy_headers() {
+        let request = parse_request_head(
+            b"GET http://example.com/path HTTP/1.1\r\nHost: example.com\r\nX-Word: caf\xe9\r\nProxy-Connection: keep-alive\r\nProxy-Authorization: Basic dTpw\r\n\r\n",
+        )
+        .unwrap();
+        let rewritten = rewrite_plain_request(&request, "/path");
+        assert_eq!(
+            rewritten,
+            b"GET /path HTTP/1.1\r\nHost: example.com\r\nX-Word: caf\xe9\r\n\r\n"
         );
-        assert_eq!(parse_proxy_authorization(headers.as_bytes()), None);
+    }
+
+    #[test]
+    fn parser_rejects_ambiguous_message_framing() {
+        assert!(parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 5\r\n\r\n"
+        )
+        .is_err());
+        assert!(parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\n"
+        )
+        .is_err());
+        assert!(parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nTransfer-Encoding: chunked, gzip\r\n\r\n"
+        )
+        .is_err());
+        assert!(parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nContent-Length: 5, 5\r\nContent-Length: 5\r\n\r\n"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn parse_proxy_authorization_ignores_obs_text_value_without_panic() {
+        let request =
+            parse_request_head(b"GET http://example.com/ HTTP/1.1\r\nX-Word: caf\xe9\r\n\r\n")
+                .unwrap();
+        assert_eq!(parse_proxy_authorization(&request.headers), None);
     }
 }

--- a/crates/meow-listener/tests/http_proxy_strict.rs
+++ b/crates/meow-listener/tests/http_proxy_strict.rs
@@ -1,0 +1,112 @@
+#![cfg(feature = "listener-http")]
+
+mod common;
+
+use common::direct_tunnel;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+async fn loopback_pair() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (accepted, connected) = tokio::join!(listener.accept(), TcpStream::connect(addr));
+    (accepted.unwrap().0, connected.unwrap())
+}
+
+async fn assert_bad_request(request: &[u8]) {
+    let (server_stream, mut client_stream) = loopback_pair().await;
+    let tunnel = direct_tunnel();
+    let src: SocketAddr = "127.0.0.1:1".parse().unwrap();
+    let handle = tokio::spawn(async move {
+        meow_listener::http_proxy::handle_http(&tunnel, server_stream, src, None, None, "test", 0)
+            .await;
+    });
+
+    client_stream.write_all(request).await.unwrap();
+    let mut response = Vec::new();
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        client_stream.read_to_end(&mut response),
+    )
+    .await
+    .expect("proxy did not reject malformed headers promptly")
+    .unwrap();
+    assert!(
+        response.starts_with(b"HTTP/1.1 400 Bad Request\r\n"),
+        "unexpected response: {:?}",
+        String::from_utf8_lossy(&response)
+    );
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bare_lf_header_is_rejected_instead_of_normalized() {
+    assert_bad_request(b"GET http://127.0.0.1:9/ HTTP/1.1\r\nX-A: 1\nContent-Length: 0\r\n\r\n")
+        .await;
+}
+
+#[tokio::test]
+async fn bare_cr_header_is_rejected() {
+    assert_bad_request(b"GET http://127.0.0.1:9/ HTTP/1.1\r\nX-A: 1\rContent-Length: 0\r\n\r\n")
+        .await;
+}
+
+#[tokio::test]
+async fn valid_obs_text_is_preserved_and_body_line_feeds_are_not_header_errors() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let (captured_tx, captured_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(read, 0, "origin saw EOF before the request completed");
+            request.extend_from_slice(&chunk[..read]);
+            if request
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .is_some_and(|end| request.len() >= end + 4 + 3)
+            {
+                break;
+            }
+        }
+        captured_tx.send(request).unwrap();
+        stream
+            .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+    });
+
+    let (server_stream, mut client_stream) = loopback_pair().await;
+    let tunnel = direct_tunnel();
+    let src: SocketAddr = "127.0.0.1:1".parse().unwrap();
+    let handle = tokio::spawn(async move {
+        meow_listener::http_proxy::handle_http(&tunnel, server_stream, src, None, None, "test", 0)
+            .await;
+    });
+
+    let mut request =
+        format!("POST http://{origin_addr}/upload HTTP/1.1\r\nHost: {origin_addr}\r\nX-Word: caf")
+            .into_bytes();
+    request.extend_from_slice(b"\xe9\r\nContent-Length: 3\r\n\r\na\nb");
+    client_stream.write_all(&request).await.unwrap();
+    client_stream.shutdown().await.unwrap();
+
+    let captured = tokio::time::timeout(Duration::from_secs(1), captured_rx)
+        .await
+        .expect("origin did not receive the request")
+        .unwrap();
+    let expected_prefix =
+        format!("POST /upload HTTP/1.1\r\nHost: {origin_addr}\r\nX-Word: caf").into_bytes();
+    assert!(captured.starts_with(&expected_prefix));
+    assert!(captured.ends_with(b"\xe9\r\nContent-Length: 3\r\n\r\na\nb"));
+
+    let mut response = Vec::new();
+    client_stream.read_to_end(&mut response).await.unwrap();
+    assert!(response.starts_with(b"HTTP/1.1 204 No Content\r\n"));
+    handle.await.unwrap();
+}


### PR DESCRIPTION
## Summary

- reject bare CR/LF and malformed HTTP/1 request heads with 400 before authentication or route dispatch
- parse field names and values from raw bytes, preserving legal obs-text when forwarding
- rewrite only the absolute-form request target and remove proxy-specific headers without lossy UTF-8 conversion
- reject conflicting Content-Length values, malformed transfer codings, and Transfer-Encoding plus Content-Length ambiguity
- accept valid transfer-coding parameters, including quoted commas and quoted-pairs, without weakening framing checks

## Tests

- bare LF and bare CR are rejected by the live listener
- an intermediate LF/LF sequence cannot truncate later headers
- non-UTF-8 field bytes survive the full proxy-to-origin path unchanged
- body line feeds arriving with the headers remain body bytes
- conflicting Content-Length and TE+CL combinations are rejected
- valid and malformed parameterized transfer codings
- cargo test -p meow-listener
- cargo clippy -p meow-listener --all-targets -- -D warnings
- cargo fmt --all -- --check

## Attribution

Discovered by Opus 5; verified by GPT-5.6-sol xhigh.

Fixes #366