### PR TITLE
transport: reject changed h2 write buffers after Pending

### DIFF
--- a/crates/meow-transport/src/h2.rs
+++ b/crates/meow-transport/src/h2.rs
@@ -191,12 +191,26 @@ impl AsyncWrite for H2Stream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
         let this = self.get_mut();
 
         // Stash the payload exactly once per logical write.  If pending_write
         // is already set, a previous poll returned Pending; capacity has been
-        // reserved — do not encode or reserve again.
-        if this.pending_write.is_none() {
+        // reserved - do not encode or reserve again.  A Pending poll must be
+        // retried with the same buffer; reject a changed buffer rather than
+        // silently sending stale bytes under its reported length.
+        if let Some(data) = &this.pending_write {
+            if buf != data.as_ref() {
+                this.pending_write = None;
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "h2: write buffer changed after Pending; \
+                     AsyncWrite requires retrying with the same buffer",
+                )));
+            }
+        } else {
             let data = Bytes::copy_from_slice(buf);
             this.send.reserve_capacity(data.len());
             this.pending_write = Some(data);


### PR DESCRIPTION
H2Stream reserves capacity and stashes the pending payload. If a caller
cancels a Pending write and starts a new write with another buffer, the
old code could send stale bytes while reporting the new buffer's length.
Reject that AsyncWrite contract violation with InvalidInput instead.

An empty buffer is answered with `Ok(0)` up front, before any capacity is
reserved.

This is the non-mux H2 transport fix split out of #394; it does not depend
on the mux work.

## Validation

```
cargo test -p meow-transport --features h2 --test h2_test
cargo test -p meow-transport --features h2
cargo clippy -p meow-transport --features h2 --all-targets
```

All pass. The mux checks from #394 (`cargo test -p meow-proxy --features mux`,
`cargo clippy -p meow-proxy --features mux --all-targets`) also pass and are
unrelated to this diff.
