### PR TITLE
fix(release): depend on published meow-lwip instead of a git fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,21 +2261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
-name = "lwip"
-version = "0.3.15"
-source = "git+https://github.com/madeye/lwip.git?rev=5f6f0dfe025c967157ff328d94efe488852d8755#5f6f0dfe025c967157ff328d94efe488852d8755"
-dependencies = [
- "bindgen 0.69.5",
- "bytes",
- "cc",
- "futures",
- "log",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,9 +2536,9 @@ dependencies = [
  "futures",
  "ipnet",
  "libc",
- "lwip",
  "meow-common",
  "meow-dns",
+ "meow-lwip",
  "meow-trie",
  "meow-tunnel",
  "route_manager",
@@ -2561,6 +2546,22 @@ dependencies = [
  "tokio",
  "tracing",
  "tun-rs",
+]
+
+[[package]]
+name = "meow-lwip"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22746441375482072bd0368d5f615b5a5f22553c649ac197bd91de0a64cb1dcc"
+dependencies = [
+ "bindgen 0.69.5",
+ "bytes",
+ "cc",
+ "futures",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,11 @@ iprange = "0.6"
 # `listener-tun` feature. The stack is madeye/lwip (lwIP), not smoltcp:
 # accept is post-handshake, PCB/window/memory caps live in lwipopts.h.
 tun-rs = { version = "2.8", features = ["async_tokio"] }
-lwip = { git = "https://github.com/madeye/lwip.git", rev = "5f6f0dfe025c967157ff328d94efe488852d8755" }
+# Published fork of `lwip` (madeye/lwip): single-owner core plus the
+# poll_next UAF / poll_flush deadlock / FIN_WAIT_2 leak / livelock fixes that
+# upstream `lwip` lacks. Registry version, not a `git =` pin — crates.io
+# forbids git deps in a published manifest (see docs/RELEASING.md).
+lwip = { package = "meow-lwip", version = "0.3.15" }
 route_manager = "0.2"
 
 # Crypto

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -80,13 +80,25 @@ meow-app                                     (→ everything)
 - **New versions of existing crates:** a much higher limit, so a normal release
   publishes all 11 crates back-to-back without throttling.
 
-## `anytls-rs`
+## Forked dependencies
 
-`anytls-rs` is an **opt-in, non-default** dependency (the `anytls` feature) pinned
-to its crates.io release in `[workspace.dependencies]` — crates.io forbids `git`
-dependencies, so it must stay a registry version, not the `madeye/anytls-rs` git
-fork. If you need a newer fork change, publish it to crates.io first, then bump the
-version here.
+**crates.io forbids `git` dependencies in a published manifest — even optional,
+non-default ones.** A `git =` entry anywhere in `[workspace.dependencies]` makes
+every crate that reaches it unpublishable. This bit the `0.20.2` release: a git
+pin on the `lwip` fork (added with TUN inbound, #326) aborted the publish job
+after nine crates had already uploaded, stranding `meow-listener`, `meow-api`
+and `meow-app` at `0.20.1`.
+
+So a fork has to be **vendored in-tree** or **published to the registry** before
+anything can depend on it:
+
+| Fork | Route | Notes |
+|------|-------|-------|
+| `anytls-rs` | Vendored as `crates/meow-anytls` (lib name `anytls_rs`), published with the workspace | Upstream lacks `Stream::close()`. Opt-in via `meow-proxy`'s `anytls` feature. |
+| `lwip` | Published as [`meow-lwip`](https://crates.io/crates/meow-lwip) from [madeye/lwip](https://github.com/madeye/lwip), consumed as `lwip = { package = "meow-lwip", version = "0.3.15" }` | Upstream `lwip` is **not** a substitute: the fork rewrites the Rust layer (single-owner core) and carries the `poll_next` UAF, `poll_flush` deadlock, FIN_WAIT_2 leak and livelock fixes. Required by `listener-tun`, which is in `meow-app`'s default `full` bundle. |
+
+If you need a newer fork change, publish it to crates.io first, then bump the
+version here — never point `[workspace.dependencies]` at a git rev.
 
 ## Manual fallback
 


### PR DESCRIPTION
## Problem

The [v0.20.2 publish job](https://github.com/madeye/meow-rs/actions/runs/32019809577/job/95356924108) failed **half-way through the release**:

```
error: failed to verify manifest at `crates/meow-listener/Cargo.toml`
Caused by:
  all dependencies must have a version requirement specified when publishing.
  dependency `lwip` does not specify a version
```

Nine crates had already uploaded, so crates.io is currently split:

| Crate | On crates.io |
|-------|--------------|
| `meow-common` … `meow-tunnel` (9) | **0.20.2** ✅ |
| `meow-listener`, `meow-api`, `meow-app` | **0.20.1** ❌ |

**Cause:** #401 (TUN inbound, #326) added `lwip` to `[workspace.dependencies]` as a git pin on the `madeye/lwip` fork. crates.io forbids `git` dependencies in a published manifest — **even optional, non-default ones** — so `meow-listener` cannot be packaged, `meow-api` optionally depends on it, and `meow-app` depends on both.

## Why not point at crates.io `lwip`

Upstream `ssrlive/lwip` is a different implementation. I diffed the trees: the fork **rewrites the Rust layer** — adds `core.rs`, deletes `mutex.rs`, `output.rs`, `stack_impl.rs`, `tcp_listener_impl.rs`, `tcp_stream_impl.rs`, `tcp_stream_context.rs` — and carries the `Stream::poll_next` data race / UAF fix, the `poll_flush` Pending-without-waker deadlock fix, the FIN_WAIT_2 pcb leak fix and the timer-task livelock fix. Upstream 0.4.0 has none of them. Substituting it would ship known-broken TUN behaviour to everyone, since `listener-tun` is in `meow-app`'s default `full` bundle.

## This change

The fork is now **published under its own name** — [`meow-lwip 0.3.15`](https://crates.io/crates/meow-lwip) (madeye/lwip#3) — and consumed from the registry:

```toml
lwip = { package = "meow-lwip", version = "0.3.15" }
```

`[lib] name = "lwip"` in the fork keeps the crate importable as `lwip`, so **no source changes** were needed here. `Cargo.lock` re-resolves the git source to `meow-lwip 0.3.15` from crates.io.

All 12 crates publish again — no `publish = false`, no change to `publish.yml`.

`docs/RELEASING.md` gains a **Forked dependencies** section stating the rule and recording both forks' routes (anytls vendored in-tree as `crates/meow-anytls`; lwip published to the registry). This replaces the stale `anytls-rs` section, which still claimed anytls was pinned to a crates.io release when it has since been vendored.

## Verification

- `cargo publish -p meow-listener --dry-run` — packages (30 files, 102.8 KiB compressed) and builds; this was the crate that failed the release ✅
- `cargo build --all-features -p meow-listener` — links the registry `meow-lwip` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` (default / `--no-default-features` / `--all-features`) ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✅
- `cargo test --lib` — 12/12 suites green, 0 failed ✅

`meow-api` / `meow-app` can only dry-run once `meow-listener 0.20.2` is actually on the registry (`failed to select a version for the requirement meow-listener = "^0.20.2"`); the publish loop resolves that by publishing in dependency order.

## After merge

`publish.yml` can be dispatched on `main` with **dry-run unticked** to finish 0.20.2 — the loop is idempotent, so it skips the nine crates already at 0.20.2 and uploads only `meow-listener`, `meow-api`, `meow-app`. No version bump needed, since those three were never published at 0.20.2.

## Note on the fork's branches

`meow-rs` pins `5f6f0df`, which lives only on the fork's unmerged `feature/single-owner-core` branch — 4 commits ahead of the fork's default `rust` branch, but missing 9 commits that are on `rust` (clippy/CI fixes, an snmp warning fix, a separately cherry-picked bcrypt commit). `meow-lwip 0.3.15` publishes **exactly the tree meow-rs is built and tested against**. Reconciling the two lineages is separate work worth doing in that repo.