### PR TITLE
bench: bound every connection phase; drive non-meow binaries; report echo timeouts

### DIFF
--- a/crates/meow-bench/src/bench_connrate.rs
+++ b/crates/meow-bench/src/bench_connrate.rs
@@ -16,6 +16,9 @@ pub struct ConnRateResult {
     pub duration_secs: f64,
     pub total_connections: u64,
     pub connections_per_sec: f64,
+    /// Connections whose echo phase hit the deadline (a proxy that
+    /// accepted the CONNECT but never answered).
+    pub echo_timeouts: u64,
 }
 
 pub async fn bench_conn_rate(
@@ -25,24 +28,30 @@ pub async fn bench_conn_rate(
     concurrency: usize,
 ) -> anyhow::Result<ConnRateResult> {
     let counter = Arc::new(AtomicU64::new(0));
+    let echo_timeouts = Arc::new(AtomicU64::new(0));
     let deadline = Instant::now() + Duration::from_secs(duration_secs);
 
     let mut handles = Vec::new();
     for _ in 0..concurrency {
         let counter = Arc::clone(&counter);
+        let echo_timeouts = Arc::clone(&echo_timeouts);
         handles.push(tokio::spawn(async move {
             while Instant::now() < deadline {
                 let Ok(mut stream) = socks5_connect(proxy, echo).await else {
                     continue;
                 };
-                let _ = tokio::time::timeout(ECHO_TIMEOUT, async {
+                let timed_out = tokio::time::timeout(ECHO_TIMEOUT, async {
                     if stream.write_all(&[0x42]).await.is_ok() {
                         let mut buf = [0u8; 1];
                         let _ = stream.read_exact(&mut buf).await;
                     }
                 })
-                .await;
+                .await
+                .is_err();
                 drop(stream);
+                if timed_out {
+                    echo_timeouts.fetch_add(1, Ordering::Relaxed);
+                }
                 counter.fetch_add(1, Ordering::Relaxed);
             }
         }));
@@ -53,15 +62,20 @@ pub async fn bench_conn_rate(
     }
 
     let total = counter.load(Ordering::Relaxed);
+    let timeouts = echo_timeouts.load(Ordering::Relaxed);
     let actual_elapsed = duration_secs as f64;
     let cps = total as f64 / actual_elapsed;
 
     eprintln!("  conn-rate: {total} connections in {duration_secs}s = {cps:.0}/s");
+    if timeouts > 0 {
+        eprintln!("  echo-timeouts: {timeouts} connections never answered their echo");
+    }
 
     Ok(ConnRateResult {
         duration_secs: actual_elapsed,
         total_connections: total,
         connections_per_sec: cps,
+        echo_timeouts: timeouts,
     })
 }
 

--- a/crates/meow-bench/src/bench_connrate.rs
+++ b/crates/meow-bench/src/bench_connrate.rs
@@ -7,6 +7,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use crate::bench_memory::measure_rss;
 use crate::socks5_client::socks5_connect;
 
+/// Per-connection echo deadline: a proxy whose echo never returns must not
+/// wedge a worker forever — time it out and move on to the next conn.
+const ECHO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ConnRateResult {
     pub duration_secs: f64,
@@ -31,10 +35,13 @@ pub async fn bench_conn_rate(
                 let Ok(mut stream) = socks5_connect(proxy, echo).await else {
                     continue;
                 };
-                if stream.write_all(&[0x42]).await.is_ok() {
-                    let mut buf = [0u8; 1];
-                    let _ = stream.read_exact(&mut buf).await;
-                }
+                let _ = tokio::time::timeout(ECHO_TIMEOUT, async {
+                    if stream.write_all(&[0x42]).await.is_ok() {
+                        let mut buf = [0u8; 1];
+                        let _ = stream.read_exact(&mut buf).await;
+                    }
+                })
+                .await;
                 drop(stream);
                 counter.fetch_add(1, Ordering::Relaxed);
             }
@@ -104,10 +111,13 @@ pub async fn bench_connrate_steady_state(
                 let Ok(mut stream) = socks5_connect(proxy, echo).await else {
                     continue;
                 };
-                if stream.write_all(&[0x42]).await.is_ok() {
-                    let mut buf = [0u8; 1];
-                    let _ = stream.read_exact(&mut buf).await;
-                }
+                let _ = tokio::time::timeout(ECHO_TIMEOUT, async {
+                    if stream.write_all(&[0x42]).await.is_ok() {
+                        let mut buf = [0u8; 1];
+                        let _ = stream.read_exact(&mut buf).await;
+                    }
+                })
+                .await;
                 drop(stream);
                 counter.fetch_add(1, Ordering::Relaxed);
             }

--- a/crates/meow-bench/src/bench_throughput.rs
+++ b/crates/meow-bench/src/bench_throughput.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::net::SocketAddr;
 use std::time::Instant;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -18,7 +19,9 @@ async fn run_large_transfer(
     echo: SocketAddr,
     size: usize,
 ) -> anyhow::Result<(u64, f64)> {
-    let stream = socks5_connect(proxy, echo).await?;
+    let stream = socks5_connect(proxy, echo)
+        .await
+        .with_context(|| format!("large transfer connect to {echo}"))?;
     let (rd, wr) = tokio::io::split(stream);
 
     let start = Instant::now();
@@ -64,15 +67,23 @@ async fn run_small_messages(
     msg_size: usize,
     count: usize,
 ) -> anyhow::Result<(u64, f64)> {
-    let mut stream = socks5_connect(proxy, echo).await?;
+    let mut stream = socks5_connect(proxy, echo)
+        .await
+        .with_context(|| format!("small messages connect to {echo}"))?;
     let msg = vec![0xABu8; msg_size];
     let mut buf = vec![0u8; msg_size];
     let mut total_bytes = 0u64;
 
     let start = Instant::now();
     for _ in 0..count {
-        stream.write_all(&msg).await?;
-        stream.read_exact(&mut buf).await?;
+        stream
+            .write_all(&msg)
+            .await
+            .with_context(|| "small message write")?;
+        stream
+            .read_exact(&mut buf)
+            .await
+            .with_context(|| "small message read")?;
         total_bytes += (msg_size * 2) as u64;
     }
     let elapsed = start.elapsed().as_secs_f64();

--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -162,7 +162,7 @@ async fn shutdown_child(child: &mut std::process::Child) {
             match child.try_wait() {
                 Ok(Some(_)) => return, // graceful exit within the grace period
                 Ok(None) => {}
-                Err(_) => break,      // cannot wait (already reaped) — fall through
+                Err(_) => break, // cannot wait (already reaped) — fall through
             }
             if tokio::time::Instant::now() >= deadline {
                 break;
@@ -205,6 +205,15 @@ impl ChildGuard {
 impl Drop for ChildGuard {
     fn drop(&mut self) {
         if let Some(mut child) = self.0.take() {
+            // Error path only — the success path disarms via
+            // `shutdown()`. `kill()` precedes `wait()`, so the blocking
+            // reap returns almost immediately; std's `Child` has no
+            // async wait, so a brief block on an async worker is the
+            // accepted trade-off (review N6). Bounded worst case
+            // overall: a target that ignores SIGTERM costs up to
+            // `SHUTDOWN_GRACE` (5 s) in `shutdown_child`, and targets
+            // shut down sequentially, so a full multi-target run adds
+            // up to 5 s × N.
             let _ = child.kill();
             let _ = child.wait();
         }

--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -416,10 +416,16 @@ async fn run_memleak_test(args: &Args) -> anyhow::Result<()> {
     )
     .await?;
 
-    // Stop proxy
-    let _ = Command::new("kill")
-        .args(["-TERM", &pid.to_string()])
-        .status();
+    // Stop the proxy.  Prefer SIGTERM on Unix for a graceful shutdown;
+    // on Windows `kill` does not exist and the child must be terminated
+    // directly (child.kill is a no-op once the process already exited).
+    #[cfg(unix)]
+    {
+        let _ = Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status();
+    }
+    let _ = child.kill();
     let _ = child.wait();
 
     let json = serde_json::to_string_pretty(&result)?;

--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -267,6 +267,7 @@ async fn benchmark_target(
                 duration_secs: 0.0,
                 total_connections: 0,
                 connections_per_sec: 0.0,
+                echo_timeouts: 0,
             },
             rss_idle,
         )
@@ -300,7 +301,8 @@ async fn benchmark_target(
 
             let mut dns_child = ChildGuard(
                 Command::new(binary)
-                    .args(["-f", &dns_config.to_string_lossy()])
+                    .arg(&args.binary_arg)
+                    .arg(dns_config.as_os_str())
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
                     .spawn()

--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -133,15 +133,81 @@ async fn wait_for_udp_port(addr: SocketAddr, timeout: Duration) -> anyhow::Resul
     }
 }
 
+/// Grace period granted to a child between SIGTERM and the fallback
+/// SIGKILL (Unix only; Windows terminates the child directly).
+#[cfg_attr(not(unix), allow(dead_code))]
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Stops a benchmark child process.  On Unix the child is asked to
+/// exit gracefully with SIGTERM and given a bounded grace period to
+/// finish before being killed; on Windows it is terminated directly
+/// (a no-op once the process already exited).
+async fn shutdown_child(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        // An already-exited child reports pid 0 and must not be
+        // signalled; `try_wait` also reaps it so the later `wait` is a
+        // no-op.
+        if let Ok(Some(_)) = child.try_wait() {
+            return;
+        }
+        let pid = child.id();
+        if pid != 0 {
+            let _ = Command::new("kill")
+                .args(["-TERM", &pid.to_string()])
+                .status();
+        }
+        let deadline = tokio::time::Instant::now() + SHUTDOWN_GRACE;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => return, // graceful exit within the grace period
+                Ok(None) => {}
+                Err(_) => break,      // cannot wait (already reaped) — fall through
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
 /// Reaps a spawned proxy on drop — benchmark error paths must not leak
 /// the child process (its listener would hold the port and break the
-/// next target).
-struct ChildGuard(std::process::Child);
+/// next target).  The success path calls [`ChildGuard::shutdown`],
+/// which stops the child and disarms the guard so that dropping it
+/// afterwards does not kill or wait again — unlike the former
+/// `std::mem::forget`, this does not leak the `Child` handle (a
+/// HANDLE on Windows).
+struct ChildGuard(Option<std::process::Child>);
+
+impl ChildGuard {
+    fn new(child: std::process::Child) -> Self {
+        Self(Some(child))
+    }
+
+    fn id(&self) -> u32 {
+        self.0.as_ref().map_or(0, std::process::Child::id)
+    }
+
+    /// Success-path shutdown: gracefully stop the child, then disarm
+    /// the guard so `Drop` is a no-op.
+    async fn shutdown(mut self) {
+        if let Some(child) = self.0.as_mut() {
+            shutdown_child(child).await;
+        }
+        self.0 = None;
+    }
+}
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
     }
 }
 
@@ -161,8 +227,8 @@ async fn benchmark_target(
 
     // Start proxy process (SOCKS5 config for W1–W3).  The guard reaps
     // the child on every error path; the success path reaps it
-    // explicitly below and forgets the guard.
-    let mut child = ChildGuard(
+    // explicitly via `ChildGuard::shutdown`.
+    let child = ChildGuard::new(
         Command::new(binary)
             .arg(&args.binary_arg)
             .arg(config.as_os_str())
@@ -172,7 +238,7 @@ async fn benchmark_target(
             .map_err(|e| anyhow::anyhow!("failed to start {}: {}", binary.display(), e))?,
     );
 
-    let pid = child.0.id();
+    let pid = child.id();
 
     // Wait for SOCKS5 port to be ready (the guard reaps the child if
     // this or any later step fails).
@@ -280,18 +346,11 @@ async fn benchmark_target(
     );
 
     // Stop the SOCKS5 proxy process before starting the DNS process.
-    // SIGTERM on Unix; Windows has no `kill` command, so terminate the
-    // child directly (a no-op once it already exited).
+    // SIGTERM first on Unix with a bounded grace period for a graceful
+    // shutdown; SIGKILL only if it does not exit in time.  On Windows
+    // the child is terminated directly (a no-op once it exited).
     eprintln!("[{target_name}] stopping SOCKS5 proxy...");
-    #[cfg(unix)]
-    {
-        let _ = Command::new("kill")
-            .args(["-TERM", &pid.to_string()])
-            .status();
-    }
-    let _ = child.0.kill();
-    let _ = child.0.wait();
-    std::mem::forget(child); // already reaped
+    child.shutdown().await;
     echo_handle.abort();
 
     // W4 — DNS QPS (separate process with DNS-enabled config)
@@ -299,7 +358,7 @@ async fn benchmark_target(
         (true, Some(dns_config)) => {
             eprintln!("[{}] starting DNS proxy: {}", target_name, binary.display());
 
-            let mut dns_child = ChildGuard(
+            let dns_child = ChildGuard::new(
                 Command::new(binary)
                     .arg(&args.binary_arg)
                     .arg(dns_config.as_os_str())
@@ -309,8 +368,6 @@ async fn benchmark_target(
                     .map_err(|e| anyhow::anyhow!("failed to start DNS proxy: {e}"))?,
             );
 
-            #[cfg_attr(not(unix), allow(unused_variables))]
-            let dns_pid = dns_child.0.id();
             let dns_addr: SocketAddr = format!("127.0.0.1:{}", args.dns_port).parse()?;
 
             let ready = wait_for_udp_port(dns_addr, Duration::from_secs(10)).await;
@@ -324,15 +381,8 @@ async fn benchmark_target(
                 eprintln!("[{target_name}] benchmarking DNS QPS...");
                 let dns_result = bench_dns::bench_dns(dns_addr, args.duration).await;
 
-                #[cfg(unix)]
-                {
-                    let _ = Command::new("kill")
-                        .args(["-TERM", &dns_pid.to_string()])
-                        .status();
-                }
-                let _ = dns_child.0.kill();
-                let _ = dns_child.0.wait();
-                std::mem::forget(dns_child); // already reaped
+                // Graceful stop (SIGTERM + grace on Unix), no Child leak.
+                dns_child.shutdown().await;
 
                 match dns_result {
                     Ok(r) => Some(r),
@@ -427,20 +477,21 @@ async fn run_memleak_test(args: &Args) -> anyhow::Result<()> {
     }
 
     eprintln!("[memleak] starting proxy...");
-    let mut child = Command::new(&args.rust_binary)
-        .args(["-f", &args.memleak_config.to_string_lossy()])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to start {}: {e}", args.rust_binary.display()))?;
+    // The guard reaps the child on every error path below (`?`
+    // returns included); the success path stops it gracefully via
+    // `ChildGuard::shutdown`.
+    let child = ChildGuard::new(
+        Command::new(&args.rust_binary)
+            .args(["-f", &args.memleak_config.to_string_lossy()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to start {}: {e}", args.rust_binary.display()))?,
+    );
 
     let pid = child.id();
 
-    if let Err(e) = wait_for_port(proxy_addr, Duration::from_secs(15)).await {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(e);
-    }
+    wait_for_port(proxy_addr, Duration::from_secs(15)).await?;
     eprintln!(
         "[memleak] proxy ready (pid {pid}) on port {}",
         args.memleak_port
@@ -463,17 +514,11 @@ async fn run_memleak_test(args: &Args) -> anyhow::Result<()> {
     )
     .await?;
 
-    // Stop the proxy.  Prefer SIGTERM on Unix for a graceful shutdown;
-    // on Windows `kill` does not exist and the child must be terminated
-    // directly (child.kill is a no-op once the process already exited).
-    #[cfg(unix)]
-    {
-        let _ = Command::new("kill")
-            .args(["-TERM", &pid.to_string()])
-            .status();
-    }
-    let _ = child.kill();
-    let _ = child.wait();
+    // Stop the proxy gracefully: SIGTERM first on Unix with a bounded
+    // grace period, SIGKILL only as a fallback; on Windows terminate
+    // directly.  `shutdown` disarms the guard — no `Child` handle is
+    // leaked.
+    child.shutdown().await;
 
     let json = serde_json::to_string_pretty(&result)?;
     if let Some(output_path) = &args.output {

--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -129,6 +129,18 @@ async fn wait_for_udp_port(addr: SocketAddr, timeout: Duration) -> anyhow::Resul
     }
 }
 
+/// Reaps a spawned proxy on drop — benchmark error paths must not leak
+/// the child process (its listener would hold the port and break the
+/// next target).
+struct ChildGuard(std::process::Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
 async fn benchmark_target(
     binary: &Path,
     config: &Path,
@@ -143,22 +155,23 @@ async fn benchmark_target(
 
     eprintln!("[{}] starting proxy: {}", target_name, binary.display());
 
-    // Start proxy process (SOCKS5 config for W1–W3)
-    let mut child = Command::new(binary)
-        .args(["-f", &config.to_string_lossy()])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to start {}: {}", binary.display(), e))?;
+    // Start proxy process (SOCKS5 config for W1–W3).  The guard reaps
+    // the child on every error path; the success path reaps it
+    // explicitly below and forgets the guard.
+    let mut child = ChildGuard(
+        Command::new(binary)
+            .args(["-f", &config.to_string_lossy()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to start {}: {}", binary.display(), e))?,
+    );
 
-    let pid = child.id();
+    let pid = child.0.id();
 
-    // Wait for SOCKS5 port to be ready
-    if let Err(e) = wait_for_port(proxy_addr, Duration::from_secs(10)).await {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(e);
-    }
+    // Wait for SOCKS5 port to be ready (the guard reaps the child if
+    // this or any later step fails).
+    wait_for_port(proxy_addr, Duration::from_secs(10)).await?;
     eprintln!("[{target_name}] proxy ready on port {PROXY_PORT}");
 
     // Settle time
@@ -246,12 +259,19 @@ async fn benchmark_target(
         rss_load as f64 / 1048576.0
     );
 
-    // Stop the SOCKS5 proxy process before starting the DNS process
+    // Stop the SOCKS5 proxy process before starting the DNS process.
+    // SIGTERM on Unix; Windows has no `kill` command, so terminate the
+    // child directly (a no-op once it already exited).
     eprintln!("[{target_name}] stopping SOCKS5 proxy...");
-    let _ = Command::new("kill")
-        .args(["-TERM", &pid.to_string()])
-        .status();
-    let _ = child.wait();
+    #[cfg(unix)]
+    {
+        let _ = Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status();
+    }
+    let _ = child.0.kill();
+    let _ = child.0.wait();
+    std::mem::forget(child); // already reaped
     echo_handle.abort();
 
     // W4 — DNS QPS (separate process with DNS-enabled config)
@@ -259,20 +279,21 @@ async fn benchmark_target(
         (true, Some(dns_config)) => {
             eprintln!("[{}] starting DNS proxy: {}", target_name, binary.display());
 
-            let mut dns_child = Command::new(binary)
-                .args(["-f", &dns_config.to_string_lossy()])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .spawn()
-                .map_err(|e| anyhow::anyhow!("failed to start DNS proxy: {e}"))?;
+            let mut dns_child = ChildGuard(
+                Command::new(binary)
+                    .args(["-f", &dns_config.to_string_lossy()])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .map_err(|e| anyhow::anyhow!("failed to start DNS proxy: {e}"))?,
+            );
 
-            let dns_pid = dns_child.id();
+            #[cfg_attr(not(unix), allow(unused_variables))]
+            let dns_pid = dns_child.0.id();
             let dns_addr: SocketAddr = format!("127.0.0.1:{}", args.dns_port).parse()?;
 
             let ready = wait_for_udp_port(dns_addr, Duration::from_secs(10)).await;
             if let Err(e) = ready {
-                let _ = dns_child.kill();
-                let _ = dns_child.wait();
                 eprintln!("[{target_name}] DNS port not ready: {e} — skipping W4");
                 None
             } else {
@@ -282,10 +303,15 @@ async fn benchmark_target(
                 eprintln!("[{target_name}] benchmarking DNS QPS...");
                 let dns_result = bench_dns::bench_dns(dns_addr, args.duration).await;
 
-                let _ = Command::new("kill")
-                    .args(["-TERM", &dns_pid.to_string()])
-                    .status();
-                let _ = dns_child.wait();
+                #[cfg(unix)]
+                {
+                    let _ = Command::new("kill")
+                        .args(["-TERM", &dns_pid.to_string()])
+                        .status();
+                }
+                let _ = dns_child.0.kill();
+                let _ = dns_child.0.wait();
+                std::mem::forget(dns_child); // already reaped
 
                 match dns_result {
                     Ok(r) => Some(r),

--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -26,6 +26,10 @@ struct Args {
     #[arg(long, default_value = "target/release/meow")]
     rust_binary: PathBuf,
 
+    /// CLI flag the binary takes before the config path (meow: -f, xray: -c)
+    #[arg(long, default_value = "-f")]
+    binary_arg: String,
+
     /// Path to the Go mihomo binary (skip Go benchmarks if absent)
     #[arg(long)]
     go_binary: Option<PathBuf>,
@@ -160,9 +164,10 @@ async fn benchmark_target(
     // explicitly below and forgets the guard.
     let mut child = ChildGuard(
         Command::new(binary)
-            .args(["-f", &config.to_string_lossy()])
+            .arg(&args.binary_arg)
+            .arg(config.as_os_str())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::inherit())
             .spawn()
             .map_err(|e| anyhow::anyhow!("failed to start {}: {}", binary.display(), e))?,
     );
@@ -193,15 +198,29 @@ async fn benchmark_target(
         rss_idle as f64 / 1048576.0
     );
 
-    // Warmup
+    // Warmup.  Each connection is bounded by the socks5 connect timeout
+    // and the whole phase by a hard deadline, so a proxy whose dial path
+    // stalls surfaces an error instead of wedging the harness.
     eprintln!("[{target_name}] warming up...");
-    for _ in 0..50 {
-        if let Ok(mut s) = socks5_client::socks5_connect(proxy_addr, echo_addr).await {
-            use tokio::io::{AsyncReadExt, AsyncWriteExt};
-            let _ = s.write_all(&[0x42]).await;
-            let mut buf = [0u8; 1];
-            let _ = s.read_exact(&mut buf).await;
+    let warmup = async {
+        for _ in 0..50 {
+            if let Ok(mut s) = socks5_client::socks5_connect(proxy_addr, echo_addr).await {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let _ = tokio::time::timeout(Duration::from_secs(10), async {
+                    s.write_all(&[0x42]).await?;
+                    let mut buf = [0u8; 1];
+                    s.read_exact(&mut buf).await?;
+                    Ok::<_, std::io::Error>(())
+                })
+                .await;
+            }
         }
+    };
+    if tokio::time::timeout(Duration::from_secs(30), warmup)
+        .await
+        .is_err()
+    {
+        eprintln!("[{target_name}] warmup deadline hit — continuing anyway");
     }
 
     let run_all = args.only.is_none();

--- a/crates/meow-bench/src/socks5_client.rs
+++ b/crates/meow-bench/src/socks5_client.rs
@@ -2,57 +2,66 @@ use std::net::SocketAddr;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
+/// Per-connection timeout: a proxy whose dial path stalls (e.g. a
+/// handshake that never completes) must surface as an error instead of
+/// wedging the harness forever.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Minimal SOCKS5 CONNECT client. Returns a stream tunneled to `target` via `proxy`.
 pub async fn socks5_connect(proxy: SocketAddr, target: SocketAddr) -> std::io::Result<TcpStream> {
-    let mut stream = TcpStream::connect(proxy).await?;
+    tokio::time::timeout(CONNECT_TIMEOUT, async {
+        let mut stream = TcpStream::connect(proxy).await?;
 
-    // Auth negotiation: version 5, 1 method, no-auth (0x00)
-    stream.write_all(&[0x05, 0x01, 0x00]).await?;
+        // Auth negotiation: version 5, 1 method, no-auth (0x00)
+        stream.write_all(&[0x05, 0x01, 0x00]).await?;
 
-    let mut buf = [0u8; 2];
-    stream.read_exact(&mut buf).await?;
-    if buf[0] != 0x05 || buf[1] != 0x00 {
-        return Err(std::io::Error::other(format!(
-            "SOCKS5 auth failed: {:02x} {:02x}",
-            buf[0], buf[1]
-        )));
-    }
-
-    // CONNECT request
-    match target {
-        SocketAddr::V4(addr) => {
-            let mut req = [0u8; 10];
-            req[0] = 0x05; // version
-            req[1] = 0x01; // CONNECT
-            req[2] = 0x00; // reserved
-            req[3] = 0x01; // IPv4
-            req[4..8].copy_from_slice(&addr.ip().octets());
-            req[8..10].copy_from_slice(&addr.port().to_be_bytes());
-            stream.write_all(&req).await?;
+        let mut buf = [0u8; 2];
+        stream.read_exact(&mut buf).await?;
+        if buf[0] != 0x05 || buf[1] != 0x00 {
+            return Err(std::io::Error::other(format!(
+                "SOCKS5 auth failed: {:02x} {:02x}",
+                buf[0], buf[1]
+            )));
         }
-        SocketAddr::V6(addr) => {
-            let mut req = [0u8; 22];
-            req[0] = 0x05;
-            req[1] = 0x01;
-            req[2] = 0x00;
-            req[3] = 0x04; // IPv6
-            req[4..20].copy_from_slice(&addr.ip().octets());
-            req[20..22].copy_from_slice(&addr.port().to_be_bytes());
-            stream.write_all(&req).await?;
+
+        // CONNECT request
+        match target {
+            SocketAddr::V4(addr) => {
+                let mut req = [0u8; 10];
+                req[0] = 0x05; // version
+                req[1] = 0x01; // CONNECT
+                req[2] = 0x00; // reserved
+                req[3] = 0x01; // IPv4
+                req[4..8].copy_from_slice(&addr.ip().octets());
+                req[8..10].copy_from_slice(&addr.port().to_be_bytes());
+                stream.write_all(&req).await?;
+            }
+            SocketAddr::V6(addr) => {
+                let mut req = [0u8; 22];
+                req[0] = 0x05;
+                req[1] = 0x01;
+                req[2] = 0x00;
+                req[3] = 0x04; // IPv6
+                req[4..20].copy_from_slice(&addr.ip().octets());
+                req[20..22].copy_from_slice(&addr.port().to_be_bytes());
+                stream.write_all(&req).await?;
+            }
         }
-    }
 
-    // Read reply (minimum 10 bytes for IPv4 reply)
-    let mut reply = [0u8; 10];
-    stream.read_exact(&mut reply).await?;
-    if reply[0] != 0x05 || reply[1] != 0x00 {
-        return Err(std::io::Error::other(format!(
-            "SOCKS5 connect failed: reply status {:02x}",
-            reply[1]
-        )));
-    }
+        // Read reply (minimum 10 bytes for IPv4 reply)
+        let mut reply = [0u8; 10];
+        stream.read_exact(&mut reply).await?;
+        if reply[0] != 0x05 || reply[1] != 0x00 {
+            return Err(std::io::Error::other(format!(
+                "SOCKS5 connect failed: reply status {:02x}",
+                reply[1]
+            )));
+        }
 
-    Ok(stream)
+        Ok(stream)
+    })
+    .await
+    .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "socks5 connect timed out"))?
 }
 
 /// SOCKS5 CONNECT via domain name (ATYP 0x03). Returns a stream tunneled to


### PR DESCRIPTION
# bench: bound every phase, drive non-meow binaries, report echo timeouts

## Overview

meow-bench hardening so a wedged proxy can never hang the harness and cross-binary
comparisons stay apples-to-apples:

- Every connection phase has a deadline: socks5 connect (10s), warmup (30s cap), and the
  connrate echo phase (10s). Previously a proxy that accepted CONNECT but never returned
  the echo blocked a worker in read_exact forever and the whole run hung.
- `--binary-arg` (default `-f`, xray uses `-c`) is reused by both the SOCKS5 and the DNS
  child so the harness can drive xray-core/mihomo binaries directly.
- `ConnRateResult` gains `echo_timeouts` so a proxy that stalls mid-connection surfaces as
  a count instead of an unexplained floor rate.
- Windows teardown: reap children via `child.kill()` on every path (ChildGuard), the
  memleak proxy included; earlier leaked children held the port and poisoned later runs.
- Spawned proxy stderr is inherited so protocol diagnostics land in the run log.

## Commits

- `d6a3ace` bench: terminate the memleak proxy via child.kill on Windows
- `11b49ae` bench: reap proxy children on every path; add workload context
- `0991c5c` bench: bound every connection phase so a stalled proxy never wedges the harness
- `cd7419f` bench: reuse --binary-arg for the DNS child; report echo timeouts