### PR TITLE
feat(listener): ephemeral (port 0) listeners with runtime port discovery

### DIFF
--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -807,57 +807,6 @@ async fn run(
         });
     }
 
-    // Start REST API if configured
-    if let Some(api_addr) = config.api.external_controller {
-        // `external-ui-url` auto-download is gated behind the optional
-        // `external-ui-download` feature (it pulls in the `zip` crate, against
-        // the ADR-0007 size caps). Without the feature we just hint the user to
-        // populate the directory manually. See issue #223.
-        if let (Some(url), Some(dir)) = (&config.api.external_ui_url, &config.api.external_ui) {
-            if !dir.is_dir() {
-                // Auto-download is gated behind `external-ui-download` AND is
-                // force-disabled on iOS/Android (mobile ships its own UI).
-                #[cfg(all(
-                    feature = "external-ui-download",
-                    not(any(target_os = "ios", target_os = "android"))
-                ))]
-                {
-                    if let Err(e) = meow_config::external_ui::download_external_ui(url, dir).await {
-                        warn!("failed to download external-ui from {url}: {e:#}");
-                    }
-                }
-                #[cfg(not(all(
-                    feature = "external-ui-download",
-                    not(any(target_os = "ios", target_os = "android"))
-                )))]
-                {
-                    warn!(
-                        "external-ui-url ({url}) is set but auto-download is unavailable in this \
-                         build; download and extract the UI into {} manually",
-                        dir.display()
-                    );
-                }
-            }
-        }
-        let api_server = ApiServer::new(
-            tunnel.clone(),
-            api_addr,
-            config.api.secret.clone(),
-            config_path.clone(),
-            Arc::clone(&raw_config),
-            log_tx.clone(),
-            Arc::clone(&proxy_providers),
-            Arc::clone(&rule_providers),
-            config.listeners.named.clone(),
-            config.api.external_ui.clone(),
-        );
-        tokio::spawn(async move {
-            if let Err(e) = api_server.run().await {
-                error!("API server error: {}", e);
-            }
-        });
-    }
-
     // Spawn background refresh tasks for HTTP rule-providers with interval > 0.
     {
         let providers_snap: Vec<_> = rule_providers
@@ -926,10 +875,14 @@ async fn run(
     // consumed only inside feature-gated listener blocks below.
     let _ = (&sniffer_runtime, &auth);
 
-    // Start listeners
+    // Start listeners. Bind before spawning the accept loops so a `port: 0`
+    // (ephemeral) listener resolves to its OS-assigned port up front; the
+    // resolved ports are patched into `named_listeners`, which feeds the
+    // startup logs and the API snapshot (`GET /listeners`) below.
     use meow_config::ListenerType;
 
-    for nl in &config.listeners.named {
+    let mut named_listeners = config.listeners.named.clone();
+    for nl in &mut named_listeners {
         let addr = bind_socket_addr(&nl.listen, nl.port)
             .map_err(|e| anyhow::anyhow!("listener '{}': {e}", nl.name))?;
         // Suppress unused-variable warning: addr is consumed only inside
@@ -939,12 +892,21 @@ async fn run(
             ListenerType::Mixed | ListenerType::Http | ListenerType::Socks5 => {
                 #[cfg(feature = "listener-mixed")]
                 {
-                    let listener = MixedListener::new(tunnel.clone(), addr, nl.name.clone())
+                    let socket = match tokio::net::TcpListener::bind(addr).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!("listener '{}': bind {} failed: {}", nl.name, addr, e);
+                            continue;
+                        }
+                    };
+                    let bound = socket.local_addr().unwrap_or(addr);
+                    nl.port = bound.port();
+                    let listener = MixedListener::new(tunnel.clone(), bound, nl.name.clone())
                         .with_sniffer(Arc::clone(&sniffer_runtime))
                         .with_auth(Arc::clone(&auth))
                         .with_max_connections(nl.max_connections);
                     tokio::spawn(async move {
-                        if let Err(e) = listener.run().await {
+                        if let Err(e) = listener.run_on(socket).await {
                             error!("Listener error: {}", e);
                         }
                     });
@@ -959,16 +921,25 @@ async fn run(
             ListenerType::TProxy => {
                 #[cfg(feature = "listener-tproxy")]
                 {
+                    let socket = match tokio::net::TcpListener::bind(addr).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!("listener '{}': bind {} failed: {}", nl.name, addr, e);
+                            continue;
+                        }
+                    };
+                    let bound = socket.local_addr().unwrap_or(addr);
+                    nl.port = bound.port();
                     let listener = TProxyListener::new(
                         tunnel.clone(),
-                        addr,
+                        bound,
                         nl.tproxy_sni,
                         config.listeners.routing_mark,
                         nl.name.clone(),
                     )
                     .with_sniffer(Arc::clone(&sniffer_runtime));
                     tokio::spawn(async move {
-                        if let Err(e) = listener.run().await {
+                        if let Err(e) = listener.run_on(socket).await {
                             error!("TProxy listener error: {}", e);
                         }
                     });
@@ -980,6 +951,59 @@ async fn run(
                 );
             }
         }
+    }
+
+    // Start REST API if configured. Runs after the listener bind phase so the
+    // `GET /listeners` snapshot reports OS-assigned ports for `port: 0`
+    // (ephemeral) listeners rather than the configured `0`.
+    if let Some(api_addr) = config.api.external_controller {
+        // `external-ui-url` auto-download is gated behind the optional
+        // `external-ui-download` feature (it pulls in the `zip` crate, against
+        // the ADR-0007 size caps). Without the feature we just hint the user to
+        // populate the directory manually. See issue #223.
+        if let (Some(url), Some(dir)) = (&config.api.external_ui_url, &config.api.external_ui) {
+            if !dir.is_dir() {
+                // Auto-download is gated behind `external-ui-download` AND is
+                // force-disabled on iOS/Android (mobile ships its own UI).
+                #[cfg(all(
+                    feature = "external-ui-download",
+                    not(any(target_os = "ios", target_os = "android"))
+                ))]
+                {
+                    if let Err(e) = meow_config::external_ui::download_external_ui(url, dir).await {
+                        warn!("failed to download external-ui from {url}: {e:#}");
+                    }
+                }
+                #[cfg(not(all(
+                    feature = "external-ui-download",
+                    not(any(target_os = "ios", target_os = "android"))
+                )))]
+                {
+                    warn!(
+                        "external-ui-url ({url}) is set but auto-download is unavailable in this \
+                         build; download and extract the UI into {} manually",
+                        dir.display()
+                    );
+                }
+            }
+        }
+        let api_server = ApiServer::new(
+            tunnel.clone(),
+            api_addr,
+            config.api.secret.clone(),
+            config_path.clone(),
+            Arc::clone(&raw_config),
+            log_tx.clone(),
+            Arc::clone(&proxy_providers),
+            Arc::clone(&rule_providers),
+            named_listeners.clone(),
+            config.api.external_ui.clone(),
+        );
+        tokio::spawn(async move {
+            if let Err(e) = api_server.run().await {
+                error!("API server error: {}", e);
+            }
+        });
     }
 
     // TUN inbound (issue #326) — spawned from the top-level `tun:` section,

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -27,7 +27,7 @@ use proxy_provider::ProxyProvider;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -1326,6 +1326,40 @@ fn resource_cache_dir_for_config_path_with_home(path: &str, home_dir: Option<Pat
         )
 }
 
+/// Resolve a listener `listen` field plus optional `port`.
+///
+/// `listen` may be:
+/// - an IP literal (`127.0.0.1`, `::`, `0.0.0.0`) — combined with `port`
+/// - a socket address (`127.0.0.1:0`, `[::1]:7890`) — port taken from the
+///   address unless it is `0` and an explicit `port` was also given
+///
+/// Port `0` means the OS picks an ephemeral port at bind time.
+pub(crate) fn resolve_listener_bind(
+    listen: &str,
+    port: Option<u16>,
+) -> Result<(String, u16), anyhow::Error> {
+    let explicit_port = port.unwrap_or(0);
+
+    if listen.parse::<IpAddr>().is_ok() {
+        return Ok((listen.to_string(), explicit_port));
+    }
+
+    if let Ok(addr) = listen.parse::<SocketAddr>() {
+        let listen_port = addr.port();
+        let resolved = match (listen_port, explicit_port) {
+            (0, p) => p,
+            (lp, 0) => lp,
+            (lp, p) if lp == p => lp,
+            (lp, p) => anyhow::bail!("listen '{listen}' port {lp} conflicts with port {p}"),
+        };
+        return Ok((addr.ip().to_string(), resolved));
+    }
+
+    anyhow::bail!(
+        "invalid bind address '{listen}': expected an IP literal or host:port (e.g. 127.0.0.1:0)"
+    )
+}
+
 /// Parse `type:` string from a `listeners:` entry into `ListenerType`.
 /// Hard errors on unknown types (Class A per ADR-0002).
 fn parse_listener_type(s: &str) -> Result<ListenerType, anyhow::Error> {
@@ -1361,17 +1395,21 @@ fn build_named_listeners(
                    tproxy_sni: bool,
                    max_connections: usize|
      -> Result<(), anyhow::Error> {
-        if let Some(existing) = used_ports.get(&port) {
-            anyhow::bail!(
-                "port {port} already used by listener '{existing}' (duplicate port, Class A per ADR-0002)"
-            );
+        // Port 0 is "OS assigns an ephemeral port" — each such listener binds
+        // a distinct port at runtime, so they are not duplicates of each other.
+        if port != 0 {
+            if let Some(existing) = used_ports.get(&port) {
+                anyhow::bail!(
+                    "port {port} already used by listener '{existing}' (duplicate port, Class A per ADR-0002)"
+                );
+            }
+            used_ports.insert(port, name.to_string());
         }
         if !used_names.insert(name.to_string()) {
             anyhow::bail!(
                 "listener name '{name}' already defined (duplicate name, Class A per ADR-0002)"
             );
         }
-        used_ports.insert(port, name.to_string());
         result.push(NamedListener {
             name: name.to_string(),
             listener_type: ltype,
@@ -1383,8 +1421,11 @@ fn build_named_listeners(
         Ok(())
     };
 
-    // Shorthand fields → auto-named listeners (inherit global max-connections)
-    if let Some(port) = raw.mixed_port {
+    // Shorthand fields → auto-named listeners (inherit global max-connections).
+    // Port `0` on a shorthand field means "disabled", matching upstream mihomo
+    // (`mixed-port: 0` is how generated configs turn an inbound off). Ephemeral
+    // ports are an explicit `listeners:`-entry opt-in only.
+    if let Some(port) = raw.mixed_port.filter(|p| *p != 0) {
         add(
             "mixed",
             ListenerType::Mixed,
@@ -1394,7 +1435,7 @@ fn build_named_listeners(
             global_max_conns,
         )?;
     }
-    if let Some(port) = raw.socks_port {
+    if let Some(port) = raw.socks_port.filter(|p| *p != 0) {
         add(
             "socks",
             ListenerType::Socks5,
@@ -1404,7 +1445,7 @@ fn build_named_listeners(
             global_max_conns,
         )?;
     }
-    if let Some(port) = raw.port {
+    if let Some(port) = raw.port.filter(|p| *p != 0) {
         add(
             "http",
             ListenerType::Http,
@@ -1414,7 +1455,7 @@ fn build_named_listeners(
             global_max_conns,
         )?;
     }
-    if let Some(port) = raw.tproxy_port {
+    if let Some(port) = raw.tproxy_port.filter(|p| *p != 0) {
         add(
             "tproxy",
             ListenerType::TProxy,
@@ -1428,7 +1469,7 @@ fn build_named_listeners(
     // Explicit `listeners:` entries
     for raw_l in raw.listeners.as_deref().unwrap_or(&[]) {
         let ltype = parse_listener_type(&raw_l.listener_type)?;
-        let listen = raw_l
+        let listen_raw = raw_l
             .listen
             .as_deref()
             .unwrap_or(if ltype == ListenerType::TProxy {
@@ -1436,13 +1477,14 @@ fn build_named_listeners(
             } else {
                 default_bind
             });
+        let (listen, port) = resolve_listener_bind(listen_raw, raw_l.port)?;
         let tproxy_sni = raw_l.tproxy_sni.unwrap_or(global_tproxy_sni);
         let max_connections = raw_l.max_connections.unwrap_or(global_max_conns);
         add(
             &raw_l.name,
             ltype,
-            raw_l.port,
-            listen,
+            port,
+            &listen,
             tproxy_sni,
             max_connections,
         )?;
@@ -2237,9 +2279,79 @@ mod socket_address_tests {
         assert!(parse_optional_socket_addr("dns.listen", Some("127.0.0.1:70000")).is_err());
         assert!(parse_optional_socket_addr("external-controller", Some("[::1]:9090")).is_ok());
         assert_eq!(
+            parse_optional_socket_addr("dns.listen", Some("127.0.0.1:0")).unwrap(),
+            Some("127.0.0.1:0".parse().unwrap())
+        );
+        assert_eq!(
             parse_optional_socket_addr("dns.listen", None).unwrap(),
             None
         );
+    }
+}
+
+#[cfg(test)]
+mod listener_bind_tests {
+    use super::resolve_listener_bind;
+
+    #[test]
+    fn ip_literal_plus_port() {
+        assert_eq!(
+            resolve_listener_bind("127.0.0.1", Some(7890)).unwrap(),
+            ("127.0.0.1".into(), 7890)
+        );
+        assert_eq!(
+            resolve_listener_bind("0.0.0.0", None).unwrap(),
+            ("0.0.0.0".into(), 0)
+        );
+        assert_eq!(
+            resolve_listener_bind("::", Some(7890)).unwrap(),
+            ("::".into(), 7890)
+        );
+    }
+
+    #[test]
+    fn host_port_ephemeral() {
+        assert_eq!(
+            resolve_listener_bind("127.0.0.1:0", None).unwrap(),
+            ("127.0.0.1".into(), 0)
+        );
+        assert_eq!(
+            resolve_listener_bind("[::1]:0", None).unwrap(),
+            ("::1".into(), 0)
+        );
+    }
+
+    #[test]
+    fn host_port_explicit() {
+        assert_eq!(
+            resolve_listener_bind("0.0.0.0:7891", None).unwrap(),
+            ("0.0.0.0".into(), 7891)
+        );
+        assert_eq!(
+            resolve_listener_bind("127.0.0.1:7891", Some(7891)).unwrap(),
+            ("127.0.0.1".into(), 7891)
+        );
+        // listen :0 + explicit port uses the port field
+        assert_eq!(
+            resolve_listener_bind("127.0.0.1:0", Some(7890)).unwrap(),
+            ("127.0.0.1".into(), 7890)
+        );
+    }
+
+    #[test]
+    fn host_port_conflict_errors() {
+        let err = resolve_listener_bind("127.0.0.1:7891", Some(7892)).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("conflicts"), "msg: {msg}");
+        assert!(msg.contains("7891"), "msg: {msg}");
+        assert!(msg.contains("7892"), "msg: {msg}");
+    }
+
+    #[test]
+    fn hostname_is_rejected() {
+        let err = resolve_listener_bind("localhost:0", None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("invalid bind address"), "msg: {msg}");
     }
 }
 

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -245,7 +245,10 @@ pub struct RawListener {
     pub name: String,
     #[serde(rename = "type")]
     pub listener_type: String,
-    pub port: u16,
+    /// Optional when `listen` is a `host:port` socket address. `0` (or omitted
+    /// with no port in `listen`) means the OS assigns an ephemeral port at bind.
+    #[serde(default)]
+    pub port: Option<u16>,
     pub listen: Option<String>,
     pub tproxy_sni: Option<bool>,
     /// Per-listener override of the global `max-connections` cap. `0`

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -147,6 +147,82 @@ dns:
 }
 
 #[tokio::test]
+async fn test_dns_listen_ephemeral_port() {
+    let yaml = r#"
+dns:
+  enable: true
+  listen: 127.0.0.1:0
+  nameserver:
+    - 1.1.1.1
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert_eq!(config.dns.listen_addr.unwrap().to_string(), "127.0.0.1:0");
+}
+
+#[tokio::test]
+async fn test_named_listener_listen_host_port_ephemeral() {
+    let yaml = r#"
+listeners:
+  - name: mixed
+    type: mixed
+    listen: 127.0.0.1:0
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert_eq!(config.listeners.named.len(), 1);
+    let nl = &config.listeners.named[0];
+    assert_eq!(nl.name, "mixed");
+    assert_eq!(nl.listen, "127.0.0.1");
+    assert_eq!(nl.port, 0);
+}
+
+#[tokio::test]
+async fn test_named_listener_listen_host_port_explicit() {
+    let yaml = r#"
+listeners:
+  - name: socks
+    type: socks5
+    listen: 0.0.0.0:7891
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    let nl = &config.listeners.named[0];
+    assert_eq!(nl.name, "socks");
+    assert_eq!(nl.listen, "0.0.0.0");
+    assert_eq!(nl.port, 7891);
+}
+
+#[tokio::test]
+async fn test_named_listener_listen_port_conflict() {
+    let yaml = r#"
+listeners:
+  - name: socks
+    type: socks5
+    listen: 127.0.0.1:7891
+    port: 7892
+"#;
+    let Err(err) = load_config_from_str(yaml).await else {
+        panic!("conflicting listen/port must hard-error");
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("conflicts"), "msg: {msg}");
+}
+
+#[tokio::test]
+async fn test_two_ephemeral_listeners_do_not_conflict() {
+    let yaml = r#"
+listeners:
+  - name: a
+    type: mixed
+    listen: 127.0.0.1:0
+  - name: b
+    type: socks5
+    listen: 127.0.0.1:0
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert_eq!(config.listeners.named.len(), 2);
+    assert!(config.listeners.named.iter().all(|nl| nl.port == 0));
+}
+
+#[tokio::test]
 async fn test_dns_config_fakeip_enabled() {
     // `enhanced-mode: fake-ip` must be accepted, with the pool synthesising
     // IPs from the configured CIDR.
@@ -1028,4 +1104,18 @@ proxy-providers:
 "#;
     let config = load_config_from_str(yaml).await.unwrap();
     assert!(config.proxies.contains_key("auto"));
+}
+
+#[tokio::test]
+async fn test_shorthand_port_zero_means_disabled() {
+    // mihomo compat: `mixed-port: 0` (and the other shorthand port fields)
+    // means the inbound is disabled, not "bind an ephemeral port". Ephemeral
+    // ports are an explicit `listeners:`-entry opt-in.
+    let yaml = r#"
+mixed-port: 0
+socks-port: 0
+port: 0
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(config.listeners.named.is_empty());
 }

--- a/crates/meow-dns/src/server.rs
+++ b/crates/meow-dns/src/server.rs
@@ -50,7 +50,8 @@ impl DnsServer {
     /// "bind failed, every query will be dropped".
     pub async fn bind(&self) -> std::io::Result<BoundDnsServer> {
         let socket = Arc::new(UdpSocket::bind(self.listen_addr).await?);
-        info!("DNS server listening on {}", self.listen_addr);
+        let bound = socket.local_addr().unwrap_or(self.listen_addr);
+        info!("DNS server listening on {bound}");
         Ok(BoundDnsServer {
             resolver: Arc::clone(&self.resolver),
             socket,

--- a/crates/meow-listener/src/mixed.rs
+++ b/crates/meow-listener/src/mixed.rs
@@ -61,15 +61,26 @@ impl MixedListener {
 
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let listener = TcpListener::bind(self.listen_addr).await?;
+        self.run_on(listener).await
+    }
+
+    /// Serve on an already-bound socket. Lets the caller bind first (e.g. to
+    /// resolve a `port: 0` ephemeral listener to its OS-assigned port before
+    /// the API snapshot is taken) and hand the socket over.
+    pub async fn run_on(
+        &self,
+        listener: TcpListener,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let bound_addr = listener.local_addr().unwrap_or(self.listen_addr);
         if self.max_connections == 0 {
             info!(
                 "Mixed listener '{}' on {} (max_connections=unlimited)",
-                self.name, self.listen_addr
+                self.name, bound_addr
             );
         } else {
             info!(
                 "Mixed listener '{}' on {} (max_connections={})",
-                self.name, self.listen_addr, self.max_connections
+                self.name, bound_addr, self.max_connections
             );
         }
 
@@ -122,7 +133,7 @@ impl MixedListener {
             let tunnel = self.tunnel.clone();
             let sniffer = self.sniffer.clone();
             let name = self.name.clone();
-            let port = self.listen_addr.port();
+            let port = bound_addr.port();
             let auth = self.auth.clone();
             tokio::spawn(async move {
                 handle_connection(tunnel, stream, src_addr, sniffer, name, port, auth).await;

--- a/crates/meow-listener/src/tproxy/mod.rs
+++ b/crates/meow-listener/src/tproxy/mod.rs
@@ -62,23 +62,34 @@ impl TProxyListener {
     }
 
     pub async fn run(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Bind first so a port-0 listen can resolve to the OS-assigned port
+        // before firewall rules are installed against it.
+        let listener = TcpListener::bind(self.listen_addr).await?;
+        self.run_on(listener).await
+    }
+
+    /// Serve on an already-bound socket, letting the caller resolve a
+    /// `port: 0` ephemeral listener to its OS-assigned port first. Firewall
+    /// redirect rules are installed against the socket's actual local port,
+    /// so ephemeral listeners redirect correctly.
+    pub async fn run_on(
+        self,
+        listener: TcpListener,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Collect upstream proxy server IPs for firewall bypass
         let bypass_ips = collect_proxy_server_ips(&self.tunnel);
 
-        // Set up firewall redirect rules (tears down on drop)
-        let _firewall =
-            FirewallGuard::setup(self.listen_addr.port(), self.routing_mark, &bypass_ips)?;
+        let bound_addr = listener.local_addr().unwrap_or(self.listen_addr);
 
-        let listener = TcpListener::bind(self.listen_addr).await?;
-        info!(
-            "TProxy listener '{}' started on {}",
-            self.name, self.listen_addr
-        );
+        // Set up firewall redirect rules (tears down on drop)
+        let _firewall = FirewallGuard::setup(bound_addr.port(), self.routing_mark, &bypass_ips)?;
+
+        info!("TProxy listener '{}' started on {}", self.name, bound_addr);
 
         loop {
             let (stream, src_addr) = listener.accept().await?;
             let tunnel = self.tunnel.clone();
-            let listen_addr = self.listen_addr;
+            let listen_addr = bound_addr;
             let sniffer = self.sniffer.clone();
             let name = self.name.clone();
 

--- a/website/guide/listeners.md
+++ b/website/guide/listeners.md
@@ -20,6 +20,9 @@ mixed-port: 7890
 
 `mixed-port` is usually all you need — it serves both HTTP and SOCKS5 clients on one port.
 
+Setting a shorthand port to `0` disables that inbound (mihomo-compatible) — it does
+**not** bind an ephemeral port. Ephemeral ports are a `listeners`-array feature.
+
 ## The `listeners` array
 
 For multiple instances, per-listener binds, or per-listener limits, declare them
@@ -45,16 +48,33 @@ listeners:
 | --- | --- | --- | --- | --- |
 | `name` | string | ✓ | — | Unique; appears in logs, the API, and `IN-NAME` rules |
 | `type` | string | ✓ | — | `mixed` · `http` · `socks5` · `tproxy` |
-| `port` | u16 | ✓ | — | Unique across listeners; `0` is invalid |
-| `listen` | string | | per type | Bind IP literal (not a hostname) |
+| `port` | u16 | | — | Unique across listeners; omit or `0` to let the OS assign an ephemeral port |
+| `listen` | string | | per type | Bind IP literal, or `host:port` (e.g. `127.0.0.1:0`) |
 | `tproxy-sni` | bool | | global | (tproxy) deprecated SNI shorthand — prefer [`sniffer`](./sniffer) |
 | `max-connections` | usize | | global | Per-listener concurrency cap; `0` = unlimited |
 
 `listen` defaults to `127.0.0.1` for `tproxy` and to the global `bind-address` otherwise.
 
+### Ephemeral ports
+
+A listener with port `0` (via `port: 0`, an omitted `port`, or `listen: 127.0.0.1:0`)
+binds an OS-assigned ephemeral port at startup. Discover the assigned port from the
+startup log line (`Mixed listener 'auto' on 127.0.0.1:49321 …`) or from
+[`GET /listeners`](#inspecting-listeners) on the REST API, which reports the actual
+bound port.
+Giving both `listen: host:port` and `port` with different values is a load-time error.
+
+```yaml
+listeners:
+  - name: auto
+    type: mixed
+    listen: 127.0.0.1:0
+```
+
 ::: warning Duplicates are fatal
 Duplicate listener **ports** or **names** are a hard load-time error (unlike upstream,
-which may accept them silently).
+which may accept them silently). Multiple port-`0` listeners are fine — each gets its
+own OS-assigned port.
 :::
 
 ## Listener types
@@ -98,4 +118,5 @@ rules:
 ## Inspecting listeners
 
 `GET /listeners` returns the active listeners with their name, type, port, and bind
-address. See the [REST API reference](../reference/rest-api).
+address. For [ephemeral listeners](#ephemeral-ports) the reported port is the actual
+OS-assigned one, not the configured `0`. See the [REST API reference](../reference/rest-api).


### PR DESCRIPTION
## What

Named `listeners:` entries can now bind an OS-assigned ephemeral port — useful for test harnesses, CI, and embedders that must avoid port collisions.

```yaml
listeners:
  - name: auto
    type: mixed
    listen: 127.0.0.1:0   # or: port: 0, or omit port entirely
```

- `port` is now optional; `0` or omitted = OS assigns at bind time.
- `listen` additionally accepts a `host:port` socket address (`127.0.0.1:0`, `[::1]:7890`); conflicting `listen: host:port` + `port` values are a Class A load-time error.
- The duplicate-port check skips port-0 entries — multiple ephemeral listeners coexist, each getting its own port.
- **Port discovery:** meow-app binds sockets before spawning accept loops (new `MixedListener::run_on` / `TProxyListener::run_on`) and patches the assigned ports into the API snapshot, so **`GET /listeners` reports the actual bound port**, and startup logs print the real bound address (mixed, tproxy, DNS). TProxy installs firewall redirects against the bound port, after bind.
- **mihomo compat:** shorthand `mixed-port: 0` / `socks-port: 0` / `port: 0` / `tproxy-port: 0` now mean "inbound disabled" (upstream semantics); ephemeral ports are an explicit `listeners:` opt-in.
- `IN-PORT` rule metadata uses the bound port, so rules keep working for ephemeral inbounds.

Bind failures for individual listeners still log-and-continue (now at spawn time instead of inside the accept task). Side effect of bind-first ordering: `external-ui` auto-download no longer delays listener startup.

## Verification

- End-to-end: two `listen: 127.0.0.1:0` listeners → distinct OS ports (`62930`/`62931`); log lines and `GET /listeners` both report the assigned ports; `curl -x` through the discovered port proxies successfully; `mixed-port: 0` yields no listener.
- New tests: `resolve_listener_bind` unit tests (IP literal, host:port, ephemeral, conflict, hostname rejection), config-level tests for ephemeral/explicit/conflict/multi-ephemeral listeners, DNS `listen: 127.0.0.1:0`, and shorthand-0-disabled.
- Regression bar: `cargo fmt --check`, three-way clippy (default / no-default / all-features) with `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib` (12 suites) — all pass.

Docs: `website/guide/listeners.md` updated (ephemeral section, shorthand-0 semantics, `GET /listeners` discovery).