### PR TITLE
feat(config): wire DirectAdapter connect timeout to config

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -529,6 +529,9 @@ fn rebuild_from_raw_impl(
     if let Some(resolver) = resolver {
         direct = direct.with_resolver(resolver);
     }
+    if let Some(secs) = raw.tcp_connect_timeout {
+        direct = direct.with_connect_timeout(std::time::Duration::from_secs(secs));
+    }
     proxies.insert(
         SmolStr::new_static("DIRECT"),
         Arc::new(proxy_parser::WrappedProxy::new(Box::new(direct))),

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -492,6 +492,17 @@ fn parse_direct(
 
     let mut adapter = DirectAdapter::new();
 
+    // Optional `connect-timeout:` (seconds) — per-proxy counterpart of the
+    // global `tcp-connect-timeout:` that covers the built-in DIRECT. Hard
+    // error on a non-integer (Class A per ADR-0002): silently ignoring it
+    // would leave the connect unbounded when the user asked for a bound.
+    if let Some(v) = config.get("connect-timeout") {
+        let secs = v.as_u64().ok_or_else(|| {
+            format!("direct[{name}]: connect-timeout must be a non-negative integer (seconds)")
+        })?;
+        adapter = adapter.with_connect_timeout(std::time::Duration::from_secs(secs));
+    }
+
     if let Some(v) = config.get("dns") {
         let entries: Vec<String> = match v {
             serde_yaml::Value::String(s) => vec![s.clone()],
@@ -2145,6 +2156,32 @@ tls: true
             panic!("empty dns list must hard-error (Class A)");
         };
         assert!(err.contains("dns list is empty"), "msg: {err}");
+    }
+
+    #[test]
+    fn parse_direct_with_connect_timeout_wires_adapter() {
+        let cfg = direct_config("name: d\ntype: direct\nconnect-timeout: 7\n");
+        let adapter = parse_direct("d", &cfg).unwrap();
+        assert_eq!(
+            adapter.connect_timeout(),
+            Some(std::time::Duration::from_secs(7))
+        );
+    }
+
+    #[test]
+    fn parse_direct_without_connect_timeout_is_unbounded() {
+        let cfg = direct_config("name: d\ntype: direct\n");
+        let adapter = parse_direct("d", &cfg).unwrap();
+        assert_eq!(adapter.connect_timeout(), None);
+    }
+
+    #[test]
+    fn parse_direct_rejects_non_integer_connect_timeout() {
+        let cfg = direct_config("name: bad\ntype: direct\nconnect-timeout: fast\n");
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("non-integer connect-timeout must hard-error (Class A)");
+        };
+        assert!(err.contains("connect-timeout"), "msg: {err}");
     }
 
     #[test]

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -160,6 +160,15 @@ pub struct RawConfig {
     pub tproxy_port: Option<u16>,
     pub tproxy_sni: Option<bool>,
     pub routing_mark: Option<u32>,
+    /// Wall-clock bound, in seconds, on the built-in DIRECT adapter's
+    /// `TcpStream::connect`. Unset = unbounded (legacy behaviour, subject
+    /// only to the OS connect timeout). Motivated by iOS/macOS
+    /// scoped-routing and reachability-cache transients that can leave a
+    /// direct connect hanging indefinitely — see meow-ios
+    /// docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md.
+    /// Explicit `type: direct` proxy blocks are NOT covered by this
+    /// global; they accept their own per-proxy `connect-timeout` field.
+    pub tcp_connect_timeout: Option<u64>,
     /// Static host → IP mappings, preferred over upstream DNS lookups.
     /// Values may be a single IP string or a list of IPs.
     pub hosts: Option<HashMap<String, HostsValue>>,
@@ -529,7 +538,7 @@ pub struct RawSubscription {
 
 #[cfg(test)]
 mod tests {
-    use super::{RawHealthCheck, RawProxyGroup};
+    use super::{RawConfig, RawHealthCheck, RawProxyGroup};
 
     #[test]
     fn expected_status_accepts_integer_scalar() {
@@ -563,5 +572,17 @@ mod tests {
 
         let hc: RawHealthCheck = serde_yaml::from_str("enable: true\n").unwrap();
         assert_eq!(hc.expected_status, None);
+    }
+
+    #[test]
+    fn tcp_connect_timeout_parses_from_kebab_yaml() {
+        let raw: RawConfig = serde_yaml::from_str("tcp-connect-timeout: 10\n").unwrap();
+        assert_eq!(raw.tcp_connect_timeout, Some(10));
+    }
+
+    #[test]
+    fn tcp_connect_timeout_defaults_to_none() {
+        let raw: RawConfig = serde_yaml::from_str("mixed-port: 7890\n").unwrap();
+        assert_eq!(raw.tcp_connect_timeout, None);
     }
 }

--- a/crates/meow-proxy/src/direct.rs
+++ b/crates/meow-proxy/src/direct.rs
@@ -58,6 +58,13 @@ impl DirectAdapter {
         self
     }
 
+    /// Read back the configured connect bound. `None` = unbounded. Lets
+    /// config-layer tests assert the `tcp-connect-timeout` /
+    /// `connect-timeout` wiring without dialing anything.
+    pub fn connect_timeout(&self) -> Option<Duration> {
+        self.connect_timeout
+    }
+
     /// Determine the concrete `SocketAddr` candidates to dial for `metadata`,
     /// avoiding the OS resolver whenever possible.
     async fn resolve_targets(&self, metadata: &Metadata) -> Result<Vec<SocketAddr>> {


### PR DESCRIPTION
## Summary

`DirectAdapter::with_connect_timeout` existed (added for the meow-ios 2026-05-18 tcp-direct-rule-disconnect investigation) but had **no callers**, so the built-in DIRECT adapter's `TcpStream::connect` stayed unbounded — an iOS/macOS scoped-routing or reachability-cache transient can hang a direct dial indefinitely, and the tun2socks-side watchdog that was supposed to compensate turned out to be inert (meow-ios is removing it in favor of this bound).

- New global `tcp-connect-timeout:` (seconds) wires into the built-in DIRECT adapter in `rebuild_from_raw_impl`. Unset = unbounded (legacy behaviour), so nothing changes for existing configs.
- Explicit `type: direct` proxy blocks accept a per-proxy `connect-timeout:` (seconds); non-integer values hard-error (Class A per ADR-0002).
- `DirectAdapter::connect_timeout()` getter so config-layer tests assert the wiring without dialing.

Timeout behaviour itself (`apply_connect_timeout`, `ErrorKind::TimedOut`) was already implemented and tested in `direct.rs`; this PR only adds the config plumbing.

This is the same change as `ios/connect-timeout-0.20.1` (041c986a, pinned by meow-ios), forward-ported to main.

## Local verification

- `cargo fmt --all -- --check` → clean
- `cargo clippy -p meow-config -p meow-proxy --all-targets -- -D warnings` → clean
- `cargo test -p meow-config --lib` → 171 passed; `cargo test -p meow-proxy --lib` → 286 passed
- Full workspace `cargo test --lib` → running locally; CI will confirm