### PR TITLE
tunnel: 32 KiB relay buffers - bulk throughput was cycle-latency bound

### DIFF
--- a/crates/meow-tunnel/src/relay.rs
+++ b/crates/meow-tunnel/src/relay.rs
@@ -33,10 +33,15 @@ use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 /// Buffer size used for each relay direction.
-/// 4 KiB halves the tokio default (8 KiB) to save 8 KiB/conn at the
-/// cost of more syscalls; acceptable for proxy workloads where connections
-/// are long-lived and latency matters less than memory at 5k+ conns.
-pub const RELAY_BUF_SIZE: usize = 4 * 1024;
+///
+/// 32 KiB keeps per-cycle syscall+task-wakeup overhead small on bulk
+/// transfers: at 4 KiB a 64 MB transfer ran 16k fill+drain cycles and the
+/// per-cycle wakeup latency (tens of µs on loopback) dominated the
+/// throughput (~0.4 Gbps through the tunnel vs ~2 Gbps with larger buffers).
+/// 32 KiB is four 8 KiB mux frames (or two 16 KiB TLS records) per write,
+/// so the pipeline stays deep without ballooning the per-connection async
+/// frame (2 × 32 KiB).
+pub const RELAY_BUF_SIZE: usize = 32 * 1024;
 
 /// Idle window granted to the surviving relay direction after the *other*
 /// direction has reached EOF.
@@ -66,7 +71,7 @@ pub const RELAY_HALF_CLOSE_LINGER: Duration = Duration::from_secs(30);
 /// same magnitude, but coop is an implementation detail of tokio's leaf
 /// resources — custom `ProxyConn` stacks (or the in-memory streams used in
 /// tests) may never return `Pending` on their own. This cap makes the yield
-/// deterministic: at 4 KiB per cycle it bounds one poll at 256 KiB relayed.
+/// deterministic: at 32 KiB per cycle it bounds one poll at 2 MiB relayed.
 const RELAY_CYCLES_PER_POLL: u32 = 64;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# tunnel: 32 KiB relay buffers (bulk throughput was cycle-latency bound)

## Overview

`RELAY_BUF_SIZE` 4 KiB → 32 KiB. The bidirectional relay (`crates/meow-tunnel/src/relay.rs`)
advances one fill+drain cycle per buffer, and each cycle costs a socket wakeup + task
reschedule (tens of µs on loopback). At 4 KiB a 64 MB transfer ran ~16k cycles and the
per-cycle wakeup latency dominated: bulk throughput was ~3-5x below xray-core on the same
setup. 32 KiB cuts the cycle count 8x (4 muxcool frames per cycle), while keeping
the per-connection async frame at 2 × 32 KiB — still stack arrays in the caller's frame, so
the ADR-0011 zero-per-relay-allocation invariant is unchanged (only the frame is larger).

## Measured (local sing-box v1.13.18, meow-bench throughput)

| 64 MB x 1 through | before | after |
|---|---|---|
| VLESS tls+vision + muxcool | 0.36-0.72 Gbps | 2.09-3.01 Gbps |
| VLESS tls+vision plain | 1.30 Gbps | 2.03-3.42 Gbps |
| xray-core 26.3.27 mux (reference) | — | 2.06-2.42 Gbps |

connrate and latency are unchanged (small messages never fill the buffer).

## Notes

- Comment updates for `RELAY_CYCLES_PER_POLL` (now 2 MiB/poll at 32 KiB).
- This PR is independent of the mux feature — it improves every protocol that goes
  through the tunnel relay.

## Commits

- `b4a1fce` tunnel: 32 KiB relay buffers - bulk throughput was cycle-latency bound