### PR TITLE
fix(config): accept short-id: null and bind-address '*' for mihomo compat

### DIFF
--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -731,9 +731,16 @@ fn run_cmd(cmd: &str, args: &[&str]) -> Result<()> {
 /// of `format!("{listen}:{port}")`. The string form produces an unparseable
 /// `:::7890` for an IPv6 listen address like `::`, which silently broke
 /// dual-stack binding (`bind-address: '::'`); `SocketAddr::new` handles IPv4
-/// and IPv6 uniformly. `listen` is always an IP literal here (`0.0.0.0`, `::`,
-/// `127.0.0.1`, or a specific address).
+/// and IPv6 uniformly. `listen` is normally an IP literal here (`0.0.0.0`,
+/// `::`, `127.0.0.1`, or a specific address); the mihomo wildcard `'*'` is
+/// normalised to `0.0.0.0`.
 fn bind_socket_addr(listen: &str, port: u16) -> Result<SocketAddr> {
+    // mihomo treats `bind-address: '*'` as the wildcard "all interfaces" — it is
+    // the idiomatic value Clash Verge writes. This only surfaces when allow-lan
+    // is on, since allow-lan:off already forces 127.0.0.1 upstream, so map it to
+    // the IPv4-any literal instead of aborting the whole process (issue #388).
+    // `::` remains the explicit dual-stack opt-in.
+    let listen = if listen == "*" { "0.0.0.0" } else { listen };
     let ip: IpAddr = listen
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid bind address '{listen}': {e}"))?;
@@ -1080,6 +1087,15 @@ mod tests {
     #[test]
     fn invalid_bind_address_errors() {
         assert!(bind_socket_addr("not-an-ip", 80).is_err());
+    }
+
+    #[test]
+    fn wildcard_bind_address_is_ipv4_any() {
+        // mihomo wildcard: `bind-address: '*'` binds all interfaces (0.0.0.0)
+        // instead of aborting the process (issue #388).
+        let a = bind_socket_addr("*", 7890).unwrap();
+        assert_eq!(a.to_string(), "0.0.0.0:7890");
+        assert!(a.is_ipv4());
     }
 
     #[cfg(target_os = "windows")]

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1474,11 +1474,14 @@ fn parse_vless_reality_opts(
     let mut public_key = [0u8; 32];
     public_key.copy_from_slice(&public_key_bytes);
 
+    // mihomo tolerates `short-id: null` — many subscription generators emit it
+    // when the server has no short ID — and treats it as absent. Map it to the
+    // empty short ID instead of rejecting (and silently dropping) the node.
     let short_id_str = match opts.get("short-id") {
+        Some(serde_yaml::Value::Null) | None => "",
         Some(value) => value
             .as_str()
             .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?,
-        None => "",
     };
     let short_id_vec = parse_reality_short_id(short_id_str)?;
     let mut short_id = [0u8; 8];
@@ -1973,6 +1976,36 @@ mod tests {
         assert_eq!(decoded.len(), 32);
         // Garbage is still rejected.
         assert!(decode_raw_url_base64_lenient("!!!not base64!!!").is_none());
+    }
+
+    #[cfg(feature = "vless")]
+    #[test]
+    fn reality_short_id_null_treated_as_absent() {
+        // mihomo tolerates `short-id: null` — many subscription generators emit
+        // it when the server has no short ID — so it must not drop the node
+        // (issue #388). The 32-byte key is the one from the test above.
+        let key = "OKkD6Wt1lC4-9avJj2t3PkvIDkvcA1Fu0b09QwJ7GGh";
+
+        let cfg = proxy_config(&format!(
+            "reality-opts:\n  public-key: {key}\n  short-id: null\n"
+        ));
+        let opts = parse_vless_reality_opts(&cfg)
+            .expect("null short-id must parse")
+            .expect("reality-opts present");
+        assert_eq!(opts.short_id, [0u8; 8]);
+
+        // An explicit hex short-id still decodes and zero-pads to 8 bytes.
+        let cfg = proxy_config(&format!(
+            "reality-opts:\n  public-key: {key}\n  short-id: \"01ab\"\n"
+        ));
+        let opts = parse_vless_reality_opts(&cfg).unwrap().unwrap();
+        assert_eq!(opts.short_id, [0x01, 0xab, 0, 0, 0, 0, 0, 0]);
+
+        // A present but non-hex short-id is still rejected.
+        let cfg = proxy_config(&format!(
+            "reality-opts:\n  public-key: {key}\n  short-id: \"zz\"\n"
+        ));
+        assert!(parse_vless_reality_opts(&cfg).is_err());
     }
 
     #[cfg(any(feature = "vless", feature = "vmess"))]


### PR DESCRIPTION
Closes #388.

Two config constructs that are common in real-world subscription / Clash Verge
profiles are accepted by mihomo but were rejected by meow-rs — one silently
dropped nodes, the other aborted the process. This PR makes meow-rs tolerate
both, matching mihomo.

## 1. `reality-opts.short-id: null` (YAML null) no longer drops VLESS nodes

mihomo decodes `short-id` into a Go `string` (`adapter/outbound/reality.go`):
a YAML `null` becomes the zero value `""`, and `hex.Decode(dst, "")` succeeds
with `n == 0`, yielding `ShortID == [8]byte{0}` — no error. Many subscription
generators emit `short-id: null` when the server has no short ID, so mihomo runs
these nodes fine while meow-rs rejected them with
`vless: reality-opts.short-id must be a hex string` and dropped the node
(cascading into `group has no valid proxies`).

**Fix:** treat `Value::Null` the same as an absent key → empty short ID, instead
of erroring. Explicit values are unchanged: a present string is still required
to be valid hex (`parse_reality_short_id`), and a present non-string still
errors.

## 2. `bind-address: '*'` no longer aborts the process

mihomo maps the wildcard to "all interfaces" only when `allow-lan` is on
(`listener/listener.go` `genAddr`): `allow-lan: true` + `bind-address: '*'` →
`:port`; `allow-lan: false` → `127.0.0.1:port` regardless. meow-rs fed the raw
`'*'` to `IpAddr::from_str`, which failed and exited the whole process at
listener startup.

**Fix:** normalise `'*'` → `0.0.0.0` in `bind_socket_addr`. This is only reached
when `allow-lan` is on, because `allow-lan: false` already forces `127.0.0.1`
upstream in `meow-config` — so the loopback-only default is unchanged.

> Deliberate deviation, flagging for review: mihomo binds `:port` (dual-stack on
> Linux); this maps to `0.0.0.0` (all-IPv4), which is the conventional,
> cross-platform-safe reading and matches meow-rs's existing `0.0.0.0` wildcard
> convention. `bind-address: '::'` remains the explicit dual-stack opt-in. Happy
> to switch to `::` if you'd rather mirror mihomo's dual-stack exactly.

## Testing

- New unit tests: `reality_short_id_null_treated_as_absent` (null → empty; hex
  still decodes; non-hex still rejected) and `wildcard_bind_address_is_ipv4_any`
  (`*` → `0.0.0.0`).
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets` clean under
  default / `--no-default-features` / `--all-features`.
- `cargo test` for `meow-config` (282) and `meow-app` (14): all pass.
- Functional check against a live 50-node mihomo subscription (40 AnyTLS + 10
  VLESS-with-`short-id: null`): previously the 10 VLESS nodes were dropped; with
  this patch all 65 proxies load and the null-short-id VLESS nodes complete the
  REALITY handshake (measured real latencies) and proxy end-to-end.

Note: one unrelated test, `meow-api`'s
`post_dns_query_unknown_name_returns_null_answer`, fails when run on a machine
whose DNS is intercepted by a fake-ip proxy (it resolves `no-such-host.invalid`
to a `198.18.x.x` fake-ip instead of NXDOMAIN). It fails identically on
unmodified `main` under that environment and is untouched by this PR.
