### PR TITLE
chore(release): 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "futures",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -226,16 +226,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.19.0" }
-meow-trie = { path = "crates/meow-trie", version = "0.19.0" }
+meow-common = { path = "crates/meow-common", version = "0.20.0" }
+meow-trie = { path = "crates/meow-trie", version = "0.20.0" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.19.0" }
-meow-dns = { path = "crates/meow-dns", version = "0.19.0", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.19.0" }
-meow-transport = { path = "crates/meow-transport", version = "0.19.0" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.19.0", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.19.0" }
-meow-listener = { path = "crates/meow-listener", version = "0.19.0", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.19.0" }
-meow-config = { path = "crates/meow-config", version = "0.19.0", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.20.0" }
+meow-dns = { path = "crates/meow-dns", version = "0.20.0", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.20.0" }
+meow-transport = { path = "crates/meow-transport", version = "0.20.0" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.20.0", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.20.0" }
+meow-listener = { path = "crates/meow-listener", version = "0.20.0", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.20.0" }
+meow-config = { path = "crates/meow-config", version = "0.20.0", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,7 +12,7 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
@@ -26,7 +26,7 @@ name = "anytls_rs"
 path = "src/lib.rs"
 
 [dependencies]
-meow-common = { path = "../meow-common", version = "0.19.0" }
+meow-common = { path = "../meow-common", version = "0.20.0" }
 tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",


### PR DESCRIPTION
Workspace version bump to `0.20.0` (root `[workspace.package]`, the pinned
`[workspace.dependencies]` entries, `meow-anytls`, and `Cargo.lock` via
`cargo update -w`). No code changes.

Minor bump rather than a patch because the `full` bundle gained a protocol:
AnyTLS is now compiled into the release binaries.

## Since v0.19.0

- **#377 item 2 — vless over gRPC/h2 could never carry traffic** (#381). Both
  transports awaited the server's response HEADERS inside `connect()`, while
  xray's `Tun` handler and grpc-go wait for the client's first DATA frame — a
  deadlock that presented as a healthy handshake followed by a silent hang.
  Resolved lazily on first read now, matching upstream's `Conn.Init`.
- **#377 item 2 — REALITY was gated behind `boring-tls`** (#381), so the
  armv7/i686-musl, MIPS, windows-gnu and iOS builds warn-and-skipped every
  REALITY proxy while `-t` still reported success. Now its own `reality`
  feature using pure-Rust X25519.
- **#377 item 1 — AnyTLS is in the `full` bundle** (#381), so the published
  binaries carry it; `minimal` still excludes it per ADR-0007.
- gRPC `:authority` matches mihomo (`servername`, falling back to the dial
  host only when empty) (#381).
- #378 RUSTSEC-2026-0221, #357 traffic-sampling misattribution, #370 plain-HTTP
  connection reuse, and the remaining #377 parity items (hysteria2 `port`,
  rule-provider `proxy:`) from #380.

`cargo check --workspace` passes on the bumped tree.