### PR TITLE
Support hosts domain aliases

### DIFF
--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -4,7 +4,7 @@ use http_body_util::BodyExt;
 use meow_api::routes::{create_router, AppState};
 use meow_common::{DnsMode, Proxy};
 use meow_config::raw::{RawConfig, RawProxyGroup, RawSubscription};
-use meow_dns::Resolver;
+use meow_dns::{HostEntry, Resolver};
 use meow_trie::DomainTrie;
 use meow_tunnel::Tunnel;
 use parking_lot::RwLock;
@@ -2727,8 +2727,8 @@ async fn delete_all_connections_clears_all() {
 fn test_state_with_hosts_entry() -> Arc<AppState> {
     use std::net::IpAddr;
     let ip: IpAddr = "192.0.2.1".parse().unwrap();
-    let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
-    hosts.insert("test.local", vec![ip]);
+    let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
+    hosts.insert("test.local", vec![ip].into());
 
     let resolver = Arc::new(Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true));
     let tunnel = Tunnel::new(resolver);

--- a/crates/meow-config/src/dns_parser.rs
+++ b/crates/meow-config/src/dns_parser.rs
@@ -2,7 +2,9 @@ use crate::raw::{HostsValue, RawConfig};
 use crate::DnsConfig;
 use meow_common::DnsMode;
 use meow_dns::fakeip::{FileStore, MemoryStore, Pool, Skipper, SkipperMode, Store};
-use meow_dns::resolver::{FallbackFilter, NameserverPolicy, NameserverPolicyMatcher, PolicyEntry};
+use meow_dns::resolver::{
+    FallbackFilter, HostEntry, NameserverPolicy, NameserverPolicyMatcher, PolicyEntry,
+};
 use meow_dns::upstream::{NameServerEntry, NameServerUrl};
 use meow_dns::{DnsClient, HostOrIp, Resolver};
 use meow_trie::DomainTrie;
@@ -573,55 +575,104 @@ fn build_fallback_filter(
     }
 }
 
-/// Build the hosts trie from `dns.hosts` config entries.
-///
-/// Returns an error if any IP value is malformed (Class A per ADR-0002 —
-/// malformed IPs in hosts are almost certainly typos).
+/// Build the hosts trie from top-level mihomo-compatible `hosts:` entries.
+/// A single value may be an IP or domain alias; lists must contain only IPs.
+/// Malformed values and alias cycles are hard errors (Class A per ADR-0002).
 fn build_hosts_trie(
     hosts: Option<&HashMap<String, HostsValue>>,
-) -> Result<DomainTrie<Vec<IpAddr>>, anyhow::Error> {
-    let mut trie: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+) -> Result<DomainTrie<HostEntry>, anyhow::Error> {
+    let mut trie: DomainTrie<HostEntry> = DomainTrie::new();
     let Some(hosts) = hosts else {
         return Ok(trie);
     };
+    let mut aliases = Vec::new();
     for (host, value) in hosts {
-        let raw_ips = value.as_slice();
-        let mut ips: Vec<IpAddr> = Vec::with_capacity(raw_ips.len());
-        for s in &raw_ips {
-            match s.parse::<IpAddr>() {
-                Ok(ip) => ips.push(ip),
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "dns.hosts: invalid IP '{s}' for host '{host}': {e} \
-                        (Class A per ADR-0002 — malformed hosts entries are almost certainly typos)"
-                    ));
-                }
-            }
-        }
-        if ips.is_empty() {
-            warn!("dns.hosts: entry '{}' has no IPs, skipping", host);
+        let values = value.as_slice();
+        if values.is_empty() {
+            warn!("hosts: entry '{}' has no values, skipping", host);
             continue;
         }
+        let host_entry = if values.len() == 1 {
+            let raw = values[0].trim();
+            match raw.parse::<IpAddr>() {
+                Ok(ip) => HostEntry::Addresses(vec![ip]),
+                Err(_) => {
+                    let alias = parse_host_alias(raw, host)?;
+                    aliases.push((normalize_hosts_wildcard(host.trim()), alias.clone()));
+                    HostEntry::Alias(alias.into())
+                }
+            }
+        } else {
+            let mut ips = Vec::with_capacity(values.len());
+            for raw in values {
+                let ip = raw.parse::<IpAddr>().map_err(|e| {
+                    anyhow::anyhow!(
+                        "hosts: invalid IP '{raw}' for host '{host}': {e} \
+                         (lists may contain only IP addresses)"
+                    )
+                })?;
+                ips.push(ip);
+            }
+            HostEntry::Addresses(ips)
+        };
         // Rewrite *.foo → +.foo for DomainTrie wildcard semantics at parse time.
         let entry = normalize_hosts_wildcard(host.trim());
-        if !trie.insert(&entry, ips.clone()) {
-            warn!("dns.hosts: failed to insert '{}' into trie", host);
+        if !trie.insert(&entry, host_entry.clone()) {
+            warn!("hosts: failed to insert '{}' into trie", host);
         }
         // DomainTrie's +. semantics don't include the root domain itself — insert
         // it explicitly so that "corp.internal" matches "+.corp.internal".
         if let Some(bare) = entry.strip_prefix("+.") {
-            trie.insert(bare, ips);
+            trie.insert(bare, host_entry);
         }
     }
+    reject_host_alias_cycles(&trie, &aliases)?;
     Ok(trie)
 }
 
+fn parse_host_alias(value: &str, host: &str) -> Result<String, anyhow::Error> {
+    let alias = value.trim_end_matches('.').to_ascii_lowercase();
+    let valid = alias.contains('.')
+        && !alias.contains('*')
+        && !alias.contains('+')
+        && hickory_proto::rr::Name::from_ascii(&alias).is_ok();
+    if !valid {
+        return Err(anyhow::anyhow!(
+            "hosts: value '{value}' for host '{host}' is neither an IP address nor a valid domain alias"
+        ));
+    }
+    Ok(alias)
+}
+
+fn reject_host_alias_cycles(
+    trie: &DomainTrie<HostEntry>,
+    aliases: &[(String, String)],
+) -> Result<(), anyhow::Error> {
+    for (source, target) in aliases {
+        let mut seen = std::collections::HashSet::new();
+        seen.insert(source.to_ascii_lowercase());
+        let mut current = target.as_str();
+        loop {
+            if !seen.insert(current.to_ascii_lowercase()) {
+                return Err(anyhow::anyhow!(
+                    "hosts: domain alias cycle detected starting at '{source}'"
+                ));
+            }
+            match trie.search(current) {
+                Some(HostEntry::Alias(next)) => current = next.as_str(),
+                Some(HostEntry::Addresses(_)) | None => break,
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Merge system hosts entries into the trie at lower priority than config entries.
-async fn merge_system_hosts(trie: &mut DomainTrie<Vec<IpAddr>>) {
+async fn merge_system_hosts(trie: &mut DomainTrie<HostEntry>) {
     let entries = parse_system_hosts().await;
     for (domain, ips) in entries {
         if trie.search(&domain).is_none() {
-            trie.insert(&domain, ips);
+            trie.insert(&domain, HostEntry::Addresses(ips));
         }
     }
 }
@@ -699,6 +750,13 @@ mod tests {
         HostsValue::Many(ss.iter().map(std::string::ToString::to_string).collect())
     }
 
+    fn addresses(entry: &HostEntry) -> &[IpAddr] {
+        match entry {
+            HostEntry::Addresses(ips) => ips,
+            HostEntry::Alias(alias) => panic!("expected addresses, got alias {alias}"),
+        }
+    }
+
     #[test]
     fn build_hosts_trie_none_is_empty() {
         let trie = build_hosts_trie(None).unwrap();
@@ -711,7 +769,7 @@ mod tests {
         map.insert("example.com".to_string(), one("1.2.3.4"));
         let trie = build_hosts_trie(Some(&map)).unwrap();
         let v = trie.search("example.com").expect("must hit");
-        assert_eq!(v, &vec![IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))]);
+        assert_eq!(addresses(v), &[IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))]);
     }
 
     #[test]
@@ -720,10 +778,45 @@ mod tests {
         map.insert("dual.test".to_string(), many(&["1.1.1.1", "::1"]));
         let trie = build_hosts_trie(Some(&map)).unwrap();
         let v = trie.search("dual.test").expect("must hit");
-        assert_eq!(v.len(), 2);
+        assert_eq!(addresses(v).len(), 2);
     }
 
-    // Malformed IP in dns.hosts → hard error (Class A per ADR-0002).
+    #[test]
+    fn build_hosts_trie_domain_alias() {
+        let mut map = HashMap::new();
+        map.insert("node.example".to_string(), one("origin.example"));
+        let trie = build_hosts_trie(Some(&map)).unwrap();
+        assert_eq!(
+            trie.search("node.example"),
+            Some(&HostEntry::Alias("origin.example".into()))
+        );
+    }
+
+    #[test]
+    fn build_hosts_trie_rejects_alias_cycle() {
+        let mut map = HashMap::new();
+        map.insert("a.example".to_string(), one("b.example"));
+        map.insert("b.example".to_string(), one("a.example"));
+        let err = build_hosts_trie(Some(&map))
+            .err()
+            .expect("domain alias cycles must be rejected");
+        assert!(err.to_string().contains("alias cycle"));
+    }
+
+    #[test]
+    fn build_hosts_trie_rejects_domain_in_multi_value_list() {
+        let mut map = HashMap::new();
+        map.insert(
+            "bad.example".to_string(),
+            many(&["192.0.2.1", "origin.example"]),
+        );
+        let err = build_hosts_trie(Some(&map))
+            .err()
+            .expect("multi-value hosts entries may contain only IPs");
+        assert!(err.to_string().contains("lists may contain only IP"));
+    }
+
+    // A value that is neither an IP nor a valid alias is a hard error.
     // Upstream: silently skips malformed IPs. NOT silent skip — Class A per ADR-0002.
     #[test]
     fn build_hosts_trie_malformed_ip_hard_error() {
@@ -732,7 +825,7 @@ mod tests {
         let result = build_hosts_trie(Some(&map));
         let err = result
             .err()
-            .expect("malformed IP in dns.hosts must be a hard error (Class A)");
+            .expect("malformed hosts value must be a hard error (Class A)");
         let msg = err.to_string();
         assert!(
             msg.contains("not-an-ip") && msg.contains("bad.test"),
@@ -779,7 +872,7 @@ mod tests {
         let exact = trie.search("dns.corp.internal").expect("must hit exact");
         let exact_addr: IpAddr = exact_ip.parse().unwrap();
         assert_eq!(
-            exact.first().copied(),
+            addresses(exact).first().copied(),
             Some(exact_addr),
             "exact entry must override wildcard"
         );

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -48,10 +48,15 @@ pub(crate) fn parse_optional_socket_addr(
     value: Option<&str>,
 ) -> Result<Option<SocketAddr>, anyhow::Error> {
     match value {
-        Some(value) if !value.is_empty() => value
-            .parse()
-            .map(Some)
-            .map_err(|e| anyhow::anyhow!("invalid {field} socket address '{value}': {e}")),
+        Some(value) if !value.is_empty() => {
+            let normalized = value
+                .strip_prefix(':')
+                .map_or_else(|| value.to_string(), |port| format!("0.0.0.0:{port}"));
+            normalized
+                .parse()
+                .map(Some)
+                .map_err(|e| anyhow::anyhow!("invalid {field} socket address '{value}': {e}"))
+        }
         _ => Ok(None),
     }
 }
@@ -2344,6 +2349,10 @@ mod socket_address_tests {
         assert!(parse_optional_socket_addr("dns.listen", Some("localhost")).is_err());
         assert!(parse_optional_socket_addr("dns.listen", Some("127.0.0.1:70000")).is_err());
         assert!(parse_optional_socket_addr("external-controller", Some("[::1]:9090")).is_ok());
+        assert_eq!(
+            parse_optional_socket_addr("external-controller", Some(":9090")).unwrap(),
+            Some("0.0.0.0:9090".parse().unwrap())
+        );
         assert_eq!(
             parse_optional_socket_addr("dns.listen", Some("127.0.0.1:0")).unwrap(),
             Some("127.0.0.1:0".parse().unwrap())

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -544,7 +544,7 @@ fn parse_direct(
             servers,
             Vec::new(),
             DnsMode::Normal,
-            DomainTrie::<Vec<IpAddr>>::new(),
+            DomainTrie::new(),
             false,
         ));
         adapter = adapter.with_resolver(resolver);

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -169,8 +169,8 @@ pub struct RawConfig {
     /// Explicit `type: direct` proxy blocks are NOT covered by this
     /// global; they accept their own per-proxy `connect-timeout` field.
     pub tcp_connect_timeout: Option<u64>,
-    /// Static host → IP mappings, preferred over upstream DNS lookups.
-    /// Values may be a single IP string or a list of IPs.
+    /// Static host mappings, preferred over upstream DNS lookups. Values may
+    /// be a single IP, a list of IPs, or one domain-name alias.
     pub hosts: Option<HashMap<String, HostsValue>>,
     pub sniffer: Option<RawSniffer>,
     /// Named listener array. Each entry defines an explicitly-named proxy
@@ -188,7 +188,7 @@ pub struct RawConfig {
     pub max_connections: Option<usize>,
 }
 
-/// A `hosts:` map value: either a single IP address or a list of addresses.
+/// A `hosts:` map value: one IP/domain alias or a list of IP addresses.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum HostsValue {
@@ -301,7 +301,7 @@ pub struct RawDns {
     /// If false, the hosts trie lookup is skipped entirely at query time.
     pub use_hosts: Option<bool>,
     /// If true, `/etc/hosts` is read at startup and merged (lower priority than
-    /// `dns.hosts` config entries). No-op + warn on Windows.
+    /// top-level `hosts` config entries). No-op + warn on Windows.
     pub use_system_hosts: Option<bool>,
     /// Per-domain nameserver routing: each key is an exact domain or a `+.`
     /// wildcard prefix; value is a single server URL or a list of URLs.

--- a/crates/meow-dns/src/lib.rs
+++ b/crates/meow-dns/src/lib.rs
@@ -10,6 +10,8 @@ pub use cache::{DnsCache, DnsCacheSnapshotEntry, ReverseSnapshotEntry};
 pub use client::{set_socket_factory, ClientError, DnsClient, SocketFactory};
 pub use fakeip::{FileStore, MemoryStore, Pool, PoolError, Skipper, SkipperMode, Store};
 pub use host_resolver_hook::ResolverHostHook;
-pub use resolver::{BootstrapError, FallbackFilter, NameserverPolicy, PolicyEntry, Resolver};
+pub use resolver::{
+    BootstrapError, FallbackFilter, HostEntry, NameserverPolicy, PolicyEntry, Resolver,
+};
 pub use server::{BoundDnsServer, DnsServer};
 pub use upstream::{HostOrIp, NameServerEntry, NameServerParseError, NameServerUrl};

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -17,6 +17,23 @@ use tracing::debug;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// A mihomo-compatible `hosts:` value.
+///
+/// A mapping may pin a host to one or more addresses, or redirect it to a
+/// different domain. Domain redirects are followed before consulting the DNS
+/// cache/upstreams, so they also apply to outbound proxy server resolution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HostEntry {
+    Addresses(Vec<IpAddr>),
+    Alias(SmolStr),
+}
+
+impl From<Vec<IpAddr>> for HostEntry {
+    fn from(value: Vec<IpAddr>) -> Self {
+        Self::Addresses(value)
+    }
+}
+
 /// Error returned by `Resolver::new_with_bootstrap`.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -166,7 +183,7 @@ pub struct Resolver {
     fallback: Option<Vec<Arc<DnsClient>>>,
     cache: DnsCache,
     mode: DnsMode,
-    hosts: DomainTrie<Vec<IpAddr>>,
+    hosts: DomainTrie<HostEntry>,
     use_hosts: bool,
     inflight: DashMap<Arc<str>, InflightTx>,
     policy: Option<NameserverPolicy>,
@@ -181,6 +198,11 @@ pub struct Resolver {
     /// TTL stamped on synthesised A/AAAA responses. Short by design so
     /// clients re-query rather than caching a fake IP after pool eviction.
     fakeip_ttl: Duration,
+}
+
+enum HostsLookup<'a> {
+    Addresses(&'a Vec<IpAddr>),
+    Alias(&'a str),
 }
 
 struct InflightGuard<'a> {
@@ -460,12 +482,32 @@ async fn query_pool_generic(
 }
 
 impl Resolver {
+    /// Follow a mihomo-style hosts alias chain. Config parsing rejects cycles;
+    /// the depth guard is a defensive backstop for programmatically-built
+    /// tries passed to the public constructors.
+    fn lookup_hosts_entry<'a>(&'a self, host: &str) -> Option<HostsLookup<'a>> {
+        let mut current = host;
+        let mut terminal_alias = None;
+        for _ in 0..64 {
+            match self.hosts.search(current) {
+                Some(HostEntry::Addresses(ips)) => return Some(HostsLookup::Addresses(ips)),
+                Some(HostEntry::Alias(alias)) => {
+                    terminal_alias = Some(alias.as_str());
+                    current = alias.as_str();
+                }
+                None => return terminal_alias.map(HostsLookup::Alias),
+            }
+        }
+        tracing::error!(host, "hosts alias chain exceeded 64 entries");
+        None
+    }
+
     #[allow(clippy::needless_pass_by_value)] // Vec<SocketAddr> is conventional for public constructors
     pub fn new(
         main_servers: Vec<SocketAddr>,
         fallback_servers: Vec<SocketAddr>,
         mode: DnsMode,
-        hosts: DomainTrie<Vec<IpAddr>>,
+        hosts: DomainTrie<HostEntry>,
         use_hosts: bool,
     ) -> Self {
         let main = Self::build_clients(&main_servers);
@@ -511,7 +553,7 @@ impl Resolver {
         fallback_urls: Vec<NameServerUrl>,
         default_ns: Vec<NameServerUrl>,
         mode: DnsMode,
-        hosts: DomainTrie<Vec<IpAddr>>,
+        hosts: DomainTrie<HostEntry>,
         use_hosts: bool,
         policy: Option<NameserverPolicy>,
         fallback_filter: Option<FallbackFilter>,
@@ -544,7 +586,7 @@ impl Resolver {
         fallback_urls: Vec<NameServerEntry>,
         default_ns: Vec<NameServerEntry>,
         mode: DnsMode,
-        hosts: DomainTrie<Vec<IpAddr>>,
+        hosts: DomainTrie<HostEntry>,
         use_hosts: bool,
         policy: Option<NameserverPolicy>,
         fallback_filter: Option<FallbackFilter>,
@@ -799,19 +841,23 @@ impl Resolver {
     }
 
     pub async fn resolve_ips(&self, host: &str) -> Option<Vec<IpAddr>> {
-        if self.use_hosts {
-            if let Some(ips) = self.hosts.search(host) {
-                if !ips.is_empty() {
+        let lookup_host = if self.use_hosts {
+            match self.lookup_hosts_entry(host) {
+                Some(HostsLookup::Addresses(ips)) if !ips.is_empty() => {
                     return Some(ips.clone());
                 }
+                Some(HostsLookup::Alias(alias)) => alias,
+                _ => host,
             }
-        }
-        if let Some(ips) = self.cache.get(host) {
+        } else {
+            host
+        };
+        if let Some(ips) = self.cache.get(lookup_host) {
             if !ips.is_empty() {
                 return Some(ips.to_vec());
             }
         }
-        self.lookup_actual_all(host).await
+        self.lookup_actual_all(lookup_host).await
     }
 
     pub async fn resolve_ip(&self, host: &str) -> Option<IpAddr> {
@@ -832,12 +878,22 @@ impl Resolver {
     /// lookups. Hosts-trie hits get [`HOSTS_ANSWER_TTL`] — static mappings
     /// have no upstream TTL to honor.
     pub async fn lookup_ipv4_with_ttl(&self, host: &str) -> Option<(IpAddr, Duration)> {
-        if self.use_hosts {
-            if let Some(ips) = self.hosts.search(host) {
-                let ip = ips.iter().find(|ip| ip.is_ipv4()).copied()?;
-                return Some((ip, HOSTS_ANSWER_TTL));
+        let lookup_host = if self.use_hosts {
+            match self.lookup_hosts_entry(host) {
+                Some(HostsLookup::Addresses(ips)) => {
+                    let ip = ips.iter().find(|ip| ip.is_ipv4()).copied()?;
+                    return Some((ip, HOSTS_ANSWER_TTL));
+                }
+                Some(HostsLookup::Alias(alias)) => {
+                    return self
+                        .lookup_real_with_ttl(alias, std::net::IpAddr::is_ipv4)
+                        .await;
+                }
+                None => host,
             }
-        }
+        } else {
+            host
+        };
         // Fake-IP mode: synthesise from the v4 pool unless the skipper says
         // bypass. The hosts trie above still wins — explicit user mappings
         // never get rewritten to a fake address.
@@ -848,7 +904,7 @@ impl Resolver {
                 }
             }
         }
-        self.lookup_real_with_ttl(host, std::net::IpAddr::is_ipv4)
+        self.lookup_real_with_ttl(lookup_host, std::net::IpAddr::is_ipv4)
             .await
     }
 
@@ -858,12 +914,22 @@ impl Resolver {
 
     /// AAAA counterpart of [`Self::lookup_ipv4_with_ttl`] — same TTL contract.
     pub async fn lookup_ipv6_with_ttl(&self, host: &str) -> Option<(IpAddr, Duration)> {
-        if self.use_hosts {
-            if let Some(ips) = self.hosts.search(host) {
-                let ip = ips.iter().find(|ip| ip.is_ipv6()).copied()?;
-                return Some((ip, HOSTS_ANSWER_TTL));
+        let lookup_host = if self.use_hosts {
+            match self.lookup_hosts_entry(host) {
+                Some(HostsLookup::Addresses(ips)) => {
+                    let ip = ips.iter().find(|ip| ip.is_ipv6()).copied()?;
+                    return Some((ip, HOSTS_ANSWER_TTL));
+                }
+                Some(HostsLookup::Alias(alias)) => {
+                    return self
+                        .lookup_real_with_ttl(alias, std::net::IpAddr::is_ipv6)
+                        .await;
+                }
+                None => host,
             }
-        }
+        } else {
+            host
+        };
         // Fake-IP mode for AAAA: synthesise from the v6 pool if configured.
         // If only a v4 pool is configured (the common case — upstream
         // default is `198.18.0.1/16` only), return None so the server emits
@@ -878,7 +944,7 @@ impl Resolver {
                 return None;
             }
         }
-        self.lookup_real_with_ttl(host, std::net::IpAddr::is_ipv6)
+        self.lookup_real_with_ttl(lookup_host, std::net::IpAddr::is_ipv6)
             .await
     }
 
@@ -922,7 +988,10 @@ impl Resolver {
         if !self.use_hosts {
             return None;
         }
-        self.hosts.search(host)
+        match self.lookup_hosts_entry(host) {
+            Some(HostsLookup::Addresses(ips)) => Some(ips),
+            Some(HostsLookup::Alias(_)) | None => None,
+        }
     }
 
     async fn lookup_actual_all(&self, host: &str) -> Option<Vec<IpAddr>> {
@@ -1257,9 +1326,9 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_ip_uses_hosts_file() {
-        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
-        hosts.insert("example.test", vec![real]);
+        hosts.insert("example.test", vec![real].into());
         let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
         assert_eq!(resolver.resolve_ip("example.test").await, Some(real));
         assert_eq!(resolver.resolve_ip_real("example.test").await, Some(real));
@@ -1267,12 +1336,12 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_ips_preserves_all_hosts_file_addresses() {
-        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let ips = vec![
             IpAddr::V6(Ipv6Addr::LOCALHOST),
             IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
         ];
-        hosts.insert("example.test", ips.clone());
+        hosts.insert("example.test", ips.clone().into());
         let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
 
         assert_eq!(resolver.resolve_ips("example.test").await, Some(ips));
@@ -1283,8 +1352,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_ips_follows_hosts_domain_alias_chain() {
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
+        let real = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+        hosts.insert("alias.test", HostEntry::Alias("middle.test".into()));
+        hosts.insert("middle.test", HostEntry::Alias("origin.test".into()));
+        hosts.insert("origin.test", HostEntry::Addresses(vec![real]));
+        let resolver = Resolver::new(vec![], vec![], DnsMode::FakeIp, hosts, true);
+
+        assert_eq!(resolver.resolve_ips("alias.test").await, Some(vec![real]));
+        assert_eq!(
+            resolver.lookup_ipv4("alias.test").await,
+            Some(real),
+            "an explicit alias must bypass fake-IP synthesis"
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_ip_returns_cached_entry() {
-        let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
         let real = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
         resolver
@@ -1295,7 +1381,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_ips_preserves_all_cached_addresses() {
-        let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
         let ips = vec![
             IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
@@ -1312,7 +1398,7 @@ mod tests {
     fn fake_ip_active_for_gates_on_mode_pool_and_skipper() {
         use crate::fakeip::{MemoryStore, SkipperMode};
 
-        let new_hosts = || -> DomainTrie<Vec<IpAddr>> { DomainTrie::new() };
+        let new_hosts = || -> DomainTrie<HostEntry> { DomainTrie::new() };
 
         // Normal mode: never active.
         let normal = Resolver::new(vec![], vec![], DnsMode::Normal, new_hosts(), true);
@@ -1420,9 +1506,9 @@ mod tests {
 
     #[tokio::test]
     async fn lookup_with_ttl_uses_hosts_ttl_for_static_mappings() {
-        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let pinned = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-        hosts.insert("pinned.test", vec![pinned]);
+        hosts.insert("pinned.test", vec![pinned].into());
         let resolver = Resolver::new(vec![], vec![], DnsMode::Mapping, hosts, true);
         assert_eq!(
             resolver.lookup_ipv4_with_ttl("pinned.test").await,
@@ -1496,7 +1582,7 @@ mod tests {
 
     #[tokio::test]
     async fn inflight_entry_cleared_after_lookup_miss() {
-        let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
         let _ = resolver.lookup_actual_all("nonexistent.test").await;
         assert!(
@@ -1508,7 +1594,7 @@ mod tests {
 
     #[tokio::test]
     async fn inflight_concurrent_callers_share_one_lookup() {
-        let hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let resolver =
             std::sync::Arc::new(Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true));
         let r1 = Arc::clone(&resolver);
@@ -1769,9 +1855,9 @@ mod tests {
     // Upstream: use-hosts is always on in upstream. NOT a bypass here — Class B per ADR-0002 (deferred config option).
     #[tokio::test]
     async fn use_hosts_false_bypasses_hosts_trie() {
-        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
         let hosts_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-        hosts.insert("example.test", vec![hosts_ip]);
+        hosts.insert("example.test", vec![hosts_ip].into());
         let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, false);
         // With use_hosts=false, hosts lookup is bypassed, no upstream → None.
         assert_eq!(
@@ -1785,8 +1871,11 @@ mod tests {
     #[test]
     fn lookup_hosts_all_respects_use_hosts_flag() {
         let make_hosts = || {
-            let mut h: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
-            h.insert("example.test", vec![IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))]);
+            let mut h: DomainTrie<HostEntry> = DomainTrie::new();
+            h.insert(
+                "example.test",
+                vec![IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))].into(),
+            );
             h
         };
         let r_on = Resolver::new(vec![], vec![], DnsMode::Normal, make_hosts(), true);

--- a/crates/meow-proxy/src/direct.rs
+++ b/crates/meow-proxy/src/direct.rs
@@ -349,6 +349,7 @@ impl ProxyAdapter for DirectAdapter {
 mod tests {
     use super::*;
     use meow_common::DnsMode;
+    use meow_dns::HostEntry;
     use meow_trie::DomainTrie;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
@@ -377,13 +378,14 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
         hosts.insert(
             "multi.test",
             vec![
                 IpAddr::V6(Ipv6Addr::LOCALHOST),
                 IpAddr::V4(Ipv4Addr::LOCALHOST),
-            ],
+            ]
+            .into(),
         );
         let resolver = Arc::new(Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true));
         let adapter = DirectAdapter::new()

--- a/crates/meow-tunnel/tests/fakeip_test.rs
+++ b/crates/meow-tunnel/tests/fakeip_test.rs
@@ -9,15 +9,15 @@
 use ipnet::IpNet;
 use meow_common::{DnsMode, Metadata, Network};
 use meow_dns::fakeip::{MemoryStore, Pool};
-use meow_dns::Resolver;
+use meow_dns::{HostEntry, Resolver};
 use meow_trie::DomainTrie;
 use meow_tunnel::Tunnel;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 fn build_fakeip_resolver(real_host: &str, real_ip: IpAddr) -> Arc<Resolver> {
-    let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
-    hosts.insert(real_host, vec![real_ip]);
+    let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
+    hosts.insert(real_host, vec![real_ip].into());
     // hosts trie is consulted BEFORE the fake-IP pool, so put the host in
     // the trie. That mirrors the production wiring: explicit `hosts:`
     // entries override fake-IP. For the rewrite test we want the resolver

--- a/crates/meow-tunnel/tests/lazy_resolve_test.rs
+++ b/crates/meow-tunnel/tests/lazy_resolve_test.rs
@@ -3,7 +3,7 @@
 //! entirely when an earlier rule already matched.
 
 use meow_common::{DnsMode, Metadata, Network, Rule};
-use meow_dns::Resolver;
+use meow_dns::{HostEntry, Resolver};
 use meow_rules::{domain_suffix::DomainSuffixRule, final_rule::FinalRule, ipcidr::IpCidrRule};
 use meow_trie::DomainTrie;
 use meow_tunnel::Tunnel;
@@ -11,8 +11,8 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 fn build_resolver_with_host(host: &str, ip: IpAddr) -> Arc<Resolver> {
-    let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
-    hosts.insert(host, vec![ip]);
+    let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
+    hosts.insert(host, vec![ip].into());
     Arc::new(Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true))
 }
 

--- a/crates/meow-tunnel/tests/pre_resolve_test.rs
+++ b/crates/meow-tunnel/tests/pre_resolve_test.rs
@@ -2,7 +2,7 @@
 //! IP-CIDR / GeoIP rule matching, using the internal Resolver.
 
 use meow_common::{DnsMode, Metadata, Network, Rule};
-use meow_dns::Resolver;
+use meow_dns::{HostEntry, Resolver};
 use meow_rules::ipcidr::IpCidrRule;
 use meow_trie::DomainTrie;
 use meow_tunnel::Tunnel;
@@ -10,8 +10,8 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 fn build_resolver_with_host(host: &str, ip: IpAddr) -> Arc<Resolver> {
-    let mut hosts: DomainTrie<Vec<IpAddr>> = DomainTrie::new();
-    hosts.insert(host, vec![ip]);
+    let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
+    hosts.insert(host, vec![ip].into());
     Arc::new(Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true))
 }
 


### PR DESCRIPTION
## Summary

- support Mihomo-compatible single-domain values in top-level `hosts`
- follow alias chains for outbound resolution while preserving IP and wildcard precedence
- reject alias cycles and non-IP multi-value entries
- accept `:port` socket-address shorthand used by Mihomo configurations
- update resolver construction tests for the typed hosts representation

## Root cause

The hosts table stored only vectors of IP addresses, so a valid hostname-to-hostname mapping was treated as a malformed IP. After that was fixed, validation exposed the standard `:port` listener shorthand as a second compatibility gap.

## Impact

Real-world Mihomo profiles using domain aliases now validate and resolve proxy server hostnames through meow's internal resolver. Explicit aliases bypass fake-IP synthesis, and malformed/cyclic mappings still fail loudly.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (1,034 tests)
- full configuration validation through `meow -t`
- redacted Gitleaks scan of the commit