### PR TITLE
fix(config): apply group-level filter/exclude-filter/exclude-type to provider members

### DIFF
--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1742,9 +1742,19 @@ fn parse_proxy_group_inner(
         }
     }
 
+    // Group-level filter/exclude-filter/exclude-type (issue #358): applies to
+    // provider-sourced members only, mirroring mihomo (static `proxies:`
+    // members bypass it — upstream never filters compatible providers).
+    let group_filter = crate::proxy_provider::GroupFilter::from_raw_group(config)
+        .map_err(|e| format!("group '{}': {e}", config.name))?;
+    let provider_slot = |p: &Arc<crate::proxy_provider::ProxyProvider>| match &group_filter {
+        Some(f) => p.derived_slot(f),
+        None => Arc::clone(&p.slot),
+    };
+
     // Collect provider slots: include_all wires every provider; use: wires specific ones.
     let slots: Vec<meow_common::ProviderSlot> = if config.include_all.unwrap_or(false) {
-        providers.values().map(|p| Arc::clone(&p.slot)).collect()
+        providers.values().map(&provider_slot).collect()
     } else {
         config
             .use_providers
@@ -1753,7 +1763,7 @@ fn parse_proxy_group_inner(
             .iter()
             .filter_map(|pname| {
                 if let Some(p) = providers.get(pname.as_str()) {
-                    Some(Arc::clone(&p.slot))
+                    Some(provider_slot(p))
                 } else {
                     tracing::warn!(
                         "proxy-provider '{}' not found for group '{}', skipping",
@@ -2378,6 +2388,94 @@ tls: true
         };
         parse_proxy_group(&config, &existing, &Default::default())
             .expect("relay with url+interval must not hard-error");
+    }
+
+    // ─── group-level filter on provider members (issue #358) ────────────────
+
+    #[cfg(feature = "ss")]
+    async fn file_provider_with(
+        path: &std::path::Path,
+        entries: &str,
+    ) -> HashMap<String, Arc<crate::proxy_provider::ProxyProvider>> {
+        std::fs::write(path, entries).unwrap();
+        let raw = crate::raw::RawProxyProvider {
+            provider_type: "file".to_string(),
+            url: None,
+            path: Some(path.to_str().unwrap().to_string()),
+            interval: None,
+            filter: None,
+            exclude_filter: None,
+            exclude_type: None,
+            health_check: None,
+            header: None,
+        };
+        let provider = crate::proxy_provider::ProxyProvider::new("airport", &raw, None).unwrap();
+        provider.refresh().await.unwrap();
+        let mut providers = HashMap::new();
+        providers.insert("airport".to_string(), Arc::new(provider));
+        providers
+    }
+
+    #[cfg(feature = "ss")]
+    const PROVIDER_YAML: &str = "proxies:\n\
+        - {name: \"US 1\", type: ss, server: 127.0.0.1, port: 443, cipher: aes-128-gcm, password: p}\n\
+        - {name: \"US 2 expat\", type: ss, server: 127.0.0.1, port: 443, cipher: aes-128-gcm, password: p}\n\
+        - {name: \"HK 1\", type: ss, server: 127.0.0.1, port: 443, cipher: aes-128-gcm, password: p}\n";
+
+    #[cfg(feature = "ss")]
+    #[tokio::test]
+    async fn group_filter_applies_to_provider_members() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let providers = file_provider_with(tmp.path(), PROVIDER_YAML).await;
+
+        let config = crate::raw::RawProxyGroup {
+            name: "US".to_string(),
+            group_type: "url-test".to_string(),
+            use_providers: Some(vec!["airport".to_string()]),
+            filter: Some("(?i)^us".to_string()),
+            exclude_filter: Some("expat".to_string()),
+            ..Default::default()
+        };
+        let group = parse_proxy_group(&config, &HashMap::new(), &providers).unwrap();
+        assert_eq!(group.members().unwrap(), ["US 1"]);
+    }
+
+    #[cfg(feature = "ss")]
+    #[tokio::test]
+    async fn group_without_filter_sees_all_provider_members() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let providers = file_provider_with(tmp.path(), PROVIDER_YAML).await;
+
+        let config = crate::raw::RawProxyGroup {
+            name: "ALL".to_string(),
+            group_type: "select".to_string(),
+            use_providers: Some(vec!["airport".to_string()]),
+            ..Default::default()
+        };
+        let group = parse_proxy_group(&config, &HashMap::new(), &providers).unwrap();
+        assert_eq!(group.members().unwrap(), ["US 1", "US 2 expat", "HK 1"]);
+    }
+
+    #[cfg(feature = "ss")]
+    #[tokio::test]
+    async fn group_filter_invalid_regex_errors_with_group_name() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let providers = file_provider_with(tmp.path(), PROVIDER_YAML).await;
+
+        let config = crate::raw::RawProxyGroup {
+            name: "US".to_string(),
+            group_type: "select".to_string(),
+            use_providers: Some(vec!["airport".to_string()]),
+            filter: Some("(".to_string()),
+            ..Default::default()
+        };
+        let err = parse_proxy_group(&config, &HashMap::new(), &providers)
+            .err()
+            .expect("invalid filter regex must error");
+        assert!(
+            err.contains("group 'US'") && err.contains("filter regex error"),
+            "unexpected error: {err}"
+        );
     }
 
     // ─── snell proxy parser ───────────────────────────────────────────────────

--- a/crates/meow-config/src/proxy_provider.rs
+++ b/crates/meow-config/src/proxy_provider.rs
@@ -29,6 +29,83 @@ pub struct ProxyProvider {
     pub health_check: Option<HealthCheckConfig>,
     updated_at: AtomicU,
     header: HashMap<String, String>,
+    /// Group-level filtered views of `slot` (issue #358), re-populated on
+    /// every refresh. Weak: each view is kept alive by the group built from
+    /// it, so views belonging to dropped or rebuilt groups get pruned here.
+    derived: RwLock<Vec<(GroupFilter, WeakSlot)>>,
+}
+
+/// Weak counterpart of [`ProviderSlot`].
+type WeakSlot = std::sync::Weak<RwLock<Vec<Arc<dyn Proxy>>>>;
+
+/// Compiled group-level member filter (issue #358): the `filter`,
+/// `exclude-filter`, and `exclude-type` fields declared on a proxy-group
+/// apply to the proxies that group pulls from providers (`use:` /
+/// `include-all`), mirroring mihomo. Static `proxies:` members bypass the
+/// filter, also matching upstream (compatible providers are not filtered).
+#[derive(Clone, Debug)]
+pub struct GroupFilter {
+    filter: Option<regex::Regex>,
+    exclude_filter: Option<regex::Regex>,
+    exclude_type: Vec<String>,
+}
+
+impl GroupFilter {
+    /// Compile the filter fields of a raw proxy-group. Returns `Ok(None)`
+    /// when the group declares no filtering at all.
+    pub fn from_raw_group(raw: &crate::raw::RawProxyGroup) -> Result<Option<Self>, String> {
+        let filter = compile_opt_regex(&raw.filter, "filter")?;
+        let exclude_filter = compile_opt_regex(&raw.exclude_filter, "exclude-filter")?;
+        let exclude_type = split_exclude_types(raw.exclude_type.as_deref());
+        if filter.is_none() && exclude_filter.is_none() && exclude_type.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            filter,
+            exclude_filter,
+            exclude_type,
+        }))
+    }
+
+    fn keep(&self, proxy: &dyn Proxy) -> bool {
+        let name = proxy.name();
+        if let Some(re) = &self.filter {
+            if !re.is_match(name) {
+                return false;
+            }
+        }
+        if let Some(re) = &self.exclude_filter {
+            if re.is_match(name) {
+                return false;
+            }
+        }
+        !self
+            .exclude_type
+            .iter()
+            .any(|t| adapter_type_matches(t, proxy.adapter_type()))
+    }
+}
+
+/// Match an `exclude-type` token against a parsed adapter's type. Accepts
+/// both the adapter display name ("Shadowsocks") and the config-file alias
+/// ("ss") so either spelling works, case-insensitively.
+fn adapter_type_matches(token: &str, adapter_type: meow_common::AdapterType) -> bool {
+    if token.eq_ignore_ascii_case(&adapter_type.to_string()) {
+        return true;
+    }
+    matches!(adapter_type, meow_common::AdapterType::Shadowsocks)
+        && token.eq_ignore_ascii_case("ss")
+}
+
+/// `exclude-type` accepts a YAML list or a mihomo-style `|`-separated string
+/// ("ss|http"); flatten both into lowercase tokens.
+fn split_exclude_types(raw: Option<&[String]>) -> Vec<String> {
+    raw.unwrap_or(&[])
+        .iter()
+        .flat_map(|s| s.split('|'))
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 enum Vehicle {
@@ -88,13 +165,7 @@ impl ProxyProvider {
 
         let filter = compile_opt_regex(&raw.filter, "filter")?;
         let exclude_filter = compile_opt_regex(&raw.exclude_filter, "exclude-filter")?;
-        let exclude_type: Vec<String> = raw
-            .exclude_type
-            .as_deref()
-            .unwrap_or(&[])
-            .iter()
-            .map(|s| s.to_lowercase())
-            .collect();
+        let exclude_type = split_exclude_types(raw.exclude_type.as_deref());
 
         let health_check = build_health_check_config(raw.health_check.as_ref());
         let header = raw.header.clone().unwrap_or_default();
@@ -110,7 +181,41 @@ impl ProxyProvider {
             health_check,
             updated_at: AtomicU::new(0),
             header,
+            derived: RwLock::new(Vec::new()),
         })
+    }
+
+    /// Create a live filtered view of this provider's proxies for one group
+    /// (issue #358). The view is seeded from the current slot contents and
+    /// re-populated on every [`refresh`](Self::refresh).
+    pub fn derived_slot(&self, filter: &GroupFilter) -> ProviderSlot {
+        let seeded: Vec<Arc<dyn Proxy>> = self
+            .slot
+            .read()
+            .iter()
+            .filter(|p| filter.keep(p.as_ref()))
+            .map(Arc::clone)
+            .collect();
+        let slot: ProviderSlot = Arc::new(RwLock::new(seeded));
+        self.derived
+            .write()
+            .push((filter.clone(), Arc::downgrade(&slot)));
+        slot
+    }
+
+    fn update_derived(&self, proxies: &[Arc<dyn Proxy>]) {
+        let mut derived = self.derived.write();
+        derived.retain(|(filter, weak)| {
+            let Some(slot) = weak.upgrade() else {
+                return false;
+            };
+            *slot.write() = proxies
+                .iter()
+                .filter(|p| filter.keep(p.as_ref()))
+                .map(Arc::clone)
+                .collect();
+            true
+        });
     }
 
     async fn fetch_content(&self) -> Result<String, String> {
@@ -236,6 +341,7 @@ impl ProxyProvider {
             Ok(content) => {
                 let proxies = self.parse_proxies(&content).await;
                 info!(provider = %self.name, count = proxies.len(), "proxy-provider refreshed");
+                self.update_derived(&proxies);
                 *self.slot.write() = proxies;
                 self.updated_at.store(
                     SystemTime::now()
@@ -255,6 +361,11 @@ impl ProxyProvider {
 
     pub fn proxies(&self) -> Vec<Arc<dyn Proxy>> {
         self.slot.read().clone()
+    }
+
+    #[cfg(test)]
+    fn derived_len(&self) -> usize {
+        self.derived.read().len()
     }
 
     pub fn updated_at_secs(&self) -> u64 {
@@ -291,9 +402,15 @@ fn compile_opt_regex(
     field: &str,
 ) -> Result<Option<regex::Regex>, String> {
     match pattern.as_deref() {
-        Some(p) => regex::Regex::new(p)
-            .map(Some)
-            .map_err(|e| format!("{field} regex error: {e}")),
+        Some(p) => regex::Regex::new(p).map(Some).map_err(|e| {
+            let hint = if ["(?!", "(?=", "(?<"].iter().any(|la| p.contains(la)) {
+                "; look-around assertions are not supported — split the pattern \
+                 into `filter` + `exclude-filter` instead"
+            } else {
+                ""
+            };
+            format!("{field} regex error: {e}{hint}")
+        }),
         None => Ok(None),
     }
 }
@@ -394,5 +511,124 @@ header:
         assert!(raw.header.is_none());
         let p = ProxyProvider::new("p", &raw, None).unwrap();
         assert!(p.header.is_empty());
+    }
+
+    fn group_filter(
+        filter: Option<&str>,
+        exclude_filter: Option<&str>,
+        exclude_type: Option<&[&str]>,
+    ) -> GroupFilter {
+        let raw = crate::raw::RawProxyGroup {
+            name: "g".to_string(),
+            group_type: "select".to_string(),
+            filter: filter.map(str::to_string),
+            exclude_filter: exclude_filter.map(str::to_string),
+            exclude_type: exclude_type.map(|v| v.iter().map(|s| (*s).to_string()).collect()),
+            ..Default::default()
+        };
+        GroupFilter::from_raw_group(&raw).unwrap().unwrap()
+    }
+
+    fn write_provider_file(path: &std::path::Path, entries: &[(&str, &str)]) {
+        use std::fmt::Write as _;
+        let mut yaml = String::from("proxies:\n");
+        for (name, ty) in entries {
+            writeln!(
+                yaml,
+                "  - {{name: \"{name}\", type: {ty}, server: 127.0.0.1, port: 443, \
+                 cipher: aes-128-gcm, password: pass}}"
+            )
+            .unwrap();
+        }
+        std::fs::write(path, yaml).unwrap();
+    }
+
+    fn slot_names(slot: &ProviderSlot) -> Vec<String> {
+        slot.read().iter().map(|p| p.name().to_string()).collect()
+    }
+
+    async fn file_provider(path: &std::path::Path) -> ProxyProvider {
+        let raw = raw_file_provider(path.to_str().unwrap());
+        let p = ProxyProvider::new("airport", &raw, None).unwrap();
+        p.refresh().await.unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn derived_slot_applies_group_filter() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_provider_file(
+            tmp.path(),
+            &[("US 1", "ss"), ("US 2", "ss"), ("HK 1", "ss")],
+        );
+        let provider = file_provider(tmp.path()).await;
+
+        let f = group_filter(Some("(?i)us"), Some("2"), None);
+        let derived = provider.derived_slot(&f);
+        assert_eq!(slot_names(&derived), ["US 1"]);
+        // The provider's own slot stays unfiltered.
+        assert_eq!(provider.proxies().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn derived_slot_updates_on_refresh_and_prunes_dropped_views() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_provider_file(tmp.path(), &[("US 1", "ss"), ("HK 1", "ss")]);
+        let provider = file_provider(tmp.path()).await;
+
+        let f = group_filter(Some("US"), None, None);
+        let derived = provider.derived_slot(&f);
+        assert_eq!(slot_names(&derived), ["US 1"]);
+
+        write_provider_file(
+            tmp.path(),
+            &[("US 1", "ss"), ("US 9", "ss"), ("HK 2", "ss")],
+        );
+        provider.refresh().await.unwrap();
+        assert_eq!(slot_names(&derived), ["US 1", "US 9"]);
+
+        drop(derived);
+        provider.refresh().await.unwrap();
+        assert_eq!(provider.derived_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn derived_slot_exclude_type_accepts_alias_and_display_name() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_provider_file(tmp.path(), &[("US ss", "ss"), ("US direct", "direct")]);
+        let provider = file_provider(tmp.path()).await;
+
+        // Note: parse_direct keeps DirectAdapter's hardcoded "DIRECT" name.
+        let by_alias = provider.derived_slot(&group_filter(None, None, Some(&["ss"])));
+        assert_eq!(slot_names(&by_alias), ["DIRECT"]);
+
+        let by_display = provider.derived_slot(&group_filter(None, None, Some(&["Shadowsocks"])));
+        assert_eq!(slot_names(&by_display), ["DIRECT"]);
+
+        // mihomo-style `|`-separated string form.
+        let piped = provider.derived_slot(&group_filter(None, None, Some(&["ss|direct"])));
+        assert!(slot_names(&piped).is_empty());
+    }
+
+    #[test]
+    fn group_filter_absent_fields_yield_none() {
+        let raw = crate::raw::RawProxyGroup {
+            name: "g".to_string(),
+            group_type: "select".to_string(),
+            ..Default::default()
+        };
+        assert!(GroupFilter::from_raw_group(&raw).unwrap().is_none());
+    }
+
+    #[test]
+    fn group_filter_lookahead_error_carries_hint() {
+        let raw = crate::raw::RawProxyGroup {
+            name: "g".to_string(),
+            group_type: "select".to_string(),
+            filter: Some("^(?!.*expat).*US".to_string()),
+            ..Default::default()
+        };
+        let err = GroupFilter::from_raw_group(&raw).unwrap_err();
+        assert!(err.contains("look-around"), "unexpected error: {err}");
     }
 }

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -279,9 +279,9 @@ Missing: `respect-rules`, `prefer-h3`, `cache-algorithm`.
 
 ### Proxy group sub-keys
 
-Supported: `name`, `type`, `proxies`, `url`, `interval`, `tolerance`.
+Supported: `name`, `type`, `proxies`, `url`, `interval`, `tolerance`, `expected-status`, `strategy` (for load-balance), `use` (proxy-provider reference), `include-all`, `include-all-proxies`, `filter`, `exclude-filter`, `exclude-type` (group-level, applied to provider-sourced members; issue #358).
 
-Missing: `lazy`, `disable-udp`, `filter`, `exclude-filter`, `exclude-type`, `hidden`, `icon`, `strategy` (for load-balance), `use` (proxy-provider reference), `include-all`, `include-all-proxies`, `include-all-providers`, `expected-status`.
+Missing: `lazy`, `disable-udp`, `hidden`, `icon`, `include-all-providers`.
 
 ---
 

--- a/docs/specs/proxy-providers.md
+++ b/docs/specs/proxy-providers.md
@@ -170,9 +170,9 @@ proxy-groups:
 | `use` | `[]string` | no | `[]` | Provider names to merge into this group's proxy list. Unknown provider name = warn-once at load (not a hard error — the provider may not be defined in all config variants). |
 | `include-all` | bool | no | `false` | If true, merge proxies from all defined providers. Equivalent to listing every provider name in `use:`. |
 | `include-all-proxies` | bool | no | `false` | Upstream alias for `include-all`; accepted, warn-once "use include-all:", treated identically. |
-| `filter` | string | no | `""` | Applied to all proxies in the group (both explicit and from providers). |
-| `exclude-filter` | string | no | `""` | Applied after `filter`. |
-| `exclude-type` | string | no | `""` | Applied after `filter`/`exclude-filter`. |
+| `filter` | string | no | `""` | Applied to provider-sourced members only (`use:` / `include-all`), matching upstream mihomo — explicit `proxies:` entries are never filtered (otherwise `proxies: [DIRECT]` + `filter: "^HK"` would drop DIRECT). |
+| `exclude-filter` | string | no | `""` | Applied after `filter`. Provider-sourced members only. |
+| `exclude-type` | string | no | `""` | Applied after `filter`/`exclude-filter`. Provider-sourced members only. |
 
 ### Override
 


### PR DESCRIPTION
Fixes #358.

## Problem

`filter` / `exclude-filter` / `exclude-type` on `proxy-groups` were parsed into `RawProxyGroup` but never applied — `parse_proxy_group_inner` wired each provider's raw `ProviderSlot` straight into the group, so every provider proxy appeared in every group.

## Fix

- `ProxyProvider` can now hand out **derived slots**: live filtered views of its proxy list. They are seeded from the current contents, re-populated on every provider refresh, and held weakly so views owned by dropped/rebuilt groups are pruned automatically.
- `parse_proxy_group_inner` compiles the group's filter fields into a `GroupFilter` once and wires a derived slot per provider (both `use:` and `include-all:` paths). Groups keep consuming plain `ProviderSlot`s — **zero changes to group code and zero dial-time cost** (filtering runs once per refresh, not per read).

## Semantics (mihomo-compatible)

- The group filter applies to **provider-sourced members only**; explicit `proxies:` entries bypass it, matching upstream (compatible providers are never filtered — otherwise `proxies: [DIRECT]` + `filter: "^HK"` would drop DIRECT). Corrected the stale spec table in `docs/specs/proxy-providers.md` accordingly.
- Group filter composes on top of the provider-level filter (derived views are built from the provider's already-filtered list).
- `exclude-type` accepts the config alias (`ss`) and the adapter display name (`Shadowsocks`), case-insensitively, in both YAML-list and mihomo `|`-separated string forms. The `|`-splitting also fixes provider-level `exclude-type: "ss|http"`, which previously compared the unsplit string and never matched.

## Caveat: look-around regexes

The issue's example filter uses `(?!...)` (negative lookahead), which the Rust `regex` crate intentionally doesn't support (mihomo uses backtracking regexp2). Such patterns now fail with an explicit hint to split into `filter` + `exclude-filter`, which expresses the same thing:

```yaml
filter: "(?i)美|波特兰|达拉斯|…|US|United States"
exclude-filter: "仅海外用户"
```

If full look-around support is wanted for parity, that's a separate decision (`fancy-regex` dependency, ADR-0007 binary-size impact) — happy to file a follow-up issue.

## Tests

- `derived_slot_applies_group_filter`, `derived_slot_updates_on_refresh_and_prunes_dropped_views`, `derived_slot_exclude_type_accepts_alias_and_display_name`, `group_filter_absent_fields_yield_none`, `group_filter_lookahead_error_carries_hint` (provider side)
- `group_filter_applies_to_provider_members`, `group_without_filter_sees_all_provider_members`, `group_filter_invalid_regex_errors_with_group_name` (end-to-end through `parse_proxy_group`)

Full regression bar green locally: `cargo fmt --check`, three-way clippy (`default` / `--no-default-features` / `--all-features`) with `-D warnings`, `cargo doc -D warnings`, `cargo test --lib` (all 12 suites).

No ADR-0011 key types or relay hot paths touched; `Metadata`/`ConnectionInfo`/`UdpSession`/DNS cache entries unchanged.