### PR TITLE
fix(vless): defer Vision request header and fix REALITY auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1177,7 +1177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1506,9 +1506,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1773,7 +1773,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1992,7 +1992,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2917,7 +2917,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3298,7 +3298,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3335,7 +3335,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3672,7 +3672,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4052,7 +4052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4182,7 +4182,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4998,7 +4998,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5382,7 +5382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/meow-proxy/src/vless/conn.rs
+++ b/crates/meow-proxy/src/vless/conn.rs
@@ -9,14 +9,14 @@
 
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use meow_common::{MeowError, ProxyConn, ProxyPacketConn, Result};
 use meow_transport::Stream;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 
-use super::header::{decode_response, encode_request, Cmd, VlessAddr};
+use super::header::{encode_request, Cmd, VlessAddr};
 
 // ─── VlessConn ────────────────────────────────────────────────────────────────
 
@@ -29,6 +29,23 @@ pub struct VlessConn {
     pub(crate) inner: Box<dyn Stream>,
     /// `true` until the 2-byte response header has been consumed.
     pub(crate) response_pending: bool,
+    /// Partial response-header read progress.  Cancel-safe: a Pending
+    /// between the two header bytes must not lose the byte already
+    /// consumed (a local buffer would shift the whole stream by one byte).
+    pub(crate) response_buf: [u8; 2],
+    pub(crate) response_pos: usize,
+    /// Scratch buffer for the response addon bytes (usually empty).
+    pub(crate) response_addon: Vec<u8>,
+    /// Pre-encoded request header, written ahead of the first payload.
+    /// `Some` only for deferred-header connections (Vision): the request
+    /// must ride inside the first Vision-padded record, matching
+    /// mihomo/xray, so it is emitted on the first write instead of during
+    /// construction.
+    pub(crate) header_pending: Option<Bytes>,
+    /// Set once the deferred header has reached the inner stream and cleared
+    /// after the next flush.  A read-first protocol must flush the request
+    /// before waiting for the server response.
+    pub(crate) header_needs_flush: bool,
 }
 
 impl VlessConn {
@@ -54,13 +71,101 @@ impl VlessConn {
         Ok(Self {
             inner: stream,
             response_pending: true,
+            response_buf: [0; 2],
+            response_pos: 0,
+            response_addon: Vec::new(),
+            header_pending: None,
+            header_needs_flush: false,
         })
     }
 
+    /// Like [`Self::new`], but defers the request header to the first
+    /// write so a wrapping Vision layer can pad it together with the first
+    /// payload (xray expects the request inside the first Vision record).
+    #[cfg(feature = "vless-vision")]
+    pub async fn new_deferred(
+        stream: Box<dyn Stream>,
+        uuid_bytes: &[u8; 16],
+        flow: Option<&str>,
+        cmd: Cmd,
+        dst_port: u16,
+        addr: &VlessAddr,
+    ) -> Result<Self> {
+        let mut buf = BytesMut::new();
+        encode_request(&mut buf, uuid_bytes, flow, cmd, dst_port, addr);
+        Ok(Self {
+            inner: stream,
+            response_pending: true,
+            response_buf: [0; 2],
+            response_pos: 0,
+            response_addon: Vec::new(),
+            header_pending: Some(buf.freeze()),
+            header_needs_flush: false,
+        })
+    }
+
+    /// Write a deferred request header before the caller's first payload.
+    /// Header-only progress may continue inside one poll; payload progress is
+    /// reported immediately so `AsyncWrite` never returns `Pending` or
+    /// `Ok(0)` after consuming caller bytes.
+    fn poll_write_deferred(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        loop {
+            let Some(header) = self.header_pending.take() else {
+                return Pin::new(&mut *self.inner).poll_write(cx, buf);
+            };
+            let header_len = header.len();
+            let mut combined = BytesMut::with_capacity(header_len + buf.len());
+            combined.extend_from_slice(&header);
+            combined.extend_from_slice(buf);
+            match Pin::new(&mut *self.inner).poll_write(cx, &combined) {
+                Poll::Pending => {
+                    self.header_pending = Some(header);
+                    return Poll::Pending;
+                }
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Ready(Ok(0)) => {
+                    self.header_pending = Some(header);
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "vless: failed to write deferred request header",
+                    )));
+                }
+                Poll::Ready(Ok(written)) if written < header_len => {
+                    self.header_pending = Some(header.slice(written..));
+                }
+                Poll::Ready(Ok(written)) => {
+                    self.header_needs_flush = true;
+                    let payload_written = written - header_len;
+                    if payload_written > 0 || buf.is_empty() {
+                        return Poll::Ready(Ok(payload_written));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Ensure a deferred request is sent and flushed before reading or
+    /// shutting down.  This is the server-first path used by SMTP, IMAP,
+    /// MySQL and similar protocols that do not write application data first.
+    fn poll_flush_deferred_header(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        while self.header_pending.is_some() {
+            let written = ready!(self.poll_write_deferred(cx, &[]))?;
+            debug_assert_eq!(written, 0);
+        }
+        if self.header_needs_flush {
+            ready!(Pin::new(&mut *self.inner).poll_flush(cx))?;
+            self.header_needs_flush = false;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    // Called only from the Vision wrapper (vless-vision feature).
+    #[cfg_attr(not(feature = "vless-vision"), allow(dead_code))]
     pub(crate) fn enable_raw_read_passthrough(&mut self) -> bool {
         meow_transport::enable_raw_read_passthrough(&mut *self.inner)
     }
 
+    #[cfg_attr(not(feature = "vless-vision"), allow(dead_code))]
     pub(crate) fn enable_raw_write_passthrough(&mut self) -> bool {
         meow_transport::enable_raw_write_passthrough(&mut *self.inner)
     }
@@ -74,21 +179,17 @@ impl AsyncRead for VlessConn {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        // Lazily consume the response header on first read.
-        if self.response_pending {
-            // Use a pinned future to read the 2-byte response header.
-            let inner = &mut self.inner;
-            // We need to read version(1) + addon_length(1).
-            // For simplicity, we do a synchronous-style poll loop here.
-            // Read the two header bytes using poll_read directly.
-            let mut hdr_buf = [0u8; 2];
-            let mut hdr_read = 0;
-            loop {
-                if hdr_read >= 2 {
-                    break;
-                }
-                let mut tmp = ReadBuf::new(&mut hdr_buf[hdr_read..]);
-                match Pin::new(&mut *inner).poll_read(cx, &mut tmp) {
+        // Lazily consume the response header on first read.  Progress lives
+        // in self (response_buf/response_pos): a Pending between the two
+        // header bytes must keep the byte already consumed — a local buffer
+        // would lose it and shift the whole stream by one byte.
+        let this = &mut *self;
+        ready!(this.poll_flush_deferred_header(cx))?;
+        if this.response_pending {
+            while this.response_pos < 2 {
+                let pos = this.response_pos;
+                let mut tmp = ReadBuf::new(&mut this.response_buf[pos..]);
+                match Pin::new(&mut *this.inner).poll_read(cx, &mut tmp) {
                     Poll::Ready(Ok(())) => {
                         let n = tmp.filled().len();
                         if n == 0 {
@@ -97,30 +198,31 @@ impl AsyncRead for VlessConn {
                                 "vless: server closed before response header",
                             )));
                         }
-                        hdr_read += n;
+                        this.response_pos += n;
                     }
                     Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                     Poll::Pending => return Poll::Pending,
                 }
             }
-            let version = hdr_buf[0];
-            let addon_length = hdr_buf[1] as usize;
+            let version = this.response_buf[0];
+            let addon_length = this.response_buf[1] as usize;
             if version != 0x00 {
                 return Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("vless: version mismatch: expected 0x00, got {version:#04x}"),
                 )));
             }
-            // Discard addon bytes if any
+            // Discard addon bytes if any — also cancel-safe: progress
+            // counts against the persistent response_pos, and the scratch
+            // buffer survives Pending.
             if addon_length > 0 {
-                let mut discard = vec![0u8; addon_length];
-                let mut disc_read = 0;
-                loop {
-                    if disc_read >= addon_length {
-                        break;
-                    }
-                    let mut tmp = ReadBuf::new(&mut discard[disc_read..]);
-                    match Pin::new(&mut *inner).poll_read(cx, &mut tmp) {
+                if this.response_addon.len() != addon_length {
+                    this.response_addon = vec![0u8; addon_length];
+                }
+                while this.response_pos - 2 < addon_length {
+                    let pos = this.response_pos - 2;
+                    let mut tmp = ReadBuf::new(&mut this.response_addon[pos..]);
+                    match Pin::new(&mut *this.inner).poll_read(cx, &mut tmp) {
                         Poll::Ready(Ok(())) => {
                             let n = tmp.filled().len();
                             if n == 0 {
@@ -129,14 +231,15 @@ impl AsyncRead for VlessConn {
                                     "vless: EOF during addon discard",
                                 )));
                             }
-                            disc_read += n;
+                            this.response_pos += n;
                         }
                         Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                         Poll::Pending => return Poll::Pending,
                     }
                 }
             }
-            self.response_pending = false;
+            this.response_pending = false;
+            this.response_addon = Vec::new();
             tracing::debug!("VLESS: response header consumed lazily");
         }
         Pin::new(&mut self.inner).poll_read(cx, buf)
@@ -145,19 +248,24 @@ impl AsyncRead for VlessConn {
 
 impl AsyncWrite for VlessConn {
     fn poll_write(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
+        let this = self.get_mut();
+        this.poll_write_deferred(cx, buf)
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        ready!(this.poll_flush_deferred_header(cx))?;
+        Pin::new(&mut *this.inner).poll_flush(cx)
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        ready!(this.poll_flush_deferred_header(cx))?;
+        Pin::new(&mut *this.inner).poll_shutdown(cx)
     }
 }
 
@@ -170,7 +278,11 @@ impl ProxyConn for VlessConn {}
 /// A VLESS UDP connection over TCP.
 ///
 /// Each datagram is framed as `u16_be(length) + data`.  The VLESS request
-/// header (cmd=0x02) is sent on construction; the response header is consumed.
+/// header (cmd=0x02) is sent on construction; the response header is
+/// consumed **lazily** on the first read — xray/sing-vmess only write it
+/// together with the first reply datagram, so eager consumption during
+/// construction would deadlock (server waits for the first datagram before
+/// answering, client waits for the answer before sending it).
 ///
 /// The stream is split into independent read/write halves, each behind its
 /// own `Mutex`, so a `read_packet` parked waiting for a server datagram never
@@ -179,8 +291,169 @@ impl ProxyConn for VlessConn {}
 /// lock any flow needing interleaved sends while a recv is pending (QUIC,
 /// WireGuard, games) stalled after the first packet.
 pub struct VlessPacketConn {
-    reader: tokio::sync::Mutex<tokio::io::ReadHalf<Box<dyn Stream>>>,
+    reader: tokio::sync::Mutex<VlessUdpReader>,
     writer: tokio::sync::Mutex<tokio::io::WriteHalf<Box<dyn Stream>>>,
+}
+
+/// Cancel-safe UDP reader.  The response header, the per-datagram length
+/// prefix and the payload all persist their read progress across dropped
+/// `read_packet` futures — the TUN pump recreates its read inside
+/// `select!`, and a lost half-read would desynchronise the UDP-over-TCP
+/// framing forever.
+struct VlessUdpReader {
+    stream: tokio::io::ReadHalf<Box<dyn Stream>>,
+    /// VLESS response header `[version][addon_length]`; `hdr_pos < 2`
+    /// means the response phase is still active.
+    hdr: [u8; 2],
+    hdr_pos: usize,
+    /// True once the response header (and any addon bytes) were consumed.
+    header_done: bool,
+    /// Per-datagram length prefix, big-endian.
+    len: [u8; 2],
+    len_pos: usize,
+    /// Datagram payload (or the response addon bytes mid-discard).
+    payload: Vec<u8>,
+    payload_pos: usize,
+}
+
+impl VlessUdpReader {
+    fn new(stream: tokio::io::ReadHalf<Box<dyn Stream>>) -> Self {
+        Self {
+            stream,
+            hdr: [0; 2],
+            hdr_pos: 0,
+            header_done: false,
+            len: [0; 2],
+            len_pos: 0,
+            payload: Vec::new(),
+            payload_pos: 0,
+        }
+    }
+
+    /// Reset the per-datagram state for the next packet (the response
+    /// header is read exactly once and stays consumed).
+    fn reset_datagram(&mut self) {
+        self.len_pos = 0;
+        self.payload.clear();
+        self.payload_pos = 0;
+    }
+
+    async fn read_packet(&mut self, buf: &mut [u8]) -> Result<(usize, std::net::SocketAddr)> {
+        use tokio::io::AsyncReadExt;
+        // Phase 1: response header [version][addon_length], consumed
+        // lazily on the first read (it rides with the first reply
+        // datagram).  Progress persists so a cancelled read resumes
+        // instead of shifting the stream by the lost bytes.
+        if !self.header_done {
+            while self.hdr_pos < self.hdr.len() {
+                let n = self
+                    .stream
+                    .read(&mut self.hdr[self.hdr_pos..])
+                    .await
+                    .map_err(MeowError::Io)?;
+                if n == 0 {
+                    return Err(MeowError::Proxy(
+                        "vless: server closed after header — check UUID and server config".into(),
+                    ));
+                }
+                self.hdr_pos += n;
+            }
+            let version = self.hdr[0];
+            let addon_length = self.hdr[1] as usize;
+            if version != 0x00 {
+                // upstream: closes silently. NOT silent — we surface the reason.
+                tracing::warn!(
+                    version = %format!("{:#04x}", version),
+                    "vless: response version mismatch (expected 0x00) — \
+                     check UUID and whether a TLS layer is required"
+                );
+                return Err(MeowError::Proxy(format!(
+                    "vless: version mismatch: expected 0x00, got {version:#04x}"
+                )));
+            }
+            if addon_length > 0 {
+                // Discard the addon bytes (UDP sends none; keep the same
+                // tolerance as the TCP path) with persistent progress.
+                // Only reset when the size changes: a cancelled
+                // `read_packet` future re-enters here with `header_done`
+                // still false, and resetting `payload_pos` to 0 would
+                // re-read `addon_length` bytes, eating the head of the
+                // first datagram and desyncing the UDP framing.
+                if self.payload.len() != addon_length {
+                    self.payload.resize(addon_length, 0);
+                    self.payload_pos = 0;
+                }
+                while self.payload_pos < self.payload.len() {
+                    let n = self
+                        .stream
+                        .read(&mut self.payload[self.payload_pos..])
+                        .await
+                        .map_err(MeowError::Io)?;
+                    if n == 0 {
+                        return Err(MeowError::Proxy(
+                            "vless: server closed mid response-header addon".into(),
+                        ));
+                    }
+                    self.payload_pos += n;
+                }
+                self.payload.clear();
+                self.payload_pos = 0;
+            }
+            self.header_done = true;
+        }
+        // Phase 2: per-datagram `u16_be(len)`.
+        while self.len_pos < self.len.len() {
+            let n = self
+                .stream
+                .read(&mut self.len[self.len_pos..])
+                .await
+                .map_err(MeowError::Io)?;
+            if n == 0 {
+                return Err(MeowError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "vless: EOF while reading UDP packet length",
+                )));
+            }
+            self.len_pos += n;
+        }
+        // Phase 3: payload (sized once per datagram; partial progress
+        // survives cancellation).
+        if self.payload.is_empty() && self.payload_pos == 0 {
+            self.payload
+                .resize(u16::from_be_bytes(self.len) as usize, 0);
+        }
+        while self.payload_pos < self.payload.len() {
+            let n = self
+                .stream
+                .read(&mut self.payload[self.payload_pos..])
+                .await
+                .map_err(MeowError::Io)?;
+            if n == 0 {
+                return Err(MeowError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "vless: EOF while reading UDP packet payload",
+                )));
+            }
+            self.payload_pos += n;
+        }
+        let packet_len = self.payload.len();
+        if packet_len > buf.len() {
+            // The oversized payload was fully drained into the internal
+            // buffer, so the stream framing stays aligned for the next
+            // read — surface the error only after the drain.
+            self.reset_datagram();
+            return Err(MeowError::Proxy(format!(
+                "vless: UDP packet ({packet_len} bytes) exceeds read buffer ({} bytes)",
+                buf.len()
+            )));
+        }
+        buf[..packet_len].copy_from_slice(&self.payload);
+        self.reset_datagram();
+        // Return a placeholder source address (connection-oriented
+        // UDP-over-TCP has no per-datagram source addr).
+        let placeholder: std::net::SocketAddr = "0.0.0.0:0".parse().unwrap();
+        Ok((packet_len, placeholder))
+    }
 }
 
 impl VlessPacketConn {
@@ -197,12 +470,9 @@ impl VlessPacketConn {
         stream.write_all(&buf).await.map_err(MeowError::Io)?;
         stream.flush().await.map_err(MeowError::Io)?;
 
-        // Read and discard the response header.
-        decode_response(&mut stream).await?;
-
         let (reader, writer) = tokio::io::split(stream);
         Ok(Self {
-            reader: tokio::sync::Mutex::new(reader),
+            reader: tokio::sync::Mutex::new(VlessUdpReader::new(reader)),
             writer: tokio::sync::Mutex::new(writer),
         })
     }
@@ -221,31 +491,13 @@ impl ProxyPacketConn for VlessPacketConn {
         Ok(buf.len())
     }
 
-    /// Read a UDP packet: consume `u16_be(len)` then `len` bytes.
+    /// Read a UDP packet: consume `u16_be(len)` then `len` bytes.  The
+    /// VLESS response header is consumed lazily on the first read (it rides
+    /// with the first reply datagram).  All progress is persistent, so a
+    /// cancelled future resumes from where it stopped.
     async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, std::net::SocketAddr)> {
-        use tokio::io::AsyncReadExt;
         let mut reader = self.reader.lock().await;
-        let mut len_buf = [0u8; 2];
-        reader
-            .read_exact(&mut len_buf)
-            .await
-            .map_err(MeowError::Io)?;
-        let pkt_len = u16::from_be_bytes(len_buf) as usize;
-        if pkt_len > buf.len() {
-            return Err(MeowError::Proxy(format!(
-                "vless: UDP packet ({} bytes) exceeds read buffer ({} bytes)",
-                pkt_len,
-                buf.len()
-            )));
-        }
-        reader
-            .read_exact(&mut buf[..pkt_len])
-            .await
-            .map_err(MeowError::Io)?;
-        // Return a placeholder source address (connection-oriented UDP-over-TCP
-        // has no per-datagram source addr).
-        let placeholder: std::net::SocketAddr = "0.0.0.0:0".parse().unwrap();
-        Ok((pkt_len, placeholder))
+        reader.read_packet(buf).await
     }
 
     fn local_addr(&self) -> Result<std::net::SocketAddr> {
@@ -265,7 +517,44 @@ impl ProxyPacketConn for VlessPacketConn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
+
+    struct ChunkedStream {
+        inner: tokio::io::DuplexStream,
+        max_write: usize,
+    }
+
+    impl AsyncRead for ChunkedStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for ChunkedStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let this = self.get_mut();
+            let count = buf.len().min(this.max_write);
+            Pin::new(&mut this.inner).poll_write(cx, &buf[..count])
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+        }
+    }
 
     /// Test UUID: b831381d-6324-4d53-ad4f-8cda48b30811
     const TEST_UUID: [u8; 16] = [
@@ -335,6 +624,62 @@ mod tests {
         assert_eq!(hdr[0], 0x00, "version byte must be 0x00");
         // uuid must match
         assert_eq!(&hdr[1..17], &TEST_UUID, "uuid must match");
+    }
+
+    #[cfg(feature = "vless-vision")]
+    #[tokio::test]
+    async fn deferred_header_handles_one_byte_partial_writes() {
+        let (client, mut server) = duplex(1024);
+        tokio::spawn(async move {
+            let mut request = vec![0u8; 26 + 4];
+            server.read_exact(&mut request).await.unwrap();
+            assert_eq!(&request[26..], b"ping");
+            server.write_all(&[0x00, 0x00, b'!']).await.unwrap();
+        });
+
+        let mut conn = VlessConn::new_deferred(
+            Box::new(ChunkedStream {
+                inner: client,
+                max_write: 1,
+            }),
+            &TEST_UUID,
+            None,
+            Cmd::Tcp,
+            80,
+            &VlessAddr::Ipv4([1, 2, 3, 4]),
+        )
+        .await
+        .unwrap();
+        conn.write_all(b"ping").await.unwrap();
+        let mut response = [0u8; 1];
+        conn.read_exact(&mut response).await.unwrap();
+        assert_eq!(response, [b'!']);
+    }
+
+    #[cfg(feature = "vless-vision")]
+    #[tokio::test]
+    async fn deferred_header_is_flushed_before_server_first_read() {
+        let (client, mut server) = duplex(1024);
+        tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x00, 0x00]).await.unwrap();
+            server.write_all(b"banner").await.unwrap();
+        });
+
+        let mut conn = VlessConn::new_deferred(
+            Box::new(client),
+            &TEST_UUID,
+            None,
+            Cmd::Tcp,
+            25,
+            &VlessAddr::Ipv4([1, 2, 3, 4]),
+        )
+        .await
+        .unwrap();
+        let mut banner = [0u8; 6];
+        conn.read_exact(&mut banner).await.unwrap();
+        assert_eq!(&banner, b"banner");
     }
 
     // ─── F2: payload round-trip ───────────────────────────────────────────────
@@ -581,6 +926,50 @@ mod tests {
         assert_eq!(echoed, b"ping");
     }
 
+    // ─── F8b: lazy response header (xray/sing-vmess semantics) ───────────────
+
+    /// The server answers the VLESS response header only together with the
+    /// first reply datagram.  `VlessPacketConn::new` must return without
+    /// waiting for it (eager consumption deadlocks: the server waits for the
+    /// first datagram before answering, the client waits for the answer
+    /// before sending that datagram).
+    #[tokio::test]
+    async fn vless_packet_conn_handles_lazy_response_header() {
+        use tokio::io::AsyncWriteExt;
+
+        let (client, server) = duplex(4096);
+        tokio::spawn(async move {
+            let mut s = server;
+            let mut hdr = vec![0u8; 26];
+            s.read_exact(&mut hdr).await.unwrap();
+            // NO response header yet — wait for the first datagram frame.
+            let mut len = [0u8; 2];
+            s.read_exact(&mut len).await.unwrap();
+            let n = u16::from_be_bytes(len) as usize;
+            let mut payload = vec![0u8; n];
+            s.read_exact(&mut payload).await.unwrap();
+            // First server write = response header + echoed datagram frame.
+            s.write_all(&[0x00, 0x00]).await.unwrap();
+            s.write_all(&len).await.unwrap();
+            s.write_all(&payload).await.unwrap();
+        });
+
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .expect("VlessPacketConn::new");
+
+        let dst = "8.8.8.8:53".parse().unwrap();
+        conn.write_packet(b"ping", &dst).await.unwrap();
+        let mut buf = [0u8; 8];
+        let (n, _src) = conn.read_packet(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"ping");
+    }
+
     // ─── F7: UDP cmd byte is 0x02 ─────────────────────────────────────────────
 
     /// Guards against copy-paste of the TCP path without flipping the cmd byte.
@@ -612,5 +1001,179 @@ mod tests {
         let hdr = rx.await.expect("header");
         // cmd byte at offset 18 (version=1 + uuid=16 + addon_length=1)
         assert_eq!(hdr[18], 0x02, "UDP cmd must be 0x02, not 0x01");
+    }
+
+    // ─── F6: UDP reader cancellation safety ─────────────────────────────────
+
+    /// A read cancelled halfway through the response header must resume
+    /// instead of shifting the stream: the next read sees the full
+    /// datagram.
+    #[tokio::test]
+    async fn udp_read_survives_cancellation_mid_response() {
+        let (client, mut server) = duplex(1024);
+        let (go_tx, go_rx) = tokio::sync::oneshot::channel::<()>();
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x00]).await.unwrap(); // first header byte only
+            let _ = go_rx.await;
+            server
+                .write_all(&[0x00, 0x00, 0x04, b'p', b'o', b'n', b'g'])
+                .await
+                .unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                conn.read_packet(&mut buf)
+            )
+            .await
+            .is_err(),
+            "the read must wait for the second response byte"
+        );
+        go_tx.send(()).unwrap();
+        let (n, _) = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            conn.read_packet(&mut buf),
+        )
+        .await
+        .expect("the resumed read must complete")
+        .unwrap();
+        assert_eq!(&buf[..n], b"pong");
+        server_task.await.unwrap();
+    }
+
+    /// A read cancelled halfway through a datagram payload must resume
+    /// the same datagram.
+    #[tokio::test]
+    async fn udp_read_survives_cancellation_mid_payload() {
+        let (client, mut server) = duplex(1024);
+        let (go_tx, go_rx) = tokio::sync::oneshot::channel::<()>();
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            // Full response + length prefix + half the payload.
+            server
+                .write_all(&[0x00, 0x00, 0x00, 0x04, b'p', b'o'])
+                .await
+                .unwrap();
+            let _ = go_rx.await;
+            server.write_all(b"ng").await.unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                conn.read_packet(&mut buf)
+            )
+            .await
+            .is_err(),
+            "the read must wait for the rest of the payload"
+        );
+        go_tx.send(()).unwrap();
+        let (n, _) = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            conn.read_packet(&mut buf),
+        )
+        .await
+        .expect("the resumed read must complete")
+        .unwrap();
+        assert_eq!(&buf[..n], b"pong");
+        server_task.await.unwrap();
+    }
+
+    /// Response version mismatch → hard error naming the problem (the
+    /// shared decode_response behavior, now owned by the UDP reader).
+    #[tokio::test]
+    async fn udp_response_version_mismatch_errors() {
+        let (client, mut server) = duplex(1024);
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x01, 0x00]).await.unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        let err = conn.read_packet(&mut buf).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("version mismatch"),
+            "error must mention the version mismatch, got: {msg}"
+        );
+        server_task.await.unwrap();
+    }
+
+    /// Non-zero addon_length: the addon bytes are discarded and the next
+    /// datagram reads aligned.
+    #[tokio::test]
+    async fn udp_response_addon_is_discarded() {
+        let (client, mut server) = duplex(1024);
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server
+                .write_all(&[0x00, 0x02, 0xAA, 0xBB, 0x00, 0x04, b'p', b'o', b'n', b'g'])
+                .await
+                .unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        let (n, _) = conn.read_packet(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"pong");
+        server_task.await.unwrap();
+    }
+
+    /// A response truncated mid-header must error cleanly, not panic.
+    #[tokio::test]
+    async fn udp_truncated_response_errors() {
+        let (client, mut server) = duplex(1024);
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x00]).await.unwrap();
+            drop(server);
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        assert!(conn.read_packet(&mut buf).await.is_err());
+        server_task.await.unwrap();
     }
 }

--- a/crates/meow-proxy/src/vless/header.rs
+++ b/crates/meow-proxy/src/vless/header.rs
@@ -31,8 +31,7 @@
 // upstream SHA: xray-core/xray-core (2024) — pin on first Vision integration
 
 use bytes::{BufMut, BytesMut};
-use meow_common::{MeowError, Metadata, Result};
-use tokio::io::AsyncReadExt;
+use meow_common::Metadata;
 
 // ─── Address type ─────────────────────────────────────────────────────────────
 
@@ -109,19 +108,8 @@ pub(crate) fn encode_request(
     // uuid (16 bytes, binary form)
     dst.put_slice(uuid_bytes);
 
-    // addon
-    // NOT prost — two hardcoded bytes + string copy (spec §Addon encoding).
-    match flow {
-        Some("xtls-rprx-vision") => {
-            dst.put_u8(18); // addon_length = 18
-            dst.put_u8(0x0A); // protobuf field 1, wire type 2
-            dst.put_u8(0x10); // varint 16  (len("xtls-rprx-vision") = 16)
-            dst.put_slice(b"xtls-rprx-vision");
-        }
-        _ => {
-            dst.put_u8(0x00); // addon_length = 0
-        }
-    }
+    // addon (shared with the Mux request encoder below)
+    put_flow_addon(dst, flow);
 
     // command
     dst.put_u8(cmd as u8);
@@ -148,55 +136,26 @@ pub(crate) fn encode_request(
     }
 }
 
-// ─── Response decoder ─────────────────────────────────────────────────────────
-
-/// Read and discard the VLESS response header from `stream`.
+/// Append the flow addon block (length byte + protobuf blob, if any).
 ///
-/// Returns `Err` if version != 0x00 (logs `warn!` before returning).
-///
-/// upstream: transport/vless/conn.go::ReadResponseHeader
-pub(crate) async fn decode_response<S>(stream: &mut S) -> Result<()>
-where
-    S: AsyncReadExt + Unpin,
-{
-    let mut hdr = [0u8; 2]; // version + addon_length
-    stream.read_exact(&mut hdr).await.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::UnexpectedEof {
-            MeowError::Proxy(
-                "vless: server closed after header — check UUID and server config".into(),
-            )
-        } else {
-            MeowError::Io(e)
+/// NOT prost — two hardcoded bytes + string copy (spec §Addon encoding).
+fn put_flow_addon(dst: &mut BytesMut, flow: Option<&str>) {
+    match flow {
+        Some("xtls-rprx-vision") => {
+            dst.put_u8(18); // addon_length = 18
+            dst.put_u8(0x0A); // protobuf field 1, wire type 2
+            dst.put_u8(0x10); // varint 16  (len("xtls-rprx-vision") = 16)
+            dst.put_slice(b"xtls-rprx-vision");
         }
-    })?;
-
-    let version = hdr[0];
-    let addon_length = hdr[1] as usize;
-
-    if version != 0x00 {
-        // upstream: closes silently. NOT silent — we surface the reason.
-        // Class B per ADR-0002: connection goes to same destination, but user
-        // may be missing TLS or have the wrong UUID.
-        tracing::warn!(
-            version = %format!("{:#04x}", version),
-            "vless: response version mismatch (expected 0x00) — \
-             check UUID and whether a TLS layer is required"
-        );
-        return Err(MeowError::Proxy(format!(
-            "vless: version mismatch: expected 0x00, got {version:#04x}"
-        )));
+        _ => {
+            dst.put_u8(0x00); // addon_length = 0
+        }
     }
-
-    if addon_length > 0 {
-        let mut discard = vec![0u8; addon_length];
-        stream
-            .read_exact(&mut discard)
-            .await
-            .map_err(MeowError::Io)?;
-    }
-
-    Ok(())
 }
+
+// The VLESS response header `[version][addon_length][addon…]` is consumed
+// by `VlessConn::poll_read` (TCP) and `VlessUdpReader::read_packet` (UDP)
+// with persistent, cancellation-safe progress in `vless/conn.rs`.
 
 // ─── Unit tests (§A, §B) ─────────────────────────────────────────────────────
 
@@ -449,144 +408,15 @@ mod tests {
         // Send a valid response header back.
         server.write_all(&[0x00, 0x00]).await.unwrap();
 
-        // decode_response must succeed.
-        decode_response(&mut client)
+        // The response header round-trips as [version=0][addon_length=0].
+        let mut resp = [0u8; 2];
+        tokio::io::AsyncReadExt::read_exact(&mut client, &mut resp)
             .await
             .expect("round-trip decode ok");
+        assert_eq!(resp, [0x00, 0x00]);
     }
 
-    // ─── B1: response version 0 ok ───────────────────────────────────────────
-
-    #[tokio::test]
-    async fn response_decode_version_zero_ok() {
-        use tokio::io::duplex;
-        use tokio::io::AsyncWriteExt;
-
-        let (mut client, mut server) = duplex(64);
-        server.write_all(&[0x00, 0x00]).await.unwrap();
-        decode_response(&mut client)
-            .await
-            .expect("version 0 must succeed");
-    }
-
-    // ─── B2: response with non-zero addon_length ──────────────────────────────
-
-    /// version=0, addon_length=2, addon bytes read+discarded.
-    /// Guards against ignoring addon_length and misaligning subsequent reads.
-    #[tokio::test]
-    async fn response_decode_version_zero_with_addon() {
-        use tokio::io::duplex;
-        use tokio::io::AsyncWriteExt;
-
-        let (mut client, mut server) = duplex(64);
-        server.write_all(&[0x00, 0x02, 0xAA, 0xBB]).await.unwrap();
-        decode_response(&mut client)
-            .await
-            .expect("version 0 with addon must succeed");
-
-        // Confirm the stream is now aligned: next byte (if any) is payload, not addon.
-        // No further bytes queued, so just assert decode succeeded.
-    }
-
-    // ─── B3: version mismatch warns + errors ─────────────────────────────────
-
-    /// Input [0x01, 0x00] → Err; tracing shows a warn with "version" or "mismatch".
-    /// upstream: transport/vless/conn.go closes silently.
-    /// NOT silent — we surface the reason for debugging.
-    #[test]
-    fn response_decode_version_mismatch_warns_and_errors() {
-        use std::sync::{Arc, Mutex};
-        use tokio::io::duplex;
-        use tracing_subscriber::fmt::MakeWriter;
-
-        // Capture warnings.
-        let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let line_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
-
-        #[derive(Clone)]
-        struct CapWriter(Arc<Mutex<Vec<String>>>, Arc<Mutex<String>>);
-        impl std::io::Write for CapWriter {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                let s = String::from_utf8_lossy(buf).to_string();
-                let mut lb = self.1.lock().unwrap();
-                lb.push_str(&s);
-                if lb.contains('\n') {
-                    let mut log = self.0.lock().unwrap();
-                    for line in lb.split('\n') {
-                        let t = line.trim();
-                        if !t.is_empty() {
-                            log.push(t.to_string());
-                        }
-                    }
-                    lb.clear();
-                }
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-        impl<'a> MakeWriter<'a> for CapWriter {
-            type Writer = Self;
-            fn make_writer(&'a self) -> Self {
-                self.clone()
-            }
-        }
-
-        let cap = CapWriter(Arc::clone(&captured), line_buf);
-        let sub = tracing_subscriber::fmt()
-            .with_writer(cap)
-            .with_ansi(false)
-            .with_level(true)
-            .finish();
-
-        let result = tracing::subscriber::with_default(sub, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .unwrap();
-            rt.block_on(async {
-                let (mut client, mut server) = duplex(64);
-                tokio::io::AsyncWriteExt::write_all(&mut server, &[0x01, 0x00])
-                    .await
-                    .unwrap();
-                decode_response(&mut client).await
-            })
-        });
-
-        assert!(result.is_err(), "version mismatch must return Err");
-        let err_str = result.unwrap_err().to_string();
-        assert!(
-            err_str.contains("version") || err_str.contains("mismatch"),
-            "error must mention version mismatch, got: {err_str}"
-        );
-
-        let logs = captured.lock().unwrap();
-        let warn_count = logs
-            .iter()
-            .filter(|l| l.contains("WARN") && (l.contains("version") || l.contains("mismatch")))
-            .count();
-        assert_eq!(
-            warn_count, 1,
-            "exactly one warn must be emitted; got: {:?}",
-            *logs
-        );
-    }
-
-    // ─── B4: truncated buffer → clean Err, no panic ──────────────────────────
-
-    #[tokio::test]
-    async fn response_decode_truncated_buffer_errors() {
-        use tokio::io::duplex;
-        use tokio::io::AsyncWriteExt;
-
-        let (mut client, mut server) = duplex(64);
-        // Only send version byte, close before addon_length.
-        server.write_all(&[0x00]).await.unwrap();
-        drop(server); // EOF after 1 byte
-        let result = decode_response(&mut client).await;
-        assert!(
-            result.is_err(),
-            "truncated response must return Err, not panic"
-        );
-    }
+    // Response-header decode coverage (B1-B4) lives with the consumers
+    // now: `vless/conn.rs` tests `VlessUdpReader` for version mismatch,
+    // addon discard and truncated-header errors.
 }

--- a/crates/meow-proxy/src/vless/vision.rs
+++ b/crates/meow-proxy/src/vless/vision.rs
@@ -545,10 +545,17 @@ impl AsyncWrite for VisionConn {
             return Poll::Pending;
         }
 
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
         if !this.write_padding {
             return Pin::new(&mut this.inner).poll_write(cx, buf);
         }
-        this.build_write_frame(buf);
+        // The padding frame carries u16 content/padding length fields:
+        // chunk large writes so those fields cannot wrap and
+        // desynchronise the peer's vision decoder.
+        let chunk_len = buf.len().min(16 * 1024);
+        this.build_write_frame(&buf[..chunk_len]);
         match this.drain_pending_write(cx) {
             Poll::Ready(Ok(Some(n))) => Poll::Ready(Ok(n)),
             Poll::Ready(Ok(None)) => Poll::Ready(Ok(0)),

--- a/crates/meow-proxy/src/vless_adapter.rs
+++ b/crates/meow-proxy/src/vless_adapter.rs
@@ -164,21 +164,38 @@ impl ProxyAdapter for VlessAdapter {
             }
         };
 
-        let conn = VlessConn::new(
-            stream,
-            &self.uuid_bytes,
-            flow_str,
-            Cmd::Tcp,
-            metadata.dst_port,
-            &addr,
-        )
-        .await?;
-
-        match self.flow {
+        // Vision must wrap the connection BEFORE the request header is sent:
+        // xray expects the VLESS request inside the first Vision-padded record
+        // (mihomo wires it the same way), so the header is deferred to the
+        // first write through the Vision layer.
+        let conn = match self.flow {
             #[cfg(feature = "vless-vision")]
-            Some(VlessFlow::XtlsRprxVision) => Ok(Box::new(VisionConn::new(conn, self.uuid_bytes))),
-            _ => Ok(Box::new(StreamConn(Box::new(conn)))),
-        }
+            Some(VlessFlow::XtlsRprxVision) => {
+                let vless = VlessConn::new_deferred(
+                    stream,
+                    &self.uuid_bytes,
+                    flow_str,
+                    Cmd::Tcp,
+                    metadata.dst_port,
+                    &addr,
+                )
+                .await?;
+                Box::new(VisionConn::new(vless, self.uuid_bytes)) as Box<dyn ProxyConn>
+            }
+            _ => {
+                let conn = VlessConn::new(
+                    stream,
+                    &self.uuid_bytes,
+                    flow_str,
+                    Cmd::Tcp,
+                    metadata.dst_port,
+                    &addr,
+                )
+                .await?;
+                Box::new(StreamConn(Box::new(conn)))
+            }
+        };
+        Ok(conn)
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -430,10 +430,19 @@ impl AsyncWrite for RealityTlsStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        if let Poll::Ready(done) = self.drain_pending_write(cx) {
-            done?;
-        } else {
-            return Poll::Pending;
+        // Drain any in-flight record first.  If the drain is still
+        // Pending, nothing from the incoming `buf` has been consumed —
+        // return Pending so the caller retries with the same buffer.
+        // If the drain completes, fall through to seal the new buffer
+        // rather than reporting the *old* record's length against the
+        // new buffer (AsyncWrite does not guarantee the same buffer is
+        // presented after a Pending).
+        if self.write_pending.is_some() {
+            match self.drain_pending_write(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {} // drained — fall through
+            }
         }
 
         if buf.is_empty() {
@@ -444,14 +453,23 @@ impl AsyncWrite for RealityTlsStream {
             return Pin::new(&mut self.inner).poll_write(cx, buf);
         }
 
+        // TLS records carry a u16 length: chunk large writes into
+        // standard 16 KiB records instead of letting the length field
+        // wrap (which would desynchronise the peer's TLS reader).
+        let chunk_len = buf.len().min(16 * 1024);
         let frame = self
             .write_key
-            .seal(TLS_RECORD_APPLICATION_DATA, buf)
+            .seal(TLS_RECORD_APPLICATION_DATA, &buf[..chunk_len])
             .map_err(transport_io_error)?;
         self.write_pending = Some(StreamPendingWrite { frame, pos: 0 });
+        // The record is buffered; report chunk_len immediately whether
+        // or not the drain completes now.  The next poll_write /
+        // poll_flush / poll_shutdown drains it.  Returning Pending here
+        // would be unsafe: the sealed record's plaintext length would
+        // be reported against whatever buffer arrives on the next poll.
         match self.drain_pending_write(cx) {
-            Poll::Ready(Ok(())) | Poll::Pending => Poll::Ready(Ok(buf.len())),
             Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            _ => Poll::Ready(Ok(chunk_len)),
         }
     }
 
@@ -553,9 +571,17 @@ fn build_reality_client_hello(
         .duration_since(UNIX_EPOCH)
         .map_err(|e| TransportError::Tls(format!("system clock before UNIX_EPOCH: {e}")))?
         .as_secs() as u32;
+    // Auth payload layout must match the server's expectation.  The first
+    // three bytes are the REALITY ClientVer triple.  sing-box hardcodes
+    // [1, 8, 1] (common/tls/reality_client.go:186-188); xray-core uses its
+    // own version bytes (transport/internet/reality/reality.go:143-145).
+    // Neither server validates these bytes — they are part of the 16-byte
+    // AES-GCM auth payload, and the server only checks the short_id and
+    // timestamp after decryption.  Using sing-box's value is the safe
+    // interop choice: it works with both sing-box and xray servers.
     reality_plain[0] = 1;
     reality_plain[1] = 8;
-    reality_plain[2] = 2;
+    reality_plain[2] = 1;
     reality_plain[3] = 0;
     reality_plain[4..8].copy_from_slice(&unix.to_be_bytes());
     reality_plain[8..16].copy_from_slice(&reality.short_id);
@@ -1063,6 +1089,11 @@ impl RecordKey {
         body.push(inner_type);
 
         let record_len = body.len() + 16;
+        if record_len > u16::MAX as usize {
+            return Err(TransportError::Tls(format!(
+                "TLS record exceeds u16 length: {record_len}"
+            )));
+        }
         let mut header = Vec::with_capacity(5);
         header.push(TLS_RECORD_APPLICATION_DATA);
         header.extend_from_slice(&[0x03, 0x03]);
@@ -1435,11 +1466,145 @@ mod tests {
         assert!(extract_ed25519_spki(&spki[2..]).is_none());
     }
 
+    // ─── Split + concurrent direction polling (mux regression) ───────────────
+
+    /// Deterministic chunk bytes for a (seq, len) pair.
+    fn chunk(seq: u32, len: usize) -> Vec<u8> {
+        let mut state = seq.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            out.push((state >> 24) as u8);
+        }
+        out
+    }
+
+    /// Invariant test backing the mux corruption investigation: the REALITY
+    /// record layer, driven through tokio split (read and write halves
+    /// polled from two tasks concurrently), must preserve data byte-exact.
+    /// The stress-era corruption was traced to the mux layer's stored-future
+    /// write (a Pending re-poll re-framed the same chunk, duplicating it),
+    /// NOT to this layer — this test locks that conclusion in: if split
+    /// driving ever corrupts here, the layer needs its own fix.
+    /// (see proxy-mux.md §6)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn split_concurrent_read_write_preserves_data() {
+        let (client_io, server_io) = tokio::io::duplex(512 * 1024);
+        let secret = [0x5Au8; 32];
+
+        let client_stream = RealityTlsStream {
+            inner: Box::new(client_io),
+            read_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            write_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            read_raw_passthrough: false,
+            write_raw_passthrough: false,
+            read_plain: VecDeque::new(),
+            read_state: StreamReadState::Header {
+                buf: [0; 5],
+                pos: 0,
+            },
+            write_pending: None,
+        };
+        let server_stream = RealityTlsStream {
+            inner: Box::new(server_io),
+            read_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            write_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            read_raw_passthrough: false,
+            write_raw_passthrough: false,
+            read_plain: VecDeque::new(),
+            read_state: StreamReadState::Header {
+                buf: [0; 5],
+                pos: 0,
+            },
+            write_pending: None,
+        };
+
+        // Server: read [u32 LE len][data] plaintext frames, echo them back.
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let mut s = server_stream;
+            loop {
+                let mut len_b = [0u8; 4];
+                if s.read_exact(&mut len_b).await.is_err() {
+                    return;
+                }
+                let len = u32::from_le_bytes(len_b) as usize;
+                if len == 0 {
+                    return;
+                }
+                let mut data = vec![0u8; len];
+                if s.read_exact(&mut data).await.is_err() {
+                    return;
+                }
+                if s.write_all(&len_b).await.is_err()
+                    || s.write_all(&data).await.is_err()
+                    || s.flush().await.is_err()
+                {
+                    return;
+                }
+            }
+        });
+
+        let (rd, wr) = tokio::io::split(Box::new(client_stream) as Box<dyn Stream>);
+
+        // Reader task: verify every echoed chunk against the deterministic
+        // generator — any corruption shows up as a mismatch.
+        let reader = tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut rd = rd;
+            let mut seq = 0u32;
+            let mut bad = 0u32;
+            let mut count = 0u32;
+            loop {
+                let mut len_b = [0u8; 4];
+                if rd.read_exact(&mut len_b).await.is_err() {
+                    return (count, bad);
+                }
+                let len = u32::from_le_bytes(len_b) as usize;
+                if len == 0 {
+                    return (count, bad);
+                }
+                let mut data = vec![0u8; len];
+                if rd.read_exact(&mut data).await.is_err() {
+                    return (count, bad);
+                }
+                if data != chunk(seq, len) {
+                    bad += 1;
+                }
+                count += 1;
+                seq += 1;
+            }
+        });
+
+        // Writer task: full-duplex pressure against the parked reader.
+        let write_task = tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let mut wr = wr;
+            for seq in 0..2000u32 {
+                let len = 1 + ((seq.wrapping_mul(2_654_435_761)) % 8192) as usize;
+                let data = chunk(seq, len);
+                let mut frame = Vec::with_capacity(4 + len);
+                frame.extend_from_slice(&(len as u32).to_le_bytes());
+                frame.extend_from_slice(&data);
+                if wr.write_all(&frame).await.is_err() || wr.flush().await.is_err() {
+                    return;
+                }
+            }
+            let _ = wr.write_all(&[0u8; 4]).await;
+            let _ = wr.flush().await;
+        });
+        write_task.await.unwrap();
+
+        let (count, bad) = reader.await.unwrap();
+        assert_eq!(bad, 0, "corrupted echoes under concurrent split polling");
+        assert_eq!(count, 2000, "all chunks must be echoed");
+    }
+
     // ─── Reality ClientHello session_id seal ──────────────────────────────────
 
     /// The 32-byte session_id must decrypt, under the key/nonce/AAD a real
     /// Reality server reconstructs, to the authentication payload
-    /// (`[1, 8, 2, 0] || timestamp || short_id`). Asserting the plaintext —
+    /// (`[1, 8, 1, 0] || timestamp || short_id`). Asserting the plaintext —
     /// not just the length — is what proves the server could authenticate us.
     #[test]
     fn reality_client_hello_session_id_decrypts_to_auth_payload() {
@@ -1479,7 +1644,12 @@ mod tests {
             .decrypt_in_place_detached(nonce, &aad, &mut buf, Tag::from_slice(tag))
             .expect("session_id must decrypt under the server-derived key");
 
-        assert_eq!(&buf[0..4], &[1, 8, 2, 0], "reality auth header");
+        // ClientVer triple [1, 8, 1] — sing-box's hardcoded value
+        // (common/tls/reality_client.go:186-188). Neither sing-box nor
+        // xray servers validate these bytes; they are part of the
+        // AES-GCM auth payload and the server only checks short_id
+        // and timestamp after decryption.
+        assert_eq!(&buf[0..4], &[1, 8, 1, 0], "reality auth header");
         assert_eq!(&buf[8..16], &reality.short_id, "short_id echoed");
     }
 
@@ -1502,5 +1672,114 @@ mod tests {
         let mut buf = vec![0u8; 50];
         buf[0] = HS_CLIENT_HELLO; // wrong handshake type
         assert!(parse_server_hello(&buf).is_err());
+    }
+
+    // ─── poll_write changed-buffer safety ─────────────────────────────────────
+
+    /// A mock inner stream whose first `poll_write` returns `Pending`
+    /// (after self-waking) so that `drain_pending_write` can't complete
+    /// on the initial seal.  Subsequent calls accept all bytes.
+    struct PendingOnce {
+        pending: bool,
+        written: Vec<u8>,
+    }
+
+    impl AsyncRead for PendingOnce {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for PendingOnce {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            if self.pending {
+                self.pending = false;
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            self.written.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl Unpin for PendingOnce {}
+
+    /// After `poll_write` seals a record and the inner stream returns
+    /// `Pending`, the caller is told `Ok(chunk_len)` immediately (the
+    /// record is buffered).  A *second* `poll_write` with a different
+    /// buffer must drain the pending record first, then seal and report
+    /// the *new* buffer's length — never the old record's length.
+    ///
+    /// This is the changed-buffer hazard from the #413 review: before
+    /// the fix the top path returned `Ok(consumed)` (the old record's
+    /// plaintext length) against whatever buffer arrived, sending stale
+    /// bytes while claiming the new buffer was consumed.
+    #[test]
+    fn poll_write_reports_new_chunk_len_after_pending_drain() {
+        let secret = [0x5Au8; 32];
+        let mut stream = RealityTlsStream {
+            inner: Box::new(PendingOnce {
+                pending: true,
+                written: Vec::new(),
+            }),
+            read_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            write_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            read_raw_passthrough: false,
+            write_raw_passthrough: false,
+            read_plain: VecDeque::new(),
+            read_state: StreamReadState::Header {
+                buf: [0; 5],
+                pos: 0,
+            },
+            write_pending: None,
+        };
+
+        use tokio::io::AsyncWriteExt;
+
+        // First write: 10 bytes.  Inner returns Pending → drain returns
+        // Pending → poll_write returns Ok(10) with the record buffered.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let n = stream.write(&[0xAA; 10]).await.unwrap();
+            assert_eq!(n, 10, "first write: chunk_len reported immediately");
+        });
+
+        // The pending record is buffered (not fully drained).
+        assert!(
+            stream.write_pending.is_some(),
+            "record buffered after Pending drain"
+        );
+
+        // Second write: 5 different bytes.  The top path drains the
+        // pending record (inner now accepts), then seals the new buffer.
+        // Must report 5 (the new chunk_len), NOT 10 (the old record).
+        rt.block_on(async {
+            let n = stream.write(&[0xBB; 5]).await.unwrap();
+            assert_eq!(n, 5, "second write: new chunk_len, not old record's length");
+        });
+
+        // The pending record from the second write should also be
+        // drainable (inner accepts everything now).
+        assert!(
+            stream.write_pending.is_none(),
+            "second record drained on this call"
+        );
     }
 }


### PR DESCRIPTION
### Description

This is the first layer of the mux work from #394. It isolates the VLESS and REALITY transport prerequisites from the protocol implementations that follow.

VLESS Vision connections now defer the request header until the first application write. Deferred response handling is cancellation-safe across partial writes and cancelled polls. REALITY authentication payload construction is corrected, and oversized writes are chunked without violating the transport write-size invariant.

This PR contains no mux protocol implementation.

This branch is the base of the stack:

- Base: `main`
- Next: `pr2-mux-smux`

### How did you test this change?

Given a Vision connection whose request body has not been written, when the connection is established, the complete VLESS request header is deferred until application data is written.

Given a deferred header write is cancelled and retried, the next poll does not duplicate the header or associate it with the wrong payload.

Given concurrent REALITY reads and writes, oversized application data is split into valid writes while the authentication payload remains intact.

The branch was also checked with repository formatting, all three clippy feature modes, a locked workspace check, affected crate tests, and configuration integration tests before preparing this stack entry.

### Key points

The deferred header behavior is kept in the prerequisite PR because every later VLESS mux implementation relies on the same first-write and response lifecycle. Keeping it separate makes the mux protocol reviews smaller and avoids mixing transport correctness with protocol dispatch.

### Notes for reviewers

Start with the VLESS connection lifecycle and the REALITY payload change. The following stacked PR adds the shared mux client and smux; yamux, h2mux, and Mux.Cool are intentionally not part of this diff.

This branch is based on the current `origin/main`, not the historical base of #394.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @aimkiray will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

Part of the stacked mux implementation tracked in #412.
> **Stack note:** branches are submitted from the fork, so each PR targets `main` (GitHub does not support cross-fork stacked bases). The stack order is preserved by the branch names and commit ancestry: PR1 -> PR2 (on pr1-vless-deferred) -> PR3 (on pr2-mux-smux) -> PR4 (on pr3-mux-ss-vmess) -> PR5 (on pr4-mux-yamux) -> PR6 (on pr5-mux-h2mux). Reviewers can read each layer as the incremental commits on top of the previous branch.

> Note: this PR also bumps `h2` 0.4.14 → 0.4.16 in `Cargo.lock` to clear advisory [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) (unbounded empty DATA frames, DoS; patched in 0.4.16). h2 0.4.14 is inherited from `main` via `meow-transport`'s h2 transport feature, so the bump sits at the stack base and clears the security-audit for every layer. No code change.
