### PR TITLE
Accept null reality short-id and wildcard bind-address (mihomo compat)

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -1516,10 +1516,15 @@ async fn build_config(
         .parse::<TunnelMode>()
         .unwrap_or(TunnelMode::Rule);
     let log_level = raw.log_level.clone().unwrap_or_else(|| "info".to_string());
-    let bind_address = raw
-        .bind_address
-        .clone()
-        .unwrap_or_else(|| "127.0.0.1".to_string());
+    // mihomo (and Clash Verge output) use `bind-address: '*'` as the
+    // all-interfaces wildcard; normalize it here so listeners never see the
+    // raw `*`, which is not an IP literal (#388). Dual-stack wildcard stays
+    // spellable as `'::'`.
+    let bind_address = match raw.bind_address.as_deref() {
+        None => "127.0.0.1".to_string(),
+        Some("*" | "") => "0.0.0.0".to_string(),
+        Some(addr) => addr.to_string(),
+    };
 
     let general = GeneralConfig {
         mode,
@@ -2352,6 +2357,48 @@ mod listener_bind_tests {
         let err = resolve_listener_bind("localhost:0", None).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("invalid bind address"), "msg: {msg}");
+    }
+}
+
+#[cfg(test)]
+mod bind_address_tests {
+    use super::load_config_from_str;
+
+    // Regression tests for #388: mihomo/Clash Verge configs use
+    // `bind-address: '*'` as the all-interfaces wildcard; feeding the raw
+    // `*` to the listener's IpAddr parse was a fatal startup error.
+
+    #[tokio::test]
+    async fn wildcard_star_normalizes_to_unspecified_ipv4() {
+        let config = load_config_from_str("mixed-port: 7890\nallow-lan: true\nbind-address: '*'\n")
+            .await
+            .expect("bind-address '*' must be accepted");
+        assert_eq!(config.general.bind_address, "0.0.0.0");
+        assert_eq!(config.listeners.bind_address, "0.0.0.0");
+    }
+
+    #[tokio::test]
+    async fn empty_bind_address_normalizes_to_unspecified_ipv4() {
+        let config = load_config_from_str("allow-lan: true\nbind-address: ''\n")
+            .await
+            .expect("empty bind-address must be accepted");
+        assert_eq!(config.general.bind_address, "0.0.0.0");
+    }
+
+    #[tokio::test]
+    async fn explicit_bind_address_is_preserved() {
+        let config = load_config_from_str("allow-lan: true\nbind-address: '::'\n")
+            .await
+            .expect("explicit bind-address must load");
+        assert_eq!(config.general.bind_address, "::");
+    }
+
+    #[tokio::test]
+    async fn default_bind_address_is_loopback() {
+        let config = load_config_from_str("mixed-port: 7890\n")
+            .await
+            .expect("minimal config must load");
+        assert_eq!(config.general.bind_address, "127.0.0.1");
     }
 }
 

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1509,11 +1509,13 @@ fn parse_vless_reality_opts(
     let mut public_key = [0u8; 32];
     public_key.copy_from_slice(&public_key_bytes);
 
+    // Subscription generators (e.g. Clash Verge) emit `short-id: null` when
+    // the server has no short-id; mihomo treats it as absent (#388).
     let short_id_str = match opts.get("short-id") {
+        None | Some(serde_yaml::Value::Null) => "",
         Some(value) => value
             .as_str()
             .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?,
-        None => "",
     };
     let short_id_vec = parse_reality_short_id(short_id_str)?;
     let mut short_id = [0u8; 8];

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -430,6 +430,33 @@ proxies:
     );
 }
 
+/// Subscription generators (e.g. Clash Verge) emit `short-id: null` when the
+/// server has no short-id; mihomo treats it as absent and the node works.
+/// Rejecting the explicit null silently dropped every such VLESS node (#388).
+#[tokio::test]
+async fn parse_vless_reality_opts_null_short_id_treated_as_absent() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+      short-id: null
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("REALITY VLESS config with null short-id must load");
+    assert!(
+        config.proxies.contains_key("v"),
+        "REALITY VLESS proxy with `short-id: null` must be registered, not dropped"
+    );
+}
+
 // ─── D10: tls: false + plain VLESS → warn once, loads ok ─────────────────────
 
 /// D10: `parse_vless_tls_false_plain_warns_once`


### PR DESCRIPTION
Fixes #388.

Two config constructs common in real-world subscription / Clash Verge profiles and accepted by mihomo were rejected:

- **`reality-opts.short-id: null`** silently dropped every such VLESS node (cascading into empty proxy groups). YAML `null`/`~` is now treated like an absent short-id — hex validation still applies when a value is present.
- **`bind-address: '*'`** was a fatal startup error (`invalid IP address syntax`). `'*'` and the empty string are now normalized to `0.0.0.0` at config parse, before any listener sees them. Dual-stack wildcard remains `'::'`.

Verification:
- 5 new regression tests (4 bind-address normalization in `meow-config` lib tests, 1 null short-id in `vless_config_test`)
- Both repro configs from #388 now pass `meow -t`
- Full regression bar green locally: `fmt --check`, three-way clippy `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib` (all 12 suites)