### PR TITLE
fix(config): accept integer expected-status; clarify compiled-out proxy type errors

### DIFF
--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -203,8 +203,43 @@ pub fn parse_proxy(
             let adapter = parse_snell(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
+        #[cfg(not(feature = "ss"))]
+        "ss" => Err(feature_gated_proxy_type("ss")),
+        #[cfg(not(feature = "trojan"))]
+        "trojan" => Err(feature_gated_proxy_type("trojan")),
+        #[cfg(not(feature = "vless"))]
+        "vless" => Err(feature_gated_proxy_type("vless")),
+        #[cfg(not(feature = "anytls"))]
+        "anytls" => Err(feature_gated_proxy_type("anytls")),
+        #[cfg(not(feature = "hysteria2"))]
+        "hysteria2" => Err(feature_gated_proxy_type("hysteria2")),
+        #[cfg(not(feature = "vmess"))]
+        "vmess" => Err(feature_gated_proxy_type("vmess")),
+        #[cfg(not(feature = "snell"))]
+        "snell" => Err(feature_gated_proxy_type("snell")),
         _ => Err(format!("unsupported proxy type: {proxy_type}")),
     }
+}
+
+/// Error for a proxy type this codebase implements but which was compiled out
+/// of the running binary. The generic "unsupported proxy type" message made
+/// users think the protocol was missing entirely, when the actual fix is to
+/// use a full-featured build (issue #390).
+#[cfg(not(all(
+    feature = "ss",
+    feature = "trojan",
+    feature = "vless",
+    feature = "anytls",
+    feature = "hysteria2",
+    feature = "vmess",
+    feature = "snell"
+)))]
+fn feature_gated_proxy_type(proxy_type: &str) -> String {
+    format!(
+        "proxy type '{proxy_type}' is not compiled into this build; \
+         use an official release binary or rebuild with `--features full` \
+         (or `--features {proxy_type}`)"
+    )
 }
 
 /// Parse a `type: snell` proxy block.

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -41,6 +41,50 @@ where
     deserializer.deserialize_any(StringOrSeq)
 }
 
+/// `expected-status` accepts either a bare integer (`204`) or a string
+/// (`"204"`, `"200-299"`, `"200,204"`). The docs and upstream mihomo both
+/// allow the unquoted integer form; normalize it to the string form the
+/// health-check range parser consumes (issue #390).
+fn deserialize_status_or_int<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+    use std::fmt;
+
+    struct StatusOrInt;
+
+    impl Visitor<'_> for StatusOrInt {
+        type Value = Option<String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("an HTTP status code (integer) or status-range string")
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+            Ok(Some(v.to_string()))
+        }
+
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+            Ok(Some(v.to_string()))
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            Ok(Some(v.to_owned()))
+        }
+    }
+
+    deserializer.deserialize_any(StatusOrInt)
+}
+
 /// `geodata:` YAML subsection — path overrides, download URLs, auto-update.
 ///
 /// Fields `geodata-mode`, `geodata-loader`, and `geoip-matcher` exist in
@@ -276,6 +320,11 @@ pub struct RawProxyGroup {
     pub url: Option<String>,
     pub interval: Option<u64>,
     pub tolerance: Option<u16>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_status_or_int",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub expected_status: Option<String>,
     pub strategy: Option<String>,
     pub lazy: Option<bool>,
@@ -321,6 +370,11 @@ pub struct RawHealthCheck {
     pub url: Option<String>,
     pub interval: Option<u64>,
     pub timeout: Option<u64>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_status_or_int",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub expected_status: Option<String>,
     pub lazy: Option<bool>,
 }
@@ -453,4 +507,43 @@ pub struct RawSubscription {
     pub url: String,
     pub interval: Option<u64>,
     pub last_updated: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RawHealthCheck, RawProxyGroup};
+
+    #[test]
+    fn expected_status_accepts_integer_scalar() {
+        // issue #390: docs promise `expected-status: 204` (integer); it used
+        // to fail with "invalid type: integer `204`, expected a string".
+        let group: RawProxyGroup =
+            serde_yaml::from_str("name: auto\ntype: url-test\nexpected-status: 204\n").unwrap();
+        assert_eq!(group.expected_status.as_deref(), Some("204"));
+
+        let hc: RawHealthCheck =
+            serde_yaml::from_str("enable: true\nexpected-status: 204\n").unwrap();
+        assert_eq!(hc.expected_status.as_deref(), Some("204"));
+    }
+
+    #[test]
+    fn expected_status_accepts_string_forms() {
+        let group: RawProxyGroup =
+            serde_yaml::from_str("name: auto\ntype: url-test\nexpected-status: \"200-299\"\n")
+                .unwrap();
+        assert_eq!(group.expected_status.as_deref(), Some("200-299"));
+
+        let hc: RawHealthCheck =
+            serde_yaml::from_str("enable: true\nexpected-status: \"204\"\n").unwrap();
+        assert_eq!(hc.expected_status.as_deref(), Some("204"));
+    }
+
+    #[test]
+    fn expected_status_absent_is_none() {
+        let group: RawProxyGroup = serde_yaml::from_str("name: auto\ntype: url-test\n").unwrap();
+        assert_eq!(group.expected_status, None);
+
+        let hc: RawHealthCheck = serde_yaml::from_str("enable: true\n").unwrap();
+        assert_eq!(hc.expected_status, None);
+    }
 }

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -996,3 +996,36 @@ rules:
     let config = load_config_from_str(yaml).await.unwrap();
     assert_eq!(config.rules.len(), 2);
 }
+
+#[tokio::test]
+async fn test_expected_status_integer_accepted_end_to_end() {
+    // issue #390: `expected-status: 204` (unquoted integer, as documented)
+    // used to abort config load with "invalid type: integer `204`, expected
+    // a string" — in both proxy-groups and proxy-provider health-checks.
+    let yaml = r#"
+proxies:
+  - name: p1
+    type: ss
+    server: 127.0.0.1
+    port: 8388
+    cipher: aes-256-gcm
+    password: test
+proxy-groups:
+  - name: auto
+    type: url-test
+    proxies: [p1]
+    url: http://www.gstatic.com/generate_204
+    interval: 300
+    expected-status: 204
+proxy-providers:
+  prov:
+    type: file
+    path: /nonexistent/meow-issue-390-provider.yaml
+    health-check:
+      enable: true
+      interval: 300
+      expected-status: 204
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(config.proxies.contains_key("auto"));
+}

--- a/docs/specs/proxy-providers.md
+++ b/docs/specs/proxy-providers.md
@@ -157,7 +157,7 @@ proxy-groups:
 | `health-check.url` | string | if `enable` | — | URL used for reachability probes. |
 | `health-check.interval` | integer | no | `300` | Health-check sweep interval in seconds. |
 | `health-check.lazy` | bool | no | `true` | If true, defer first probe until the proxy is first used by a connection. |
-| `health-check.expected-status` | integer | no | `204` | HTTP status code that counts as healthy. |
+| `health-check.expected-status` | integer or string | no | any 2xx | HTTP status that counts as healthy: a bare code (`204`) or a range string (`"200-299"`, `"200,204"`). |
 | `override` | map | no | `{}` | Key-value overrides applied to every proxy. See §Override. |
 | `filter` | string | no | `""` | Regex. Include only proxies whose `name` matches. Empty = include all. |
 | `exclude-filter` | string | no | `""` | Regex. Exclude proxies whose `name` matches. Applied after `filter`. |


### PR DESCRIPTION
Fixes #390.

## What

Two changes, both in `meow-config`:

1. **`expected-status` accepts the documented integer form.** `expected-status: 204` (unquoted, as shown in the docs and accepted by mihomo) previously aborted config load with `invalid type: integer 204, expected a string`. Both proxy-group `expected-status` and proxy-provider `health-check.expected-status` now accept a bare integer or a string; integers are normalized to the string form the health-check range parser consumes. String range syntax (`"200-299"`, `"200,204"`) is unchanged.

2. **Clearer error for compiled-out proxy types.** The issue's second symptom — `unsupported proxy type: vless/anytls/hysteria2/vmess` from proxy-providers — does **not** reproduce on official full builds: the v0.20.1 release binary parses all four provider entries fine (verified locally). It only happens on binaries built without those protocol features, but the generic message made it look like the protocols were missing entirely. `parse_proxy` now distinguishes the two cases:

   ```
   proxy type 'vless' is not compiled into this build; use an official release binary or rebuild with `--features full` (or `--features vless`)
   ```

## Verification

- Reproduced both symptoms first: `expected-status: 204` fails on the official v0.20.1 binary; the four provider proxy types parse fine on it (so symptom 2 is build-flavor, not a parser gap).
- With this fix, the issue's config loads end-to-end (`meow -t` passes, provider refreshes with `count=4`).
- A `--features minimal` build now emits the new per-type message for vless/anytls/hysteria2/vmess provider entries instead of the misleading generic one.
- New unit tests (`raw.rs`) cover integer, string-range, and absent forms; new integration test (`config_test.rs`) covers the issue's exact config shape.
- Regression bar: `cargo fmt --check`, three-way clippy (`default` / `--no-default-features` / `--all-features`) with `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, and `cargo test --lib` (12 suites) all pass.

Note for the reporter: if you see `unsupported proxy type` on ≥0.20.0, please share `meow -v` and where the binary came from — official release archives since v0.20.0 include all protocols.