### PR TITLE
TUN global route mode: config surface + Linux loop-safe path

### DIFF
--- a/crates/meow-api/src/lib.rs
+++ b/crates/meow-api/src/lib.rs
@@ -44,6 +44,11 @@ pub fn tun_config_to_listener_config(
         mtu: tun.mtu,
         inet4_address: tun.inet4_address,
         auto_route: tun.auto_route,
+        route_scope: match tun.route_mode {
+            meow_config::TunRouteMode::FakeIp => meow_listener::TunRouteScope::FakeIp,
+            meow_config::TunRouteMode::Global => meow_listener::TunRouteScope::Global,
+        },
+        outbound_interface: tun.outbound_interface.clone(),
         dns_hijack: tun.dns_hijack,
         udp_timeout: tun.udp_timeout,
     }

--- a/crates/meow-common/Cargo.toml
+++ b/crates/meow-common/Cargo.toml
@@ -29,6 +29,7 @@ libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
+socket2 = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14"

--- a/crates/meow-common/src/lib.rs
+++ b/crates/meow-common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod home_dir;
 pub mod metadata;
 pub mod network;
+pub mod outbound_iface;
 pub mod process_lookup;
 pub mod rule;
 pub mod sniffer;
@@ -25,6 +26,9 @@ pub use error::{MeowError, Result};
 pub use home_dir::{meow_home_dir, set_home_dir};
 pub use metadata::{AddrDisplay, Metadata};
 pub use network::Network;
+#[cfg(target_os = "linux")]
+pub use outbound_iface::apply_outbound_interface;
+pub use outbound_iface::{clear_outbound_interface, outbound_interface, set_outbound_interface};
 pub use process_lookup::{find_process, ProcessInfo};
 pub use rule::{Rule, RuleMatchHelper, RuleType};
 pub use sniffer::SnifferConfig;

--- a/crates/meow-common/src/outbound_iface.rs
+++ b/crates/meow-common/src/outbound_iface.rs
@@ -1,0 +1,138 @@
+//! Outbound-socket interface binding for TUN global-route mode (#375).
+//!
+//! With `tun.auto-route: global` the split default routes send *all* IPv4
+//! traffic into the TUN device — including, without countermeasures, meow's
+//! own dials to proxy upstreams and DIRECT destinations, which would re-enter
+//! the device and loop. The countermeasure is per-socket: every outbound
+//! socket meow creates is bound to the physical interface **before**
+//! `connect()`/`bind()`, so its packets take the physical route regardless of
+//! the routing table (Linux `SO_BINDTODEVICE`; macOS `IP_BOUND_IF` and
+//! Windows `IP_UNICAST_IF` are follow-ups tracked on #375).
+//!
+//! This module is the process-global registry for that interface, mirroring
+//! the `SocketProtector` pattern in [`crate::socket_protect`]: the TUN
+//! listener installs the interface at startup (and clears it on teardown),
+//! and the dial chokepoints ([`crate::connect_tcp`], [`crate::bind_udp`],
+//! plus the marked-socket path in `meow-proxy`) apply it to each socket.
+//!
+//! The registry itself compiles on every platform so call sites stay free of
+//! `cfg` spaghetti; [`set_outbound_interface`] fails with `Unsupported` on
+//! platforms where the binding syscall is not implemented yet, which lets the
+//! TUN listener fail closed instead of starting a looping configuration.
+
+use std::io;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+static INTERFACE: RwLock<Option<Arc<str>>> = RwLock::new(None);
+
+/// Install the physical interface every subsequent outbound socket binds to.
+/// Validates that the interface exists (Linux `if_nametoindex`). Errors with
+/// `Unsupported` on platforms where per-socket binding is not implemented —
+/// callers must treat that as fatal for global-route mode, not a warning.
+pub fn set_outbound_interface(name: &str) -> io::Result<()> {
+    if name.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "outbound interface name is empty",
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let c_name = std::ffi::CString::new(name).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("outbound interface name '{name}' contains a NUL byte"),
+            )
+        })?;
+        // SAFETY: `c_name` is a valid NUL-terminated string for the call.
+        let index = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
+        if index == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("outbound interface '{name}' does not exist"),
+            ));
+        }
+        *INTERFACE.write() = Some(Arc::from(name));
+        tracing::info!("outbound sockets bound to interface '{name}' (SO_BINDTODEVICE)");
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "outbound interface binding ('{name}') is not implemented on this \
+                 platform yet (tracked on #375; Linux only for now)"
+            ),
+        ))
+    }
+}
+
+/// Remove the installed interface; subsequent sockets bind normally.
+pub fn clear_outbound_interface() {
+    if INTERFACE.write().take().is_some() {
+        tracing::info!("outbound interface binding cleared");
+    }
+}
+
+/// The currently installed interface, if any.
+pub fn outbound_interface() -> Option<Arc<str>> {
+    INTERFACE.read().clone()
+}
+
+/// Bind `socket` to the installed interface, if one is installed. No-op when
+/// none is. Callers must invoke this **before** `connect()`/`bind()` so the
+/// very first packet already takes the physical route.
+#[cfg(target_os = "linux")]
+pub fn apply_outbound_interface(socket: &socket2::Socket) -> io::Result<()> {
+    if let Some(name) = outbound_interface() {
+        socket.bind_device(Some(name.as_bytes()))?;
+    }
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    /// One test drives the whole install → apply → clear sequence because the
+    /// registry is process-global; separate `#[test]` fns would race.
+    #[test]
+    fn install_apply_clear_roundtrip() {
+        assert!(outbound_interface().is_none());
+
+        // A bogus interface must be rejected and leave nothing installed.
+        assert!(set_outbound_interface("no-such-iface-zz9").is_err());
+        assert!(set_outbound_interface("").is_err());
+        assert!(outbound_interface().is_none());
+
+        // Loopback exists on every Linux CI host.
+        set_outbound_interface("lo").expect("lo must exist");
+        assert_eq!(outbound_interface().as_deref(), Some("lo"));
+
+        // Binding a fresh socket to lo succeeds and loopback dials still work.
+        let socket = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::STREAM,
+            Some(socket2::Protocol::TCP),
+        )
+        .unwrap();
+        apply_outbound_interface(&socket).expect("bind_device to lo");
+
+        clear_outbound_interface();
+        assert!(outbound_interface().is_none());
+
+        // With nothing installed, apply is a no-op.
+        let socket2 = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::STREAM,
+            Some(socket2::Protocol::TCP),
+        )
+        .unwrap();
+        apply_outbound_interface(&socket2).expect("no-op apply");
+    }
+}

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -271,7 +271,33 @@ pub async fn connect_tcp(addr: SocketAddr) -> io::Result<TcpStream> {
             return android::connect_tcp_protected(addr, p.as_ref()).await;
         }
     }
+    // TUN global-route loop avoidance (#375): when an outbound interface is
+    // installed, bind the socket to it before connect() so the SYN already
+    // takes the physical route past the TUN default routes.
+    #[cfg(target_os = "linux")]
+    {
+        if crate::outbound_iface::outbound_interface().is_some() {
+            return connect_tcp_iface_bound(addr).await;
+        }
+    }
     TcpStream::connect(addr).await
+}
+
+/// Dial with the socket bound to the installed outbound interface
+/// (`SO_BINDTODEVICE`) before `connect()`. Uses `tokio::net::TcpSocket` for
+/// the async connect so connection errors surface here, not on first I/O.
+#[cfg(target_os = "linux")]
+async fn connect_tcp_iface_bound(addr: SocketAddr) -> io::Result<TcpStream> {
+    let domain = if addr.is_ipv4() {
+        socket2::Domain::IPV4
+    } else {
+        socket2::Domain::IPV6
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+    crate::outbound_iface::apply_outbound_interface(&socket)?;
+    socket.set_nonblocking(true)?;
+    let tokio_socket = tokio::net::TcpSocket::from_std_stream(socket.into());
+    tokio_socket.connect(addr).await
 }
 
 /// Single resolution chokepoint shared by [`connect_tcp_host`],
@@ -399,7 +425,38 @@ pub async fn bind_udp<A: ToSocketAddrs>(local: A) -> io::Result<UdpSocket> {
             return android::bind_udp_protected(resolved, p.as_ref());
         }
     }
+    // TUN global-route loop avoidance (#375): bind the socket to the
+    // installed outbound interface before the local-address bind, mirroring
+    // `connect_tcp` — so the first datagram already bypasses the TUN routes.
+    #[cfg(target_os = "linux")]
+    {
+        if crate::outbound_iface::outbound_interface().is_some() {
+            let resolved = tokio::net::lookup_host(local)
+                .await?
+                .next()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "bind_udp: no address resolved")
+                })?;
+            return bind_udp_iface_bound(resolved);
+        }
+    }
     UdpSocket::bind(local).await
+}
+
+/// Bind a UDP socket to the installed outbound interface
+/// (`SO_BINDTODEVICE`), then to `local`.
+#[cfg(target_os = "linux")]
+fn bind_udp_iface_bound(local: SocketAddr) -> io::Result<UdpSocket> {
+    let domain = if local.is_ipv4() {
+        socket2::Domain::IPV4
+    } else {
+        socket2::Domain::IPV6
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
+    crate::outbound_iface::apply_outbound_interface(&socket)?;
+    socket.bind(&local.into())?;
+    socket.set_nonblocking(true)?;
+    UdpSocket::from_std(socket.into())
 }
 
 #[cfg(all(test, unix))]

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -134,9 +134,28 @@ pub struct TunConfig {
     /// Address + prefix assigned to the device.
     pub inet4_address: ipnet::Ipv4Net,
     pub auto_route: bool,
+    /// Which routes `auto-route` installs (#375). Only meaningful when
+    /// `auto_route` is true.
+    pub route_mode: TunRouteMode,
+    /// Physical interface outbound sockets bind to in global mode; `None`
+    /// = auto-detect from the default route at listener startup.
+    pub outbound_interface: Option<String>,
     /// True when `dns-hijack` contains at least one usable (`:53`) entry.
     pub dns_hijack: bool,
     pub udp_timeout: std::time::Duration,
+}
+
+/// Scope of the routes `tun.auto-route` installs (#375).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TunRouteMode {
+    /// v1 behavior: route only the fake-IP range into the device. Loop-free
+    /// by construction; IP-literal traffic is not captured.
+    #[default]
+    FakeIp,
+    /// Route all IPv4 traffic into the device (split default routes) and
+    /// bind outbound sockets to the physical interface for loop avoidance.
+    /// Experimental; currently Linux-only.
+    Global,
 }
 
 impl Default for TunConfig {
@@ -148,6 +167,8 @@ impl Default for TunConfig {
             // mihomo's default TUN subnet.
             inet4_address: "172.19.0.1/30".parse().expect("static CIDR parses"),
             auto_route: true,
+            route_mode: TunRouteMode::FakeIp,
+            outbound_interface: None,
             dns_hijack: false,
             udp_timeout: std::time::Duration::from_secs(60),
         }
@@ -227,12 +248,39 @@ pub fn parse_tun_config(raw: Option<&raw::RawTun>) -> Result<TunConfig, anyhow::
         None => defaults.udp_timeout.as_secs(),
     });
 
+    // `auto-route` (#375): mihomo boolean, or a mode string selecting what
+    // gets routed. `true` keeps the loop-free v1 fake-IP scope.
+    let (auto_route, route_mode) = match r.auto_route.as_ref() {
+        None => (defaults.auto_route, defaults.route_mode),
+        Some(raw::RawAutoRoute::Enabled(on)) => (*on, TunRouteMode::FakeIp),
+        Some(raw::RawAutoRoute::Mode(s)) => match s.as_str() {
+            "fake-ip" => (true, TunRouteMode::FakeIp),
+            "global" => (true, TunRouteMode::Global),
+            other => {
+                return Err(anyhow::anyhow!(
+                    "tun.auto-route: unknown value '{other}' (expected true, false, \
+                     fake-ip, or global)"
+                ));
+            }
+        },
+    };
+
+    let outbound_interface = r.outbound_interface.clone().filter(|s| !s.is_empty());
+    if outbound_interface.is_some() && route_mode != TunRouteMode::Global {
+        warn!(
+            "tun.outbound-interface: only used with 'auto-route: global'; \
+             ignored in fake-ip mode"
+        );
+    }
+
     Ok(TunConfig {
         enable: r.enable,
         device: r.device.clone().filter(|s| !s.is_empty()),
         mtu,
         inet4_address,
-        auto_route: r.auto_route.unwrap_or(defaults.auto_route),
+        auto_route,
+        route_mode,
+        outbound_interface,
         dns_hijack,
         udp_timeout,
     })

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -216,8 +216,14 @@ pub struct RawTun {
     pub mtu: Option<u16>,
     /// CIDR assigned to the device, e.g. `172.19.0.1/30` (default).
     pub inet4_address: Option<String>,
-    /// Install the fake-IP-range route on startup. Default true.
-    pub auto_route: Option<bool>,
+    /// Route installation on startup. Accepts the mihomo boolean
+    /// (`true` = fake-IP scope, `false` = off) plus the #375 mode strings
+    /// `fake-ip` and `global`. Default true (fake-IP scope).
+    pub auto_route: Option<RawAutoRoute>,
+    /// Physical interface outbound sockets bind to in `auto-route: global`
+    /// mode (loop avoidance, #375). Auto-detected from the default route
+    /// when omitted. Ignored outside global mode.
+    pub outbound_interface: Option<String>,
     /// DNS hijack targets. meow-rs v1 hijacks all UDP :53 flows entering
     /// the device whenever this list is non-empty; entries with a port
     /// other than 53 warn and are ignored.
@@ -236,6 +242,15 @@ pub struct RawTun {
     pub route_exclude_address: Option<serde_yaml::Value>,
     pub include_uid: Option<serde_yaml::Value>,
     pub exclude_uid: Option<serde_yaml::Value>,
+}
+
+/// `tun.auto-route` value: mihomo's boolean or a #375 mode string.
+/// Untagged so `auto-route: true` and `auto-route: global` both parse.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum RawAutoRoute {
+    Enabled(bool),
+    Mode(String),
 }
 
 /// One entry in the `listeners:` array.

--- a/crates/meow-config/tests/tun_config_test.rs
+++ b/crates/meow-config/tests/tun_config_test.rs
@@ -191,3 +191,68 @@ tun:
     assert!(!cfg.tun.enable);
     assert_eq!(cfg.tun.device.as_deref(), Some("meow0"));
 }
+
+// ─── T11–T14: auto-route modes (#375) ─────────────────────────────────────
+
+#[tokio::test]
+async fn t11_auto_route_bool_compat_maps_to_fake_ip() {
+    use meow_config::TunRouteMode;
+
+    // mihomo's boolean forms keep working: true = fake-IP scope, false = off.
+    let on = load_config_from_str("tun:\n  enable: true\n  auto-route: true\n")
+        .await
+        .expect("config must load");
+    assert!(on.tun.auto_route);
+    assert_eq!(on.tun.route_mode, TunRouteMode::FakeIp);
+
+    let off = load_config_from_str("tun:\n  enable: true\n  auto-route: false\n")
+        .await
+        .expect("config must load");
+    assert!(!off.tun.auto_route);
+
+    // Absent → default on, fake-IP scope.
+    let default = load_config_from_str("tun:\n  enable: true\n")
+        .await
+        .expect("config must load");
+    assert!(default.tun.auto_route);
+    assert_eq!(default.tun.route_mode, TunRouteMode::FakeIp);
+}
+
+#[tokio::test]
+async fn t12_auto_route_mode_strings() {
+    use meow_config::TunRouteMode;
+
+    let fake = load_config_from_str("tun:\n  enable: true\n  auto-route: fake-ip\n")
+        .await
+        .expect("config must load");
+    assert!(fake.tun.auto_route);
+    assert_eq!(fake.tun.route_mode, TunRouteMode::FakeIp);
+
+    let global = load_config_from_str("tun:\n  enable: true\n  auto-route: global\n")
+        .await
+        .expect("config must load");
+    assert!(global.tun.auto_route);
+    assert_eq!(global.tun.route_mode, TunRouteMode::Global);
+}
+
+#[tokio::test]
+async fn t13_auto_route_unknown_mode_is_a_hard_error() {
+    let err = expect_load_err("tun:\n  enable: true\n  auto-route: everything\n").await;
+    assert!(
+        err.contains("auto-route") && err.contains("everything"),
+        "error must name the field and the bad value: got {err}"
+    );
+}
+
+#[tokio::test]
+async fn t14_outbound_interface_lands_and_empty_is_none() {
+    let yaml = "tun:\n  enable: true\n  auto-route: global\n  outbound-interface: eth0\n";
+    let cfg = load_config_from_str(yaml).await.expect("config must load");
+    assert_eq!(cfg.tun.outbound_interface.as_deref(), Some("eth0"));
+
+    // Empty string is treated as unset (auto-detect), and setting the field
+    // in fake-ip mode is warn-only, not an error.
+    let yaml = "tun:\n  enable: true\n  outbound-interface: ''\n";
+    let cfg = load_config_from_str(yaml).await.expect("config must load");
+    assert_eq!(cfg.tun.outbound_interface, None);
+}

--- a/crates/meow-listener/src/lib.rs
+++ b/crates/meow-listener/src/lib.rs
@@ -21,4 +21,4 @@ pub use sniffer::SnifferRuntime;
 #[cfg(feature = "listener-tproxy")]
 pub use tproxy::TProxyListener;
 #[cfg(feature = "listener-tun")]
-pub use tun::{TunListener, TunListenerConfig, TunReady};
+pub use tun::{TunListener, TunListenerConfig, TunReady, TunRouteScope};

--- a/crates/meow-listener/src/tun/mod.rs
+++ b/crates/meow-listener/src/tun/mod.rs
@@ -23,9 +23,16 @@
 //!    cannot loop. No SO_MARK, interface binding, or bypass routes needed.
 //!
 //! The trade-off: IP-literal traffic (no DNS lookup) is not captured.
-//! Global capture ("route everything") needs loop protection on the
-//! outbound path and is left to a follow-up; `auto-route` therefore only
-//! installs the fake-IP-range route.
+//!
+//! ## Global route scope (#375, experimental, Linux-only)
+//!
+//! [`TunRouteScope::Global`] opts into capturing everything: `auto-route`
+//! installs split default routes (`0.0.0.0/1` + `128.0.0.0/1`), and loop
+//! freedom moves from route scoping to the outbound path — every socket
+//! meow creates is bound to the physical interface
+//! (`meow_common::set_outbound_interface`, `SO_BINDTODEVICE`) before
+//! connect/bind, and hostname dials resolve through meow's own resolver
+//! hook. Startup fails closed if the binding cannot be installed.
 //!
 //! On Windows the device is a wintun adapter: `wintun.dll` must be present
 //! next to the binary (or on the DLL search path) and the process must run
@@ -107,12 +114,30 @@ pub struct TunListenerConfig {
     pub mtu: u16,
     /// Address + prefix assigned to the device.
     pub inet4_address: Ipv4Net,
-    /// Install the fake-IP-range route on startup (removed on shutdown).
+    /// Install routes on startup (removed on shutdown). What gets routed is
+    /// selected by `route_scope`.
     pub auto_route: bool,
+    /// Scope of the installed routes (#375).
+    pub route_scope: TunRouteScope,
+    /// Physical interface outbound sockets bind to in global scope; `None`
+    /// = auto-detect from the default route. Ignored in fake-IP scope.
+    pub outbound_interface: Option<String>,
     /// Answer UDP :53 flows with the in-process DNS resolver.
     pub dns_hijack: bool,
     /// Idle timeout for UDP flows (flow-table eviction).
     pub udp_timeout: Duration,
+}
+
+/// Which routes `auto_route` installs (#375).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TunRouteScope {
+    /// v1: route only the fake-IP range — loop-free by construction.
+    #[default]
+    FakeIp,
+    /// Route all IPv4 (split defaults `0.0.0.0/1` + `128.0.0.0/1`) into the
+    /// device; outbound sockets bind to the physical interface for loop
+    /// avoidance. Experimental, Linux-only.
+    Global,
 }
 
 /// Outcome of TUN listener startup, sent through the readiness channel.
@@ -183,7 +208,23 @@ struct TunDevice {
     /// this field is dropped, before `device` is destroyed.
     #[allow(dead_code)]
     route_guard: Option<RouteGuard>,
+    /// Held only for its `Drop` side effect — clears the process-global
+    /// outbound-interface binding installed for global route scope.
+    #[allow(dead_code)]
+    iface_guard: Option<OutboundIfaceGuard>,
     pub(super) device: tun_rs::AsyncDevice,
+}
+
+/// RAII wrapper for `meow_common::set_outbound_interface`: global route
+/// scope installs the binding at startup; dropping this (listener teardown /
+/// config reload) clears it so later sessions don't inherit a stale
+/// interface.
+struct OutboundIfaceGuard;
+
+impl Drop for OutboundIfaceGuard {
+    fn drop(&mut self) {
+        meow_common::clear_outbound_interface();
+    }
 }
 
 pub struct TunListener {
@@ -331,20 +372,73 @@ impl TunListener {
         // Obtain the interface index before moving `device` into `TunDevice`.
         let if_index = device.if_index()?;
 
-        // auto-route v1: capture exactly the fake-IP range (see module docs).
+        // Global route scope (#375): before any routes go in, install the
+        // outbound-interface binding so meow's own dials cannot loop back
+        // into the device. Fail closed — a global default route without
+        // working loop avoidance would blackhole the host's connectivity.
+        let iface_guard = if cfg.auto_route && cfg.route_scope == TunRouteScope::Global {
+            if !cfg!(target_os = "linux") {
+                return Err(Box::new(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "tun auto-route: global is currently Linux-only (tracked on #375); \
+                     use auto-route: fake-ip on this platform",
+                )));
+            }
+            let iface = match cfg.outbound_interface.clone() {
+                Some(name) => name,
+                None => route::default_interface().map_err(|e| {
+                    io::Error::other(format!(
+                        "tun auto-route: global: could not auto-detect the physical \
+                         interface ({e}); set tun.outbound-interface explicitly"
+                    ))
+                })?,
+            };
+            meow_common::set_outbound_interface(&iface).map_err(|e| {
+                io::Error::other(format!(
+                    "tun auto-route: global: outbound interface binding failed ({e}); \
+                     refusing to install default routes without loop avoidance"
+                ))
+            })?;
+            info!(
+                "tun '{}': global route scope — outbound sockets bound to '{iface}' \
+                 (experimental, #375)",
+                self.name
+            );
+            Some(OutboundIfaceGuard)
+        } else {
+            None
+        };
+
+        // auto-route: install the scope's routes (see module docs).
         //
         // RouteManager::add() calls into OS routing APIs that may block
         // (PowerShell on Windows), so it runs on a blocking thread. The
         // outer TUN_STARTUP_TIMEOUT guards the overall startup.
+        let route_nets: Option<Vec<ipnet::IpNet>> = if cfg.auto_route {
+            match cfg.route_scope {
+                // Split defaults: two /1s cover all IPv4 while staying more
+                // specific than the physical 0/0 default, so the original
+                // route survives untouched and restore-on-drop is trivial.
+                // The device's own /30 and the fake-IP range (if any) are
+                // inside the /1s already.
+                TunRouteScope::Global => Some(vec![
+                    "0.0.0.0/1".parse().expect("static CIDR parses"),
+                    "128.0.0.0/1".parse().expect("static CIDR parses"),
+                ]),
+                TunRouteScope::FakeIp => self.tunnel.resolver().fake_ip_v4_net().map(|n| vec![n]),
+            }
+        } else {
+            None
+        };
+
         let route_guard = if cfg.auto_route {
-            match self.tunnel.resolver().fake_ip_v4_net() {
-                Some(fake_net) => {
+            match route_nets {
+                Some(nets) => {
                     let t_route = Instant::now();
 
-                    let result = tokio::task::spawn_blocking(move || {
-                        RouteGuard::setup(if_index, &[fake_net])
-                    })
-                    .await;
+                    let result =
+                        tokio::task::spawn_blocking(move || RouteGuard::setup(if_index, &nets))
+                            .await;
 
                     match result {
                         Ok(Ok(g)) => {
@@ -386,6 +480,7 @@ impl TunListener {
         // succeeds because the adapter is still alive.
         let device = Arc::new(TunDevice {
             route_guard,
+            iface_guard,
             device,
         });
 

--- a/crates/meow-listener/src/tun/route.rs
+++ b/crates/meow-listener/src/tun/route.rs
@@ -49,3 +49,76 @@ impl Drop for RouteGuard {
         }
     }
 }
+
+/// Detect the physical interface carrying the IPv4 default route, for
+/// global route scope's outbound-socket binding (#375). Linux-only for now:
+/// reads `/proc/net/route` and returns the interface of the first UP
+/// `0.0.0.0/0` entry — captured **before** the TUN's own split defaults go
+/// in, so the TUN device can never be the answer.
+pub(super) fn default_interface() -> std::io::Result<String> {
+    #[cfg(target_os = "linux")]
+    {
+        let table = std::fs::read_to_string("/proc/net/route")?;
+        parse_default_interface(&table).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no IPv4 default route found in /proc/net/route",
+            )
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "default-interface auto-detection is Linux-only (tracked on #375)",
+        ))
+    }
+}
+
+/// Pure parser behind [`default_interface`], split out for unit testing on
+/// every host (hence `test` in the cfg — only Linux uses it at runtime).
+/// `/proc/net/route` columns: Iface, Destination (hex LE),
+/// Gateway, Flags (hex; bit 0 = RTF_UP), … A default route has destination
+/// `00000000` and the UP flag set.
+#[cfg(any(target_os = "linux", test))]
+fn parse_default_interface(table: &str) -> Option<String> {
+    for line in table.lines().skip(1) {
+        let mut cols = line.split_whitespace();
+        let (Some(iface), Some(dest), _gateway, Some(flags)) =
+            (cols.next(), cols.next(), cols.next(), cols.next())
+        else {
+            continue;
+        };
+        let up = u32::from_str_radix(flags, 16).is_ok_and(|f| f & 0x1 != 0);
+        if dest == "00000000" && up {
+            return Some(iface.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_default_interface;
+
+    const SAMPLE: &str = "\
+Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT
+docker0\t000011AC\t00000000\t0001\t0\t0\t0\t0000FFFF\t0\t0\t0
+eth0\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0
+eth0\t0001A8C0\t00000000\t0001\t0\t0\t100\t00FFFFFF\t0\t0\t0
+";
+
+    #[test]
+    fn picks_the_up_default_route_interface() {
+        assert_eq!(parse_default_interface(SAMPLE).as_deref(), Some("eth0"));
+    }
+
+    #[test]
+    fn ignores_down_defaults_and_empty_tables() {
+        // Same default entry but with the UP bit clear → not a candidate.
+        let down = SAMPLE.replace("00000000\t0101A8C0\t0003", "00000000\t0101A8C0\t0002");
+        assert_eq!(parse_default_interface(&down), None);
+        assert_eq!(parse_default_interface("Iface\tDestination\n"), None);
+        assert_eq!(parse_default_interface(""), None);
+    }
+}

--- a/crates/meow-proxy/src/direct.rs
+++ b/crates/meow-proxy/src/direct.rs
@@ -232,6 +232,10 @@ async fn connect_with_mark(
 
         let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
         socket.set_mark(mark)?;
+        // TUN global-route loop avoidance (#375): this branch bypasses
+        // `meow_common::connect_tcp`, so apply the outbound-interface
+        // binding here too (no-op when none is installed).
+        meow_common::apply_outbound_interface(&socket)?;
         socket.set_nonblocking(true)?;
 
         match socket.connect(&dest.into()) {

--- a/docs/tun.md
+++ b/docs/tun.md
@@ -75,8 +75,8 @@ side-steps the entire problem class:
 
 The trade-off: **traffic that never does a DNS lookup (IP-literal
 connections) is not captured.** For domain-based traffic — the overwhelming
-majority — capture is complete. Global capture ("route everything") needs
-outbound loop protection and is tracked as follow-up work.
+majority — capture is complete. Global capture ("route everything") is the
+opt-in `auto-route: global` mode below (#375).
 
 Consequences:
 
@@ -88,6 +88,63 @@ Consequences:
   stack itself — `ping` to a fake IP confirms the tun is up, but is not an
   end-to-end probe of the remote host.
 
+## Global route mode — `auto-route: global` (experimental, Linux-only)
+
+Tracked on [#375](https://github.com/madeye/meow-rs/issues/375). Routes
+**all IPv4 traffic** into the device instead of just the fake-ip range, so
+IP-literal connections are captured too:
+
+```yaml
+tun:
+  enable: true
+  auto-route: global
+  # outbound-interface: eth0   # optional; auto-detected from the default route
+  dns-hijack:
+    - any:53
+```
+
+How each loop-avoidance piece works:
+
+1. **Split default routes.** `auto-route: global` installs `0.0.0.0/1` and
+   `128.0.0.0/1` into the device. The two /1s are more specific than the
+   physical `0.0.0.0/0`, so the original default route is never touched and
+   teardown is a plain route delete — no restore step that can be lost to a
+   crash.
+2. **Outbound interface binding.** Every outbound socket meow creates (proxy
+   upstream dials, DIRECT, marked sockets) is bound to the physical
+   interface with `SO_BINDTODEVICE` *before* connect/bind, so its packets
+   take the physical route regardless of the routing table. The interface is
+   `tun.outbound-interface` if set, otherwise auto-detected from
+   `/proc/net/route` **before** the split defaults go in. If the binding
+   cannot be installed, startup **fails closed** — no default routes are
+   installed without loop avoidance.
+3. **Own-resolver hostname dials.** Proxy-server domains are resolved
+   through meow's resolver hook (installed at startup), not libc's
+   `getaddrinfo`, so those lookups don't depend on the OS resolver's
+   routing either.
+
+Scope and caveats:
+
+- **Linux-only for now.** macOS (`IP_BOUND_IF`) and Windows
+  (`IP_UNICAST_IF`) bindings are follow-ups on #375; `auto-route: global`
+  on those platforms is a startup error. On Windows the fake-ip mode
+  remains the supported transparent path.
+- IPv4 only, matching the rest of the TUN v1 flow (no `inet6-address`).
+- `fake-ip` DNS mode is still recommended so domain rules match; global
+  mode adds IP-literal capture on top rather than replacing the DNS flow.
+- Requires root/`CAP_NET_ADMIN` like the rest of the TUN inbound.
+
+Verification on a Linux host (or VM):
+
+```bash
+sudo ./meow -f config.yaml            # global mode active
+curl 1.1.1.1                          # IP literal — captured (check meow logs)
+ip route get 1.1.1.1                  # shows the tun device
+curl https://example.com              # domain flow — still captured
+# teardown: stop meow, then confirm both /1 routes are gone:
+ip route | grep -c '/1 dev' # → 0
+```
+
 ## `tun:` reference
 
 | Field | Default | Notes |
@@ -96,7 +153,8 @@ Consequences:
 | `device` | platform-chosen | Adapter name. macOS always auto-assigns `utunN`. |
 | `mtu` | `1500` | Hard error below 1280 (userspace-stack minimum). |
 | `inet4-address` | `172.19.0.1/30` | CIDR assigned to the device. |
-| `auto-route` | `true` | Install the fake-ip-range route at startup, remove on shutdown. |
+| `auto-route` | `true` | What to route into the device at startup (removed on shutdown): `true`/`fake-ip` = the fake-ip range; `global` = all IPv4 (experimental, Linux-only, see above); `false` = nothing. |
+| `outbound-interface` | auto-detect | Physical interface outbound sockets bind to in `global` mode. Ignored otherwise. |
 | `dns-hijack` | off | List of targets; any `:53` entry turns on in-process answering of UDP :53 flows entering the device. Non-`:53` entries warn and are ignored. |
 | `udp-timeout` | `60` | Seconds of idle before a UDP flow is evicted. |
 


### PR DESCRIPTION
First slice of #375 — the config surface and the Linux path, per the tracking comment's ask. **Does not close #375**: macOS/Windows binding and real-machine verification remain.

## Config surface
```yaml
tun:
  enable: true
  auto-route: global          # true | false | fake-ip | global
  # outbound-interface: eth0  # optional; auto-detected from the default route
```
- `auto-route` keeps full mihomo boolean compat (`true` = the loop-free fake-IP scope, unchanged default); the mode strings opt into #375 behavior. Unknown strings are a hard parse error.
- `outbound-interface` is only consulted in global mode (warn otherwise).

## Linux path (the three legs from the tracking comment)
1. **Routes**: global mode installs split defaults `0.0.0.0/1` + `128.0.0.0/1` — more specific than the physical `0/0`, so the original default route is never touched and teardown is a plain delete (crash-safe: no restore step to lose).
2. **Loop avoidance**: new `meow_common::outbound_iface` registry (same pattern as the Android `SocketProtector`); `connect_tcp`/`bind_udp` and meow-proxy's marked-socket branch bind every outbound socket with `SO_BINDTODEVICE` *before* connect/bind. The TUN listener installs the binding before any routes go in — interface from config or auto-detected from `/proc/net/route` — and clears it via RAII on teardown. **Fail closed**: binding failure (or an unsupported platform) aborts startup rather than installing default routes without loop protection; `auto-route: global` on macOS/Windows is a clean startup error pointing at #375.
3. **Own-resolver dials**: already covered — `set_host_resolver` is installed at startup, so hostname dials bypass `getaddrinfo`.

## Verification
- 4 new tun-config tests (bool compat, mode strings, unknown-mode error, outbound-interface), `/proc/net/route` parser tests (run everywhere), Linux-gated registry roundtrip test (runs on Linux CI).
- Full regression bar green on macOS; `cargo zigbuild --target x86_64-unknown-linux-gnu` of `meow-app --all-features` compiles clean.
- docs/tun.md gains a *Global route mode* section with mechanism, caveats, and an on-host verification recipe — that runtime verification on a real Linux host/VM is the remaining gate before the mode leaves experimental status.

## Follow-ups on #375
- macOS `IP_BOUND_IF`/`IPV6_BOUND_IF`, Windows `IP_UNICAST_IF`
- IPv6 route coverage
- Linux VM runtime verification (recipe in docs)