### PR TITLE
fix(anytls): dial sessions through a host-app TcpDialer hook

### DIFF
--- a/crates/meow-anytls/src/client/client.rs
+++ b/crates/meow-anytls/src/client/client.rs
@@ -216,11 +216,16 @@ impl Client {
             "[Client] Connecting TCP to {} (this may trigger DNS lookup)",
             self.server_addr
         );
-        // Dial via the socket-protect helper so a host VPN (Android) can
-        // call `VpnService.protect(fd)` on the outbound socket before the
-        // SYN — otherwise the connection loops back into the same VPN.
-        // Off-Android the helper degrades to `TcpStream::connect`.
-        let tcp_stream = match crate::util::socket_protect::connect_tcp(&self.server_addr).await {
+        // Dial via the socket-protect helper: an installed `TcpDialer`
+        // (host-app bridge, e.g. meow-common's resolver + protector stack)
+        // takes the whole resolve+connect path; otherwise the fallback
+        // applies the `SocketProtector` (Android) around a system-resolver
+        // dial, degrading to plain `TcpStream::connect` off-Android. The
+        // dialer hook matters inside VPN apps whose system DNS is a fake-IP
+        // server — `lookup_host` there returns unroutable fake IPs.
+        let tcp_stream = match crate::util::socket_protect::connect_tcp_addr(&self.server_addr)
+            .await
+        {
             Ok(stream) => stream,
             Err(e) => {
                 tracing::error!("[Client] Failed to connect to {}: {}", self.server_addr, e);

--- a/crates/meow-anytls/src/util/mod.rs
+++ b/crates/meow-anytls/src/util/mod.rs
@@ -23,6 +23,9 @@ pub use net::*;
 pub use socket_protect::{
     SocketProtector, clear_socket_protector, set_socket_protector, socket_protector,
 };
-pub use socket_protect::{bind_udp, connect_tcp};
+pub use socket_protect::{
+    TcpDialer, bind_udp, clear_tcp_dialer, connect_tcp, connect_tcp_addr, set_tcp_dialer,
+    tcp_dialer,
+};
 pub use string_map::*;
 pub use tls::*;

--- a/crates/meow-anytls/src/util/socket_protect.rs
+++ b/crates/meow-anytls/src/util/socket_protect.rs
@@ -175,3 +175,112 @@ pub async fn bind_udp<A: ToSocketAddrs>(local: A) -> io::Result<UdpSocket> {
     }
     UdpSocket::bind(local).await
 }
+
+/// Pluggable outbound TCP dialer hook.
+///
+/// [`connect_tcp`] resolves hostnames with `tokio::net::lookup_host`, i.e.
+/// the operating-system resolver. When `anytls-rs` runs inside a VPN app
+/// that is itself the system's DNS handler (meow-rs on Android answers the
+/// TUN's DNS with an in-process fake-IP server), that resolver hands back
+/// fake IPs — so the (correctly protected) socket dials a blackhole and
+/// times out. The host app installs a dialer here that resolves through its
+/// own real-IP resolver stack (e.g. meow-common's `connect_tcp_host`); when
+/// present it fully replaces the resolve+connect path, protector included.
+pub trait TcpDialer: Send + Sync {
+    /// Dial `host:port` and return a connected stream. `host` may be a
+    /// hostname or an IP literal.
+    fn dial<'a>(
+        &'a self,
+        host: &'a str,
+        port: u16,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = io::Result<TcpStream>> + Send + 'a>>;
+}
+
+static TCP_DIALER: std::sync::RwLock<Option<std::sync::Arc<dyn TcpDialer>>> =
+    std::sync::RwLock::new(None);
+
+/// Install the global TCP dialer. Call once during app startup, before any
+/// AnyTLS client dials. Re-installing is allowed; the new dialer takes
+/// effect on the next outbound connection.
+pub fn set_tcp_dialer(dialer: std::sync::Arc<dyn TcpDialer>) {
+    if let Ok(mut guard) = TCP_DIALER.write() {
+        *guard = Some(dialer);
+    }
+}
+
+/// Remove the currently installed dialer, if any.
+pub fn clear_tcp_dialer() {
+    if let Ok(mut guard) = TCP_DIALER.write() {
+        *guard = None;
+    }
+}
+
+/// Snapshot of the currently-installed dialer.
+pub fn tcp_dialer() -> Option<std::sync::Arc<dyn TcpDialer>> {
+    TCP_DIALER.read().ok().and_then(|g| g.clone())
+}
+
+/// Split a `host:port` / `[v6]:port` address string.
+fn split_host_port(addr: &str) -> Option<(&str, u16)> {
+    let (host, port) = addr.rsplit_once(':')?;
+    let port: u16 = port.parse().ok()?;
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    if host.is_empty() {
+        None
+    } else {
+        Some((host, port))
+    }
+}
+
+/// Dial a `host:port` address string, preferring the installed [`TcpDialer`]
+/// and falling back to [`connect_tcp`] (system resolver + optional
+/// protector) when none is installed or the address doesn't split.
+pub async fn connect_tcp_addr(addr: &str) -> io::Result<TcpStream> {
+    if let (Some(dialer), Some((host, port))) = (tcp_dialer(), split_host_port(addr)) {
+        return dialer.dial(host, port).await;
+    }
+    connect_tcp(addr).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_host_port_forms() {
+        assert_eq!(
+            split_host_port("example.com:443"),
+            Some(("example.com", 443))
+        );
+        assert_eq!(split_host_port("1.2.3.4:80"), Some(("1.2.3.4", 80)));
+        assert_eq!(split_host_port("[::1]:8443"), Some(("::1", 8443)));
+        assert_eq!(split_host_port("no-port"), None);
+        assert_eq!(split_host_port(":443"), None);
+        assert_eq!(split_host_port("host:notaport"), None);
+    }
+
+    #[test]
+    fn dialer_registry_roundtrip() {
+        struct Nop;
+        impl TcpDialer for Nop {
+            fn dial<'a>(
+                &'a self,
+                _host: &'a str,
+                _port: u16,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = io::Result<TcpStream>> + Send + 'a>,
+            > {
+                Box::pin(async { Err(io::Error::other("nop")) })
+            }
+        }
+        clear_tcp_dialer();
+        assert!(tcp_dialer().is_none());
+        set_tcp_dialer(std::sync::Arc::new(Nop));
+        assert!(tcp_dialer().is_some());
+        clear_tcp_dialer();
+        assert!(tcp_dialer().is_none());
+    }
+}

--- a/crates/meow-proxy/src/anytls_adapter.rs
+++ b/crates/meow-proxy/src/anytls_adapter.rs
@@ -53,12 +53,10 @@ impl AnytlsAdapter {
         sni: Option<&str>,
         skip_cert_verify: bool,
     ) -> std::result::Result<Self, String> {
-        // Bridge meow_common's `SocketProtector` into anytls-rs's separate
-        // registry exactly once. anytls-rs ships its own protector trait
-        // (it can't depend on meow_common), so the host VPN only installs
-        // a `meow_common::SocketProtector` and this shim re-forwards every
-        // protect call into the anytls-rs registry.
-        install_anytls_protector_bridge();
+        // Bridge meow_common's outbound-socket hooks (resolver-aware TCP
+        // dialer + Android `SocketProtector`) into anytls-rs's separate
+        // registries exactly once — see `install_anytls_bridges`.
+        install_anytls_bridges();
 
         let server_addr = format!("{server}:{port}");
 
@@ -392,33 +390,59 @@ fn build_tls_client_config(
 
 // ─── meow_common ⇄ anytls_rs protector bridge ────────────────────────────────
 //
-// On Android, `meow_common` and `anytls_rs` each ship their own
-// `SocketProtector` registry — `anytls-rs` can't depend on `meow_common`
-// and vice-versa. The host VPN installs a `meow_common::SocketProtector`
-// once at startup; this bridge re-publishes every protect call into the
-// `anytls-rs` registry so the AnyTLS client-side dials (`connect_tcp`,
-// `bind_udp`) fire the same JNI hook. Installed exactly once via the
-// `Once` guard inside `AnytlsAdapter::new`.
-#[cfg(target_os = "android")]
-fn install_anytls_protector_bridge() {
+// `anytls_rs` can't depend on `meow_common` (or vice-versa), so each ships
+// its own outbound-socket hook registries. These bridges — installed exactly
+// once via the `Once` guard inside `AnytlsAdapter::new` — re-publish
+// meow_common's hooks into the `anytls-rs` registries:
+//
+// - `TcpDialer` (all targets): routes the client-side session dial through
+//   `meow_common::connect_tcp_host`, i.e. the installed `HostResolver` +
+//   `SocketProtector` stack. Without it `anytls-rs` resolves the server
+//   hostname with `tokio::net::lookup_host` (the system resolver), which
+//   inside a meow VPN is the in-process fake-IP DNS — the protected socket
+//   then dials an unroutable fake IP and times out (the loop-routing
+//   failure mode described in `meow_common::socket_protect`).
+//
+// - `SocketProtector` (Android): covers the remaining direct socket sites
+//   in `anytls-rs` (the per-stream UDP relay's `bind_udp`), which don't go
+//   through the dialer.
+fn install_anytls_bridges() {
     use std::sync::Once;
 
     static INIT: Once = Once::new();
     INIT.call_once(|| {
-        struct Bridge;
-        impl anytls_rs::SocketProtector for Bridge {
-            fn protect(&self, fd: std::os::fd::RawFd) -> std::io::Result<()> {
-                match meow_common::socket_protector() {
-                    Some(p) => p.protect(fd),
-                    // No protector installed on the meow_common side — match
-                    // the off-Android no-protector behaviour: just allow.
-                    None => Ok(()),
-                }
+        struct DialBridge;
+        impl anytls_rs::TcpDialer for DialBridge {
+            fn dial<'a>(
+                &'a self,
+                host: &'a str,
+                port: u16,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = std::io::Result<tokio::net::TcpStream>>
+                        + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(meow_common::connect_tcp_host(host, port))
             }
         }
-        anytls_rs::set_socket_protector(Arc::new(Bridge));
+        anytls_rs::set_tcp_dialer(Arc::new(DialBridge));
+
+        #[cfg(target_os = "android")]
+        {
+            struct Bridge;
+            impl anytls_rs::SocketProtector for Bridge {
+                fn protect(&self, fd: std::os::fd::RawFd) -> std::io::Result<()> {
+                    match meow_common::socket_protector() {
+                        Some(p) => p.protect(fd),
+                        // No protector installed on the meow_common side —
+                        // match the off-Android no-protector behaviour.
+                        None => Ok(()),
+                    }
+                }
+            }
+            anytls_rs::set_socket_protector(Arc::new(Bridge));
+        }
     });
 }
-
-#[cfg(not(target_os = "android"))]
-fn install_anytls_protector_bridge() {}


### PR DESCRIPTION
anytls-rs resolved its server hostname via the system resolver, which inside a meow VPN is the in-process fake-IP DNS — the protected session socket then dialed an unroutable fake IP and timed out (every anytls node dead on Android; found debugging meow-android against a real all-anytls subscription).

Adds a `TcpDialer` hook to anytls-rs (mirroring the `SocketProtector` registry) and installs a bridge in `AnytlsAdapter` to `meow_common::connect_tcp_host`, so anytls dials resolve and connect exactly like every other adapter. Unit tests for the addr splitting + registry; full workspace `cargo test --lib`, clippy `-D warnings`, fmt clean.

Verified on-device: see madeye/meow — anytls sessions establish after this fix.