### PR TITLE
fix(transport): unblock vless over grpc/h2, ship anytls + REALITY in every build (#377)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "tracing-subscriber",
  "webpki-root-certs",
  "webpki-roots 0.26.11",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A high-performance Rust implementation of the [mihomo](https://github.com/MetaCu
 - **HTTP** -- HTTP CONNECT outbound proxy with optional TLS and basic auth
 - **SOCKS5** -- SOCKS5 outbound proxy with optional TLS and auth
 - **Snell** -- v3/v4/v5 TCP, UDP-over-TCP, optional HTTP/TLS obfs; v4/v5 connection reuse
-- **AnyTLS** -- Optional AnyTLS outbound (`anytls` feature)
+- **AnyTLS** -- AnyTLS outbound (`anytls` feature; in the `full` bundle, so the release binaries include it)
 - **Direct** -- Direct connection to destination
 - **Reject** -- Drop connections (with configurable behavior)
 

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -28,6 +28,9 @@ vless-vision = ["vless", "meow-config/vless-vision", "meow-proxy/vless-vision"]
 vless-encryption = ["vless", "meow-config/vless-encryption", "meow-proxy/vless-encryption"]
 vmess = ["meow-config/vmess", "meow-proxy/vmess"]
 snell = ["meow-config/snell", "meow-proxy/snell"]
+# AnyTLS outbound (issue #377 item 1) — in the `full` bundle so release
+# binaries carry it; excluded from `minimal` (ADR-0007 binary-size caps).
+anytls = ["meow-config/anytls", "meow-proxy/anytls"]
 hysteria2 = ["meow-config/hysteria2", "meow-proxy/hysteria2"]
 ech-tls-tunnel = [
     "ss",
@@ -51,7 +54,7 @@ listener-tun = ["meow-listener/listener-tun", "meow-api/listener-tun"]
 # Convenience bundles
 minimal = ["ss", "trojan", "dns-server", "listener-mixed"]
 full = [
-    "ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "ech-tls-tunnel",
+    "ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel",
     "dns-server", "dns-encrypted",
     "listener-http", "listener-socks5", "listener-tproxy", "listener-mixed", "listener-tun",
 ]

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -12,7 +12,11 @@ homepage.workspace = true
 default = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "ech-tls-tunnel", "vmess", "snell", "hysteria2"]
 ss = ["meow-proxy/ss"]
 trojan = ["meow-proxy/trojan"]
-vless = ["meow-proxy/vless"]
+# `meow-transport/reality` rides along with vless: `reality-opts` is only
+# reachable from the vless parser, and REALITY must not depend on boring-tls
+# (issue #377 — boring-sys does not build for armv7/i686 musl, MIPS,
+# windows-gnu or iOS, and those builds silently lost every REALITY proxy).
+vless = ["meow-proxy/vless", "meow-transport/reality"]
 vless-vision = ["vless", "meow-proxy/vless-vision"]
 vless-encryption = ["vless", "meow-proxy/vless-encryption"]
 vmess = ["meow-proxy/vmess"]

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1282,11 +1282,18 @@ fn parse_vless(
                 .and_then(|v| v.as_str())
                 .unwrap_or("GunService")
                 .to_string();
-            // Authority: use the outbound server address so the gRPC virtual
-            // host matches the TLS SNI. Upstream hard-codes "localhost" when
-            // unset; we normalise here per ADR-0001 §1 (transport never infers
-            // context-sensitive values).
-            let authority = server.to_string();
+            // Authority: mihomo's gun transport sets `Host` to `servername`
+            // and only falls back to the dial host when `servername` is empty
+            // (adapter/outbound/vless.go). Front-ends that route gRPC by
+            // `:authority` are provisioned against that value, so match it
+            // rather than always sending the dial host (issue #377). Resolved
+            // here per ADR-0001 §1 — the transport never infers it.
+            let authority = config
+                .get("servername")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(server)
+                .to_string();
             let grpc_cfg = GrpcConfig {
                 service_name,
                 authority,

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -401,9 +401,12 @@ proxies:
     );
 }
 
-#[cfg(feature = "boring-tls")]
+/// REALITY must load on any build that has the `vless` feature — it no longer
+/// needs `boring-tls`. Release targets where boring-sys cannot be compiled
+/// (armv7/i686 musl, MIPS, windows-gnu, iOS) used to warn-and-skip every
+/// REALITY proxy, which read as "vless just doesn't work" (issue #377).
 #[tokio::test]
-async fn parse_vless_reality_opts_valid_loads_with_boring_tls() {
+async fn parse_vless_reality_opts_valid_loads_without_boring_tls() {
     let yaml = r#"
 proxies:
   - name: v

--- a/crates/meow-transport/Cargo.toml
+++ b/crates/meow-transport/Cargo.toml
@@ -25,11 +25,23 @@ tls = [
 # TlsConfig.ech returns TransportError::Config at construction time.
 boring-tls = [
     "tls",
+    "reality",
     "dep:boring",
     "dep:tokio-boring",
     "dep:boring-sys",
     "dep:rand",
     "dep:webpki-root-certs",
+]
+# reality: xray REALITY client handshake (issue #377). The record layer, the
+# X25519 / HKDF / AES-GCM crypto and the ClientHello builder are all in-tree
+# (`reality_tls.rs`) on top of the always-present aes-gcm/hmac/sha2 deps, so
+# this is independent of `boring-tls` — REALITY has to keep working on the
+# targets where boring-sys cannot be built (armv7/i686 musl time64, MIPS,
+# windows-gnu, iOS). `boring-tls` implies it for backwards compatibility.
+reality = [
+    "tls",
+    "dep:rand",
+    "dep:x25519-dalek",
 ]
 ws = [
     "dep:tokio-tungstenite",
@@ -85,6 +97,10 @@ rand = { workspace = true, optional = true }
 
 # httpupgrade feature
 httparse = { version = "1", optional = true }
+
+# reality feature — pure-Rust X25519 so the REALITY handshake does not need
+# BoringSSL's `X25519` FFI (boring-sys does not build on every release target).
+x25519-dalek = { workspace = true, optional = true }
 
 # boring-tls feature
 boring             = { workspace = true, optional = true }

--- a/crates/meow-transport/src/grpc.rs
+++ b/crates/meow-transport/src/grpc.rs
@@ -36,6 +36,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+use crate::h2_common::RecvState;
 use crate::{Result, Stream, Transport, TransportError};
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -115,13 +116,15 @@ impl Transport for GrpcLayer {
             .send_request(request, false)
             .map_err(|e| TransportError::Grpc(e.to_string()))?;
 
-        // Await the server's 200 response to get the response body stream.
-        let response = response_future
-            .await
-            .map_err(|e| TransportError::Grpc(e.to_string()))?;
-        let recv_stream = response.into_body();
-
-        Ok(Box::new(GunStream::new(send_stream, recv_stream)))
+        // Do NOT await the response here: upstream's `Tun` handler reads the
+        // client's first hunk before it writes anything, and grpc-go only
+        // flushes response headers on the first `SendMsg`. Awaiting would
+        // deadlock the tunnel (issue #377). The response is resolved on the
+        // first read instead — see `h2_common::RecvState`.
+        Ok(Box::new(GunStream::new(
+            send_stream,
+            RecvState::new(response_future),
+        )))
     }
 }
 
@@ -259,7 +262,8 @@ const MAX_GUN_FRAME_LEN: usize = 16 * 1024 * 1024;
 /// A bidirectional gRPC-framed stream over a single h2 request/response pair.
 struct GunStream {
     send: h2::SendStream<Bytes>,
-    recv: h2::RecvStream,
+    /// Response body, resolved on the first read (see [`RecvState`]).
+    recv: RecvState,
     /// Decoded payload bytes from the most-recently parsed gun frame.
     read_buf: Bytes,
     /// Raw h2 DATA bytes accumulating across multiple `poll_data` calls until
@@ -273,7 +277,7 @@ struct GunStream {
 }
 
 impl GunStream {
-    fn new(send: h2::SendStream<Bytes>, recv: h2::RecvStream) -> Self {
+    fn new(send: h2::SendStream<Bytes>, recv: RecvState) -> Self {
         Self {
             send,
             recv,
@@ -348,7 +352,15 @@ impl AsyncRead for GunStream {
             }
 
             // ── Need more bytes from the h2 DATA stream ───────────────────────
-            match this.recv.poll_data(cx) {
+            // Resolving the response is part of the read path, not of
+            // `connect()`; see `h2_common::RecvState`.
+            match this.recv.poll_ready(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {}
+            }
+            let recv = this.recv.stream().expect("poll_ready resolved Ok");
+            match recv.poll_data(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(None) => return Poll::Ready(Ok(())), // clean EOF
                 Poll::Ready(Some(Err(e))) => {
@@ -356,7 +368,7 @@ impl AsyncRead for GunStream {
                 }
                 Poll::Ready(Some(Ok(bytes))) => {
                     // Release flow-control window back to the sender.
-                    let _ = this.recv.flow_control().release_capacity(bytes.len());
+                    let _ = recv.flow_control().release_capacity(bytes.len());
                     this.pending_frame.extend_from_slice(&bytes);
                     // loop → re-check pending_frame for a complete frame
                 }

--- a/crates/meow-transport/src/h2.rs
+++ b/crates/meow-transport/src/h2.rs
@@ -16,6 +16,7 @@ use bytes::Bytes;
 use rand::seq::IndexedRandom as _;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+use crate::h2_common::RecvState;
 use crate::{Result, Stream, Transport, TransportError};
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -100,13 +101,14 @@ impl Transport for H2Layer {
             .send_request(request, false)
             .map_err(|e| TransportError::H2(e.to_string()))?;
 
-        // Await the server's 200 response to get the inbound body stream.
-        let response = response_future
-            .await
-            .map_err(|e| TransportError::H2(e.to_string()))?;
-        let recv_stream = response.into_body();
-
-        Ok(Box::new(H2Stream::new(send_stream, recv_stream)))
+        // Do NOT await the response here: upstream's h2 handler reads the
+        // client's first DATA frame before it writes anything, so awaiting
+        // would deadlock the tunnel (issue #377). The response is resolved on
+        // the first read instead — see `h2_common::RecvState`.
+        Ok(Box::new(H2Stream::new(
+            send_stream,
+            RecvState::new(response_future),
+        )))
     }
 }
 
@@ -118,7 +120,8 @@ impl Transport for H2Layer {
 /// through the h2 DATA frames verbatim.
 struct H2Stream {
     send: h2::SendStream<Bytes>,
-    recv: h2::RecvStream,
+    /// Response body, resolved on the first read (see [`RecvState`]).
+    recv: RecvState,
     /// Buffered payload bytes from the most recently received DATA frame.
     read_buf: Bytes,
     /// Pre-encoded payload stashed while we wait for h2 send-window capacity.
@@ -129,7 +132,7 @@ struct H2Stream {
 }
 
 impl H2Stream {
-    fn new(send: h2::SendStream<Bytes>, recv: h2::RecvStream) -> Self {
+    fn new(send: h2::SendStream<Bytes>, recv: RecvState) -> Self {
         Self {
             send,
             recv,
@@ -156,8 +159,16 @@ impl AsyncRead for H2Stream {
                 return Poll::Ready(Ok(()));
             }
 
-            // Fetch the next DATA frame from the h2 receive stream.
-            match this.recv.poll_data(cx) {
+            // Fetch the next DATA frame from the h2 receive stream. Resolving
+            // the response is part of the read path, not of `connect()`; see
+            // `h2_common::RecvState`.
+            match this.recv.poll_ready(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {}
+            }
+            let recv = this.recv.stream().expect("poll_ready resolved Ok");
+            match recv.poll_data(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(None) => return Poll::Ready(Ok(())), // clean EOF
                 Poll::Ready(Some(Err(e))) => {
@@ -165,7 +176,7 @@ impl AsyncRead for H2Stream {
                 }
                 Poll::Ready(Some(Ok(bytes))) => {
                     // Release flow-control window back to the sender.
-                    let _ = this.recv.flow_control().release_capacity(bytes.len());
+                    let _ = recv.flow_control().release_capacity(bytes.len());
                     this.read_buf = bytes;
                     // loop → drain read_buf
                 }

--- a/crates/meow-transport/src/h2_common.rs
+++ b/crates/meow-transport/src/h2_common.rs
@@ -1,0 +1,73 @@
+//! Shared HTTP/2 plumbing for the `grpc` (gun) and `h2` transports.
+//!
+//! Both transports open a single long-lived `POST` and use its request/response
+//! bodies as a bidirectional byte stream. The one thing they must *not* do is
+//! wait for the server's response HEADERS before handing the stream to the
+//! proxy codec: xray's `Tun` gRPC handler and mihomo's h2 handler both block
+//! reading the client's first DATA frame before they write anything, and Go's
+//! `grpc-go` only flushes response headers on the first `SendMsg`. A client
+//! that awaits the response first therefore deadlocks — the tunnel comes up,
+//! the REALITY/TLS handshake succeeds, and then nothing ever moves (issue
+//! #377).
+//!
+//! [`RecvState`] defers that await to the first read, which is what upstream
+//! does (`transport/gun/gun.go` resolves the response inside `Read`).
+
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Receive half of a client-initiated h2 request, resolved lazily on first read.
+pub(crate) enum RecvState {
+    /// Response HEADERS not seen yet.
+    Pending(h2::client::ResponseFuture),
+    /// Response received and accepted; body stream ready.
+    Ready(h2::RecvStream),
+    /// Response resolved to an error (transport failure or non-2xx status).
+    Failed,
+}
+
+impl RecvState {
+    pub(crate) fn new(response: h2::client::ResponseFuture) -> Self {
+        Self::Pending(response)
+    }
+
+    /// Drive the response future far enough that [`Self::stream`] returns the
+    /// body. Once this resolves `Ready(Ok(()))` the state is [`Self::Ready`].
+    pub(crate) fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self {
+            Self::Ready(_) => Poll::Ready(Ok(())),
+            Self::Failed => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "h2: response stream already failed",
+            ))),
+            Self::Pending(future) => match Pin::new(future).poll(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Ok(response)) => {
+                    let status = response.status();
+                    if !status.is_success() {
+                        *self = Self::Failed;
+                        return Poll::Ready(Err(io::Error::other(format!(
+                            "h2: server answered with status {status}, expected 2xx"
+                        ))));
+                    }
+                    *self = Self::Ready(response.into_body());
+                    Poll::Ready(Ok(()))
+                }
+                Poll::Ready(Err(e)) => {
+                    *self = Self::Failed;
+                    Poll::Ready(Err(io::Error::other(e)))
+                }
+            },
+        }
+    }
+
+    /// The body stream. Only `Some` after [`Self::poll_ready`] resolved `Ok`.
+    pub(crate) fn stream(&mut self) -> Option<&mut h2::RecvStream> {
+        match self {
+            Self::Ready(recv) => Some(recv),
+            _ => None,
+        }
+    }
+}

--- a/crates/meow-transport/src/lib.rs
+++ b/crates/meow-transport/src/lib.rs
@@ -31,11 +31,14 @@ mod error;
 #[cfg(feature = "tls")]
 pub mod tls;
 
-#[cfg(all(feature = "tls", feature = "boring-tls"))]
+#[cfg(all(feature = "tls", feature = "reality"))]
 mod reality_tls;
 
 #[cfg(feature = "ws")]
 pub mod ws;
+
+#[cfg(any(feature = "grpc", feature = "h2"))]
+mod h2_common;
 
 #[cfg(feature = "grpc")]
 pub mod grpc;
@@ -73,7 +76,7 @@ pub fn enable_raw_passthrough(stream: &mut dyn Stream) -> bool {
 }
 
 pub fn enable_raw_read_passthrough(stream: &mut dyn Stream) -> bool {
-    #[cfg(all(feature = "tls", feature = "boring-tls"))]
+    #[cfg(all(feature = "tls", feature = "reality"))]
     {
         if let Some(reality) = stream
             .as_any_mut()
@@ -89,7 +92,7 @@ pub fn enable_raw_read_passthrough(stream: &mut dyn Stream) -> bool {
 }
 
 pub fn enable_raw_write_passthrough(stream: &mut dyn Stream) -> bool {
-    #[cfg(all(feature = "tls", feature = "boring-tls"))]
+    #[cfg(all(feature = "tls", feature = "reality"))]
     {
         if let Some(reality) = stream
             .as_any_mut()

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -1202,22 +1202,17 @@ fn clamp_x25519_private(private: &mut [u8; 32]) {
 }
 
 fn x25519_public_from_private(private: &[u8; 32]) -> [u8; 32] {
-    let mut public = [0u8; 32];
-    unsafe {
-        boring_sys::X25519_public_from_private(public.as_mut_ptr(), private.as_ptr());
-    }
-    public
+    x25519_dalek::x25519(*private, x25519_dalek::X25519_BASEPOINT_BYTES)
 }
 
 fn x25519(private: &[u8; 32], peer_public: &[u8; 32]) -> Result<[u8; 32]> {
-    let mut out = [0u8; 32];
-    let ok =
-        unsafe { boring_sys::X25519(out.as_mut_ptr(), private.as_ptr(), peer_public.as_ptr()) };
-    if ok == 1 {
-        Ok(out)
-    } else {
-        Err(TransportError::Tls("X25519 ECDH failed".into()))
+    let out = x25519_dalek::x25519(*private, *peer_public);
+    // An all-zero shared secret means the peer sent a low-order point; BoringSSL's
+    // `X25519` reports that as a failure and RFC 7748 §6.1 requires rejecting it.
+    if out == [0u8; 32] {
+        return Err(TransportError::Tls("X25519 ECDH failed".into()));
     }
+    Ok(out)
 }
 
 fn take<'a>(input: &'a [u8], pos: &mut usize, len: usize) -> Result<&'a [u8]> {

--- a/crates/meow-transport/src/tls.rs
+++ b/crates/meow-transport/src/tls.rs
@@ -197,7 +197,7 @@ pub struct ClientCert {
 
 enum TlsBackend {
     Rustls(RustlsInner),
-    #[cfg(feature = "boring-tls")]
+    #[cfg(feature = "reality")]
     Reality(crate::reality_tls::RealityTlsLayer),
     #[cfg(feature = "boring-tls")]
     Boring(Box<LazyBoringInner>),
@@ -261,16 +261,16 @@ impl TlsLayer {
     /// * [`TransportError::Config`] — `client_cert` PEM is unparseable (rustls path).
     /// * [`TransportError::Tls`] — client cert + key don't match (rustls path).
     pub fn new(config: &TlsConfig) -> Result<Self> {
-        #[cfg(not(feature = "boring-tls"))]
+        #[cfg(not(feature = "reality"))]
         if config.reality.is_some() {
             return Err(TransportError::Config(
-                "reality-opts requires the `boring-tls` Cargo feature in this build; \
-                 recompile with `--features boring-tls`."
+                "reality-opts requires the `reality` Cargo feature in this build; \
+                 recompile with `--features reality`."
                     .into(),
             ));
         }
 
-        #[cfg(feature = "boring-tls")]
+        #[cfg(feature = "reality")]
         if config.reality.is_some() {
             return Ok(Self {
                 backend: TlsBackend::Reality(crate::reality_tls::RealityTlsLayer::new(config)?),
@@ -326,7 +326,7 @@ impl Transport for TlsLayer {
     async fn connect(&self, inner: Box<dyn Stream>) -> Result<Box<dyn Stream>> {
         match &self.backend {
             TlsBackend::Rustls(r) => r.connect(inner).await,
-            #[cfg(feature = "boring-tls")]
+            #[cfg(feature = "reality")]
             TlsBackend::Reality(r) => r.connect(inner).await,
             #[cfg(feature = "boring-tls")]
             TlsBackend::Boring(lazy) => lazy.connect(inner).await,

--- a/crates/meow-transport/tests/grpc_test.rs
+++ b/crates/meow-transport/tests/grpc_test.rs
@@ -11,6 +11,7 @@
 //! | B  | `grpc_service_name_in_path` — `:path` must be `/{service_name}/Tun` |
 //! | C  | `grpc_content_type_header` — request must carry `content-type: application/grpc` |
 //! | D  | `grpc_round_trip` — 4 MiB loopback echo through a real h2 server |
+//! | E  | `grpc_round_trip_with_deferred_response` — server withholds response HEADERS until the first client hunk (issue #377) |
 
 mod support;
 
@@ -21,7 +22,7 @@ use meow_transport::Transport;
 use meow_transport::TransportError;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use support::loopback::spawn_grpc_server;
+use support::loopback::{spawn_grpc_server, spawn_grpc_server_deferred_response};
 
 async fn assert_grpc_config_error(config: GrpcConfig, expected: &str) {
     let (client, _server) = tokio::io::duplex(64);
@@ -275,4 +276,43 @@ async fn grpc_round_trip() {
         "received byte count must match sent byte count"
     );
     assert_eq!(recv_buf, send_buf, "round-trip bytes must be identical");
+}
+
+// ─── E: Response HEADERS withheld until the first client hunk ─────────────────
+
+/// E: `grpc_round_trip_with_deferred_response`
+///
+/// Regression test for issue #377. xray's `Tun` handler reads the client's
+/// first hunk before writing anything, and grpc-go only flushes response
+/// headers on the first `SendMsg`, so a client that awaits the response inside
+/// `connect()` deadlocks: the server waits for data that the client will not
+/// send until the response arrives. `GrpcLayer::connect` must therefore return
+/// as soon as the request HEADERS are queued and resolve the response lazily on
+/// the first read.
+#[tokio::test]
+async fn grpc_round_trip_with_deferred_response() {
+    let (addr, _info_rx) = spawn_grpc_server_deferred_response().await;
+
+    let tcp = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("tcp connect");
+
+    let layer = GrpcLayer::new(GrpcConfig::default());
+    let mut stream = tokio::time::timeout(Duration::from_secs(5), layer.connect(Box::new(tcp)))
+        .await
+        .expect("connect must not block on the server's response")
+        .expect("grpc connect");
+
+    stream.write_all(b"ping").await.expect("write");
+    stream.flush().await.expect("flush");
+
+    let mut got = [0u8; 4];
+    tokio::time::timeout(Duration::from_secs(5), stream.read_exact(&mut got))
+        .await
+        .expect("echo must arrive once the server answers")
+        .expect("read_exact");
+    assert_eq!(
+        &got, b"ping",
+        "round-trip bytes must survive the deferred response"
+    );
 }

--- a/crates/meow-transport/tests/h2_test.rs
+++ b/crates/meow-transport/tests/h2_test.rs
@@ -11,6 +11,7 @@
 //! | D2 | `h2_host_selection_is_uniform`    — 1000 connections × 4 hosts, every host seen |
 //! | D3 | `h2_single_host_no_randomness_needed` — single host, 10 conns, no panic |
 //! | D4 | `h2_path_forwarded`               — `:path` pseudo-header matches config |
+//! | D5 | `h2_round_trip_with_deferred_response` — server withholds response HEADERS until the first client DATA frame (issue #377) |
 
 mod support;
 
@@ -19,7 +20,7 @@ use std::time::Duration;
 use meow_transport::h2::{H2Config, H2Layer};
 use meow_transport::Transport;
 use meow_transport::TransportError;
-use support::loopback::spawn_h2_server;
+use support::loopback::{spawn_h2_server, spawn_h2_server_deferred_response};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 async fn assert_h2_config_error(config: H2Config, expected: &str) {
@@ -234,4 +235,43 @@ async fn h2_rejects_invalid_request_config_before_handshake() {
         "invalid request config",
     )
     .await;
+}
+
+// ─── D5: Response HEADERS withheld until the first client DATA frame ──────────
+
+/// D5: `h2_round_trip_with_deferred_response`
+///
+/// Regression test for issue #377 (h2 half of the gRPC deadlock). The peer's
+/// handler reads the client's first DATA frame before writing anything, so
+/// `H2Layer::connect` must not await the response — it has to return once the
+/// request HEADERS are queued and resolve the response on the first read.
+#[tokio::test]
+async fn h2_round_trip_with_deferred_response() {
+    let (addr, _info_rx) = spawn_h2_server_deferred_response(1).await;
+
+    let tcp = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("tcp connect");
+
+    let layer = H2Layer::new(H2Config {
+        path: "/".into(),
+        hosts: vec!["example.com".into()],
+    });
+    let mut stream = tokio::time::timeout(Duration::from_secs(5), layer.connect(Box::new(tcp)))
+        .await
+        .expect("connect must not block on the server's response")
+        .expect("h2 connect");
+
+    stream.write_all(b"ping").await.expect("write");
+    stream.flush().await.expect("flush");
+
+    let mut got = [0u8; 4];
+    tokio::time::timeout(Duration::from_secs(5), stream.read_exact(&mut got))
+        .await
+        .expect("echo must arrive once the server answers")
+        .expect("read_exact");
+    assert_eq!(
+        &got, b"ping",
+        "round-trip bytes must survive the deferred response"
+    );
 }

--- a/crates/meow-transport/tests/support/loopback.rs
+++ b/crates/meow-transport/tests/support/loopback.rs
@@ -197,6 +197,31 @@ pub async fn spawn_grpc_server() -> (
     std::net::SocketAddr,
     tokio::sync::oneshot::Receiver<GrpcConnInfo>,
 ) {
+    spawn_grpc_server_inner(false).await
+}
+
+/// Same as [`spawn_grpc_server`] but withholds the response HEADERS until the
+/// client's first DATA frame arrives.
+///
+/// This is how the real peers behave: xray's `Tun` handler reads the first hunk
+/// before writing, and grpc-go only flushes response headers on the first
+/// `SendMsg`. A client that awaits the response inside `connect()` deadlocks
+/// against this server (issue #377).
+#[cfg(feature = "grpc")]
+pub async fn spawn_grpc_server_deferred_response() -> (
+    std::net::SocketAddr,
+    tokio::sync::oneshot::Receiver<GrpcConnInfo>,
+) {
+    spawn_grpc_server_inner(true).await
+}
+
+#[cfg(feature = "grpc")]
+async fn spawn_grpc_server_inner(
+    defer_response: bool,
+) -> (
+    std::net::SocketAddr,
+    tokio::sync::oneshot::Receiver<GrpcConnInfo>,
+) {
     let (tx, rx) = tokio::sync::oneshot::channel::<GrpcConnInfo>();
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -235,13 +260,23 @@ pub async fn spawn_grpc_server() -> (
         // and processes all connection-level frames.
         tokio::spawn(async move { while conn.accept().await.is_some() {} });
 
-        // Send a 200 OK with end_of_stream=false (streaming response).
-        let response = http::Response::builder()
-            .status(200)
-            .body(())
-            .expect("response build");
-        let Ok(mut send) = respond.send_response(response, false) else {
-            return;
+        // Send a 200 OK with end_of_stream=false (streaming response), unless
+        // the caller asked for the grpc-go behaviour of withholding headers
+        // until the request body starts flowing.
+        let send_response = |respond: &mut h2::server::SendResponse<bytes::Bytes>| {
+            let response = http::Response::builder()
+                .status(200)
+                .body(())
+                .expect("response build");
+            respond.send_response(response, false)
+        };
+        let mut send = if defer_response {
+            None
+        } else {
+            match send_response(&mut respond) {
+                Ok(send) => Some(send),
+                Err(_) => return,
+            }
         };
 
         // Echo every DATA frame back verbatim (same gun-framed bytes).
@@ -252,6 +287,13 @@ pub async fn spawn_grpc_server() -> (
                 Some(Ok(data)) => {
                     // Release flow-control window so the client can keep sending.
                     let _ = body.flow_control().release_capacity(data.len());
+                    let send = match &mut send {
+                        Some(send) => send,
+                        None => match send_response(&mut respond) {
+                            Ok(new) => send.insert(new),
+                            Err(_) => return,
+                        },
+                    };
                     if send.send_data(data, false).is_err() {
                         return;
                     }
@@ -259,6 +301,7 @@ pub async fn spawn_grpc_server() -> (
                 None | Some(Err(_)) => break,
             }
         }
+        let Some(mut send) = send else { return };
 
         // Close the response stream.
         let _ = send.send_data(bytes::Bytes::new(), true);
@@ -286,9 +329,9 @@ pub struct H2ReqInfo {
 ///
 /// 1. Accepts a TCP connection and performs the HTTP/2 handshake.
 /// 2. Accepts one h2 request, captures `:authority` and `:path`.
-/// 3. Sends [`H2ReqInfo`] through the mpsc channel **before** sending the
-///    response, so by the time the client's `connect()` returns the info is
-///    already in the channel.
+/// 3. Sends [`H2ReqInfo`] through the mpsc channel as soon as the request
+///    HEADERS arrive — i.e. before the response — so a caller that awaits the
+///    receiver sees the metadata without having to exchange body bytes first.
 /// 4. Sends a `200 OK` streaming response and echoes every DATA frame back.
 ///
 /// Using mpsc (not oneshot) allows multi-connection tests (e.g. D2 with 1000
@@ -296,6 +339,25 @@ pub struct H2ReqInfo {
 #[cfg(feature = "h2")]
 pub async fn spawn_h2_server(
     max_connections: usize,
+) -> (std::net::SocketAddr, tokio::sync::mpsc::Receiver<H2ReqInfo>) {
+    spawn_h2_server_inner(max_connections, false).await
+}
+
+/// Same as [`spawn_h2_server`] but withholds the response HEADERS until the
+/// client's first DATA frame arrives, the way mihomo's h2 handler behaves.
+/// A client that awaits the response inside `connect()` deadlocks here
+/// (issue #377).
+#[cfg(feature = "h2")]
+pub async fn spawn_h2_server_deferred_response(
+    max_connections: usize,
+) -> (std::net::SocketAddr, tokio::sync::mpsc::Receiver<H2ReqInfo>) {
+    spawn_h2_server_inner(max_connections, true).await
+}
+
+#[cfg(feature = "h2")]
+async fn spawn_h2_server_inner(
+    max_connections: usize,
+    defer_response: bool,
 ) -> (std::net::SocketAddr, tokio::sync::mpsc::Receiver<H2ReqInfo>) {
     let (tx, rx) = tokio::sync::mpsc::channel(max_connections.max(1));
     let listener = TcpListener::bind("127.0.0.1:0")
@@ -311,7 +373,7 @@ pub async fn spawn_h2_server(
             };
             remaining -= 1;
             let tx = tx.clone();
-            tokio::spawn(h2_handle_conn(tcp, tx));
+            tokio::spawn(h2_handle_conn(tcp, tx, defer_response));
         }
     });
 
@@ -319,7 +381,11 @@ pub async fn spawn_h2_server(
 }
 
 #[cfg(feature = "h2")]
-async fn h2_handle_conn(tcp: tokio::net::TcpStream, tx: tokio::sync::mpsc::Sender<H2ReqInfo>) {
+async fn h2_handle_conn(
+    tcp: tokio::net::TcpStream,
+    tx: tokio::sync::mpsc::Sender<H2ReqInfo>,
+    defer_response: bool,
+) {
     let Ok(mut conn) = h2::server::handshake(tcp).await else {
         eprintln!("h2 loopback handshake error");
         return;
@@ -333,20 +399,28 @@ async fn h2_handle_conn(tcp: tokio::net::TcpStream, tx: tokio::sync::mpsc::Sende
     let authority = req.uri().authority().map(std::string::ToString::to_string);
     let path = req.uri().path().to_string();
 
-    // Send info BEFORE the 200 response — callers can safely `recv()` after
-    // `connect()` returns because connect() awaits the 200 which we send next.
+    // Publish the request metadata as soon as the HEADERS arrive, so tests can
+    // assert on it without depending on when the response is sent.
     let _ = tx.send(H2ReqInfo { authority, path }).await;
 
     // Drive the h2 connection (SETTINGS, WINDOW_UPDATE, …) in background.
     tokio::spawn(async move { while conn.accept().await.is_some() {} });
 
     // Send 200 OK (streaming response, end_of_stream=false).
-    let response = http::Response::builder()
-        .status(200)
-        .body(())
-        .expect("response build");
-    let Ok(mut send) = respond.send_response(response, false) else {
-        return;
+    let send_response = |respond: &mut h2::server::SendResponse<bytes::Bytes>| {
+        let response = http::Response::builder()
+            .status(200)
+            .body(())
+            .expect("response build");
+        respond.send_response(response, false)
+    };
+    let mut send = if defer_response {
+        None
+    } else {
+        match send_response(&mut respond) {
+            Ok(send) => Some(send),
+            Err(_) => return,
+        }
     };
 
     // Echo every DATA frame back verbatim.
@@ -356,6 +430,13 @@ async fn h2_handle_conn(tcp: tokio::net::TcpStream, tx: tokio::sync::mpsc::Sende
         match chunk {
             Some(Ok(data)) => {
                 let _ = body.flow_control().release_capacity(data.len());
+                let send = match &mut send {
+                    Some(send) => send,
+                    None => match send_response(&mut respond) {
+                        Ok(new) => send.insert(new),
+                        Err(_) => return,
+                    },
+                };
                 if send.send_data(data, false).is_err() {
                     return;
                 }
@@ -363,6 +444,7 @@ async fn h2_handle_conn(tcp: tokio::net::TcpStream, tx: tokio::sync::mpsc::Sende
             None | Some(Err(_)) => break,
         }
     }
+    let Some(mut send) = send else { return };
     let _ = send.send_data(bytes::Bytes::new(), true);
 }
 

--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -58,7 +58,7 @@ cause problems; items marked ~ work with caveats; items marked ✓ work.
 | `proxies:` — SOCKS5 outbound | ✓ | Full parity (M1.B-4). |
 | `proxies:` — Snell | ✓ | v3/v4/v5, UDP-over-TCP, optional HTTP/TLS obfs. |
 | `proxies:` — Hysteria2 | ✓ | QUIC TCP/UDP, Salamander obfs, port hopping, bandwidth hints. |
-| `proxies:` — AnyTLS | ~ | Implemented behind the opt-in `anytls` feature, not in the default app bundle. |
+| `proxies:` — AnyTLS | ✓ | In the `full` bundle, and therefore in the release binaries; excluded from `minimal`. |
 | `proxies:` — TUIC / WireGuard / SSH | ✗ | Not implemented. |
 | `proxy-groups:` — selector, url-test, fallback | ✓ | Fully supported. |
 | `proxy-groups:` — load-balance | ✓ | round-robin + consistent-hashing (M1.C-1). |
@@ -273,8 +273,8 @@ otherwise:
 - **TUIC** — not implemented.
 - **WireGuard** — niche; deferred.
 - **SSH** — niche; deferred.
-- **AnyTLS** — implemented behind the opt-in `anytls` feature, not compiled
-  into the default `meow-app` bundle.
+- **AnyTLS** — supported. Part of the `full` bundle, so the published release
+  binaries carry it; `minimal` builds leave it out (ADR-0007 binary-size caps).
 
 ---
 
@@ -538,7 +538,7 @@ meow-rs uses Cargo feature flags where Go mihomo uses build tags:
 | BoringSSL-backed uTLS/ECH paths | `meow-app/boring-tls` | on for `meow-app` |
 | Full app bundle | `meow-app/full` | on |
 | Minimal app bundle | `meow-app/minimal` | off |
-| AnyTLS outbound | non-default build enabling `meow-config/anytls` and `meow-proxy/anytls` | off |
+| AnyTLS outbound | `meow-app/anytls` (in `full`, not in `minimal`) | on |
 
 To build without encrypted DNS (smaller binary):
 
@@ -555,9 +555,9 @@ cargo build --release --no-default-features -p meow-dns
 Most common format from public providers. Typical issues:
 
 1. **Unsupported proxy types** — TUIC, WireGuard, SSH, ShadowsocksR, and other
-   niche upstream protocols still need replacement or removal. AnyTLS requires
-   a non-default build enabling the `meow-config/anytls` and `meow-proxy/anytls`
-   features.
+   niche upstream protocols still need replacement or removal. AnyTLS works
+   out of the box in the release binaries; a `minimal` build needs
+   `--features anytls`.
 2. **`enhanced-mode: fake-ip`** — supported. Migration from a prior
    meow-rs release that warned-and-fell-back to `normal` is automatic;
    no config change required.
@@ -628,8 +628,8 @@ The following are unsupported or intentionally rejected:
 
 - **`quic://` nameservers** — hard error; replace with `tls://` or `https://`.
 - **TUIC / WireGuard / SSH / ShadowsocksR proxies** — hard error; no default-build adapter.
-- **AnyTLS proxies in the default app build** — hard error unless the binary is
-  built with the opt-in `anytls` feature wiring.
+- **AnyTLS proxies in a `minimal` build** — hard error; the `full` bundle and
+  the release binaries support them.
 - **Snell v1/v2** — hard error; use Snell v3/v4/v5.
 - **`vless` with `flow: xtls-rprx-direct`** — hard error; use `xtls-rprx-vision`.
 - **External dashboard auto-download** (`external-ui-url`) — not performed.


### PR DESCRIPTION
Closes the two remaining items of #377 (the reporter's [latest comment](https://github.com/madeye/meow-rs/issues/377#issuecomment-5234868168) — items 3 and 4 landed in #380).

Both were reproduced end-to-end against a real **xray-core 26.3.27** VLESS + REALITY + gRPC server running in Docker, using the exact node shape from the issue.

## Item 2 — "this vless config does not work"

Two independent defects, either of which is fatal on its own for that config.

### 1. gRPC and h2 transports deadlock

`GrpcLayer::connect` and `H2Layer::connect` awaited the server's response HEADERS before handing the stream to the proxy codec. But xray's `Tun` handler reads the client's first hunk before it writes anything, and grpc-go only flushes response headers on the first `SendMsg` — so the server waits for data the client will not send until the response arrives.

The visible symptom is the worst kind: TCP connects, TLS/REALITY completes on both sides, xray logs a healthy handshake, and then nothing moves until the client times out. Server-side it ends as:

```
REALITY ... hs.c.isHandshakeComplete.Load(): true
app/proxyman/inbound: connection ends > transport/internet/grpc/encoding:
  failed to fetch hunk from gRPC tunnel > rpc error: code = Canceled
```

Upstream resolves the response lazily inside `Read` (`transport/gun/gun.go`, `Conn.Init`). This PR does the same via a small shared `h2_common::RecvState`, which also validates the status is 2xx on the first read. **This affects every gRPC/h2 node, not only REALITY ones.**

Regression coverage: the loopback test servers gained a deferred-response mode that withholds HEADERS until the client's first DATA frame — i.e. real peer behaviour. Both new tests fail with a 5 s timeout against the pre-fix code and pass after.

### 2. REALITY was gated behind `boring-tls`

`boring-sys` cannot be built for armv7/i686 musl (time64 bindgen mismatch), MIPS, or windows-gnu, so the release workflow builds those with `--no-default-features --features full` — and iOS builds are in the same boat. On every one of those binaries, a REALITY proxy was warn-and-skipped at config load while `-t` still reported success:

```
WARN meow_config: Failed to parse proxy: vless: TLS layer error: invalid config:
  reality-opts requires the `boring-tls` Cargo feature in this build
INFO meow: Configuration test passed
```

Nothing in the handshake actually needed BoringSSL except its `X25519` FFI. That is now `x25519-dalek` (pure Rust, already in the tree via `vless-encryption`), and the handshake moves to a dedicated `reality` feature — implied by `boring-tls` for compatibility, and pulled in by `meow-config/vless` so it is on wherever VLESS is.

### Also: gRPC `:authority` parity

mihomo sets gun's `Host` to `servername`, falling back to the dial host only when it is empty (`adapter/outbound/vless.go`). We always sent the dial host; front-ends that route gRPC by `:authority` are provisioned against mihomo's value.

## Item 1 — anytls missing from the release binaries

`anytls` is now a `meow-app` feature and part of the `full` bundle, so every published binary carries it. `minimal` still excludes it (ADR-0007 binary-size caps). Verified the vendored crate's dependency tree builds for `aarch64-apple-ios` — the platform the reporter specifically cannot build for themselves.

## Verification

- **e2e**: `curl` through the proxy returns HTTP 200 over xray REALITY+gRPC on both the default (boring-tls) build and the `--no-default-features --features full` build. The same config hung until timeout before this change.
- `cargo fmt --check`, three-way clippy (`default` / `--no-default-features` / `--all-features`) with `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib`, `rules_test`, `trojan_integration`, `anytls_integration`, and the full `meow-transport` suite all pass.

Binary size, aarch64-apple-darwin release, `--no-default-features --features full` (unstripped):

| | bytes |
|---|---:|
| before | 7 706 880 |
| + REALITY off the boring path | 7 756 816 (+49 936) |
| + anytls in `full` | 7 940 896 (+184 080) |

+234 016 B total, well inside the ADR-0007 `default` caps. No changes to `Metadata`, `ConnectionInfo`, `UdpSession`, DNS cache entries, or the relay hot path.

## Known, still divergent (out of scope here)

- `packet-encoding: xudp` is read by no adapter — plain VLESS UDP is used instead.
- `grpc-opts` `grpc-user-agent` and `ping-interval` are ignored.