### PR TITLE
fix(anytls): 32-bit-atomic targets + release 0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "base64",
  "futures",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "criterion",
  "proptest",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -226,16 +226,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.20.0" }
-meow-trie = { path = "crates/meow-trie", version = "0.20.0" }
+meow-common = { path = "crates/meow-common", version = "0.20.1" }
+meow-trie = { path = "crates/meow-trie", version = "0.20.1" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.20.0" }
-meow-dns = { path = "crates/meow-dns", version = "0.20.0", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.20.0" }
-meow-transport = { path = "crates/meow-transport", version = "0.20.0" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.20.0", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.20.0" }
-meow-listener = { path = "crates/meow-listener", version = "0.20.0", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.20.0" }
-meow-config = { path = "crates/meow-config", version = "0.20.0", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.20.1" }
+meow-dns = { path = "crates/meow-dns", version = "0.20.1", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.20.1" }
+meow-transport = { path = "crates/meow-transport", version = "0.20.1" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.20.1", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.20.1" }
+meow-listener = { path = "crates/meow-listener", version = "0.20.1", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.20.1" }
+meow-config = { path = "crates/meow-config", version = "0.20.1", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,7 +12,7 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
@@ -26,7 +26,7 @@ name = "anytls_rs"
 path = "src/lib.rs"
 
 [dependencies]
-meow-common = { path = "../meow-common", version = "0.20.0" }
+meow-common = { path = "../meow-common", version = "0.20.1" }
 tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",

--- a/crates/meow-anytls/src/client/client.rs
+++ b/crates/meow-anytls/src/client/client.rs
@@ -305,7 +305,13 @@ impl Client {
 
         // Set sequence number for pool ordering (use timestamp-based counter)
         static SEQ_COUNTER: meow_common::atomic::AtomicU = meow_common::atomic::AtomicU::new(0);
-        let seq = SEQ_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        #[allow(
+            clippy::useless_conversion,
+            reason = "identity on 64-bit; widens u32 on targets without 64-bit atomics"
+        )]
+        let seq: u64 = SEQ_COUNTER
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .into();
         session.set_seq(seq);
         tracing::debug!("[Client] Session created with seq={}", seq);
 

--- a/crates/meow-anytls/src/client/session_pool.rs
+++ b/crates/meow-anytls/src/client/session_pool.rs
@@ -84,7 +84,13 @@ impl SessionPool {
 
     /// Get the next sequence number
     pub fn next_seq(&self) -> u64 {
-        self.next_seq.fetch_add(1, Ordering::Relaxed)
+        // `AtomicU` is 32-bit on targets without 64-bit atomics (MIPS32); the
+        // public sequence stays u64 and simply wraps sooner there.
+        #[allow(
+            clippy::useless_conversion,
+            reason = "identity on 64-bit; widens u32 on targets without 64-bit atomics"
+        )]
+        self.next_seq.fetch_add(1, Ordering::Relaxed).into()
     }
 
     /// Get an idle session for reuse (the most recent live one, largest seq).

--- a/crates/meow-anytls/src/server/handler.rs
+++ b/crates/meow-anytls/src/server/handler.rs
@@ -4,7 +4,7 @@ use crate::protocol::{Command, Frame};
 use crate::session::{Session, Stream};
 use crate::util::{AnyTlsError, Result, configure_tcp_stream, resolve_host_with_cache};
 use bytes::Bytes;
-use meow_common::atomic::AtomicU;
+use meow_common::atomic::{AtomicU, Uint};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -428,7 +428,7 @@ async fn proxy_tcp_connection_data_forwarding(
                 tracing::error!("[Proxy-Task1] Outbound write error: {}", e);
                 break;
             }
-            bytes_to_outbound_clone.fetch_add(n as u64, Ordering::Relaxed);
+            bytes_to_outbound_clone.fetch_add(n as Uint, Ordering::Relaxed);
 
             tracing::trace!(
                 "[Proxy-Task1] Forwarded {} bytes to outbound (iteration={})",
@@ -493,7 +493,7 @@ async fn proxy_tcp_connection_data_forwarding(
                 );
                 break;
             }
-            bytes_to_client_clone.fetch_add(n as u64, Ordering::Relaxed);
+            bytes_to_client_clone.fetch_add(n as Uint, Ordering::Relaxed);
 
             tracing::trace!(
                 "[Proxy-Task2] Wrote {} bytes to stream {} (iteration={})",

--- a/crates/meow-anytls/src/server/udp_proxy.rs
+++ b/crates/meow-anytls/src/server/udp_proxy.rs
@@ -21,7 +21,7 @@
 use crate::session::{Stream, StreamReader};
 use crate::util::{AnyTlsError, Result, resolve_host_with_cache};
 use bytes::{BufMut, Bytes, BytesMut};
-use meow_common::atomic::AtomicU;
+use meow_common::atomic::{AtomicU, Uint};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -308,7 +308,7 @@ async fn stream_to_udp(
             tracing::warn!("[UDP] Partial UDP send: {} / {} bytes", sent, payload.len());
         }
         packets_counter.fetch_add(1, Ordering::Relaxed);
-        bytes_counter.fetch_add(sent as u64, Ordering::Relaxed);
+        bytes_counter.fetch_add(sent as Uint, Ordering::Relaxed);
     }
 
     Ok(())
@@ -355,7 +355,7 @@ async fn udp_to_stream(
             return Err(AnyTlsError::Protocol("Channel send failed".into()));
         }
         packets_counter.fetch_add(1, Ordering::Relaxed);
-        bytes_counter.fetch_add(len as u64, Ordering::Relaxed);
+        bytes_counter.fetch_add(len as Uint, Ordering::Relaxed);
     }
 }
 

--- a/crates/meow-anytls/src/session/session.rs
+++ b/crates/meow-anytls/src/session/session.rs
@@ -116,7 +116,13 @@ impl Session {
         W: AsyncWrite + Send + Unpin + 'static,
     {
         let (stream_data_tx, stream_data_rx) = mpsc::unbounded_channel();
-        let id = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        #[allow(
+            clippy::useless_conversion,
+            reason = "identity on 64-bit; widens u32 on targets without 64-bit atomics"
+        )]
+        let id: u64 = SESSION_COUNTER
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .into();
         let heartbeat_state = heartbeat.map(|cfg| {
             Arc::new(HeartbeatState {
                 interval: cfg.interval,
@@ -157,7 +163,13 @@ impl Session {
         W: AsyncWrite + Send + Unpin + 'static,
     {
         let (stream_data_tx, stream_data_rx) = mpsc::unbounded_channel();
-        let id = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        #[allow(
+            clippy::useless_conversion,
+            reason = "identity on 64-bit; widens u32 on targets without 64-bit atomics"
+        )]
+        let id: u64 = SESSION_COUNTER
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .into();
 
         Self {
             id,
@@ -1374,12 +1386,21 @@ impl Session {
 
     /// Get session sequence number
     pub fn seq(&self) -> u64 {
-        self.seq.load(std::sync::atomic::Ordering::Relaxed)
+        #[allow(
+            clippy::useless_conversion,
+            reason = "identity on 64-bit; widens u32 on targets without 64-bit atomics"
+        )]
+        self.seq.load(std::sync::atomic::Ordering::Relaxed).into()
     }
 
     /// Set session sequence number
     pub fn set_seq(&self, seq: u64) {
-        self.seq.store(seq, std::sync::atomic::Ordering::Relaxed);
+        // Truncates on targets whose `AtomicU` is 32-bit (MIPS32); the sequence
+        // is only used for pool ordering, so wrapping there is harmless.
+        self.seq.store(
+            seq as meow_common::atomic::Uint,
+            std::sync::atomic::Ordering::Relaxed,
+        );
     }
 
     /// Get peer version


### PR DESCRIPTION
The `v0.20.0` tag published all 12 crates to crates.io successfully, but the
**Release** workflow failed on `mips-unknown-linux-musl` and
`mipsel-unknown-linux-musl`, so no GitHub Release / prebuilt binaries were
produced ([run 31380676054](https://github.com/madeye/meow-rs/actions/runs/31380676054)).

## Cause

`meow-anytls` stores `u64` values in `meow_common::atomic::AtomicU`, which
aliases to `AtomicU32` on targets without 64-bit atomics. Nothing caught it
because the `anytls` feature was off in every build until #381 put it in the
`full` bundle — so the MIPS jobs were the first to ever type-check that crate
for a 32-bit-atomic target, and hit 10 × `E0308`:

```
error[E0308]: mismatched types
    --> crates/meow-anytls/src/session/session.rs:1382:24
1382 |         self.seq.store(seq, std::sync::atomic::Ordering::Relaxed);
     |                  ----- ^^^ expected `u32`, found `u64`
```

## Fix

Widen on read / truncate on store at the atomic boundary, matching the
convention already in `meow-tunnel`, `meow-config` and `meow-listener`
(`as meow_common::atomic::Uint` for stores, `.into()` under the workspace's
`useless_conversion` allow for loads). Session ids and pool sequence numbers
are runtime-local ordering values, so wrapping sooner on mips32 is harmless —
the same trade-off `meow-common/src/atomic.rs` already documents for traffic
counters.

## Verification

The MIPS toolchain isn't reproducible locally (`ring`'s build script needs a
`mipsel-linux-musl-gcc`), so I reproduced the *actual* failure mode instead:
aliased `AtomicU`/`Uint` to their 32-bit variants behind a temporary `force32`
feature and built the real target of the failing job —
`cargo check -p meow-app --no-default-features --features full` — which
reproduced all 10 errors before the fix and is clean after. The probe was
reverted; it is not part of this PR.

Also green: `cargo fmt --check`, three-way clippy with `-D warnings`,
`cargo doc -D warnings`, `cargo test --lib`, `anytls_integration`.

## Release 0.20.1

Second commit bumps the workspace to `0.20.1`. `0.20.0` is on crates.io and
cannot be reused, and re-tagging it would leave the git tag pointing at
different sources than the published crates. Tagging `v0.20.1` republishes
(publish.yml skips versions already on the registry) and produces the GitHub
Release with binaries that `v0.20.0` never got.