### PR TITLE
ci(release): ship only full+boring-tls targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,28 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # MIPS: tier 3 — no prebuilt rust-std, so nightly + -Zbuild-std via
-          # cross (Docker images carry the soft-float musl toolchain).
-          # boring-tls is off (boring-sys cannot cross-compile for MIPS).
-          # Note: mips musl targets default to dynamically-linked musl
-          # (fine on OpenWrt); traffic counters wrap at 4 GiB on mips32
-          # (no 64-bit atomics — see meow-common/src/atomic.rs).
-          - target: mipsel-unknown-linux-musl
-            runner: ubuntu-latest
-            minimal_budget_bytes: 0
-            minimal_soft_gate: true
-            build_std: true
-            toolchain: nightly
-            cargo_flags: --no-default-features --features full
-            use_cross: true
-          - target: mips-unknown-linux-musl
-            runner: ubuntu-latest
-            minimal_budget_bytes: 0
-            minimal_soft_gate: true
-            build_std: true
-            toolchain: nightly
-            cargo_flags: --no-default-features --features full
-            use_cross: true
+          # Every release target builds with the meow-app default feature set
+          # (`full` + `boring-tls`). Targets that cannot link boring-sys
+          # (MIPS, 32-bit musl, windows-gnu) are intentionally not shipped —
+          # operators who need them can cross-build from source with
+          # `--no-default-features --features full`.
           # Linux musl
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
@@ -59,21 +42,6 @@ jobs:
             openwrt_archs: >-
               aarch64_generic aarch64_cortex-a53 aarch64_cortex-a72
               aarch64_cortex-a76
-          - target: armv7-unknown-linux-musleabihf
-            runner: ubuntu-latest
-            # armv7: soft gate only for now (no ADR-0007 budget yet)
-            minimal_budget_bytes: 0
-            minimal_soft_gate: true
-            # boring-sys is broken on 32-bit musl (bindgen emits time64
-            # `time_t: i64` per musl 1.2, while boring passes i32), so build
-            # without the boring-tls default. Trade-off: no ECH/uTLS
-            # fingerprinting on armv7 — everything else in `full` is present.
-            cargo_flags: --no-default-features --features full
-            # Rust's armv7 musleabihf baseline is vfpv3-d16 without NEON, so
-            # the same binary is safe on every core listed here (#284).
-            openwrt_archs: >-
-              arm_cortex-a7_neon-vfpv4 arm_cortex-a8_vfpv3
-              arm_cortex-a9_vfpv3-d16 arm_cortex-a15_neon-vfpv4
           # Linux GNU
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-latest
@@ -87,23 +55,6 @@ jobs:
             runner: ubuntu-latest
             minimal_budget_bytes: 0
             minimal_soft_gate: true
-          # i686: built via cross (Docker) — its images ship a coherent i686
-          # gcc toolchain. zig 0.13 mistranslates x86 AVX-512 features
-          # (evex512, breaks blake3), and host clang mixes glibc-2.39 headers
-          # with other libcs (__isoc23_* symbol drift). boring-tls off: the
-          # 32-bit-musl time64 bindgen mismatch (see armv7 above) applies.
-          - target: i686-unknown-linux-gnu
-            runner: ubuntu-latest
-            minimal_budget_bytes: 0
-            minimal_soft_gate: true
-            cargo_flags: --no-default-features --features full
-            use_cross: true
-          - target: i686-unknown-linux-musl
-            runner: ubuntu-latest
-            minimal_budget_bytes: 0
-            minimal_soft_gate: true
-            cargo_flags: --no-default-features --features full
-            use_cross: true
           - target: riscv64gc-unknown-linux-musl
             runner: ubuntu-latest
             minimal_budget_bytes: 0
@@ -117,11 +68,6 @@ jobs:
             runner: windows-latest
             minimal_budget_bytes: 0
             minimal_soft_gate: true
-          - target: x86_64-pc-windows-gnu
-            runner: windows-latest
-            minimal_budget_bytes: 0
-            minimal_soft_gate: true
-            cargo_flags: --no-default-features --features full
           - target: i686-pc-windows-msvc
             runner: windows-latest
             minimal_budget_bytes: 0
@@ -141,14 +87,9 @@ jobs:
       - name: Setup Rust toolchain
         shell: bash
         run: |
-          TOOLCHAIN="${{ matrix.toolchain || 'stable' }}"
-          rustup toolchain install "$TOOLCHAIN" --profile minimal --no-self-update
-          rustup default "$TOOLCHAIN"
-          if [ "${{ matrix.build_std }}" = "true" ]; then
-            rustup component add rust-src --toolchain "$TOOLCHAIN"
-          else
-            rustup target add "${{ matrix.target }}" --toolchain "$TOOLCHAIN"
-          fi
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+          rustup target add "${{ matrix.target }}"
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -164,25 +105,14 @@ jobs:
       - run: cargo install --locked cargo-zigbuild
         if: runner.os == 'Linux'
 
-      - name: Install cross-compilation tools
-        if: runner.os == 'Linux'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cross@0.2.5
-
       - name: Build release binary
         shell: bash
         run: |
-          if [ "${{ matrix.use_cross }}" = "true" ]; then
-            BUILD_STD=""
-            if [ "${{ matrix.build_std }}" = "true" ]; then
-              BUILD_STD="-Zbuild-std=std,panic_abort"
-            fi
-            cross build --release --locked ${{ matrix.cargo_flags }} $BUILD_STD --target ${{ matrix.target }} --bin meow
-          elif [ "${{ runner.os }}" = "Linux" ]; then
-            cargo zigbuild --release --locked ${{ matrix.cargo_flags }} --target ${{ matrix.target }} --bin meow
+          # Default features = full + boring-tls (meow-app/Cargo.toml).
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            cargo zigbuild --release --locked --target ${{ matrix.target }} --bin meow
           else
-            cargo build --release --locked ${{ matrix.cargo_flags }} --target ${{ matrix.target }} --bin meow
+            cargo build --release --locked --target ${{ matrix.target }} --bin meow
           fi
 
       - name: Build minimal release binary (stripped, for size check)

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ tail -f ~/Library/Logs/meow/meow.log
 
 **OpenWrt (opkg + LuCI):**
 
-Official `.ipk` packages for arm/aarch64 routers — including a
+Official `.ipk` packages for aarch64 routers — including a
 `luci-app-meow` that embeds the built-in web panel in LuCI — are attached
 to every [release](https://github.com/madeye/meow-rs/releases). See
 [docs/openwrt.md](docs/openwrt.md).

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["proxy", "clash", "mihomo", "vpn", "networking"]
 categories = ["network-programming", "command-line-utilities"]
 
 [features]
+# Default = everything a release binary ships: all protocols/listeners/DNS
+# plus BoringSSL (ECH/uTLS). Targets that cannot link boring-sys are not
+# published (see .github/workflows/release.yml); build those from source with
+# `--no-default-features --features full` if needed.
 default = ["full", "boring-tls"]
 boring-tls = ["meow-config/boring-tls"]
 # Auto-download a third-party dashboard from `external-ui-url` (issue #223).

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -14,8 +14,8 @@ ss = ["meow-proxy/ss"]
 trojan = ["meow-proxy/trojan"]
 # `meow-transport/reality` rides along with vless: `reality-opts` is only
 # reachable from the vless parser, and REALITY must not depend on boring-tls
-# (issue #377 — boring-sys does not build for armv7/i686 musl, MIPS,
-# windows-gnu or iOS, and those builds silently lost every REALITY proxy).
+# (issue #377 — boring-sys cannot be linked on some targets; REALITY uses
+# x25519-dalek so it works with the rustls-only `full` feature set).
 vless = ["meow-proxy/vless", "meow-transport/reality"]
 vless-vision = ["vless", "meow-proxy/vless-vision"]
 vless-encryption = ["vless", "meow-proxy/vless-encryption"]

--- a/docs/openwrt.md
+++ b/docs/openwrt.md
@@ -1,25 +1,25 @@
 # meow on OpenWrt
 
-Official `.ipk` packages for arm OpenWrt devices are attached to every
+Official `.ipk` packages for aarch64 OpenWrt devices are attached to every
 [GitHub release](https://github.com/madeye/meow-rs/releases) (issue
 [#284](https://github.com/madeye/meow-rs/issues/284)):
 
 | Package | Architectures |
 |---------|---------------|
-| `meow_<ver>_<arch>.ipk` | `aarch64_generic`, `aarch64_cortex-a53`, `aarch64_cortex-a72`, `aarch64_cortex-a76`, `arm_cortex-a7_neon-vfpv4`, `arm_cortex-a8_vfpv3`, `arm_cortex-a9_vfpv3-d16`, `arm_cortex-a15_neon-vfpv4` |
+| `meow_<ver>_<arch>.ipk` | `aarch64_generic`, `aarch64_cortex-a53`, `aarch64_cortex-a72`, `aarch64_cortex-a76` |
 | `luci-app-meow_<ver>_all.ipk` | any (LuCI app, architecture-independent) |
 
 The binaries are fully static musl builds, so they have no library
-dependencies beyond OpenWrt's base system. All 32-bit arm packages contain
-the same `armv7` (vfpv3-d16, no NEON assumed) binary; all aarch64 packages
-contain the same `aarch64` binary — only the opkg `Architecture:` label
-differs so that `opkg` accepts the package on your device.
+dependencies beyond OpenWrt's base system. All aarch64 packages contain
+the same `aarch64` binary — only the opkg `Architecture:` label differs so
+that `opkg` accepts the package on your device.
 
-Feature note: the armv7 binaries are built without the `boring-tls`
-feature (boring-sys does not compile for 32-bit musl targets), so ECH and
-uTLS fingerprinting are unavailable on 32-bit arm; every other `full`
-feature (all protocols, DNS, listeners) is present. aarch64 binaries are
-full-featured.
+Feature note: release binaries use the default meow-app feature set
+(`full` + `boring-tls`), so ECH and uTLS fingerprinting are included.
+
+32-bit arm / MIPS OpenWrt packages are not published: `boring-sys` does not
+build for those targets. Cross-build from source with
+`--no-default-features --features full` if you need them without BoringSSL.
 
 Find your device's architecture with:
 
@@ -27,13 +27,12 @@ Find your device's architecture with:
 . /etc/openwrt_release; echo "$DISTRIB_ARCH"
 ```
 
-For example, a Linksys WRT1900ACS (Marvell Armada 385) is
-`arm_cortex-a9_vfpv3-d16`. If your architecture is not in the table but is a
-superset of one that is (e.g. a NEON-capable core), the closest smaller
-package works — the binary makes no assumptions beyond the baseline listed
-above. Devices of other families (mips, x86) can use the static binaries
-from the release tarballs directly; `x86_64` OpenWrt can also run the
-`x86_64-unknown-linux-musl` tarball binary as-is.
+For example, a Raspberry Pi 4 OpenWrt image is typically
+`aarch64_cortex-a72`. If your architecture is not in the table but is a
+superset of one that is, the closest smaller package works — the binary
+makes no assumptions beyond the aarch64 baseline. Devices of other
+families (32-bit arm, mips, x86) can use a self-built static binary or,
+for `x86_64`, the `x86_64-unknown-linux-musl` release tarball as-is.
 
 ## Install
 
@@ -129,5 +128,7 @@ bash tests/test_openwrt_qemu.sh
 - An opkg feed (per-release ipks only; `opkg update`-able feed may come
   later once this stabilizes).
 - `apk` packages for OpenWrt snapshot/main builds (which replaced opkg).
-- mips builds — blocked on Rust dropping stable `rust-std` for
-  `mipsel-unknown-linux-musl` (see ADR-0007).
+- 32-bit arm / mips release ipks — release artifacts require the default
+  `full` + `boring-tls` feature set; boring-sys does not build for those
+  targets. Build from source with `--no-default-features --features full`
+  if needed.

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -23,7 +23,9 @@ roughly 6 MiB; you can copy it to any matching host and run it directly.
 ::: tip Prebuilt binaries
 If you don't want to compile, grab a build from the
 [releases page](https://github.com/madeye/meow-rs/releases/latest). Builds are published
-for Linux (x86_64 gnu/musl, aarch64), macOS (aarch64), and Windows (x86_64).
+for Linux (x86_64/aarch64 gnu+musl, armv7 gnu, riscv64 musl), macOS
+(x86_64/aarch64), and Windows MSVC (x86_64/aarch64/i686). Every binary
+ships with the default feature set (`full` + `boring-tls`).
 :::
 
 ## Configure


### PR DESCRIPTION
## Summary
- Release matrix now builds only with meow-app defaults (`full` + `boring-tls`); no more half-featured release binaries.
- Drop targets that cannot link `boring-sys`: MIPS (musl), armv7/i686 musl/gnu Linux, windows-gnu.
- Remove `cross` / nightly / `-Zbuild-std` from the release workflow (only needed for those targets).
- Docs: OpenWrt ipks are aarch64-only; document self-build for unsupported arches.

## Kept targets (11)
Linux musl x86_64/aarch64/riscv64 · Linux gnu x86_64/aarch64/armv7 · Windows MSVC x86_64/aarch64/i686 · macOS x86_64/aarch64

## Test plan
- [x] `release.yml` YAML parses; matrix lists 11 targets
- [x] Default features remain `full` + `boring-tls`
- [ ] CI green on PR
- [ ] Next `v*` release dry-run if desired