### PR TITLE
Fix open issues: RUSTSEC-2026-0221, traffic sampling, mihomo parity (#377)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,10 @@ jobs:
 
       - name: Install ssserver
         if: steps.cache-ssserver.outputs.cache-hit != 'true'
-        run: cargo install shadowsocks-rust --features "stream-cipher aead-cipher-2022" --locked
+        # --force: on a Cargo.lock change this step's cache misses, but the
+        # rust-cache restore may already have an ssserver in ~/.cargo/bin,
+        # and a plain `cargo install` refuses to overwrite it.
+        run: cargo install shadowsocks-rust --features "stream-cipher aead-cipher-2022" --locked --force
 
       - name: Install simple-obfs (obfs-local / obfs-server)
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,11 +1214,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -588,6 +588,9 @@ fn rebuild_from_raw_impl(
     apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]));
 
     let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
+    // Per-provider `proxy:` overrides resolve against the full registry —
+    // groups and provider-sourced proxies included (issue #377).
+    let registry_lookup = |name: &str| proxies.get(name).cloned();
 
     // Fetch/read rule-provider payload bytes once — the parser-context build
     // scans them for geo keys (issue #277) and the provider load below parses
@@ -597,9 +600,12 @@ fn rebuild_from_raw_impl(
         Some(p) => p,
         None => {
             owned_payloads = match raw.rule_providers.as_ref() {
-                Some(map) if !map.is_empty() => {
-                    rule_provider::prefetch_payloads(map, cache_dir, download_proxy.as_ref())
-                }
+                Some(map) if !map.is_empty() => rule_provider::prefetch_payloads(
+                    map,
+                    cache_dir,
+                    download_proxy.as_ref(),
+                    &registry_lookup,
+                ),
                 _ => HashMap::new(),
             };
             &owned_payloads
@@ -621,6 +627,7 @@ fn rebuild_from_raw_impl(
             cache_dir,
             ctx,
             download_proxy.as_ref(),
+            &registry_lookup,
             payloads,
         ),
         _ => HashMap::new(),
@@ -691,17 +698,26 @@ async fn prefetch_rule_provider_payloads_async(
         return HashMap::new();
     };
     let raw_providers = raw_providers.clone();
-    let download_proxy: Option<Arc<dyn Proxy>> = raw
-        .proxies
-        .as_deref()
-        .unwrap_or(&[])
-        .iter()
-        .find_map(|raw_proxy| proxy_parser::parse_proxy(raw_proxy).ok());
+    let raw_proxies: Vec<HashMap<String, serde_yaml::Value>> =
+        raw.proxies.clone().unwrap_or_default();
     spawn_blocking_with_current_dispatcher(move || {
+        let default_proxy: Option<Arc<dyn Proxy>> = raw_proxies
+            .iter()
+            .find_map(|raw_proxy| proxy_parser::parse_proxy(raw_proxy).ok());
+        // Pre-registry `proxy:` resolution parses the named leaf out of the
+        // raw `proxies:` block; group names don't resolve here, so their
+        // providers skip prefetch and fetch during the registry-backed load.
+        let lookup = |wanted: &str| {
+            raw_proxies
+                .iter()
+                .filter(|p| p.get("name").and_then(serde_yaml::Value::as_str) == Some(wanted))
+                .find_map(|raw_proxy| proxy_parser::parse_proxy(raw_proxy).ok())
+        };
         rule_provider::prefetch_payloads(
             &raw_providers,
             cache_dir.as_deref(),
-            download_proxy.as_ref(),
+            default_proxy.as_ref(),
+            &lookup,
         )
     })
     .await
@@ -740,14 +756,17 @@ async fn load_rule_providers_async(
     cache_dir: Option<PathBuf>,
     ctx: meow_rules::ParserContext,
     download_proxy: Option<Arc<dyn Proxy>>,
+    registry: HashMap<SmolStr, Arc<dyn Proxy>>,
     provider_payloads: Arc<rule_provider::PrefetchedPayloads>,
 ) -> Result<HashMap<String, Arc<rule_provider::RuleProvider>>, anyhow::Error> {
     spawn_blocking_with_current_dispatcher(move || {
+        let lookup = |name: &str| registry.get(name).cloned();
         rule_provider::load_providers_prefetched(
             &raw_providers,
             cache_dir.as_deref(),
             &ctx,
             download_proxy.as_ref(),
+            &lookup,
             &provider_payloads,
         )
     })
@@ -1564,6 +1583,7 @@ async fn build_config(
                 cache_dir_buf.clone(),
                 ctx.clone(),
                 download_proxy,
+                proxies.clone(),
                 provider_payloads,
             )
             .await?
@@ -1877,6 +1897,7 @@ mod geoip_context_tests {
                 url: None,
                 path: None,
                 interval: None,
+                proxy: None,
                 payload: Some(vec!["GEOIP,KR".to_string(), "GEOSITE,youtube".to_string()]),
             },
         );

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -544,15 +544,19 @@ fn parse_anytls(
 
 /// Parse a `type: hysteria2` proxy block.
 ///
-/// Required fields: `server`, `port`, `password`. Optional fields follow the
-/// mihomo surface supported by the in-tree Rust backend: `up`, `down`,
-/// `obfs: salamander`, `obfs-password`, `ports`, `hop-interval`, `sni`,
-/// `skip-cert-verify`, `fingerprint`, `udp`, and `fast-open`.
+/// Required fields: `server`, `password`, and a port source — either `port`
+/// or a concrete `ports` hopping range (mihomo accepts either, and airport
+/// subscriptions commonly omit `port` when `ports` is set; issue #377).
+/// Optional fields follow the mihomo surface supported by the in-tree Rust
+/// backend: `up`, `down`, `obfs: salamander`, `obfs-password`, `ports`,
+/// `hop-interval`, `sni`, `skip-cert-verify`, `fingerprint`, `udp`, and
+/// `fast-open`.
 ///
 /// # Hard errors (Class A per ADR-0002)
 ///
-/// - missing `server`, `port`, or `password`.
-/// - `port == 0`.
+/// - missing `server` or `password`.
+/// - no usable port: `port` absent (or 0) and `ports` absent or wildcard.
+/// - `port == 0` with no `ports` (mihomo: "invalid port").
 /// - empty `password` — caught downstream by `Hy2Adapter::new`.
 /// - unsupported security/transport options (`gecko`, mTLS, ECH, realm).
 ///
@@ -568,7 +572,11 @@ fn parse_hysteria2(
         .get("server")
         .and_then(|v| v.as_str())
         .ok_or_else(|| format!("hysteria2[{name}]: missing server"))?;
-    let port = required_port(config, &format!("hysteria2[{name}]"))?;
+    let ports = optional_nonempty_str(config, "ports");
+    if let Some(ports) = &ports {
+        validate_hy2_ports(name, ports)?;
+    }
+    let port = hy2_dial_port(name, config, ports.as_deref())?;
     let password = config
         .get("password")
         .and_then(|v| v.as_str())
@@ -601,10 +609,6 @@ fn parse_hysteria2(
         return Err(format!("hysteria2[{name}]: missing obfs-password"));
     }
 
-    let ports = optional_nonempty_str(config, "ports");
-    if let Some(ports) = &ports {
-        validate_hy2_ports(name, ports)?;
-    }
     let hop_interval = parse_hy2_hop_interval(name, config.get("hop-interval"))?;
     let fingerprint = parse_hy2_fingerprint(name, config.get("fingerprint"))?;
     let fast_open = config
@@ -712,6 +716,56 @@ fn parse_hy2_bandwidth(input: &str) -> std::result::Result<u64, String> {
 #[cfg(feature = "hysteria2")]
 fn mbps_to_bytes_per_second(mbps: u64) -> u64 {
     mbps.saturating_mul(1_000_000) / 8
+}
+
+/// Resolve the dial port for a hysteria2 outbound. `port` wins when present
+/// and non-zero; otherwise the first concrete port in the (already validated)
+/// `ports` hopping spec stands in — the hopping socket rewrites every send to
+/// the dial port with the current hop port, so the value is a placeholder
+/// whenever hopping is active. Mirrors mihomo, which errors only when both
+/// `port` and `ports` fail to yield a port (issue #377).
+#[cfg(feature = "hysteria2")]
+fn hy2_dial_port(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+    ports: Option<&str>,
+) -> std::result::Result<u16, String> {
+    let explicit = match config.get("port") {
+        None => None,
+        Some(value) => {
+            let raw = value
+                .as_u64()
+                .ok_or_else(|| format!("hysteria2[{name}]: missing port"))?;
+            let port = u16::try_from(raw)
+                .map_err(|_| format!("hysteria2[{name}]: port {raw} exceeds 65535"))?;
+            if port == 0 && ports.is_none() {
+                return Err(format!("hysteria2[{name}]: port must be non-zero"));
+            }
+            (port != 0).then_some(port)
+        }
+    };
+    if let Some(port) = explicit {
+        return Ok(port);
+    }
+    ports.and_then(first_hy2_port).ok_or_else(|| {
+        format!("hysteria2[{name}]: missing port — set 'port' or a concrete 'ports' range")
+    })
+}
+
+/// First concrete port in a validated `ports` spec; `None` for the `*`/`all`
+/// wildcard, which names no dialable port.
+#[cfg(feature = "hysteria2")]
+fn first_hy2_port(ports: &str) -> Option<u16> {
+    let ports = ports.trim();
+    if ports == "*" || ports.eq_ignore_ascii_case("all") {
+        return None;
+    }
+    let part = ports.split(',').next()?.trim();
+    let first = match part.split_once('-') {
+        Some((start, _)) => start.trim(),
+        None => part,
+    };
+    first.parse::<u16>().ok().filter(|p| *p != 0)
 }
 
 #[cfg(feature = "hysteria2")]
@@ -2112,6 +2166,48 @@ tls: true
             panic!("must hard-error");
         };
         assert!(err.contains("port must be non-zero"), "msg: {err}");
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_accepts_ports_without_port() {
+        // Airport subscriptions commonly set only a hopping range (issue #377);
+        // mihomo accepts this, so we do too — first concrete port dials.
+        let cfg = hy2_config(
+            "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nports: 20000-30000\npassword: secret\n",
+        );
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_accepts_zero_port_with_ports() {
+        let cfg = hy2_config(
+            "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 0\nports: '443,8443'\npassword: secret\n",
+        );
+        assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_rejects_missing_port_and_ports() {
+        let cfg = hy2_config("name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\npassword: secret\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("must hard-error");
+        };
+        assert!(err.contains("missing port"), "msg: {err}");
+    }
+
+    #[cfg(feature = "hysteria2")]
+    #[test]
+    fn parse_hysteria2_rejects_wildcard_ports_without_port() {
+        let cfg = hy2_config(
+            "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nports: '*'\npassword: secret\n",
+        );
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("must hard-error");
+        };
+        assert!(err.contains("missing port"), "msg: {err}");
     }
 
     #[cfg(feature = "hysteria2")]

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1204,13 +1204,7 @@ fn parse_vless(
         };
         let mut tls_cfg = TlsConfig::new(sni);
         tls_cfg.skip_cert_verify = skip_cert_verify;
-        // Default ALPN to http/1.1 for WebSocket transports (required by
-        // many CDNs like Cloudflare to route to the correct backend).
-        tls_cfg.alpn = if alpn.is_empty() && network == "ws" {
-            vec!["http/1.1".to_string()]
-        } else {
-            alpn
-        };
+        tls_cfg.alpn = default_transport_alpn(network, alpn);
         tls_cfg.fingerprint = client_fingerprint.map(std::string::ToString::to_string);
         tls_cfg.reality = reality;
 
@@ -1426,6 +1420,23 @@ fn decode_raw_url_base64_lenient(s: &str) -> Option<Vec<u8>> {
             .with_decode_allow_trailing_bits(true),
     );
     engine.decode(s).ok()
+}
+
+/// Default the TLS ALPN by transport when the user configures none:
+/// WebSocket CDNs (notably Cloudflare) route on `http/1.1`; gRPC and h2 run
+/// on HTTP/2 and many servers — xray REALITY in particular — reject a client
+/// that does not offer `h2` (issue #377). An explicit `alpn:` always wins.
+/// upstream: mihomo forces `h2` in its gun (gRPC) transport TLS config.
+#[cfg(any(feature = "vless", feature = "vmess"))]
+fn default_transport_alpn(network: &str, alpn: Vec<String>) -> Vec<String> {
+    if !alpn.is_empty() {
+        return alpn;
+    }
+    match network {
+        "ws" => vec!["http/1.1".to_string()],
+        "grpc" | "h2" => vec!["h2".to_string()],
+        _ => alpn,
+    }
 }
 
 /// Parse VLESS `reality-opts` into transport-layer REALITY parameters.
@@ -1661,11 +1672,7 @@ fn parse_vmess(
         };
         let mut tls_cfg = TlsConfig::new(sni);
         tls_cfg.skip_cert_verify = skip_cert_verify;
-        tls_cfg.alpn = if alpn.is_empty() && network == "ws" {
-            vec!["http/1.1".to_string()]
-        } else {
-            alpn
-        };
+        tls_cfg.alpn = default_transport_alpn(network, alpn);
         tls_cfg.fingerprint = client_fingerprint.map(std::string::ToString::to_string);
         let tls_layer =
             TlsLayer::new(&tls_cfg).map_err(|e| format!("vmess: TLS layer error: {e}"))?;
@@ -1959,6 +1966,32 @@ mod tests {
         assert_eq!(decoded.len(), 32);
         // Garbage is still rejected.
         assert!(decode_raw_url_base64_lenient("!!!not base64!!!").is_none());
+    }
+
+    #[cfg(any(feature = "vless", feature = "vmess"))]
+    #[test]
+    fn default_alpn_follows_transport() {
+        // Explicit alpn always wins.
+        assert_eq!(
+            default_transport_alpn("grpc", vec!["custom".to_string()]),
+            vec!["custom".to_string()]
+        );
+        // ws → http/1.1 (CDN routing); grpc/h2 → h2 (HTTP/2 transports —
+        // xray REALITY rejects clients that don't offer it, issue #377).
+        assert_eq!(
+            default_transport_alpn("ws", Vec::new()),
+            vec!["http/1.1".to_string()]
+        );
+        assert_eq!(
+            default_transport_alpn("grpc", Vec::new()),
+            vec!["h2".to_string()]
+        );
+        assert_eq!(
+            default_transport_alpn("h2", Vec::new()),
+            vec!["h2".to_string()]
+        );
+        // Plain TCP keeps ALPN absent.
+        assert!(default_transport_alpn("tcp", Vec::new()).is_empty());
     }
 
     #[test]

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -339,6 +339,11 @@ pub struct RawRuleProvider {
     pub url: Option<String>,
     pub path: Option<String>,
     pub interval: Option<u64>,
+    /// mihomo-compatible download policy for http providers (issue #377):
+    /// the name of a proxy or group to route this provider's fetches
+    /// through, or `DIRECT` to force a direct fetch. Absent = the global
+    /// default (the first proxy in `proxies:`, direct when none).
+    pub proxy: Option<String>,
     /// Inline payload: list of rule strings (only for type=inline).
     pub payload: Option<Vec<String>>,
 }

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -135,17 +135,59 @@ impl RuleProvider {
 /// Inline providers never appear here — their payload lives in the raw config.
 pub type PrefetchedPayloads = HashMap<String, Vec<u8>>;
 
+/// Resolves a per-provider `proxy:` name (mihomo compat, issue #377) to a
+/// live proxy at load time. Returns `None` for names it cannot resolve.
+pub type ProxyLookup<'a> = &'a dyn Fn(&str) -> Option<Arc<dyn Proxy>>;
+
+/// Effective download proxy for one http provider: an explicit
+/// `proxy: DIRECT` forces a direct fetch, any other explicit name must
+/// resolve via `lookup`, and an absent field keeps the global default
+/// (historically the first proxy in `proxies:`).
+fn effective_download_proxy(
+    cfg: &RawRuleProvider,
+    default: Option<&Arc<dyn Proxy>>,
+    lookup: ProxyLookup<'_>,
+) -> Result<Option<Arc<dyn Proxy>>> {
+    match cfg.proxy.as_deref().map(str::trim) {
+        None | Some("") => Ok(default.cloned()),
+        Some(name) if name.eq_ignore_ascii_case("DIRECT") => Ok(None),
+        Some(name) => lookup(name)
+            .map(Some)
+            .ok_or_else(|| anyhow!("download proxy '{name}' is not a known proxy or group")),
+    }
+}
+
 /// Fetch/read the raw payload bytes of every file/http provider without
 /// parsing them. Failures are logged and skipped; `load_providers_prefetched`
 /// retries any provider missing from the map and reports the error there.
+///
+/// A `proxy:` name `lookup` cannot resolve (prefetch runs before groups and
+/// provider-sourced proxies exist) skips the prefetch quietly — the load
+/// pass retries against the full registry.
 pub fn prefetch_payloads(
     raw_providers: &HashMap<String, RawRuleProvider>,
     cache_dir: Option<&Path>,
-    download_proxy: Option<&Arc<dyn Proxy>>,
+    default_proxy: Option<&Arc<dyn Proxy>>,
+    lookup: ProxyLookup<'_>,
 ) -> PrefetchedPayloads {
     let mut out = HashMap::new();
     for (name, cfg) in raw_providers {
-        match read_payload_bytes(name, cfg, cache_dir, download_proxy) {
+        let download_proxy = if cfg.provider_type == "http" {
+            match effective_download_proxy(cfg, default_proxy, lookup) {
+                Ok(p) => p,
+                Err(e) => {
+                    debug!(
+                        "rule-provider '{}': prefetch skipped ({:#}); \
+                         retried once proxies are built",
+                        name, e
+                    );
+                    continue;
+                }
+            }
+        } else {
+            None
+        };
+        match read_payload_bytes(name, cfg, cache_dir, download_proxy.as_ref()) {
             Ok(Some(bytes)) => {
                 out.insert(name.clone(), bytes);
             }
@@ -204,6 +246,7 @@ pub fn load_providers(
         cache_dir,
         ctx,
         download_proxy,
+        &|_| None,
         &HashMap::new(),
     )
 }
@@ -215,7 +258,8 @@ pub fn load_providers_prefetched(
     raw_providers: &HashMap<String, RawRuleProvider>,
     cache_dir: Option<&Path>,
     ctx: &ParserContext,
-    download_proxy: Option<&Arc<dyn Proxy>>,
+    default_proxy: Option<&Arc<dyn Proxy>>,
+    lookup: ProxyLookup<'_>,
     prefetched: &PrefetchedPayloads,
 ) -> HashMap<String, Arc<RuleProvider>> {
     let mut out = HashMap::new();
@@ -223,8 +267,19 @@ pub fn load_providers_prefetched(
         return out;
     }
     for (name, cfg) in raw_providers {
+        let download_proxy = if cfg.provider_type == "http" {
+            match effective_download_proxy(cfg, default_proxy, lookup) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!("Failed to load rule-provider '{}': {:#}", name, e);
+                    continue;
+                }
+            }
+        } else {
+            None
+        };
         let payload = prefetched.get(name).map(Vec::as_slice);
-        match load_one(name, cfg, cache_dir, ctx, download_proxy, payload) {
+        match load_one(name, cfg, cache_dir, ctx, download_proxy.as_ref(), payload) {
             Ok(provider) => {
                 debug!(
                     "Loaded rule-provider '{}' ({}/{}): {} entries",
@@ -623,6 +678,94 @@ mod tests {
         ParserContext::empty()
     }
 
+    fn http_cfg(proxy: Option<&str>) -> RawRuleProvider {
+        RawRuleProvider {
+            provider_type: "http".to_string(),
+            behavior: "domain".to_string(),
+            format: Some("yaml".to_string()),
+            url: Some("http://127.0.0.1:1/rules.yaml".to_string()),
+            path: None,
+            interval: None,
+            proxy: proxy.map(str::to_string),
+            payload: None,
+        }
+    }
+
+    fn direct_proxy() -> Arc<dyn Proxy> {
+        let cfg: HashMap<String, serde_yaml::Value> =
+            serde_yaml::from_str("name: d\ntype: direct").unwrap();
+        crate::proxy_parser::parse_proxy(&cfg).unwrap()
+    }
+
+    #[test]
+    fn effective_download_proxy_follows_mihomo_policy() {
+        let d = direct_proxy();
+        // Absent field keeps the global default.
+        assert!(effective_download_proxy(&http_cfg(None), Some(&d), &|_| None)
+            .unwrap()
+            .is_some());
+        // DIRECT (case-insensitive) forces a direct fetch even with a default.
+        assert!(
+            effective_download_proxy(&http_cfg(Some("direct")), Some(&d), &|_| None)
+                .unwrap()
+                .is_none()
+        );
+        // An explicit name resolves via the lookup.
+        let hit = effective_download_proxy(&http_cfg(Some("d")), None, &|n| {
+            (n == "d").then(|| Arc::clone(&d))
+        })
+        .unwrap();
+        assert!(hit.is_some());
+        // An unknown name is an error, never a silent fallback.
+        assert!(effective_download_proxy(&http_cfg(Some("nope")), Some(&d), &|_| None).is_err());
+    }
+
+    #[test]
+    fn http_provider_with_unknown_proxy_name_is_skipped() {
+        let mut providers = HashMap::new();
+        providers.insert("p".to_string(), http_cfg(Some("NoSuch")));
+        // Payload already prefetched — resolution still fails first, so the
+        // provider is skipped rather than loaded via the wrong proxy.
+        let mut prefetched = HashMap::new();
+        prefetched.insert("p".to_string(), b"payload:\n  - example.com\n".to_vec());
+        let out = load_providers_prefetched(&providers, None, &ctx(), None, &|_| None, &prefetched);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn http_provider_with_direct_proxy_loads_prefetched_payload() {
+        let mut providers = HashMap::new();
+        providers.insert("p".to_string(), http_cfg(Some("DIRECT")));
+        let mut prefetched = HashMap::new();
+        prefetched.insert("p".to_string(), b"payload:\n  - example.com\n".to_vec());
+        let out = load_providers_prefetched(&providers, None, &ctx(), None, &|_| None, &prefetched);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out.get("p").unwrap().rule_count(), 1);
+    }
+
+    #[test]
+    fn file_provider_ignores_proxy_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("list.yaml");
+        std::fs::write(&file_path, "payload:\n  - example.com\n").unwrap();
+        let mut providers = HashMap::new();
+        providers.insert(
+            "f".to_string(),
+            RawRuleProvider {
+                provider_type: "file".to_string(),
+                behavior: "domain".to_string(),
+                format: Some("yaml".to_string()),
+                url: None,
+                path: Some(file_path.to_string_lossy().to_string()),
+                interval: None,
+                proxy: Some("NoSuch".to_string()),
+                payload: None,
+            },
+        );
+        let out = load_providers(&providers, Some(dir.path()), &ctx(), None);
+        assert_eq!(out.len(), 1);
+    }
+
     #[test]
     fn yaml_file_provider_loads() {
         let dir = tempfile::tempdir().unwrap();
@@ -638,6 +781,7 @@ mod tests {
                 url: None,
                 path: Some(file_path.to_string_lossy().to_string()),
                 interval: None,
+                proxy: None,
                 payload: None,
             },
         );
@@ -660,6 +804,7 @@ mod tests {
                 url: None,
                 path: None,
                 interval: None,
+                proxy: None,
                 payload: Some(vec!["example.com".to_string(), "+.foo.com".to_string()]),
             },
         );
@@ -679,6 +824,7 @@ mod tests {
             url: None,
             path: None,
             interval: Some(3600),
+            proxy: None,
             payload: Some(vec!["example.com".to_string()]),
         };
         let err = load_inline("p", &cfg, RuleSetBehavior::Domain, &ctx())
@@ -705,6 +851,7 @@ mod tests {
                 url: None,
                 path: Some(file_path.to_string_lossy().to_string()),
                 interval: None,
+                proxy: None,
                 payload: None,
             },
         );
@@ -729,6 +876,7 @@ mod tests {
                 url: None,
                 path: Some(file_path.to_string_lossy().to_string()),
                 interval: None,
+                proxy: None,
                 payload: None,
             },
         );
@@ -748,6 +896,7 @@ mod tests {
                 url: None,
                 path: None,
                 interval: None,
+                proxy: None,
                 payload: None,
             },
         );
@@ -770,6 +919,7 @@ mod tests {
                 url: None,
                 path: Some(file_path.to_string_lossy().to_string()),
                 interval: Some(3600),
+                proxy: None,
                 payload: None,
             },
         );
@@ -824,6 +974,7 @@ mod tests {
                 url: Some(format!("http://{addr}/rules.yaml")),
                 path: None,
                 interval: None,
+                proxy: None,
                 payload: None,
             },
         );
@@ -847,6 +998,7 @@ mod tests {
                 url: None,
                 path: None,
                 interval: None,
+                proxy: None,
                 payload: Some(vec!["example.com".to_string()]),
             },
         );
@@ -859,6 +1011,7 @@ mod tests {
                 url: None,
                 path: None,
                 interval: None,
+                proxy: None,
                 payload: Some(vec!["10.0.0.0/8".to_string()]),
             },
         );

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -701,9 +701,11 @@ mod tests {
     fn effective_download_proxy_follows_mihomo_policy() {
         let d = direct_proxy();
         // Absent field keeps the global default.
-        assert!(effective_download_proxy(&http_cfg(None), Some(&d), &|_| None)
-            .unwrap()
-            .is_some());
+        assert!(
+            effective_download_proxy(&http_cfg(None), Some(&d), &|_| None)
+                .unwrap()
+                .is_some()
+        );
         // DIRECT (case-insensitive) forces a direct fetch even with a default.
         assert!(
             effective_download_proxy(&http_cfg(Some("direct")), Some(&d), &|_| None)

--- a/crates/meow-tunnel/src/statistics.rs
+++ b/crates/meow-tunnel/src/statistics.rs
@@ -121,9 +121,10 @@ pub struct ConnectionInfo {
 
 /// Values exposed by the mihomo `/traffic` stream, captured together under
 /// one lock so a reader never mixes rates and totals from different sampling
-/// ticks (issue #338). Totals are the cumulative sum of the sampled rates
-/// (issue #340) — derived, not read from a second counter, so `rate <= total`
-/// holds by construction and no interleaving can publish an impossible pair.
+/// ticks (issue #338). Totals are the cumulative counters as observed at the
+/// last tick; rates are the delta between consecutive observations (issue
+/// #357) — derived from one counter, so `rate <= total` holds by construction
+/// and no interleaving can publish an impossible pair (issue #340).
 #[derive(Default, Clone, Copy)]
 struct TrafficSnapshot {
     upload_rate: Int,
@@ -133,12 +134,13 @@ struct TrafficSnapshot {
 }
 
 pub struct Statistics {
-    /// Bytes since the last sampler tick. The only global counters the relay
-    /// hot path touches (one relaxed `fetch_add` per direction per chunk);
-    /// totals are accumulated from these at sample time, never double-tracked
-    /// (issue #340).
-    upload_temp: AtomicI,
-    download_temp: AtomicI,
+    /// Cumulative relay byte totals. The only global counters the relay hot
+    /// path touches (one relaxed `fetch_add` per direction per chunk). The
+    /// sampler derives per-interval rates as deltas of consecutive
+    /// observations and never writes these counters, so no relay increment
+    /// can land on the wrong side of a `swap(0)`-style reset (issue #357).
+    upload_total: AtomicI,
+    download_total: AtomicI,
     traffic: Mutex<TrafficSnapshot>,
     /// Keyed by `Uuid` (16 B Copy) — formerly `String`, which heap-allocated a
     /// 36-byte hyphenated representation per insert.  REST handlers parse the
@@ -150,8 +152,8 @@ pub struct Statistics {
 impl Statistics {
     pub fn new() -> Self {
         Self {
-            upload_temp: AtomicI::new(0),
-            download_temp: AtomicI::new(0),
+            upload_total: AtomicI::new(0),
+            download_total: AtomicI::new(0),
             traffic: Mutex::new(TrafficSnapshot::default()),
             connections: DashMap::new(),
             rule_match: Arc::new(RuleMatchCounters::new()),
@@ -159,11 +161,11 @@ impl Statistics {
     }
 
     pub fn add_upload(&self, n: Int) {
-        self.upload_temp.fetch_add(n, Ordering::Relaxed);
+        self.upload_total.fetch_add(n, Ordering::Relaxed);
     }
 
     pub fn add_download(&self, n: Int) {
-        self.download_temp.fetch_add(n, Ordering::Relaxed);
+        self.download_total.fetch_add(n, Ordering::Relaxed);
     }
 
     /// Per-chunk relay accounting: two relaxed atomic adds, no map lookup.
@@ -188,20 +190,24 @@ impl Statistics {
             .map(|entry| Arc::clone(&entry.counters))
     }
 
-    /// Roll the current one-second counters into the values exposed by the
-    /// mihomo `/traffic` stream. All four values are published under one lock
-    /// so `traffic_snapshot` readers see a mutually consistent set; totals are
-    /// accumulated from the swapped rates, so they can never disagree with
-    /// them (issue #340). The hot path stays lock-free — the once-per-second
-    /// ticker plus API readers are the only contenders. The swaps happen under
-    /// the lock so [`Self::snapshot`] never sees in-flight bytes in neither
-    /// (or both of) `_temp` and the accumulated total.
+    /// Roll the cumulative counters into the values exposed by the mihomo
+    /// `/traffic` stream. All four values are published under one lock so
+    /// `traffic_snapshot` readers see a mutually consistent set; rates are the
+    /// delta between consecutive observations of the same counter, so they can
+    /// never disagree with the totals (issue #340). The hot path stays
+    /// lock-free — the once-per-second ticker plus API readers are the only
+    /// contenders. Delta sampling means the ticker only loads the counters
+    /// (issue #357): there is no reset for a concurrent relay `fetch_add` to
+    /// race against, so an increment lands in exactly one interval — this one
+    /// if the load observed it, the next one otherwise.
     pub fn sample_traffic(&self) {
         let mut snap = self.traffic.lock();
-        snap.upload_rate = self.upload_temp.swap(0, Ordering::Relaxed);
-        snap.download_rate = self.download_temp.swap(0, Ordering::Relaxed);
-        snap.upload_total += snap.upload_rate;
-        snap.download_total += snap.download_rate;
+        let upload = self.upload_total.load(Ordering::Relaxed);
+        let download = self.download_total.load(Ordering::Relaxed);
+        snap.upload_rate = upload - snap.upload_total;
+        snap.download_rate = download - snap.download_total;
+        snap.upload_total = upload;
+        snap.download_total = download;
     }
 
     /// `(upload_rate, download_rate, upload_total, download_total)` as of the
@@ -242,16 +248,14 @@ impl Statistics {
         self.connections.remove(&id);
     }
 
-    /// Live cumulative `(upload, download)` totals: bytes already rolled into
-    /// the traffic snapshot plus the not-yet-sampled remainder. Reading both
-    /// parts under the snapshot lock excludes a concurrent `sample_traffic`
-    /// from moving bytes between them mid-read, so the sum is exact and
-    /// monotonic.
+    /// Live cumulative `(upload, download)` totals, read straight from the
+    /// hot-path counters. Each counter is a single monotonic atomic — no
+    /// lock, no split between sampled and unsampled parts — so the values are
+    /// exact and monotonic per direction.
     pub fn snapshot(&self) -> (Int, Int) {
-        let snap = self.traffic.lock();
         (
-            snap.upload_total + self.upload_temp.load(Ordering::Relaxed),
-            snap.download_total + self.download_temp.load(Ordering::Relaxed),
+            self.upload_total.load(Ordering::Relaxed),
+            self.download_total.load(Ordering::Relaxed),
         )
     }
 


### PR DESCRIPTION
Batch of fixes for the open-issue backlog.

## Fixes #378 — RUSTSEC-2026-0221
Bump transitive `event-listener` 5.4.1 → 5.4.2 (unsound `Send`/`Sync` on `StackSlot`). `cargo audit` is clean after the bump.

## Fixes #357 — traffic sampling misattribution
Adopts the issue's recommended Option 1 (delta-based sampling). The relay hot path is unchanged (one relaxed `fetch_add` per direction per chunk); the sampler now only *loads* the cumulative counters and derives each interval's rate as the delta between consecutive observations. With no `swap(0)` reset there is no RMW race for an increment to land on the wrong side of, and `snapshot()` becomes two plain loads. Public API, JSON shape, and the #338/#340 consistency invariants are unchanged; no struct layout changes.

## #377 — mihomo behavior parity (items 2, 3, 4)
- **Item 3 (hysteria2 `port`)**: `port` is now optional when a concrete `ports` hopping range is present, matching mihomo (errors only when neither yields a port). The first port of the range serves as the dial placeholder; the hopping socket rewrites it per send anyway.
- **Item 4 (rule-provider download policy)**: http rule-providers gain mihomo's per-provider `proxy:` field — `DIRECT` forces a direct fetch, any other name resolves against the full registry (groups and provider-sourced proxies included), unknown names skip the provider with a warning. Absent keeps the historical first-proxy default, so existing configs are unaffected.
- **Item 2 (vless reality+grpc broken)**: found a concrete parity bug — with no explicit `alpn:`, gRPC/h2 transports sent **no ALPN at all** (only ws had a default). xray REALITY servers validate the offered ALPN and gRPC requires h2, which breaks exactly the reported node shape. gRPC/h2 now default to `h2` like mihomo's gun transport. I couldn't verify against a live reality server, so leaving #377 open for the reporter to confirm; item 1 (bundling anytls into release binaries) is a packaging/size-cap decision (ADR-0007) left to the maintainer.

## Verification
`cargo fmt --check`, three-way clippy (`default` / `--no-default-features` / `--all-features`) with `-D warnings`, `cargo doc -D warnings`, and `cargo test --lib` (989 tests) all pass. New unit tests cover the hysteria2 port fallback, the `proxy:` resolution policy, and the ALPN defaults.