### PR TITLE
fix(listener): close plain HTTP after one request

### DIFF
--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -308,13 +308,7 @@ async fn handle_http_inner(
         inner.pre_handle_metadata(&mut metadata);
         let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy_lazy(&mut metadata).await
         else {
-            stream
-                .write_all(
-                    b"HTTP/1.1 502 Bad Gateway\r\n\
-                      Connection: close\r\n\
-                      Content-Length: 0\r\n\r\n",
-                )
-                .await?;
+            write_bad_gateway(stream).await?;
             return Err("no matching rule".into());
         };
 
@@ -388,18 +382,25 @@ async fn handle_http_inner(
                     Ok((up, down)) => {
                         debug!("HTTP single-request relay closed: up={up} down={down}");
                     }
-                    Err(e) => debug!("HTTP single-request relay error: {}", e),
+                    Err(e) => {
+                        debug!("HTTP single-request relay error: {}", e);
+                        // A response head the proxy rejects (oversized,
+                        // malformed, invalid status line) aborts the relay
+                        // before anything reached the client. Turn that into
+                        // an explicit 502 rather than a silent connection
+                        // close; once response bytes have flowed, appending
+                        // an error would corrupt the stream instead.
+                        let sent_response_bytes = client.sent_response_bytes;
+                        drop(client);
+                        if !sent_response_bytes {
+                            let _ = write_bad_gateway(stream).await;
+                        }
+                    }
                 }
             }
             Err(e) => {
                 warn!("{}:{} HTTP dial error: {}", host, port, e);
-                stream
-                    .write_all(
-                        b"HTTP/1.1 502 Bad Gateway\r\n\
-                          Connection: close\r\n\
-                          Content-Length: 0\r\n\r\n",
-                    )
-                    .await?;
+                write_bad_gateway(stream).await?;
             }
         }
         // _guard drops here, removing the entry from Statistics.
@@ -784,7 +785,12 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for ShutdownGate<'_, T> {
         if this.pass_shutdown.load(Ordering::Acquire) {
             Pin::new(&mut this.inner).poll_shutdown(cx)
         } else {
-            Poll::Ready(Ok(()))
+            // Withholding the protocol-level close must not also withhold the
+            // flush that `poll_shutdown` implies. The relay goes straight from
+            // reader EOF to `poll_shutdown` without flushing, so a buffering
+            // transport (TLS, WebSocket) may still hold tail request-body
+            // bytes that would otherwise be silently discarded.
+            Pin::new(&mut this.inner).poll_flush(cx)
         }
     }
 }
@@ -804,6 +810,7 @@ struct SingleRequestClient<'stream, 'buffered, 'gate> {
     response_len: usize,
     response_pos: usize,
     response_state: ResponseWriteState,
+    sent_response_bytes: bool,
     upgrade_requested: bool,
     upgrade_declined: bool,
     pass_upstream_shutdown: &'gate AtomicBool,
@@ -832,6 +839,7 @@ impl<'stream, 'buffered, 'gate> SingleRequestClient<'stream, 'buffered, 'gate> {
             response_len: 0,
             response_pos: 0,
             response_state: ResponseWriteState::Head,
+            sent_response_bytes: false,
             upgrade_requested,
             upgrade_declined: false,
             pass_upstream_shutdown,
@@ -849,7 +857,10 @@ impl<'stream, 'buffered, 'gate> SingleRequestClient<'stream, 'buffered, 'gate> {
                         "write zero bytes to HTTP proxy client",
                     )));
                 }
-                Poll::Ready(Ok(written)) => self.response_pos += written,
+                Poll::Ready(Ok(written)) => {
+                    self.response_pos += written;
+                    self.sent_response_bytes = true;
+                }
                 Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
                 Poll::Pending => return Poll::Pending,
             }
@@ -892,6 +903,14 @@ impl<'stream, 'buffered, 'gate> SingleRequestClient<'stream, 'buffered, 'gate> {
         let status = parse_response_status(&self.response_buf[..self.response_len])?;
         self.response_pos = 0;
         if (100..200).contains(&status) && status != 101 {
+            // Interim heads previously passed through verbatim, leaking
+            // origin hop-by-hop fields (Connection, Keep-Alive, nominated
+            // headers) that contradict the close semantics of the final head.
+            self.response_len = rewrite_response_head_in_place(
+                &mut self.response_buf,
+                self.response_len,
+                ResponseConnection::Interim,
+            )?;
             self.response_state = ResponseWriteState::InterimPending;
             return Ok(());
         }
@@ -1090,16 +1109,10 @@ impl AsyncRead for SingleRequestClient<'_, '_, '_> {
                     .remaining()
                     .min(this.buffered.len() - this.buffered_pos);
                 let source = &this.buffered[this.buffered_pos..this.buffered_pos + available];
-                let mut consumed = 0;
-                for &byte in source {
-                    if let Err(error) = this.body.consume(byte) {
-                        return Poll::Ready(Err(error));
-                    }
-                    consumed += 1;
-                    if this.body.is_done() {
-                        break;
-                    }
-                }
+                let consumed = match this.body.consume_slice(source) {
+                    Ok(consumed) => consumed,
+                    Err(error) => return Poll::Ready(Err(error)),
+                };
                 destination.put_slice(&source[..consumed]);
                 this.buffered_pos += consumed;
                 continue;
@@ -1116,16 +1129,10 @@ impl AsyncRead for SingleRequestClient<'_, '_, '_> {
                 Poll::Ready(Ok(())) => {
                     let initialized = socket_read.initialized().len();
                     let filled = socket_read.filled().len();
-                    let mut consumed = 0;
-                    for &byte in socket_read.filled() {
-                        if let Err(error) = this.body.consume(byte) {
-                            return Poll::Ready(Err(error));
-                        }
-                        consumed += 1;
-                        if this.body.is_done() {
-                            break;
-                        }
-                    }
+                    let consumed = match this.body.consume_slice(socket_read.filled()) {
+                        Ok(consumed) => consumed,
+                        Err(error) => return Poll::Ready(Err(error)),
+                    };
                     let discarded = filled - consumed;
                     // `take` does not propagate the child ReadBuf's initialized
                     // length back to its parent. Record it before advancing so
@@ -1294,6 +1301,29 @@ impl RequestBodyDecoder {
                 "bytes arrived after the request body boundary",
             )),
         }
+    }
+
+    /// Consume body bytes from `bytes`, stopping at the framing boundary.
+    /// Returns how many bytes belong to the body. Content-Length bodies
+    /// advance in bulk; only chunked framing needs the per-byte state machine.
+    fn consume_slice(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if let Self::ContentLength(remaining) = self {
+            let consumed = u64::min(*remaining, bytes.len() as u64) as usize;
+            *remaining -= consumed as u64;
+            if *remaining == 0 {
+                *self = Self::Done;
+            }
+            return Ok(consumed);
+        }
+        let mut consumed = 0;
+        for &byte in bytes {
+            self.consume(byte)?;
+            consumed += 1;
+            if self.is_done() {
+                break;
+            }
+        }
+        Ok(consumed)
     }
 }
 
@@ -1471,24 +1501,25 @@ fn parse_response_status(head: &[u8]) -> io::Result<u16> {
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum ResponseConnection {
+    Interim,
     Close,
     Upgrade,
 }
 
-fn rewrite_response_head_in_place(
-    buf: &mut [u8],
-    head_len: usize,
-    connection: ResponseConnection,
-) -> io::Result<usize> {
-    let status_end = buf[..head_len]
+/// Walk the CRLF-delimited header lines of a response head, yielding the
+/// byte ranges of each field name and value. Returns the status-line end
+/// (the index of its CR) once the walk completes.
+fn for_each_response_header<F>(head: &[u8], mut visit: F) -> io::Result<usize>
+where
+    F: FnMut(std::ops::Range<usize>, std::ops::Range<usize>) -> io::Result<()>,
+{
+    let status_end = head
         .windows(2)
         .position(|window| window == b"\r\n")
         .ok_or_else(|| invalid_data("upstream response is missing a status line"))?;
-    let mut drop_lines = [0u8; MAX_RESPONSE_HEADERS.div_ceil(8)];
     let mut read = status_end + 2;
-
-    while read + 2 <= head_len {
-        let relative_end = buf[read..head_len]
+    while read + 2 <= head.len() {
+        let relative_end = head[read..]
             .windows(2)
             .position(|window| window == b"\r\n")
             .ok_or_else(|| invalid_data("malformed upstream response header"))?;
@@ -1496,19 +1527,71 @@ fn rewrite_response_head_in_place(
         if line_end == read {
             break;
         }
-        let colon = buf[read..line_end]
+        let colon = head[read..line_end]
             .iter()
             .position(|byte| *byte == b':')
             .ok_or_else(|| invalid_data("upstream response header is missing a colon"))?;
-        let name = &buf[read..read + colon];
+        visit(read..read + colon, read + colon + 1..line_end)?;
+        read = line_end + 2;
+    }
+    Ok(status_end)
+}
+
+/// Byte ranges (into the response head) of every non-empty Connection option,
+/// collected in one pass so drop checks stay linear in the head size.
+type NominatedOptions = smallvec::SmallVec<[(u16, u16); 8]>;
+
+fn collect_connection_options(head: &[u8]) -> io::Result<NominatedOptions> {
+    let mut nominated = NominatedOptions::new();
+    for_each_response_header(head, |name, value| {
+        if head[name].eq_ignore_ascii_case(b"connection") {
+            let mut option_start = value.start;
+            for index in value.start..=value.end {
+                if index != value.end && head[index] != b',' {
+                    continue;
+                }
+                let mut start = option_start;
+                let mut end = index;
+                while start < end && matches!(head[start], b' ' | b'\t') {
+                    start += 1;
+                }
+                while end > start && matches!(head[end - 1], b' ' | b'\t') {
+                    end -= 1;
+                }
+                if start < end {
+                    nominated.push((start as u16, end as u16));
+                }
+                option_start = index + 1;
+            }
+        }
+        Ok(())
+    })?;
+    Ok(nominated)
+}
+
+fn rewrite_response_head_in_place(
+    buf: &mut [u8],
+    head_len: usize,
+    connection: ResponseConnection,
+) -> io::Result<usize> {
+    let nominated = collect_connection_options(&buf[..head_len])?;
+    let mut drop_lines = [0u8; MAX_RESPONSE_HEADERS.div_ceil(8)];
+
+    let head = &buf[..head_len];
+    let status_end = for_each_response_header(head, |name_range, value_range| {
+        let read = name_range.start;
+        let name = &head[name_range];
         if name.is_empty() || !name.iter().copied().all(is_tchar) {
             return Err(invalid_data("invalid upstream response header name"));
         }
         if name.eq_ignore_ascii_case(b"connection") {
-            validate_response_connection_options(&buf[read + colon + 1..line_end])?;
+            validate_response_connection_options(&head[value_range])?;
         }
         let preserve_upgrade =
             connection == ResponseConnection::Upgrade && name.eq_ignore_ascii_case(b"upgrade");
+        let is_nominated = nominated
+            .iter()
+            .any(|&(start, end)| head[start as usize..end as usize].eq_ignore_ascii_case(name));
         let drop = name.eq_ignore_ascii_case(b"connection")
             || name.eq_ignore_ascii_case(b"proxy-connection")
             || name.eq_ignore_ascii_case(b"keep-alive")
@@ -1516,12 +1599,13 @@ fn rewrite_response_head_in_place(
             || (connection == ResponseConnection::Upgrade
                 && (name.eq_ignore_ascii_case(b"content-length")
                     || name.eq_ignore_ascii_case(b"transfer-encoding")))
-            || (response_connection_nominates(&buf[..head_len], name)? && !preserve_upgrade);
+            || (is_nominated && !preserve_upgrade);
         if drop {
             drop_lines[read / 8] |= 1 << (read % 8);
         }
-        read = line_end + 2;
-    }
+        Ok(())
+    })?;
+    let mut read;
 
     let mut write = status_end + 2;
     read = status_end + 2;
@@ -1541,7 +1625,10 @@ fn rewrite_response_head_in_place(
         read = line_end + 2;
     }
 
-    let connection_header = match connection {
+    let connection_header: &[u8] = match connection {
+        // An interim response never carries connection semantics of its own;
+        // the final response head states them.
+        ResponseConnection::Interim => b"",
         ResponseConnection::Close => CONNECTION_CLOSE_HEADER,
         ResponseConnection::Upgrade => CONNECTION_UPGRADE_HEADER,
     };
@@ -1564,31 +1651,14 @@ fn validate_upgrade_response(head: &[u8]) -> io::Result<()> {
         ));
     }
 
-    let status_end = head
-        .windows(2)
-        .position(|window| window == b"\r\n")
-        .ok_or_else(|| invalid_data("upstream response is missing a status line"))?;
-    let mut read = status_end + 2;
     let mut saw_protocol = false;
-    while read + 2 <= head.len() {
-        let relative_end = head[read..]
-            .windows(2)
-            .position(|window| window == b"\r\n")
-            .ok_or_else(|| invalid_data("malformed upstream response header"))?;
-        let line_end = read + relative_end;
-        if line_end == read {
-            break;
-        }
-        let colon = head[read..line_end]
-            .iter()
-            .position(|byte| *byte == b':')
-            .ok_or_else(|| invalid_data("upstream response header is missing a colon"))?;
-        if head[read..read + colon].eq_ignore_ascii_case(b"upgrade") {
-            validate_upgrade_protocol_list(&head[read + colon + 1..line_end], &mut saw_protocol)
+    for_each_response_header(head, |name, value| {
+        if head[name].eq_ignore_ascii_case(b"upgrade") {
+            validate_upgrade_protocol_list(&head[value], &mut saw_protocol)
                 .map_err(invalid_data)?;
         }
-        read = line_end + 2;
-    }
+        Ok(())
+    })?;
     if !saw_protocol {
         return Err(invalid_data(
             "upstream 101 response is missing an Upgrade protocol",
@@ -1598,35 +1668,19 @@ fn validate_upgrade_response(head: &[u8]) -> io::Result<()> {
 }
 
 fn response_connection_nominates(head: &[u8], candidate: &[u8]) -> io::Result<bool> {
-    let status_end = head
-        .windows(2)
-        .position(|window| window == b"\r\n")
-        .ok_or_else(|| invalid_data("upstream response is missing a status line"))?;
-    let mut read = status_end + 2;
-    while read + 2 <= head.len() {
-        let relative_end = head[read..]
-            .windows(2)
-            .position(|window| window == b"\r\n")
-            .ok_or_else(|| invalid_data("malformed upstream response header"))?;
-        let line_end = read + relative_end;
-        if line_end == read {
-            return Ok(false);
-        }
-        let colon = head[read..line_end]
-            .iter()
-            .position(|byte| *byte == b':')
-            .ok_or_else(|| invalid_data("upstream response header is missing a colon"))?;
-        if head[read..read + colon].eq_ignore_ascii_case(b"connection") {
-            for option in head[read + colon + 1..line_end].split(|byte| *byte == b',') {
+    let mut nominates = false;
+    for_each_response_header(head, |name, value| {
+        if head[name].eq_ignore_ascii_case(b"connection") {
+            for option in head[value].split(|byte| *byte == b',') {
                 let option = trim_ows(option);
                 if !option.is_empty() && option.eq_ignore_ascii_case(candidate) {
-                    return Ok(true);
+                    nominates = true;
                 }
             }
         }
-        read = line_end + 2;
-    }
-    Ok(false)
+        Ok(())
+    })?;
+    Ok(nominates)
 }
 
 fn validate_response_connection_options(value: &[u8]) -> io::Result<()> {
@@ -1849,6 +1903,16 @@ async fn write_bad_request(stream: &mut TcpStream) -> io::Result<()> {
         .await
 }
 
+async fn write_bad_gateway(stream: &mut TcpStream) -> io::Result<()> {
+    stream
+        .write_all(
+            b"HTTP/1.1 502 Bad Gateway\r\n\
+              Connection: close\r\n\
+              Content-Length: 0\r\n\r\n",
+        )
+        .await
+}
+
 /// Parse an HTTP host token as an IP literal, returning `Some(ip)` when it is
 /// one. Strips the surrounding brackets of an IPv6 literal (`[2606:..]`) so it
 /// parses; returns `None` for hostnames, which are resolved later by the
@@ -1924,6 +1988,56 @@ fn parse_proxy_authorization(headers: &[HeaderField<'_>]) -> Option<(String, Str
 mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::task::Waker;
+
+    #[derive(Default)]
+    struct FlushProbe {
+        flushed: bool,
+        shutdown: bool,
+    }
+
+    impl AsyncWrite for FlushProbe {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            source: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(source.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.get_mut().flushed = true;
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.get_mut().shutdown = true;
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[test]
+    fn shutdown_gate_flushes_while_withholding_the_close() {
+        // The relay goes straight from reader EOF to poll_shutdown without a
+        // flush; a gated shutdown must still drain a buffering transport or
+        // tail request-body bytes are lost.
+        let pass_shutdown = AtomicBool::new(false);
+        let mut gate = ShutdownGate::new(FlushProbe::default(), &pass_shutdown);
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(Pin::new(&mut gate).poll_shutdown(&mut cx).is_ready());
+        assert!(
+            gate.inner.flushed,
+            "gated shutdown must flush the transport"
+        );
+        assert!(
+            !gate.inner.shutdown,
+            "gated shutdown must not close the transport"
+        );
+
+        pass_shutdown.store(true, Ordering::Release);
+        assert!(Pin::new(&mut gate).poll_shutdown(&mut cx).is_ready());
+        assert!(gate.inner.shutdown, "open gate must pass the shutdown");
+    }
 
     #[test]
     fn host_to_ip_parses_ipv4_literal() {

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -730,6 +730,7 @@ const MAX_CHUNK_LINE: usize = 8192;
 const MAX_TRAILERS: usize = 8192;
 const CLIENT_DISCARD_BUFFER_SIZE: usize = 1024;
 const MAX_DISCARDED_CLIENT_BYTES: usize = 64 * 1024;
+const MAX_HELD_UPGRADE_BYTES: usize = 64 * 1024;
 
 /// Preserve the upstream write half when the client finishes its request.
 ///
@@ -796,6 +797,8 @@ struct SingleRequestClient<'stream, 'buffered, 'gate> {
     client_eof: bool,
     discarded_client_bytes: usize,
     discard_buf: [u8; CLIENT_DISCARD_BUFFER_SIZE],
+    held: Vec<u8>,
+    held_pos: usize,
     response_done: bool,
     response_buf: [u8; RESPONSE_BUFFER_SIZE],
     response_len: usize,
@@ -822,6 +825,8 @@ impl<'stream, 'buffered, 'gate> SingleRequestClient<'stream, 'buffered, 'gate> {
             client_eof: false,
             discarded_client_bytes: 0,
             discard_buf: [0; CLIENT_DISCARD_BUFFER_SIZE],
+            held: Vec::new(),
+            held_pos: 0,
             response_done: false,
             response_buf: [0; RESPONSE_BUFFER_SIZE],
             response_len: 0,
@@ -978,6 +983,44 @@ impl<'stream, 'buffered, 'gate> SingleRequestClient<'stream, 'buffered, 'gate> {
             Poll::Pending => Poll::Pending,
         }
     }
+
+    /// Consume early client protocol bytes into a bounded hold while the
+    /// origin decides the Upgrade. Reading them (rather than leaving them in
+    /// the kernel receive queue) keeps the client's FIN observable, so an
+    /// abandoned handshake still completes the upload relay direction and
+    /// arms the half-close linger instead of pinning the connection on a
+    /// silent origin forever. The held bytes are replayed by `poll_read` only
+    /// after a validated `101`; a declined upgrade drops them unforwarded.
+    fn poll_hold_before_upgrade(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.client_eof {
+            return Poll::Ready(Ok(()));
+        }
+        let capacity = MAX_HELD_UPGRADE_BYTES - self.held.len();
+        if capacity == 0 {
+            return Poll::Ready(Err(invalid_data(
+                "too many client bytes before the upgrade decision",
+            )));
+        }
+
+        let available = capacity.min(self.discard_buf.len());
+        let mut staged = ReadBuf::new(&mut self.discard_buf[..available]);
+        match Pin::new(&mut *self.client).poll_read(cx, &mut staged) {
+            Poll::Ready(Ok(())) if staged.filled().is_empty() => {
+                self.client_eof = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(())) => {
+                self.held.extend_from_slice(staged.filled());
+                // The socket returned data rather than registering our waker.
+                // Re-poll on a fresh task turn to keep the FIN observable
+                // without an unbounded loop in one `poll_read` call.
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
 }
 
 impl AsyncRead for SingleRequestClient<'_, '_, '_> {
@@ -999,6 +1042,12 @@ impl AsyncRead for SingleRequestClient<'_, '_, '_> {
                         &this.buffered[this.buffered_pos..this.buffered_pos + available],
                     );
                     this.buffered_pos += available;
+                    return Poll::Ready(Ok(()));
+                }
+                if this.held_pos < this.held.len() {
+                    let available = destination.remaining().min(this.held.len() - this.held_pos);
+                    destination.put_slice(&this.held[this.held_pos..this.held_pos + available]);
+                    this.held_pos += available;
                     return Poll::Ready(Ok(()));
                 }
                 return Pin::new(&mut *this.client).poll_read(cx, destination);
@@ -1028,7 +1077,7 @@ impl AsyncRead for SingleRequestClient<'_, '_, '_> {
                             | ResponseWriteState::UpgradePending
                     )
                 {
-                    return Poll::Pending;
+                    return this.poll_hold_before_upgrade(cx);
                 }
                 return this.poll_discard_after_body(cx);
             }

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -5,8 +5,11 @@ use meow_tunnel::{copy_bidirectional_buf_tracked, ConnectionGuard, Tunnel, RELAY
 use smallvec::smallvec;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::TcpStream;
 use tracing::{debug, info, warn};
 
@@ -138,6 +141,7 @@ async fn handle_http_inner(
                     .write_all(
                         b"HTTP/1.1 407 Proxy Authentication Required\r\n\
                           Proxy-Authenticate: Basic realm=\"meow-rs\"\r\n\
+                          Connection: close\r\n\
                           Content-Length: 0\r\n\r\n",
                     )
                     .await?;
@@ -149,6 +153,7 @@ async fn handle_http_inner(
                         .write_all(
                             b"HTTP/1.1 407 Proxy Authentication Required\r\n\
                               Proxy-Authenticate: Basic realm=\"meow-rs\"\r\n\
+                              Connection: close\r\n\
                               Content-Length: 0\r\n\r\n",
                         )
                         .await?;
@@ -304,7 +309,11 @@ async fn handle_http_inner(
         let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy_lazy(&mut metadata).await
         else {
             stream
-                .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                .write_all(
+                    b"HTTP/1.1 502 Bad Gateway\r\n\
+                      Connection: close\r\n\
+                      Content-Length: 0\r\n\r\n",
+                )
                 .await?;
             return Err("no matching rule".into());
         };
@@ -334,22 +343,32 @@ async fn handle_http_inner(
                 let path = extract_path_from_url(url);
                 let rewritten = rewrite_plain_request(&request, path);
 
-                // Send the rewritten request to remote, then any body bytes
-                // that arrived in the same TCP segment as the headers (POST
-                // payloads typically do).
+                // Force a one-request upstream exchange. The bounded client
+                // wrapper forwards exactly this request body, holds any
+                // pipelined request back, and marks the final response close.
                 remote.write_all(&rewritten).await?;
                 let up = Arc::clone(_guard.counters());
                 let dn = Arc::clone(_guard.counters());
-                if !leftover.is_empty() {
-                    remote.write_all(&leftover).await?;
-                    inner
-                        .stats
-                        .record_upload(&up, leftover.len() as meow_common::atomic::Int);
-                }
-
-                // Relay bidirectionally
-                match copy_bidirectional_buf_tracked(
+                // Keep the response-head scratch out of `handle_http_inner`'s
+                // async frame. CONNECT is the dominant path and must not pay
+                // for storage used only by plain HTTP exchanges.
+                let pass_upstream_shutdown = AtomicBool::new(false);
+                let mut client = Box::new(SingleRequestClient::new(
                     stream,
+                    &leftover,
+                    request.body_kind,
+                    request.upgrade_requested,
+                    &pass_upstream_shutdown,
+                ));
+                // Client EOF should finish the upload direction and arm the
+                // relay linger, but it must not half-close an encrypted proxy
+                // transport before the origin has produced its response. A
+                // validated 101 switches this gate to ordinary tunnel
+                // half-close semantics.
+                let mut remote = ShutdownGate::new(remote, &pass_upstream_shutdown);
+
+                match copy_bidirectional_buf_tracked(
+                    &mut *client,
                     &mut remote,
                     &mut relay_buf_up,
                     &mut relay_buf_dn,
@@ -367,15 +386,19 @@ async fn handle_http_inner(
                 .await
                 {
                     Ok((up, down)) => {
-                        debug!("HTTP relay closed: up={up} down={down}");
+                        debug!("HTTP single-request relay closed: up={up} down={down}");
                     }
-                    Err(e) => debug!("HTTP relay error: {}", e),
+                    Err(e) => debug!("HTTP single-request relay error: {}", e),
                 }
             }
             Err(e) => {
                 warn!("{}:{} HTTP dial error: {}", host, port, e);
                 stream
-                    .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                    .write_all(
+                        b"HTTP/1.1 502 Bad Gateway\r\n\
+                          Connection: close\r\n\
+                          Content-Length: 0\r\n\r\n",
+                    )
                     .await?;
             }
         }
@@ -434,10 +457,8 @@ struct RequestHead<'a> {
     target: &'a str,
     version: &'a str,
     headers: Vec<HeaderField<'a>>,
-    /// The single agreed-upon `Content-Length`, if the request declared one.
-    /// Forwarded as one canonical field so the next hop never sees the
-    /// list-form or duplicated spelling this parser accepts.
-    content_length: Option<u64>,
+    body_kind: RequestBodyKind,
+    upgrade_requested: bool,
 }
 
 /// Split a header block on CRLF without allocating a line vector.
@@ -515,22 +536,31 @@ fn parse_request_head(head: &[u8]) -> Result<RequestHead<'_>, &'static str> {
             raw: line,
         });
     }
-    let content_length = validate_message_framing(&headers, version)?;
+    let body_kind = validate_message_framing(&headers, version)?;
+    validate_connection_options(&headers)?;
+    let upgrade_requested = validate_upgrade_request(&headers, body_kind, version)?;
 
     Ok(RequestHead {
         method,
         target,
         version,
         headers,
-        content_length,
+        body_kind,
+        upgrade_requested,
     })
 }
 
-/// Validate request framing and return the single agreed `Content-Length`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RequestBodyKind {
+    None,
+    ContentLength(u64),
+    Chunked,
+}
+
 fn validate_message_framing(
     headers: &[HeaderField<'_>],
     version: &str,
-) -> Result<Option<u64>, &'static str> {
+) -> Result<RequestBodyKind, &'static str> {
     let mut content_length = None;
     let mut has_content_length = false;
     let mut transfer_codings = Vec::new();
@@ -580,8 +610,9 @@ fn validate_message_framing(
         {
             return Err("invalid request Transfer-Encoding");
         }
+        return Ok(RequestBodyKind::Chunked);
     }
-    Ok(content_length)
+    Ok(content_length.map_or(RequestBodyKind::None, RequestBodyKind::ContentLength))
 }
 
 #[derive(Debug)]
@@ -691,6 +722,980 @@ fn skip_ows(value: &[u8], cursor: &mut usize) {
     }
 }
 
+const CONNECTION_CLOSE_HEADER: &[u8] = b"Connection: close\r\n";
+const CONNECTION_UPGRADE_HEADER: &[u8] = b"Connection: upgrade\r\n";
+const MAX_RESPONSE_HEADERS: usize = 8192;
+const RESPONSE_BUFFER_SIZE: usize = MAX_RESPONSE_HEADERS + CONNECTION_UPGRADE_HEADER.len();
+const MAX_CHUNK_LINE: usize = 8192;
+const MAX_TRAILERS: usize = 8192;
+const CLIENT_DISCARD_BUFFER_SIZE: usize = 1024;
+const MAX_DISCARDED_CLIENT_BYTES: usize = 64 * 1024;
+
+/// Preserve the upstream write half when the client finishes its request.
+///
+/// Some outbound adapters translate `poll_shutdown` into a protocol-level
+/// close (for example TLS `close_notify`). The HTTP relay still needs the
+/// client-to-origin direction to reach `Cycle::Done` so its half-close linger
+/// can reap a silent origin, but closing the adapter here can prevent that
+/// origin from sending the response. The owned stream is dropped normally
+/// when the response finishes or the linger expires. A successful upgrade (or
+/// a declined upgrade whose final response head has arrived) opens the gate so
+/// the connection resumes ordinary tunnel half-close behavior.
+struct ShutdownGate<'gate, T> {
+    inner: T,
+    pass_shutdown: &'gate AtomicBool,
+}
+
+impl<'gate, T> ShutdownGate<'gate, T> {
+    fn new(inner: T, pass_shutdown: &'gate AtomicBool) -> Self {
+        Self {
+            inner,
+            pass_shutdown,
+        }
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for ShutdownGate<'_, T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        destination: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, destination)
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for ShutdownGate<'_, T> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        source: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, source)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if this.pass_shutdown.load(Ordering::Acquire) {
+            Pin::new(&mut this.inner).poll_shutdown(cx)
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+}
+
+struct SingleRequestClient<'stream, 'buffered, 'gate> {
+    client: &'stream mut TcpStream,
+    buffered: &'buffered [u8],
+    buffered_pos: usize,
+    body: RequestBodyDecoder,
+    client_eof: bool,
+    discarded_client_bytes: usize,
+    discard_buf: [u8; CLIENT_DISCARD_BUFFER_SIZE],
+    response_done: bool,
+    response_buf: [u8; RESPONSE_BUFFER_SIZE],
+    response_len: usize,
+    response_pos: usize,
+    response_state: ResponseWriteState,
+    upgrade_requested: bool,
+    upgrade_declined: bool,
+    pass_upstream_shutdown: &'gate AtomicBool,
+}
+
+impl<'stream, 'buffered, 'gate> SingleRequestClient<'stream, 'buffered, 'gate> {
+    fn new(
+        client: &'stream mut TcpStream,
+        buffered: &'buffered [u8],
+        body_kind: RequestBodyKind,
+        upgrade_requested: bool,
+        pass_upstream_shutdown: &'gate AtomicBool,
+    ) -> Self {
+        Self {
+            client,
+            buffered,
+            buffered_pos: 0,
+            body: RequestBodyDecoder::new(body_kind),
+            client_eof: false,
+            discarded_client_bytes: 0,
+            discard_buf: [0; CLIENT_DISCARD_BUFFER_SIZE],
+            response_done: false,
+            response_buf: [0; RESPONSE_BUFFER_SIZE],
+            response_len: 0,
+            response_pos: 0,
+            response_state: ResponseWriteState::Head,
+            upgrade_requested,
+            upgrade_declined: false,
+            pass_upstream_shutdown,
+        }
+    }
+
+    fn poll_drain_response(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        while self.response_pos < self.response_len {
+            match Pin::new(&mut *self.client)
+                .poll_write(cx, &self.response_buf[self.response_pos..self.response_len])
+            {
+                Poll::Ready(Ok(0)) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "write zero bytes to HTTP proxy client",
+                    )));
+                }
+                Poll::Ready(Ok(written)) => self.response_pos += written,
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        self.response_len = 0;
+        self.response_pos = 0;
+        self.response_state = match self.response_state {
+            ResponseWriteState::InterimPending => ResponseWriteState::Head,
+            ResponseWriteState::FinalPending => {
+                if self.upgrade_declined {
+                    // A non-101 response can otherwise leave both sides
+                    // waiting on an upstream keep-alive connection: the
+                    // client was promised close semantics, but the upgrade
+                    // request could not also ask the origin to close. Once
+                    // the final head is delivered, half-close the request
+                    // side so the origin finishes and closes its response.
+                    self.pass_upstream_shutdown.store(true, Ordering::Release);
+                    cx.waker().wake_by_ref();
+                }
+                ResponseWriteState::Streaming
+            }
+            ResponseWriteState::UpgradePending => {
+                self.pass_upstream_shutdown.store(true, Ordering::Release);
+                cx.waker().wake_by_ref();
+                ResponseWriteState::Upgraded
+            }
+            state => state,
+        };
+        Poll::Ready(Ok(()))
+    }
+
+    fn prepare_response_head(&mut self) -> io::Result<()> {
+        if has_bare_line_ending(&self.response_buf[..self.response_len]) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bare CR or LF in upstream response headers",
+            ));
+        }
+        let status = parse_response_status(&self.response_buf[..self.response_len])?;
+        self.response_pos = 0;
+        if (100..200).contains(&status) && status != 101 {
+            self.response_state = ResponseWriteState::InterimPending;
+            return Ok(());
+        }
+
+        if status == 101 {
+            if !self.upgrade_requested || !self.body.is_done() {
+                return Err(invalid_data("unexpected upstream 101 response"));
+            }
+            validate_upgrade_response(&self.response_buf[..self.response_len])?;
+            self.response_len = rewrite_response_head_in_place(
+                &mut self.response_buf,
+                self.response_len,
+                ResponseConnection::Upgrade,
+            )?;
+            self.response_state = ResponseWriteState::UpgradePending;
+        } else {
+            self.upgrade_declined = self.upgrade_requested;
+            self.response_len = rewrite_response_head_in_place(
+                &mut self.response_buf,
+                self.response_len,
+                ResponseConnection::Close,
+            )?;
+            self.response_state = ResponseWriteState::FinalPending;
+        }
+        Ok(())
+    }
+
+    fn record_discarded_client_bytes(&mut self, count: usize) -> io::Result<()> {
+        self.discarded_client_bytes = self
+            .discarded_client_bytes
+            .checked_add(count)
+            .ok_or_else(|| invalid_data("discarded client bytes overflow"))?;
+        if self.discarded_client_bytes > MAX_DISCARDED_CLIENT_BYTES {
+            return Err(invalid_data(
+                "too many client bytes after the request boundary",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Drain bytes after the framed request without forwarding them upstream.
+    ///
+    /// Before the response completes, reaching the client's FIN lets the
+    /// upload relay direction finish and arms its idle linger. After the
+    /// response completes, drain everything already queued and finish as soon
+    /// as the socket becomes idle so ordinary keep-alive clients close
+    /// promptly. The total discard cap prevents an attacker from turning this
+    /// cleanup path into an unbounded read loop.
+    fn poll_discard_after_body(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.buffered_pos < self.buffered.len() {
+            let discarded = self.buffered.len() - self.buffered_pos;
+            if let Err(error) = self.record_discarded_client_bytes(discarded) {
+                return Poll::Ready(Err(error));
+            }
+            self.buffered_pos = self.buffered.len();
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+        if self.client_eof {
+            return Poll::Ready(Ok(()));
+        }
+        if self.discarded_client_bytes == MAX_DISCARDED_CLIENT_BYTES {
+            return Poll::Ready(Err(invalid_data(
+                "too many client bytes after the request boundary",
+            )));
+        }
+
+        let available =
+            (MAX_DISCARDED_CLIENT_BYTES - self.discarded_client_bytes).min(self.discard_buf.len());
+        let mut discard = ReadBuf::new(&mut self.discard_buf[..available]);
+        match Pin::new(&mut *self.client).poll_read(cx, &mut discard) {
+            Poll::Ready(Ok(())) if discard.filled().is_empty() => {
+                self.client_eof = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(())) => {
+                let count = discard.filled().len();
+                if let Err(error) = self.record_discarded_client_bytes(count) {
+                    return Poll::Ready(Err(error));
+                }
+                // The socket returned data rather than registering our waker.
+                // Re-poll on a fresh task turn to keep draining without an
+                // unbounded loop in one `poll_read` call.
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending if self.response_done => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl AsyncRead for SingleRequestClient<'_, '_, '_> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        destination: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let initially_filled = destination.filled().len();
+
+        loop {
+            if this.response_state == ResponseWriteState::Upgraded {
+                if this.buffered_pos < this.buffered.len() {
+                    let available = destination
+                        .remaining()
+                        .min(this.buffered.len() - this.buffered_pos);
+                    destination.put_slice(
+                        &this.buffered[this.buffered_pos..this.buffered_pos + available],
+                    );
+                    this.buffered_pos += available;
+                    return Poll::Ready(Ok(()));
+                }
+                return Pin::new(&mut *this.client).poll_read(cx, destination);
+            }
+            if this.upgrade_declined && this.response_state == ResponseWriteState::Streaming {
+                return Poll::Ready(Ok(()));
+            }
+
+            // A final response may legitimately end before the client sends
+            // the declared request body (for example, an early 413). Once the
+            // upstream response has closed, stop the upload direction too so
+            // the relay does not retain the connection until its half-close
+            // linger expires while waiting for body bytes that are no longer
+            // useful.
+            if this.response_done && !this.body.is_done() {
+                return Poll::Ready(Ok(()));
+            }
+            if this.body.is_done() {
+                if destination.filled().len() != initially_filled {
+                    return Poll::Ready(Ok(()));
+                }
+                if this.upgrade_requested
+                    && matches!(
+                        this.response_state,
+                        ResponseWriteState::Head
+                            | ResponseWriteState::InterimPending
+                            | ResponseWriteState::UpgradePending
+                    )
+                {
+                    return Poll::Pending;
+                }
+                return this.poll_discard_after_body(cx);
+            }
+            if destination.remaining() == 0 {
+                return Poll::Ready(Ok(()));
+            }
+
+            if this.buffered_pos < this.buffered.len() {
+                let available = destination
+                    .remaining()
+                    .min(this.buffered.len() - this.buffered_pos);
+                let source = &this.buffered[this.buffered_pos..this.buffered_pos + available];
+                let mut consumed = 0;
+                for &byte in source {
+                    if let Err(error) = this.body.consume(byte) {
+                        return Poll::Ready(Err(error));
+                    }
+                    consumed += 1;
+                    if this.body.is_done() {
+                        break;
+                    }
+                }
+                destination.put_slice(&source[..consumed]);
+                this.buffered_pos += consumed;
+                continue;
+            }
+
+            let mut socket_read = destination.take(destination.remaining());
+            match Pin::new(&mut *this.client).poll_read(cx, &mut socket_read) {
+                Poll::Ready(Ok(())) if socket_read.filled().is_empty() => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "request body ended before its framing boundary",
+                    )));
+                }
+                Poll::Ready(Ok(())) => {
+                    let initialized = socket_read.initialized().len();
+                    let filled = socket_read.filled().len();
+                    let mut consumed = 0;
+                    for &byte in socket_read.filled() {
+                        if let Err(error) = this.body.consume(byte) {
+                            return Poll::Ready(Err(error));
+                        }
+                        consumed += 1;
+                        if this.body.is_done() {
+                            break;
+                        }
+                    }
+                    let discarded = filled - consumed;
+                    // `take` does not propagate the child ReadBuf's initialized
+                    // length back to its parent. Record it before advancing so
+                    // this adapter remains correct even if called with an
+                    // initially-uninitialized destination.
+                    unsafe { destination.assume_init(initialized) };
+                    if let Err(error) = this.record_discarded_client_bytes(discarded) {
+                        return Poll::Ready(Err(error));
+                    }
+                    destination.advance(consumed);
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Pending if destination.filled().len() != initially_filled => {
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl AsyncWrite for SingleRequestClient<'_, '_, '_> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        source: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        loop {
+            match this.response_state {
+                ResponseWriteState::InterimPending
+                | ResponseWriteState::FinalPending
+                | ResponseWriteState::UpgradePending => match this.poll_drain_response(cx) {
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                    Poll::Pending => return Poll::Pending,
+                },
+                ResponseWriteState::Streaming | ResponseWriteState::Upgraded => {
+                    return Pin::new(&mut *this.client).poll_write(cx, source);
+                }
+                ResponseWriteState::Head => {
+                    if source.is_empty() {
+                        return Poll::Ready(Ok(0));
+                    }
+                    let available = MAX_RESPONSE_HEADERS.saturating_sub(this.response_len);
+                    if available == 0 {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "upstream response headers are too large",
+                        )));
+                    }
+                    let old_len = this.response_len;
+                    let copied = available.min(source.len());
+                    this.response_buf[old_len..old_len + copied].copy_from_slice(&source[..copied]);
+                    this.response_len += copied;
+
+                    let search_start = old_len.saturating_sub(3);
+                    if let Some(marker) =
+                        find_crlf_crlf(&this.response_buf[search_start..this.response_len])
+                            .map(|relative| search_start + relative)
+                    {
+                        let head_end = marker + 4;
+                        let consumed = head_end - old_len;
+                        this.response_len = head_end;
+                        if let Err(error) = this.prepare_response_head() {
+                            return Poll::Ready(Err(error));
+                        }
+                        return Poll::Ready(Ok(consumed));
+                    }
+                    return Poll::Ready(Ok(copied));
+                }
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if matches!(
+            this.response_state,
+            ResponseWriteState::InterimPending
+                | ResponseWriteState::FinalPending
+                | ResponseWriteState::UpgradePending
+        ) {
+            match this.poll_drain_response(cx) {
+                Poll::Ready(Ok(())) => {}
+                result => return result,
+            }
+        }
+        Pin::new(&mut *this.client).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if matches!(
+            this.response_state,
+            ResponseWriteState::InterimPending
+                | ResponseWriteState::FinalPending
+                | ResponseWriteState::UpgradePending
+        ) {
+            match this.poll_drain_response(cx) {
+                Poll::Ready(Ok(())) => {}
+                result => return result,
+            }
+        }
+        if this.response_state == ResponseWriteState::Head {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "upstream closed before its final response headers completed",
+            )));
+        }
+        if !this.response_done {
+            this.response_done = true;
+            cx.waker().wake_by_ref();
+        }
+        Pin::new(&mut *this.client).poll_shutdown(cx)
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ResponseWriteState {
+    Head,
+    InterimPending,
+    FinalPending,
+    UpgradePending,
+    Streaming,
+    Upgraded,
+}
+
+enum RequestBodyDecoder {
+    ContentLength(u64),
+    Chunked(ChunkState),
+    Done,
+}
+
+impl RequestBodyDecoder {
+    fn new(kind: RequestBodyKind) -> Self {
+        match kind {
+            RequestBodyKind::None | RequestBodyKind::ContentLength(0) => Self::Done,
+            RequestBodyKind::ContentLength(length) => Self::ContentLength(length),
+            RequestBodyKind::Chunked => Self::Chunked(ChunkState::size_line()),
+        }
+    }
+
+    fn is_done(&self) -> bool {
+        matches!(self, Self::Done)
+    }
+
+    fn consume(&mut self, byte: u8) -> io::Result<()> {
+        match self {
+            Self::ContentLength(remaining) => {
+                *remaining -= 1;
+                if *remaining == 0 {
+                    *self = Self::Done;
+                }
+                Ok(())
+            }
+            Self::Chunked(state) => {
+                if state.consume(byte)? {
+                    *self = Self::Done;
+                }
+                Ok(())
+            }
+            Self::Done => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bytes arrived after the request body boundary",
+            )),
+        }
+    }
+}
+
+enum ChunkState {
+    SizeLine {
+        size: u64,
+        digits: usize,
+        in_extensions: bool,
+        saw_cr: bool,
+        line_bytes: usize,
+    },
+    Data(u64),
+    DataCr,
+    DataLf,
+    Trailers {
+        line_bytes: usize,
+        total_bytes: usize,
+        saw_cr: bool,
+    },
+}
+
+impl ChunkState {
+    fn size_line() -> Self {
+        Self::SizeLine {
+            size: 0,
+            digits: 0,
+            in_extensions: false,
+            saw_cr: false,
+            line_bytes: 0,
+        }
+    }
+
+    /// Consume one raw chunked-body byte. `true` marks the terminating empty
+    /// trailer line. Input is prefetched in 4 KiB blocks, so this byte-level
+    /// state machine does not cause byte-at-a-time socket reads or allocation.
+    fn consume(&mut self, byte: u8) -> io::Result<bool> {
+        let mut next = None;
+        match self {
+            Self::SizeLine {
+                size,
+                digits,
+                in_extensions,
+                saw_cr,
+                line_bytes,
+            } => {
+                *line_bytes += 1;
+                if *line_bytes > MAX_CHUNK_LINE {
+                    return Err(invalid_data("chunk size line is too large"));
+                }
+                if *saw_cr {
+                    if byte != b'\n' {
+                        return Err(invalid_data("chunk size CR is not followed by LF"));
+                    }
+                    if *digits == 0 {
+                        return Err(invalid_data("empty chunk size"));
+                    }
+                    next = Some(if *size == 0 {
+                        Self::Trailers {
+                            line_bytes: 0,
+                            total_bytes: 0,
+                            saw_cr: false,
+                        }
+                    } else {
+                        Self::Data(*size)
+                    });
+                } else if byte == b'\r' {
+                    *saw_cr = true;
+                } else if byte == b'\n' {
+                    return Err(invalid_data("chunk size contains a bare LF"));
+                } else if !*in_extensions {
+                    if let Some(digit) = hex_value(byte) {
+                        *digits += 1;
+                        *size = size
+                            .checked_mul(16)
+                            .and_then(|value| value.checked_add(u64::from(digit)))
+                            .ok_or_else(|| invalid_data("chunk size is too large"))?;
+                    } else if byte == b';' && *digits != 0 {
+                        *in_extensions = true;
+                    } else {
+                        return Err(invalid_data("invalid chunk size"));
+                    }
+                } else if !is_field_value_byte(byte) {
+                    return Err(invalid_data("invalid chunk extension"));
+                }
+            }
+            Self::Data(remaining) => {
+                *remaining -= 1;
+                if *remaining == 0 {
+                    next = Some(Self::DataCr);
+                }
+            }
+            Self::DataCr => {
+                if byte != b'\r' {
+                    return Err(invalid_data("chunk data is not followed by CRLF"));
+                }
+                next = Some(Self::DataLf);
+            }
+            Self::DataLf => {
+                if byte != b'\n' {
+                    return Err(invalid_data("chunk data is not followed by CRLF"));
+                }
+                next = Some(Self::size_line());
+            }
+            Self::Trailers {
+                line_bytes,
+                total_bytes,
+                saw_cr,
+            } => {
+                *total_bytes += 1;
+                if *total_bytes > MAX_TRAILERS {
+                    return Err(invalid_data("chunked trailers are too large"));
+                }
+                if *saw_cr {
+                    if byte != b'\n' {
+                        return Err(invalid_data("trailer CR is not followed by LF"));
+                    }
+                    if *line_bytes == 0 {
+                        return Ok(true);
+                    }
+                    *line_bytes = 0;
+                    *saw_cr = false;
+                } else if byte == b'\r' {
+                    *saw_cr = true;
+                } else if byte == b'\n' {
+                    return Err(invalid_data("chunked trailers contain a bare LF"));
+                } else if is_field_value_byte(byte) {
+                    *line_bytes += 1;
+                } else {
+                    return Err(invalid_data("invalid chunked trailer byte"));
+                }
+            }
+        }
+        if let Some(next) = next {
+            *self = next;
+        }
+        Ok(false)
+    }
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn is_field_value_byte(byte: u8) -> bool {
+    byte == b'\t' || (byte >= b' ' && byte != 0x7f)
+}
+
+fn invalid_data(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn parse_response_status(head: &[u8]) -> io::Result<u16> {
+    let line_end = head
+        .windows(2)
+        .position(|window| window == b"\r\n")
+        .ok_or_else(|| invalid_data("upstream response is missing a status line"))?;
+    let mut parts = head[..line_end].split(|byte| *byte == b' ');
+    let version = parts.next().unwrap_or_default();
+    let status = parts.next().unwrap_or_default();
+    if !matches!(version, b"HTTP/1.0" | b"HTTP/1.1")
+        || status.len() != 3
+        || !status.iter().all(u8::is_ascii_digit)
+    {
+        return Err(invalid_data("invalid upstream HTTP status line"));
+    }
+    Ok(status
+        .iter()
+        .fold(0u16, |value, digit| value * 10 + u16::from(*digit - b'0')))
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ResponseConnection {
+    Close,
+    Upgrade,
+}
+
+fn rewrite_response_head_in_place(
+    buf: &mut [u8],
+    head_len: usize,
+    connection: ResponseConnection,
+) -> io::Result<usize> {
+    let status_end = buf[..head_len]
+        .windows(2)
+        .position(|window| window == b"\r\n")
+        .ok_or_else(|| invalid_data("upstream response is missing a status line"))?;
+    let mut drop_lines = [0u8; MAX_RESPONSE_HEADERS.div_ceil(8)];
+    let mut read = status_end + 2;
+
+    while read + 2 <= head_len {
+        let relative_end = buf[read..head_len]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or_else(|| invalid_data("malformed upstream response header"))?;
+        let line_end = read + relative_end;
+        if line_end == read {
+            break;
+        }
+        let colon = buf[read..line_end]
+            .iter()
+            .position(|byte| *byte == b':')
+            .ok_or_else(|| invalid_data("upstream response header is missing a colon"))?;
+        let name = &buf[read..read + colon];
+        if name.is_empty() || !name.iter().copied().all(is_tchar) {
+            return Err(invalid_data("invalid upstream response header name"));
+        }
+        if name.eq_ignore_ascii_case(b"connection") {
+            validate_response_connection_options(&buf[read + colon + 1..line_end])?;
+        }
+        let preserve_upgrade =
+            connection == ResponseConnection::Upgrade && name.eq_ignore_ascii_case(b"upgrade");
+        let drop = name.eq_ignore_ascii_case(b"connection")
+            || name.eq_ignore_ascii_case(b"proxy-connection")
+            || name.eq_ignore_ascii_case(b"keep-alive")
+            || (name.eq_ignore_ascii_case(b"upgrade") && !preserve_upgrade)
+            || (connection == ResponseConnection::Upgrade
+                && (name.eq_ignore_ascii_case(b"content-length")
+                    || name.eq_ignore_ascii_case(b"transfer-encoding")))
+            || (response_connection_nominates(&buf[..head_len], name)? && !preserve_upgrade);
+        if drop {
+            drop_lines[read / 8] |= 1 << (read % 8);
+        }
+        read = line_end + 2;
+    }
+
+    let mut write = status_end + 2;
+    read = status_end + 2;
+    while read + 2 <= head_len {
+        let relative_end = buf[read..head_len]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or_else(|| invalid_data("malformed upstream response header"))?;
+        let line_end = read + relative_end;
+        if line_end == read {
+            break;
+        }
+        if drop_lines[read / 8] & (1 << (read % 8)) == 0 {
+            buf.copy_within(read..line_end + 2, write);
+            write += line_end + 2 - read;
+        }
+        read = line_end + 2;
+    }
+
+    let connection_header = match connection {
+        ResponseConnection::Close => CONNECTION_CLOSE_HEADER,
+        ResponseConnection::Upgrade => CONNECTION_UPGRADE_HEADER,
+    };
+    let required = write + connection_header.len() + 2;
+    if required > buf.len() {
+        return Err(invalid_data(
+            "rewritten upstream response headers are too large",
+        ));
+    }
+    buf[write..write + connection_header.len()].copy_from_slice(connection_header);
+    write += connection_header.len();
+    buf[write..write + 2].copy_from_slice(b"\r\n");
+    Ok(write + 2)
+}
+
+fn validate_upgrade_response(head: &[u8]) -> io::Result<()> {
+    if !response_connection_nominates(head, b"upgrade")? {
+        return Err(invalid_data(
+            "upstream 101 response is missing Connection: upgrade",
+        ));
+    }
+
+    let status_end = head
+        .windows(2)
+        .position(|window| window == b"\r\n")
+        .ok_or_else(|| invalid_data("upstream response is missing a status line"))?;
+    let mut read = status_end + 2;
+    let mut saw_protocol = false;
+    while read + 2 <= head.len() {
+        let relative_end = head[read..]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or_else(|| invalid_data("malformed upstream response header"))?;
+        let line_end = read + relative_end;
+        if line_end == read {
+            break;
+        }
+        let colon = head[read..line_end]
+            .iter()
+            .position(|byte| *byte == b':')
+            .ok_or_else(|| invalid_data("upstream response header is missing a colon"))?;
+        if head[read..read + colon].eq_ignore_ascii_case(b"upgrade") {
+            validate_upgrade_protocol_list(&head[read + colon + 1..line_end], &mut saw_protocol)
+                .map_err(invalid_data)?;
+        }
+        read = line_end + 2;
+    }
+    if !saw_protocol {
+        return Err(invalid_data(
+            "upstream 101 response is missing an Upgrade protocol",
+        ));
+    }
+    Ok(())
+}
+
+fn response_connection_nominates(head: &[u8], candidate: &[u8]) -> io::Result<bool> {
+    let status_end = head
+        .windows(2)
+        .position(|window| window == b"\r\n")
+        .ok_or_else(|| invalid_data("upstream response is missing a status line"))?;
+    let mut read = status_end + 2;
+    while read + 2 <= head.len() {
+        let relative_end = head[read..]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or_else(|| invalid_data("malformed upstream response header"))?;
+        let line_end = read + relative_end;
+        if line_end == read {
+            return Ok(false);
+        }
+        let colon = head[read..line_end]
+            .iter()
+            .position(|byte| *byte == b':')
+            .ok_or_else(|| invalid_data("upstream response header is missing a colon"))?;
+        if head[read..read + colon].eq_ignore_ascii_case(b"connection") {
+            for option in head[read + colon + 1..line_end].split(|byte| *byte == b',') {
+                let option = trim_ows(option);
+                if !option.is_empty() && option.eq_ignore_ascii_case(candidate) {
+                    return Ok(true);
+                }
+            }
+        }
+        read = line_end + 2;
+    }
+    Ok(false)
+}
+
+fn validate_response_connection_options(value: &[u8]) -> io::Result<()> {
+    for option in value.split(|byte| *byte == b',') {
+        let option = trim_ows(option);
+        // RFC 9110 section 5.6.1.2 requires recipients to accept and ignore a
+        // reasonable number of empty list elements, including a trailing comma.
+        if option.is_empty() {
+            continue;
+        }
+        if !option.iter().copied().all(is_tchar) {
+            return Err(invalid_data("invalid upstream Connection header"));
+        }
+        if option.eq_ignore_ascii_case(b"content-length")
+            || option.eq_ignore_ascii_case(b"transfer-encoding")
+        {
+            return Err(invalid_data(
+                "upstream Connection header names an HTTP framing field",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_connection_options(headers: &[HeaderField<'_>]) -> Result<(), &'static str> {
+    for header in headers {
+        if !header.name.eq_ignore_ascii_case(b"connection") {
+            continue;
+        }
+        for option in header.value.split(|byte| *byte == b',') {
+            let option = trim_ows(option);
+            if option.is_empty() {
+                continue;
+            }
+            if !option.iter().copied().all(is_tchar) {
+                return Err("invalid Connection header");
+            }
+            if option.eq_ignore_ascii_case(b"content-length")
+                || option.eq_ignore_ascii_case(b"transfer-encoding")
+                || option.eq_ignore_ascii_case(b"host")
+            {
+                return Err("Connection header names an HTTP framing field");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn connection_nominates(headers: &[HeaderField<'_>], name: &[u8]) -> bool {
+    headers.iter().any(|header| {
+        header.name.eq_ignore_ascii_case(b"connection")
+            && header
+                .value
+                .split(|byte| *byte == b',')
+                .any(|option| trim_ows(option).eq_ignore_ascii_case(name))
+    })
+}
+
+fn validate_upgrade_request(
+    headers: &[HeaderField<'_>],
+    body_kind: RequestBodyKind,
+    version: &str,
+) -> Result<bool, &'static str> {
+    if !connection_nominates(headers, b"upgrade") {
+        return Ok(false);
+    }
+    if version != "HTTP/1.1" {
+        return Err("HTTP Upgrade requires HTTP/1.1");
+    }
+    if !matches!(
+        body_kind,
+        RequestBodyKind::None | RequestBodyKind::ContentLength(0)
+    ) {
+        // Holding bytes beyond a variable request-body boundary until the 101
+        // decision would require a second body-sized staging buffer. WebSocket
+        // and the other deployed HTTP/1.1 upgrades use a bodyless handshake.
+        return Err("HTTP Upgrade request must not have a body");
+    }
+
+    let mut saw_protocol = false;
+    for header in headers {
+        if header.name.eq_ignore_ascii_case(b"upgrade") {
+            validate_upgrade_protocol_list(header.value, &mut saw_protocol)?;
+        }
+    }
+    if !saw_protocol {
+        return Err("Connection: upgrade requires an Upgrade protocol");
+    }
+    Ok(true)
+}
+
+fn validate_upgrade_protocol_list(
+    value: &[u8],
+    saw_protocol: &mut bool,
+) -> Result<(), &'static str> {
+    for protocol in value.split(|byte| *byte == b',') {
+        let protocol = trim_ows(protocol);
+        // Upgrade is a list field, so RFC 9110 section 5.6.1.2 permits empty
+        // elements. At least one real protocol is still required overall.
+        if protocol.is_empty() {
+            continue;
+        }
+        let mut parts = protocol.split(|byte| *byte == b'/');
+        let name = parts.next().unwrap_or_default();
+        let version = parts.next();
+        if name.is_empty()
+            || !name.iter().copied().all(is_tchar)
+            || version
+                .is_some_and(|version| version.is_empty() || !version.iter().copied().all(is_tchar))
+            || parts.next().is_some()
+        {
+            return Err("invalid Upgrade protocol");
+        }
+        *saw_protocol = true;
+    }
+    Ok(())
+}
+
 fn rewrite_plain_request(request: &RequestHead<'_>, path: &str) -> Vec<u8> {
     // Exact hint: request line + every forwarded field with its CRLF + the
     // canonical Content-Length + the terminating CRLF. Over-counting the few
@@ -701,7 +1706,13 @@ fn rewrite_plain_request(request: &RequestHead<'_>, path: &str) -> Vec<u8> {
         .map(|header| header.raw.len() + 2)
         .sum();
     let mut rewritten = Vec::with_capacity(
-        request.method.len() + path.len() + request.version.len() + 4 + headers_len + 32,
+        request.method.len()
+            + path.len()
+            + request.version.len()
+            + 4
+            + headers_len
+            + 32
+            + CONNECTION_CLOSE_HEADER.len(),
     );
     rewritten.extend_from_slice(request.method.as_bytes());
     rewritten.push(b' ');
@@ -710,10 +1721,16 @@ fn rewrite_plain_request(request: &RequestHead<'_>, path: &str) -> Vec<u8> {
     rewritten.extend_from_slice(request.version.as_bytes());
     rewritten.extend_from_slice(b"\r\n");
     for header in &request.headers {
+        let is_upgrade = header.name.eq_ignore_ascii_case(b"upgrade");
         if header.name.eq_ignore_ascii_case(b"proxy-connection")
             || header.name.eq_ignore_ascii_case(b"proxy-authorization")
             // Re-emitted below in canonical form.
             || header.name.eq_ignore_ascii_case(b"content-length")
+            || header.name.eq_ignore_ascii_case(b"connection")
+            || header.name.eq_ignore_ascii_case(b"keep-alive")
+            || (is_upgrade && !request.upgrade_requested)
+            || (connection_nominates(&request.headers, header.name)
+                && !(request.upgrade_requested && is_upgrade))
         {
             continue;
         }
@@ -723,10 +1740,15 @@ fn rewrite_plain_request(request: &RequestHead<'_>, path: &str) -> Vec<u8> {
     // RFC 9112 §6.3.5: a recipient forwarding a message whose Content-Length
     // was duplicated or list-form must replace it with one valid field, so the
     // next hop cannot read a different length than this one did.
-    if let Some(content_length) = request.content_length {
+    if let RequestBodyKind::ContentLength(content_length) = request.body_kind {
         use std::io::Write as _;
         let _ = write!(rewritten, "Content-Length: {content_length}\r\n");
     }
+    rewritten.extend_from_slice(if request.upgrade_requested {
+        CONNECTION_UPGRADE_HEADER
+    } else {
+        CONNECTION_CLOSE_HEADER
+    });
     rewritten.extend_from_slice(b"\r\n");
     rewritten
 }
@@ -800,11 +1822,12 @@ fn parse_host_port(target: &str, default_port: u16) -> (&str, u16) {
     (target, default_port)
 }
 
-/// Parse host and port from an absolute HTTP URL like "http://ipinfo.io/json"
+/// Parse host and port from an absolute HTTP or WebSocket URL.
 fn parse_url_host_port(url: &str) -> (&str, u16) {
     // Strip scheme
     let without_scheme = url
         .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("ws://"))
         .or_else(|| url.strip_prefix("https://"))
         .unwrap_or(url);
     // Take the authority part (before first /)
@@ -813,10 +1836,11 @@ fn parse_url_host_port(url: &str) -> (&str, u16) {
     parse_host_port(authority, default_port)
 }
 
-/// Extract the path from an absolute URL: "http://ipinfo.io/json" -> "/json"
+/// Extract the path from an absolute HTTP or WebSocket URL.
 fn extract_path_from_url(url: &str) -> &str {
     let without_scheme = url
         .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("ws://"))
         .or_else(|| url.strip_prefix("https://"))
         .unwrap_or(url);
     without_scheme
@@ -897,7 +1921,7 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_preserves_obs_text_and_only_drops_proxy_headers() {
+    fn rewrite_preserves_obs_text_and_sets_close_semantics() {
         let request = parse_request_head(
             b"GET http://example.com/path HTTP/1.1\r\nHost: example.com\r\nX-Word: caf\xe9\r\nProxy-Connection: keep-alive\r\nProxy-Authorization: Basic dTpw\r\n\r\n",
         )
@@ -905,8 +1929,126 @@ mod tests {
         let rewritten = rewrite_plain_request(&request, "/path");
         assert_eq!(
             rewritten,
-            b"GET /path HTTP/1.1\r\nHost: example.com\r\nX-Word: caf\xe9\r\n\r\n"
+            b"GET /path HTTP/1.1\r\nHost: example.com\r\nX-Word: caf\xe9\r\nConnection: close\r\n\r\n"
         );
+    }
+
+    #[test]
+    fn rewrite_removes_connection_nominated_headers() {
+        let request = parse_request_head(
+            b"GET http://example.com/path HTTP/1.1\r\nHost: example.com\r\nConnection: X-Hop, keep-alive\r\nX-Hop: secret\r\nKeep-Alive: timeout=5\r\nX-End-To-End: kept\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(
+            rewrite_plain_request(&request, "/path"),
+            b"GET /path HTTP/1.1\r\nHost: example.com\r\nX-End-To-End: kept\r\nConnection: close\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn upgrade_rewrite_preserves_only_upgrade_hop_fields() {
+        let request = parse_request_head(
+            b"GET http://example.com/chat HTTP/1.1\r\nHost: example.com\r\nConnection: Upgrade, X-Hop\r\nUpgrade: websocket\r\nX-Hop: secret\r\n\r\n",
+        )
+        .unwrap();
+        assert!(request.upgrade_requested);
+        assert_eq!(
+            rewrite_plain_request(&request, "/chat"),
+            b"GET /chat HTTP/1.1\r\nHost: example.com\r\nUpgrade: websocket\r\nConnection: upgrade\r\n\r\n"
+        );
+
+        let response = b"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade, X-Hop\r\nUpgrade: websocket\r\nX-Hop: secret\r\nContent-Length: 99\r\n\r\n";
+        validate_upgrade_response(response).unwrap();
+        let mut buffer = [0u8; RESPONSE_BUFFER_SIZE];
+        buffer[..response.len()].copy_from_slice(response);
+        let rewritten = rewrite_response_head_in_place(
+            &mut buffer,
+            response.len(),
+            ResponseConnection::Upgrade,
+        )
+        .unwrap();
+        assert_eq!(
+            &buffer[..rewritten],
+            b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: upgrade\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn parser_rejects_malformed_upgrade_handshakes() {
+        for request in [
+            b"GET http://example.com/ HTTP/1.1\r\nConnection: Upgrade\r\n\r\n".as_slice(),
+            b"POST http://example.com/ HTTP/1.1\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nContent-Length: 1\r\n\r\n",
+            b"GET http://example.com/ HTTP/1.0\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+            b"GET http://example.com/ HTTP/1.1\r\nConnection: Upgrade\r\nUpgrade: web/socket/extra\r\n\r\n",
+        ] {
+            assert!(parse_request_head(request).is_err());
+        }
+
+        assert!(validate_upgrade_response(
+            b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n"
+        )
+        .is_err());
+        assert!(validate_upgrade_response(
+            b"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\n\r\n"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn connection_lists_accept_empty_elements() {
+        let request = parse_request_head(
+            b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\nConnection: , close,\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(
+            rewrite_plain_request(&request, "/"),
+            b"GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
+        );
+
+        let response = b"HTTP/1.1 200 OK\r\nConnection: close,\r\nContent-Length: 2\r\n\r\n";
+        let mut buffer = [0u8; RESPONSE_BUFFER_SIZE];
+        buffer[..response.len()].copy_from_slice(response);
+        let rewritten =
+            rewrite_response_head_in_place(&mut buffer, response.len(), ResponseConnection::Close)
+                .unwrap();
+        assert_eq!(
+            &buffer[..rewritten],
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn response_connection_cannot_nominate_framing_headers() {
+        for framing in [b"Content-Length".as_slice(), b"Transfer-Encoding"] {
+            let response = [
+                b"HTTP/1.1 200 OK\r\nConnection: ".as_slice(),
+                framing,
+                b"\r\nContent-Length: 2\r\n\r\n",
+            ]
+            .concat();
+            let mut buffer = [0u8; RESPONSE_BUFFER_SIZE];
+            buffer[..response.len()].copy_from_slice(&response);
+            assert!(rewrite_response_head_in_place(
+                &mut buffer,
+                response.len(),
+                ResponseConnection::Close,
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn strict_parser_returns_request_body_kind() {
+        let fixed =
+            parse_request_head(b"POST http://example.com/ HTTP/1.1\r\nContent-Length: 11\r\n\r\n")
+                .unwrap();
+        assert_eq!(fixed.body_kind, RequestBodyKind::ContentLength(11));
+
+        let chunked = parse_request_head(
+            b"POST http://example.com/ HTTP/1.1\r\nTransfer-Encoding: gzip; level=1, chunked\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(chunked.body_kind, RequestBodyKind::Chunked);
     }
 
     #[test]
@@ -957,10 +2099,10 @@ mod tests {
             b"POST http://example.com/ HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5, 5\r\nX-Tail: 1\r\nContent-Length: 5\r\n\r\n",
         )
         .unwrap();
-        assert_eq!(request.content_length, Some(5));
+        assert_eq!(request.body_kind, RequestBodyKind::ContentLength(5));
         assert_eq!(
             rewrite_plain_request(&request, "/"),
-            b"POST / HTTP/1.1\r\nHost: example.com\r\nX-Tail: 1\r\nContent-Length: 5\r\n\r\n"
+            b"POST / HTTP/1.1\r\nHost: example.com\r\nX-Tail: 1\r\nContent-Length: 5\r\nConnection: close\r\n\r\n"
         );
     }
 
@@ -969,10 +2111,10 @@ mod tests {
         let request =
             parse_request_head(b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n")
                 .unwrap();
-        assert_eq!(request.content_length, None);
+        assert_eq!(request.body_kind, RequestBodyKind::None);
         assert_eq!(
             rewrite_plain_request(&request, "/"),
-            b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+            b"GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
         );
     }
 

--- a/crates/meow-listener/tests/http_proxy_strict.rs
+++ b/crates/meow-listener/tests/http_proxy_strict.rs
@@ -161,7 +161,7 @@ async fn body_line_feeds_in_a_later_read_are_not_header_errors() {
         .await
         .expect("origin did not receive the request")
         .unwrap();
-    assert!(captured.ends_with(b"Content-Length: 3\r\n\r\na\nb"));
+    assert!(captured.ends_with(b"Content-Length: 3\r\nConnection: close\r\n\r\na\nb"));
 
     let mut response = Vec::new();
     client_stream.read_to_end(&mut response).await.unwrap();
@@ -219,7 +219,7 @@ async fn valid_obs_text_is_preserved_and_body_line_feeds_are_not_header_errors()
     let expected_prefix =
         format!("POST /upload HTTP/1.1\r\nHost: {origin_addr}\r\nX-Word: caf").into_bytes();
     assert!(captured.starts_with(&expected_prefix));
-    assert!(captured.ends_with(b"\xe9\r\nContent-Length: 3\r\n\r\na\nb"));
+    assert!(captured.ends_with(b"\xe9\r\nContent-Length: 3\r\nConnection: close\r\n\r\na\nb"));
 
     let mut response = Vec::new();
     client_stream.read_to_end(&mut response).await.unwrap();

--- a/crates/meow-listener/tests/http_single_request.rs
+++ b/crates/meow-listener/tests/http_single_request.rs
@@ -669,3 +669,71 @@ async fn declined_upgrade_closes_without_forwarding_protocol_bytes() {
     origin_task.await.unwrap();
     handler.await.unwrap();
 }
+
+#[tokio::test(start_paused = true)]
+async fn abandoned_upgrade_is_reaped_by_the_half_close_linger() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let (request_seen_tx, request_seen_rx) = oneshot::channel();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the upgrade");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        request_seen_tx.send(()).unwrap();
+
+        // Never send a response. The held client protocol bytes must not
+        // reach this origin, and the proxy must still reap the connection.
+        let mut byte = [0u8; 1];
+        assert_eq!(
+            stream.read(&mut byte).await.unwrap(),
+            0,
+            "held protocol bytes were forwarded without a 101 response"
+        );
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let mut handler = spawn_proxy_handler(server_stream).await;
+    let request = format!(
+        "GET ws://{origin_addr}/chat HTTP/1.1\r\n\
+         Host: {origin_addr}\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\r\n"
+    );
+    client.write_all(request.as_bytes()).await.unwrap();
+    // Early protocol bytes exercise the bounded hold: the client FIN behind
+    // them must still be observed while the upgrade decision is pending.
+    client.write_all(b"early-protocol-bytes").await.unwrap();
+    request_seen_rx.await.unwrap();
+    // Keep the client write half open until the origin has received the
+    // request, mirroring client_eof_reaps_a_silent_origin: the paused clock
+    // must not auto-advance to the relay timer before the handshake lands.
+    client.shutdown().await.unwrap();
+
+    // Drive the hold reads and the relay before moving the paused clock; the
+    // linger deadline is created only after the upload direction reports Done.
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !handler.is_finished(),
+        "client EOF closed the connection before the half-close linger"
+    );
+    tokio::time::advance(meow_tunnel::relay::RELAY_HALF_CLOSE_LINGER - Duration::from_millis(1))
+        .await;
+    tokio::task::yield_now().await;
+    assert!(
+        !handler.is_finished(),
+        "the silent origin was reaped before the half-close linger"
+    );
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::time::timeout(Duration::from_secs(1), &mut handler)
+        .await
+        .expect("an abandoned upgrade handshake did not arm the half-close linger")
+        .unwrap();
+    origin_task.await.unwrap();
+}

--- a/crates/meow-listener/tests/http_single_request.rs
+++ b/crates/meow-listener/tests/http_single_request.rs
@@ -1,0 +1,671 @@
+//! Regression tests for routing plain HTTP proxy connections one request at a
+//! time. A second request on the client connection must never inherit the
+//! first request's destination or upstream connection.
+#![cfg(feature = "listener-http")]
+
+mod common;
+
+use common::direct_tunnel;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
+
+async fn loopback_pair() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (accept_result, connect_result) = tokio::join!(listener.accept(), TcpStream::connect(addr));
+    let (server, _) = accept_result.unwrap();
+    (server, connect_result.unwrap())
+}
+
+async fn spawn_capturing_origin(
+    expected_body: &'static [u8],
+    response: &'static [u8],
+) -> (SocketAddr, oneshot::Receiver<Vec<u8>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (sender, receiver) = oneshot::channel();
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        let boundary = loop {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before sending the request body");
+            request.extend_from_slice(&chunk[..count]);
+            if let Some(header_start) = request.windows(4).position(|window| window == b"\r\n\r\n")
+            {
+                let boundary = header_start + 4 + expected_body.len();
+                if request.len() >= boundary {
+                    break boundary;
+                }
+            }
+        };
+        assert_eq!(
+            &request[boundary - expected_body.len()..boundary],
+            expected_body
+        );
+        assert_eq!(
+            request.len(),
+            boundary,
+            "proxy forwarded a pipelined request"
+        );
+        sender.send(request).unwrap();
+        stream.write_all(response).await.unwrap();
+    });
+    (addr, receiver)
+}
+
+async fn spawn_proxy_handler(server_stream: TcpStream) -> tokio::task::JoinHandle<()> {
+    let tunnel = direct_tunnel();
+    let src: SocketAddr = "127.0.0.1:1".parse().unwrap();
+    tokio::spawn(async move {
+        meow_listener::http_proxy::handle_http(&tunnel, server_stream, src, None, None, "test", 0)
+            .await;
+    })
+}
+
+async fn read_response_and_wait_for_close(client: &mut TcpStream) -> Vec<u8> {
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(2), client.read_to_end(&mut response))
+        .await
+        .expect("proxy did not close the client connection")
+        .unwrap();
+    response
+}
+
+const OK_RESPONSE: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK";
+
+#[tokio::test]
+async fn pipelined_second_origin_is_not_sent_on_first_connection() {
+    let (first_addr, first_request) = spawn_capturing_origin(b"", OK_RESPONSE).await;
+    let second_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let second_addr = second_listener.local_addr().unwrap();
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+
+    let requests = format!(
+        "GET http://{first_addr}/one HTTP/1.1\r\n\
+         Host: {first_addr}\r\n\
+         Connection: keep-alive\r\n\r\n\
+         GET http://{second_addr}/two HTTP/1.1\r\n\
+         Host: {second_addr}\r\n\r\n"
+    );
+    client.write_all(requests.as_bytes()).await.unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert_eq!(
+        response,
+        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+    );
+
+    let received = first_request.await.unwrap();
+    let received_text = String::from_utf8(received).unwrap();
+    assert!(received_text.starts_with("GET /one HTTP/1.1\r\n"));
+    assert!(received_text.contains("\r\nConnection: close\r\n"));
+    assert!(!received_text.contains("keep-alive"));
+    assert!(!received_text.contains("/two"));
+    assert!(!received_text.contains(&second_addr.to_string()));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), second_listener.accept())
+            .await
+            .is_err(),
+        "the pipelined request was routed to its own origin instead of closing"
+    );
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn content_length_body_stops_before_pipelined_request() {
+    let (origin_addr, origin_request) = spawn_capturing_origin(b"hello world", OK_RESPONSE).await;
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+
+    let headers_and_partial_body = format!(
+        "POST http://{origin_addr}/submit HTTP/1.1\r\n\
+         Host: {origin_addr}\r\n\
+         Content-Length: 11\r\n\r\n\
+         hello"
+    );
+    client
+        .write_all(headers_and_partial_body.as_bytes())
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+    client
+        .write_all(
+            b" worldGET http://example.invalid/next HTTP/1.1\r\nHost: example.invalid\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert!(response.ends_with(b"OK"));
+
+    let received = origin_request.await.unwrap();
+    let body_start = received
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .unwrap()
+        + 4;
+    assert_eq!(&received[body_start..], b"hello world");
+    assert!(received.starts_with(b"POST /submit HTTP/1.1\r\n"));
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn chunked_body_and_trailers_stop_before_pipelined_request() {
+    const CHUNKED_BODY: &[u8] =
+        b"5\r\nhello\r\n6;sample=yes\r\n world\r\n0\r\nX-Trailer: done\r\n\r\n";
+    let (origin_addr, origin_request) = spawn_capturing_origin(CHUNKED_BODY, OK_RESPONSE).await;
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+
+    let headers = format!(
+        "POST http://{origin_addr}/chunks HTTP/1.1\r\n\
+         Host: {origin_addr}\r\n\
+         Transfer-Encoding: chunked\r\n\r\n"
+    );
+    client.write_all(headers.as_bytes()).await.unwrap();
+    client
+        .write_all(
+            b"5\r\nhello\r\n6;sample=yes\r\n world\r\n0\r\nX-Trailer: done\r\n\r\n\
+              GET http://example.invalid/next HTTP/1.1\r\nHost: example.invalid\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert!(response.ends_with(b"OK"));
+
+    let received = origin_request.await.unwrap();
+    let body_start = received
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .unwrap()
+        + 4;
+    assert_eq!(&received[body_start..], CHUNKED_BODY);
+    assert!(received.starts_with(b"POST /chunks HTTP/1.1\r\n"));
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn final_response_replaces_hop_by_hop_headers_after_informational_response() {
+    const RESPONSE: &[u8] = b"HTTP/1.1 100 Continue\r\n\r\n\
+        HTTP/1.1 200 OK\r\n\
+        Connection: X-Hop\r\n\
+        X-Hop: secret\r\n\
+        Keep-Alive: timeout=5\r\n\
+        Content-Length: 2\r\n\r\nOK";
+    let (origin_addr, origin_request) = spawn_capturing_origin(b"", RESPONSE).await;
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+
+    client
+        .write_all(
+            format!("GET http://{origin_addr}/ HTTP/1.1\r\nHost: {origin_addr}\r\n\r\n").as_bytes(),
+        )
+        .await
+        .unwrap();
+    let response = read_response_and_wait_for_close(&mut client).await;
+
+    assert_eq!(
+        response,
+        b"HTTP/1.1 100 Continue\r\n\r\n\
+          HTTP/1.1 200 OK\r\n\
+          Content-Length: 2\r\n\
+          Connection: close\r\n\r\nOK"
+    );
+    origin_request.await.unwrap();
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn bodyless_request_does_not_half_close_upstream_before_response() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy half-closed the bodyless request early");
+            request.extend_from_slice(&chunk[..count]);
+        }
+
+        let mut byte = [0u8; 1];
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), stream.read(&mut byte))
+                .await
+                .is_err(),
+            "upstream saw EOF before it sent the response"
+        );
+        stream.write_all(OK_RESPONSE).await.unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    client
+        .write_all(
+            format!("GET http://{origin_addr}/ HTTP/1.1\r\nHost: {origin_addr}\r\n\r\n").as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert!(response.ends_with(b"OK"));
+    origin_task.await.unwrap();
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn final_response_stops_an_incomplete_request_upload() {
+    const TOO_LARGE: &[u8] = b"HTTP/1.1 413 Content Too Large\r\nContent-Length: 0\r\n\r\n";
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before sending request headers");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        stream.write_all(TOO_LARGE).await.unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    client
+        .write_all(
+            format!(
+                "POST http://{origin_addr}/upload HTTP/1.1\r\n\
+                 Host: {origin_addr}\r\n\
+                 Content-Length: 100\r\n\r\n"
+            )
+            .as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert_eq!(
+        response,
+        b"HTTP/1.1 413 Content Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    );
+    origin_task.await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), handler)
+        .await
+        .expect("proxy retained an incomplete upload after the final response")
+        .unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn client_eof_reaps_a_silent_origin_without_half_closing_it_early() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let (request_seen_tx, request_seen_rx) = oneshot::channel();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the request");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        request_seen_tx.send(()).unwrap();
+
+        let mut byte = [0u8; 1];
+        assert_eq!(
+            stream.read(&mut byte).await.unwrap(),
+            0,
+            "proxy forwarded bytes beyond the request boundary"
+        );
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let mut handler = spawn_proxy_handler(server_stream).await;
+    client
+        .write_all(
+            format!("GET http://{origin_addr}/ HTTP/1.1\r\nHost: {origin_addr}\r\n\r\n").as_bytes(),
+        )
+        .await
+        .unwrap();
+    request_seen_rx.await.unwrap();
+    // Keep the client write half open until the origin has received the
+    // request. Otherwise Tokio's paused clock can auto-advance to the relay
+    // timer while this task is still waiting on the oneshot.
+    client.shutdown().await.unwrap();
+
+    // Drive the socket-read wakeup through the HTTP adapter and relay before
+    // moving the paused clock; the linger deadline is created only after that
+    // direction reports `Done`.
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !handler.is_finished(),
+        "client EOF half-closed the upstream before it could respond"
+    );
+    tokio::time::advance(meow_tunnel::relay::RELAY_HALF_CLOSE_LINGER - Duration::from_millis(1))
+        .await;
+    tokio::task::yield_now().await;
+    assert!(
+        !handler.is_finished(),
+        "silent upstream was reaped before the half-close linger"
+    );
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::time::timeout(Duration::from_secs(1), &mut handler)
+        .await
+        .expect("client EOF did not arm the half-close linger")
+        .unwrap();
+    origin_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn queued_pipeline_does_not_reset_a_large_response() {
+    const BODY_LEN: usize = 1024 * 1024;
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the request");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        assert!(!request.windows(5).any(|window| window == b"/next"));
+
+        stream
+            .write_all(format!("HTTP/1.1 200 OK\r\nContent-Length: {BODY_LEN}\r\n\r\n").as_bytes())
+            .await
+            .unwrap();
+        stream.write_all(&vec![b'x'; BODY_LEN]).await.unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    let padding = "p".repeat(16 * 1024);
+    let requests = format!(
+        "GET http://{origin_addr}/large HTTP/1.1\r\nHost: {origin_addr}\r\n\r\n\
+         GET http://example.invalid/next HTTP/1.1\r\nHost: example.invalid\r\nX-Pad: {padding}\r\n\r\n"
+    );
+    client.write_all(requests.as_bytes()).await.unwrap();
+
+    // Let the origin fill the proxy's client-facing send buffer before this
+    // client starts consuming the response. Unread pipelined request bytes at
+    // close used to turn that close into an RST and truncate the response.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let response = read_response_and_wait_for_close(&mut client).await;
+    let body_start = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .unwrap()
+        + 4;
+    assert_eq!(response.len() - body_start, BODY_LEN);
+    assert!(response[body_start..].iter().all(|byte| *byte == b'x'));
+    origin_task.await.unwrap();
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn expect_continue_forwards_the_body_after_the_interim_response() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding request headers");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        assert!(request
+            .windows(b"Expect: 100-continue".len())
+            .any(|window| window.eq_ignore_ascii_case(b"Expect: 100-continue")));
+        stream
+            .write_all(b"HTTP/1.1 100 Continue\r\n\r\n")
+            .await
+            .unwrap();
+
+        let body_start = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .unwrap()
+            + 4;
+        while request.len() - body_start < 5 {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the request body");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        assert_eq!(&request[body_start..body_start + 5], b"hello");
+        stream.write_all(OK_RESPONSE).await.unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    client
+        .write_all(
+            format!(
+                "POST http://{origin_addr}/upload HTTP/1.1\r\n\
+                 Host: {origin_addr}\r\n\
+                 Content-Length: 5\r\n\
+                 Expect: 100-continue\r\n\r\n"
+            )
+            .as_bytes(),
+        )
+        .await
+        .unwrap();
+    let mut interim = vec![0u8; b"HTTP/1.1 100 Continue\r\n\r\n".len()];
+    client.read_exact(&mut interim).await.unwrap();
+    assert_eq!(interim, b"HTTP/1.1 100 Continue\r\n\r\n");
+    client.write_all(b"hello").await.unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert_eq!(
+        response,
+        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+    );
+    origin_task.await.unwrap();
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn http_1_0_request_and_split_response_head_are_supported() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the request");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        assert!(request.starts_with(b"GET /legacy HTTP/1.0\r\n"));
+        stream.write_all(b"HTTP/1.0 200 OK\r").await.unwrap();
+        tokio::task::yield_now().await;
+        stream
+            .write_all(b"\nContent-Length: 2\r\n\r\nOK")
+            .await
+            .unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    client
+        .write_all(
+            format!("GET http://{origin_addr}/legacy HTTP/1.0\r\nHost: {origin_addr}\r\n\r\n")
+                .as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert_eq!(
+        response,
+        b"HTTP/1.0 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+    );
+    origin_task.await.unwrap();
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn websocket_upgrade_switches_to_an_opaque_tunnel() {
+    const CLIENT_FRAME: &[u8] = b"client-frame";
+    const SERVER_FRAME: &[u8] = b"server-frame";
+
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the upgrade");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        assert_eq!(
+            request,
+            format!(
+                "GET /chat HTTP/1.1\r\n\
+                 Host: {origin_addr}\r\n\
+                 Upgrade: websocket\r\n\
+                 Connection: upgrade\r\n\r\n"
+            )
+            .as_bytes()
+        );
+
+        let mut byte = [0u8; 1];
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), stream.read(&mut byte))
+                .await
+                .is_err(),
+            "client protocol bytes reached the origin before its 101 response"
+        );
+        stream
+            .write_all(
+                b"HTTP/1.1 101 Switching Protocols\r\n\
+                  Connection: Upgrade, X-Origin-Hop\r\n\
+                  Upgrade: websocket\r\n\
+                  X-Origin-Hop: drop-me\r\n\
+                  X-End-To-End: kept\r\n\r\n",
+            )
+            .await
+            .unwrap();
+
+        let mut client_frame = [0u8; CLIENT_FRAME.len()];
+        stream.read_exact(&mut client_frame).await.unwrap();
+        assert_eq!(&client_frame, CLIENT_FRAME);
+        stream.write_all(SERVER_FRAME).await.unwrap();
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), stream.read(&mut byte))
+                .await
+                .expect("client half-close was not forwarded through the upgraded tunnel")
+                .unwrap(),
+            0
+        );
+        stream.shutdown().await.unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    let request = format!(
+        "GET ws://{origin_addr}/chat HTTP/1.1\r\n\
+         Host: {origin_addr}\r\n\
+         Connection: keep-alive, Upgrade, X-Hop\r\n\
+         Upgrade: websocket\r\n\
+         X-Hop: drop-me\r\n\r\n"
+    );
+    client.write_all(request.as_bytes()).await.unwrap();
+    // Exercise bytes coalesced with the request head: they must be held until
+    // the origin has accepted the protocol switch, then relayed losslessly.
+    client.write_all(CLIENT_FRAME).await.unwrap();
+
+    let mut response_head = Vec::new();
+    while !response_head.windows(4).any(|window| window == b"\r\n\r\n") {
+        response_head.push(client.read_u8().await.unwrap());
+    }
+    assert_eq!(
+        response_head,
+        b"HTTP/1.1 101 Switching Protocols\r\n\
+          Upgrade: websocket\r\n\
+          X-End-To-End: kept\r\n\
+          Connection: upgrade\r\n\r\n"
+    );
+
+    let mut server_frame = [0u8; SERVER_FRAME.len()];
+    client.read_exact(&mut server_frame).await.unwrap();
+    assert_eq!(&server_frame, SERVER_FRAME);
+    client.shutdown().await.unwrap();
+
+    origin_task.await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), handler)
+        .await
+        .expect("upgraded relay did not close after both peers finished")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn declined_upgrade_closes_without_forwarding_protocol_bytes() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the upgrade");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut trailing = Vec::new();
+        tokio::time::timeout(Duration::from_secs(1), stream.read_to_end(&mut trailing))
+            .await
+            .expect("proxy did not half-close a declined upgrade")
+            .unwrap();
+        assert!(
+            trailing.is_empty(),
+            "protocol bytes were forwarded without a 101 response"
+        );
+        stream.write_all(b"OK").await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    let request = format!(
+        "GET http://{origin_addr}/chat HTTP/1.1\r\n\
+         Host: {origin_addr}\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\r\n"
+    );
+    client.write_all(request.as_bytes()).await.unwrap();
+    client.write_all(b"must-not-leak").await.unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert_eq!(
+        response,
+        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+    );
+    origin_task.await.unwrap();
+    handler.await.unwrap();
+}

--- a/crates/meow-listener/tests/http_single_request.rs
+++ b/crates/meow-listener/tests/http_single_request.rs
@@ -670,6 +670,94 @@ async fn declined_upgrade_closes_without_forwarding_protocol_bytes() {
     handler.await.unwrap();
 }
 
+#[tokio::test]
+async fn rejected_response_head_becomes_a_502() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the request");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        // A response head larger than the proxy's cap, never terminated.
+        // The proxy may drop the connection mid-write; ignore write errors.
+        let huge = format!("HTTP/1.1 200 OK\r\nX-Big: {}\r\n", "p".repeat(16 * 1024));
+        let _ = stream.write_all(huge.as_bytes()).await;
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    client
+        .write_all(
+            format!("GET http://{origin_addr}/ HTTP/1.1\r\nHost: {origin_addr}\r\n\r\n").as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert_eq!(
+        response, b"HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+        "a rejected upstream response head must yield an explicit 502, not a silent close"
+    );
+    origin_task.await.unwrap();
+    handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn interim_response_hop_by_hop_headers_are_stripped() {
+    let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let origin_addr = origin.local_addr().unwrap();
+    let origin_task = tokio::spawn(async move {
+        let (mut stream, _) = origin.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let mut chunk = [0u8; 1024];
+            let count = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "proxy closed before forwarding the request");
+            request.extend_from_slice(&chunk[..count]);
+        }
+        stream
+            .write_all(
+                b"HTTP/1.1 103 Early Hints\r\n\
+                  Connection: keep-alive, X-Hop\r\n\
+                  Keep-Alive: timeout=99\r\n\
+                  X-Hop: secret\r\n\
+                  Link: </style.css>; rel=preload\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK")
+            .await
+            .unwrap();
+    });
+
+    let (server_stream, mut client) = loopback_pair().await;
+    let handler = spawn_proxy_handler(server_stream).await;
+    client
+        .write_all(
+            format!("GET http://{origin_addr}/ HTTP/1.1\r\nHost: {origin_addr}\r\n\r\n").as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    let response = read_response_and_wait_for_close(&mut client).await;
+    assert_eq!(
+        response,
+        b"HTTP/1.1 103 Early Hints\r\n\
+          Link: </style.css>; rel=preload\r\n\r\n\
+          HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+            .as_slice(),
+        "interim hop-by-hop headers must not reach the client"
+    );
+    origin_task.await.unwrap();
+    handler.await.unwrap();
+}
+
 #[tokio::test(start_paused = true)]
 async fn abandoned_upgrade_is_reaped_by_the_half_close_linger() {
     let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
## Summary

- limit each non-upgraded plain HTTP client connection to one framed request while leaving CONNECT tunnels unchanged
- force `Connection: close` upstream and rewrite the final response with close semantics for the client
- strip `Connection`, `Keep-Alive`, proxy fields, and Connection-nominated hop-by-hop fields
- forward exactly the declared Content-Length or chunked body, including trailers, while withholding and draining pipelined request bytes
- preserve informational responses before rewriting the final response
- preserve valid bodyless HTTP/1.1 Upgrade requests, including `ws://`, and switch to an opaque tunnel only after a validated `101`
- observe client EOF after the request boundary so silent origins are reaped by the relay linger

## Behavior and tradeoffs

This branch is rebased onto `main`, which already contains the strict byte-oriented parser from #369.

The one-request safety fallback opens a fresh outbound connection for every ordinary plain HTTP request and can repeat an encrypted adapter handshake. A future per-request routing loop can recover connection reuse while still rerouting every request independently.

For Upgrade handshakes, the proxy preserves and normalizes `Connection: upgrade` and `Upgrade`, removes other hop-by-hop fields, and withholds client protocol bytes until the origin returns a valid `101 Switching Protocols`. It then forwards those held bytes and resumes ordinary bidirectional tunnel and half-close semantics. If the origin declines the Upgrade with a normal final response, the proxy does not forward the held protocol bytes and completes that response with `Connection: close`.

After an ordinary framed request body, the proxy drains and discards at most 64 KiB of client data. Client EOF completes the upload relay direction and arms the existing half-close linger; an upstream shutdown gate prevents that EOF from sending early TLS close semantics before the final response. Once the final response is complete, the proxy drains currently queued client bytes and closes as soon as the socket becomes idle, preventing unread pipeline data from resetting and truncating a large response.

## Footprint

Measured with `RUSTC_BOOTSTRAP=1 cargo rustc -p meow-listener --lib -- -Zprint-type-sizes`:

| revision | `handle_http_inner` | `handle_http` | `SingleRequestClient` |
|---|---:|---:|---:|
| `origin/main` (`7c43cbb`) | 19,184 B | 19,376 B | n/a |
| final (`223915b`) | 19,176 B | 19,368 B | 9,344 B |

The response and discard buffers live only in the boxed plain-HTTP state machine. This adds one plain-HTTP-only setup allocation, leaves the final connection future 8 B smaller than current `main`, and keeps CONNECT free of the 9,344 B state. `Box<SingleRequestClient>` is 8 B; the relay helper and both caller-supplied 4,096 B relay buffers remain allocation-free.

## Tests

- pipelined requests to different origins cannot enter the first origin connection
- split Content-Length bodies stop exactly before a pipelined request
- chunked bodies and trailers stop exactly before a pipelined request
- final responses replace hop-by-hop headers after informational responses
- client EOF arms half-close linger without half-closing the upstream adapter early
- queued pipeline data does not reset or truncate a 1 MiB response
- `Expect: 100-continue` forwards a body sent after the interim response
- HTTP/1.0 requests and response heads split across upstream writes are supported
- response Connection options reject framing-field nominations and accept empty list elements
- a real `ws://` Upgrade holds early protocol bytes until a validated `101`, then relays them losslessly
- a declined Upgrade closes without forwarding early protocol bytes
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib`
- `cargo test -p meow-listener` (48 unit tests plus 12 single-request integration tests and the remaining listener integration suites)

## Attribution

Discovered by Opus 5; verified by GPT-5.6-sol xhigh.

Fixes #367
