### PR TITLE
Formally scope macOS pf tproxy to loopback + manual detour

### DIFF
--- a/crates/meow-listener/src/tproxy/mod.rs
+++ b/crates/meow-listener/src/tproxy/mod.rs
@@ -86,6 +86,19 @@ impl TProxyListener {
 
         info!("TProxy listener '{}' started on {}", self.name, bound_addr);
 
+        // Scope decision for the pf path (#248): the managed ruleset
+        // intercepts loopback-traversing IPv4 TCP only; steering real
+        // outbound (en0) traffic stays a manual, documented pf detour rather
+        // than something meow rewrites the host's pf config for. Surface that
+        // at startup so "tproxy is on but my browser isn't proxied" is
+        // explained by the log, not a silent surprise.
+        #[cfg(target_os = "macos")]
+        info!(
+            "TProxy on macOS intercepts loopback IPv4 TCP only; real outbound \
+             traffic needs the manual route-to detour (docs/tproxy-macos.md) — \
+             for full transparent proxying use the TUN inbound (docs/tun.md)"
+        );
+
         loop {
             let (stream, src_addr) = listener.accept().await?;
             let tunnel = self.tunnel.clone();

--- a/docs/tproxy-macos.md
+++ b/docs/tproxy-macos.md
@@ -6,9 +6,16 @@ application proxy settings, using a `tproxy` listener and pf. For forwarding
 gateway script is experimental); for the strategic, more capable path on macOS
 (UDP, IPv6, IP-literal capture without pf) see [tun.md](tun.md).
 
-**Status: experimental.** Requires a build containing the `DIOCNATLOOK`
-direction fix (#353) and the lo0 reply-exemption fix (#355) — `main` since
-July 2026, first release after 0.18.0. Scope today: **IPv4 TCP only**, no UDP.
+**Status: experimental, scope settled (#248).** Requires a build containing
+the `DIOCNATLOOK` direction fix (#353) and the lo0 reply-exemption fix (#355)
+— `main` since July 2026, first release after 0.18.0. Scope: **IPv4 TCP
+only**, no UDP, and the *managed* ruleset intercepts **loopback-traversing
+traffic only**. Steering real outbound (`en0`) traffic is deliberately left
+to the manual `route-to` detour below rather than having meow rewrite the
+host's pf configuration — automated physical-interface steering was
+considered under #248 and rejected in favor of the TUN inbound
+([tun.md](tun.md)), which captures all traffic without pf, handles UDP, and
+is the recommended path for a fully transparent macOS setup.
 
 ## How it works
 


### PR DESCRIPTION
Closes #248.

#248 is §2-only since August (§1 original-destination recovery landed via #353/#355 and is VM-verified). The issue's own closing options were (a) have meow manage the real-traffic `route-to` steering, or (b) formally rescope the pf path as loopback-plus-manual-detour and point at TUN. This takes (b):

- **docs/tproxy-macos.md** now states the scope decision and the reasoning: managed pf stays loopback-only; `en0` steering remains the documented, VM-verified manual detour; the TUN inbound (#326, docs/tun.md) is the recommended fully-transparent path (no pf, UDP + IP-literal capture). Every managed-pf change in this issue's history required macOS-VM verification and surfaced side effects (#354's reply re-redirect), which is exactly the class of risk automating en0 steering would multiply.
- **Startup notice**: on macOS the tproxy listener logs the scope and points at the detour doc and TUN, so the "tproxy is on but my browser isn't proxied" experience is explained in the log.

Regression bar green locally (fmt, 3-way clippy -D warnings, doc -D warnings, lib tests).