### PR TITLE
feat(mux): add h2mux and shared HTTP/2 stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,6 +2611,7 @@ dependencies = [
  "tracing-subscriber",
  "webpki-roots 0.26.11",
  "x25519-dalek",
+ "yamux",
 ]
 
 [[package]]
@@ -2865,6 +2866,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -4099,6 +4106,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -5513,6 +5526,21 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "yamux"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767113d8f66a81e461362462aa71d8d0108cbf3430d4442fb88a04e31be81165"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,6 +2606,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "webpki-roots 0.26.11",
@@ -4392,6 +4393,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,6 +2578,7 @@ dependencies = [
  "crc32fast",
  "ctr",
  "futures",
+ "h2",
  "h3",
  "h3-quinn",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1177,7 +1177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1506,9 +1506,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1773,7 +1773,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1992,7 +1992,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2917,7 +2917,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3298,7 +3298,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3335,7 +3335,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3672,7 +3672,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4052,7 +4052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4182,7 +4182,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4998,7 +4998,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5382,7 +5382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,10 @@ socket2 = { version = "0.5", features = ["all"] }
 
 # Futures
 futures = "0.3"
+
+# Multiplexing (sing-mux yamux protocol; libp2p yamux is wire-compatible
+# with hashicorp/go-yamux used by sing-mux)
+yamux = "0.14"
 futures-util = "0.3"
 
 # WebSocket

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ missing_panics_doc = "allow"
 [workspace.dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 
 # Serialization
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -41,6 +41,8 @@ ech-tls-tunnel = [
     "meow-config/ech-tls-tunnel",
     "meow-proxy/ech-tls-tunnel",
 ]
+# sing-mux multiplexing (in `full`; excluded from `minimal` per ADR-0007).
+mux = ["meow-config/mux", "meow-proxy/mux"]
 
 # DNS
 dns-server = ["meow-dns/dns-server"]
@@ -58,7 +60,7 @@ listener-tun = ["meow-listener/listener-tun", "meow-api/listener-tun"]
 # Convenience bundles
 minimal = ["ss", "trojan", "dns-server", "listener-mixed"]
 full = [
-    "ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel",
+    "ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel", "mux",
     "dns-server", "dns-encrypted",
     "listener-http", "listener-socks5", "listener-tproxy", "listener-mixed", "listener-tun",
 ]

--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-default = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "ech-tls-tunnel", "vmess", "snell", "hysteria2"]
+default = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "ech-tls-tunnel", "vmess", "snell", "hysteria2", "mux"]
 ss = ["meow-proxy/ss"]
 trojan = ["meow-proxy/trojan"]
 # `meow-transport/reality` rides along with vless: `reality-opts` is only
@@ -26,6 +26,8 @@ snell = ["meow-proxy/snell"]
 boring-tls = ["meow-transport/boring-tls"]
 ech = ["meow-transport/ech"]
 ech-tls-tunnel = ["ss", "meow-proxy/ech-tls-tunnel"]
+# sing-mux multiplexing (forwarded to meow-proxy; opt-out in `minimal`).
+mux = ["meow-proxy/mux"]
 # Auto-download + unzip a third-party dashboard from `external-ui-url` (issue
 # #223). Off by default: pulls in the `zip` crate, which grows the binary
 # against the ADR-0007 size caps. Even when enabled, the code path is

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -129,7 +129,8 @@ pub fn parse_proxy(
             let plugin = config.get("plugin").and_then(|v| v.as_str());
             let plugin_opts_str = config.get("plugin-opts").and_then(serialize_plugin_opts);
 
-            let adapter = ShadowsocksAdapter::new(
+            #[cfg_attr(not(feature = "mux"), allow(unused_mut))]
+            let mut adapter = ShadowsocksAdapter::new(
                 name,
                 server,
                 port,
@@ -140,7 +141,12 @@ pub fn parse_proxy(
                 plugin_opts_str.as_deref(),
             )
             .map_err(|e| format!("ss: {e}"))?;
-            // SS mux wiring lands in a follow-up PR (sing-mux for Shadowsocks).
+            #[cfg(feature = "mux")]
+            if let Some(mux_options) = parse_mux_options(name, config)? {
+                adapter = adapter.with_mux(mux_options);
+            }
+            #[cfg(not(feature = "mux"))]
+            parse_mux_options(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         #[cfg(feature = "trojan")]
@@ -1980,9 +1986,15 @@ fn parse_vmess(
         }
     }
 
-    let adapter =
+    #[cfg_attr(not(feature = "mux"), allow(unused_mut))]
+    let mut adapter =
         meow_proxy::VmessAdapter::new(name, server, port, uuid_bytes, security, udp, chain);
-    // VMess mux wiring lands in a follow-up PR (sing-mux + Mux.Cool for VMess).
+    #[cfg(feature = "mux")]
+    if let Some(mux_options) = parse_mux_options(name, config)? {
+        adapter = adapter.with_mux(mux_options);
+    }
+    #[cfg(not(feature = "mux"))]
+    parse_mux_options(name, config)?;
 
     Ok(adapter)
 }

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1481,10 +1481,9 @@ fn parse_mux_options(
     if !enabled {
         return Ok(None);
     }
-    // Empty protocol maps to smux in this PR; h2mux (mihomo's default) lands
-    // in a follow-up PR.
+    // Empty protocol maps to h2mux, matching mihomo's default.
     let protocol_str = match mux_cfg.get("protocol") {
-        None => "smux",
+        None => "h2mux",
         Some(serde_yaml::Value::String(s)) => s.as_str(),
         Some(other) => {
             return Err(format!(
@@ -1496,7 +1495,7 @@ fn parse_mux_options(
         // mihomo hard-errors on unknown protocols; do the same so a typo
         // cannot silently speak the wrong wire protocol to the server.
         return Err(format!(
-            "{name}: unknown mux protocol '{protocol_str}'; valid value: smux (yamux/h2mux/muxcool land in follow-up PRs)"
+            "{name}: unknown mux protocol '{protocol_str}'; valid values: smux, yamux, h2mux (muxcool lands in a follow-up PR)"
         ));
     };
     // max-connections=0 AND max-streams=0 means one physical connection

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -140,6 +140,7 @@ pub fn parse_proxy(
                 plugin_opts_str.as_deref(),
             )
             .map_err(|e| format!("ss: {e}"))?;
+            // SS mux wiring lands in a follow-up PR (sing-mux for Shadowsocks).
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         #[cfg(feature = "trojan")]
@@ -163,7 +164,15 @@ pub fn parse_proxy(
                 .and_then(serde_yaml::Value::as_bool)
                 .unwrap_or(false);
 
-            let adapter = TrojanAdapter::new(name, server, port, password, sni, skip_verify, udp);
+            #[cfg_attr(not(feature = "mux"), allow(unused_mut))]
+            let mut adapter =
+                TrojanAdapter::new(name, server, port, password, sni, skip_verify, udp);
+            #[cfg(feature = "mux")]
+            if let Some(mux_options) = parse_mux_options(name, config)? {
+                adapter = adapter.with_mux(mux_options);
+            }
+            #[cfg(not(feature = "mux"))]
+            parse_mux_options(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         #[cfg(feature = "vless")]
@@ -1059,7 +1068,7 @@ fn parse_lb_strategy(strategy: Option<&str>) -> std::result::Result<LbStrategy, 
 /// # Warn-once (Class B per ADR-0002)
 ///
 /// - `tls: false` with plain VLESS — plaintext, but correct destination
-/// - `mux: { enabled: true }` — Mux.Cool not implemented; warn and ignore
+/// - `mux: { enabled: true }` — sing-mux multiplexing (server must be sing-box/mihomo)
 /// - `flow: xtls-rprx-vision` + `udp: true` — Vision is TCP-only; UDP uses plain VLESS
 #[cfg(feature = "vless")]
 fn parse_vless(
@@ -1212,21 +1221,8 @@ fn parse_vless(
         );
     }
 
-    // ── Warn: mux enabled (Class B) ───────────────────────────────────────
-    if let Some(mux) = config.get("mux") {
-        let mux_enabled = mux
-            .get("enabled")
-            .and_then(serde_yaml::Value::as_bool)
-            .unwrap_or(false);
-        if mux_enabled {
-            tracing::warn!(
-                proxy = %name,
-                "vless: mux is not implemented (Mux.Cool); \
-                 the `mux` option is ignored. \
-                 (Class B divergence — upstream runs Mux.Cool)"
-            );
-        }
-    }
+    // ── mux: sing-mux compatible connection multiplexing ─────────────────
+    // Parsed after adapter construction below — see the `with_mux` call.
 
     // ── Warn: Vision + UDP (Class B) ─────────────────────────────────────
     if flow == Some(VlessFlow::XtlsRprxVision) && udp {
@@ -1421,7 +1417,230 @@ fn parse_vless(
     let mut adapter = VlessAdapter::new(name, server, port, uuid_bytes, flow, udp, chain);
     #[cfg(feature = "vless-encryption")]
     adapter.set_encryption(vless_encryption);
+
+    #[cfg(feature = "mux")]
+    if let Some(mux_options) = parse_mux_options(name, config)? {
+        // XTLS Vision + mux is rejected by both sing-box and Xray servers.
+        // Building a Vision-wrapped mux session gets the user a connection
+        // the server tears down with no diagnostic — hard error at config
+        // time rather than a silent dial failure.
+        #[cfg(feature = "vless-vision")]
+        if flow == Some(VlessFlow::XtlsRprxVision) {
+            return Err(
+                "vless: flow xtls-rprx-vision is incompatible with multiplexing \
+                 (sing-box and Xray reject XTLS + mux)"
+                    .into(),
+            );
+        }
+        adapter = adapter.with_mux(mux_options);
+    }
+    #[cfg(not(feature = "mux"))]
+    parse_mux_options(name, config)?;
+
     Ok(adapter)
+}
+
+/// Parse the optional mihomo `smux:` block shared by
+/// VLESS/Trojan/Shadowsocks/VMess.  `mux:` remains accepted as a legacy alias.
+///
+/// Two wire protocols are available, picked by `protocol`:
+///
+/// * sing-mux (smux/yamux/h2mux, default h2mux) — the first proxy request
+///   targets the reserved mux destination and streams carry a sing-encoded
+///   Socksaddr prefix.  Server must be sing-box / mihomo based.
+/// * muxcool — Xray's Mux.Cool (CommandMux 0x03 in the VLESS/VMess request
+///   header, frame mux).  Server must be Xray / sing-box based; VLESS and
+///   VMess support it (Trojan/Shadowsocks reject it).
+///
+/// Returns `None` when the block is absent or disabled; `Err` for
+/// malformed values.  Only compiled when one of its call sites
+/// (trojan / vless / ss / vmess parsing) exists.
+#[cfg(all(
+    feature = "mux",
+    any(
+        feature = "trojan",
+        feature = "vless",
+        feature = "ss",
+        feature = "vmess"
+    )
+))]
+fn parse_mux_options(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<Option<meow_proxy::mux::MuxOptions>, String> {
+    let Some(mux_cfg) = mux_config_block(name, config)? else {
+        return Ok(None);
+    };
+    let enabled = mux_bool_field(name, mux_cfg, "enabled", false)?;
+    if !enabled {
+        return Ok(None);
+    }
+    // Empty protocol maps to smux in this PR; h2mux (mihomo's default) lands
+    // in a follow-up PR.
+    let protocol_str = match mux_cfg.get("protocol") {
+        None => "smux",
+        Some(serde_yaml::Value::String(s)) => s.as_str(),
+        Some(other) => {
+            return Err(format!(
+                "{name}: mux option 'protocol' must be a string, got {other:?}"
+            ))
+        }
+    };
+    let Some(protocol) = meow_proxy::mux::Protocol::parse(protocol_str) else {
+        // mihomo hard-errors on unknown protocols; do the same so a typo
+        // cannot silently speak the wrong wire protocol to the server.
+        return Err(format!(
+            "{name}: unknown mux protocol '{protocol_str}'; valid value: smux (yamux/h2mux/muxcool land in follow-up PRs)"
+        ));
+    };
+    // max-connections=0 AND max-streams=0 means one physical connection
+    // per stream (mirrors mihomo/sing-mux exactly) — almost never what an
+    // operator wants, so say so.
+    let max_connections = mux_usize_field(name, mux_cfg, "max-connections", 4)?;
+    let max_streams = mux_usize_field(name, mux_cfg, "max-streams", 4)?;
+    if max_connections == 0 && max_streams == 0 {
+        tracing::warn!(
+            proxy = %name,
+            "mux: max-connections and max-streams are both 0 — every stream dials its own \
+             physical connection (mirrors mihomo); consider the 4/4/4 defaults"
+        );
+    }
+    // Parsed but unsupported upstream fields: `statistic` (per-connection
+    // traffic attribution in mihomo's dialer) and `brutal-opts` (TCP Brutal,
+    // Linux-only upstream).  Warn once so operators know the divergence.
+    for unsupported in ["statistic", "brutal-opts"] {
+        if mux_cfg.get(unsupported).is_some() {
+            tracing::warn!(
+                proxy = %name,
+                "mux option '{}' is not supported in meow-rs and will be ignored",
+                unsupported
+            );
+        }
+    }
+    Ok(Some(meow_proxy::mux::MuxOptions {
+        protocol,
+        padding: mux_bool_field(name, mux_cfg, "padding", false)?,
+        max_connections,
+        min_streams: mux_usize_field(name, mux_cfg, "min-streams", 4)?,
+        max_streams,
+        only_tcp: mux_bool_field(name, mux_cfg, "only-tcp", false)?,
+    }))
+}
+
+/// No-mux builds: warn loudly instead of silently ignoring an enabled
+/// `smux:`/`mux:` block (operators would otherwise think the node is multiplexed).
+/// Only compiled when one of its call sites (trojan / vless / ss / vmess
+/// parsing) exists.
+#[cfg(all(
+    not(feature = "mux"),
+    any(
+        feature = "trojan",
+        feature = "vless",
+        feature = "ss",
+        feature = "vmess"
+    )
+))]
+fn parse_mux_options(
+    name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<(), String> {
+    if let Some(mux_cfg) = mux_config_block(name, config)? {
+        let enabled = mux_cfg
+            .get("enabled")
+            .and_then(serde_yaml::Value::as_bool)
+            .unwrap_or(false);
+        if enabled {
+            tracing::warn!(
+                proxy = %name,
+                "mux is enabled in config but this build was compiled without the `mux` feature; the option is ignored"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(
+    feature = "trojan",
+    feature = "vless",
+    feature = "ss",
+    feature = "vmess"
+))]
+fn mux_config_block<'a>(
+    name: &str,
+    config: &'a HashMap<String, serde_yaml::Value>,
+) -> std::result::Result<Option<&'a serde_yaml::Value>, String> {
+    let block = match (config.get("smux"), config.get("mux")) {
+        (Some(_), Some(_)) => {
+            // Migration-friendly: prefer the canonical key and say so,
+            // instead of rejecting the node for a likely leftover.
+            tracing::warn!(
+                proxy = %name,
+                "both `smux` and legacy alias `mux` are configured; using the canonical `smux` key"
+            );
+            config.get("smux")
+        }
+        (Some(config), None) | (None, Some(config)) => Some(config),
+        (None, None) => None,
+    };
+    let Some(block) = block else {
+        return Ok(None);
+    };
+    // A scalar like `smux: true` must not be treated as "disabled" —
+    // the operator clearly tried to enable multiplexing.
+    if !block.is_mapping() {
+        return Err(format!(
+            "{name}: `smux`/`mux` must be a mapping, got {block:?}"
+        ));
+    }
+    Ok(Some(block))
+}
+
+#[cfg(all(
+    feature = "mux",
+    any(
+        feature = "trojan",
+        feature = "vless",
+        feature = "ss",
+        feature = "vmess"
+    )
+))]
+fn mux_bool_field(
+    name: &str,
+    mux_cfg: &serde_yaml::Value,
+    key: &str,
+    default: bool,
+) -> std::result::Result<bool, String> {
+    match mux_cfg.get(key) {
+        None => Ok(default),
+        Some(serde_yaml::Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!(
+            "{name}: mux option '{key}' must be a boolean, got {other:?}"
+        )),
+    }
+}
+
+#[cfg(all(
+    feature = "mux",
+    any(
+        feature = "trojan",
+        feature = "vless",
+        feature = "ss",
+        feature = "vmess"
+    )
+))]
+fn mux_usize_field(
+    name: &str,
+    mux_cfg: &serde_yaml::Value,
+    key: &str,
+    default: usize,
+) -> std::result::Result<usize, String> {
+    match mux_cfg.get(key) {
+        None => Ok(default),
+        Some(serde_yaml::Value::Number(n)) if n.is_u64() => Ok(n.as_u64().unwrap() as usize),
+        Some(other) => Err(format!(
+            "{name}: mux option '{key}' must be a non-negative integer, got {other:?}"
+        )),
+    }
 }
 
 /// Parse the VLESS `encryption` field.
@@ -1701,20 +1920,6 @@ fn parse_vmess(
         .unwrap_or("tcp");
     let client_fingerprint = config.get("client-fingerprint").and_then(|v| v.as_str());
 
-    // Warn: mux enabled
-    if let Some(mux) = config.get("mux") {
-        if mux
-            .get("enabled")
-            .and_then(serde_yaml::Value::as_bool)
-            .unwrap_or(false)
-        {
-            tracing::warn!(
-                proxy = %name,
-                "vmess: mux is not implemented; the option is ignored"
-            );
-        }
-    }
-
     // Build transport chain (same pattern as VLESS)
     let mut chain = TransportChain::empty();
 
@@ -1775,9 +1980,11 @@ fn parse_vmess(
         }
     }
 
-    Ok(meow_proxy::VmessAdapter::new(
-        name, server, port, uuid_bytes, security, udp, chain,
-    ))
+    let adapter =
+        meow_proxy::VmessAdapter::new(name, server, port, uuid_bytes, security, udp, chain);
+    // VMess mux wiring lands in a follow-up PR (sing-mux + Mux.Cool for VMess).
+
+    Ok(adapter)
 }
 
 pub fn parse_proxy_group(

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -351,6 +351,91 @@ proxies:
     assert!(config.proxies.contains_key("trojan-server"));
 }
 
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn test_proxy_parsing_trojan_legacy_mux_enabled() {
+    let yaml = r#"
+proxies:
+  - name: "trojan-mux"
+    type: trojan
+    server: "example.com"
+    port: 443
+    password: "password123"
+    mux:
+      enabled: true
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(config.proxies.contains_key("trojan-mux"));
+}
+
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn test_proxy_parsing_trojan_smux_enabled() {
+    let yaml = r#"
+proxies:
+  - name: "trojan-smux"
+    type: trojan
+    server: "example.com"
+    port: 443
+    password: "password123"
+    smux:
+      enabled: true
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(config.proxies.contains_key("trojan-smux"));
+}
+
+#[tokio::test]
+async fn test_proxy_parsing_prefers_smux_when_both_keys_present() {
+    let yaml = r#"
+proxies:
+  - name: "trojan-double-mux"
+    type: trojan
+    server: "example.com"
+    port: 443
+    password: "password123"
+    smux:
+      enabled: true
+    mux:
+      enabled: false
+"#;
+    // The canonical smux: key wins (warn) and the node stays usable.
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(config.proxies.contains_key("trojan-double-mux"));
+}
+
+#[tokio::test]
+async fn test_proxy_parsing_rejects_non_boolean_mux_enabled() {
+    let yaml = r#"
+proxies:
+  - name: "trojan-bad-mux"
+    type: trojan
+    server: "example.com"
+    port: 443
+    password: "password123"
+    smux:
+      enabled: "true"
+"#;
+    // A string "true" must not be silently treated as disabled.
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(!config.proxies.contains_key("trojan-bad-mux"));
+}
+
+#[tokio::test]
+async fn test_proxy_parsing_rejects_scalar_mux_block() {
+    let yaml = r#"
+proxies:
+  - name: "trojan-scalar-mux"
+    type: trojan
+    server: "example.com"
+    port: 443
+    password: "password123"
+    smux: true
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(!config.proxies.contains_key("trojan-scalar-mux"));
+}
+
 #[tokio::test]
 async fn test_unsupported_proxy_type_skipped() {
     let yaml = r#"

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -436,6 +436,24 @@ proxies:
     assert!(!config.proxies.contains_key("trojan-scalar-mux"));
 }
 
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn test_proxy_parsing_trojan_mux_h2mux_accepted() {
+    let yaml = r#"
+proxies:
+  - name: "trojan-mux-h2"
+    type: trojan
+    server: "example.com"
+    port: 443
+    password: "password123"
+    mux:
+      enabled: true
+      protocol: h2mux
+"#;
+    let config = load_config_from_str(yaml).await.unwrap();
+    assert!(config.proxies.contains_key("trojan-mux-h2"));
+}
+
 #[tokio::test]
 async fn test_unsupported_proxy_type_skipped() {
     let yaml = r#"

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -1096,3 +1096,30 @@ proxies:
         .count();
     assert_eq!(mux_warns, 0, "smux: key is canonical: no warn expected");
 }
+
+/// D16c: explicit `protocol: yamux` → accepted without warn.
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn parse_vless_mux_yamux_accepted() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    mux:
+      enabled: true
+      protocol: yamux
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    result.expect("yamux mux must load");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(
+        mux_warns, 0,
+        "yamux is implemented: no warn expected; captured lines: {lines:?}"
+    );
+}

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -21,7 +21,7 @@
 //! | D13 | `parse_vless_vision_with_grpc_transport_ok`      — vision + grpc (TLS-enforcing) → ok |
 //! | D14 | `parse_vless_encryption_non_none_hard_errors`    — encryption: aes-128-gcm → hard error |
 //! | D15 | `parse_vless_encryption_empty_string_accepted`   — encryption: "" → ok |
-//! | D16 | `parse_vless_mux_enabled_warns_and_ignores`      — mux warns + loads |
+//! | D16 | `parse_vless_mux_enabled_loads_with_sing_mux`   — smux loads (h2mux default) |
 //! | D17 | `parse_vless_vision_udp_true_warns_once`         — vision + udp warns + loads |
 //! | D18 | `parse_vless_uuid_hex_and_dashed_both_accepted`  — both UUID forms ok |
 //! | D19 | `parse_vless_uuid_invalid_hard_errors`           — bad uuid → hard error |
@@ -687,16 +687,77 @@ proxies:
     );
 }
 
-// ─── D16: mux enabled → warn + ignores ───────────────────────────────────────
+// ─── D16: mux enabled → sing-mux attached ────────────────────────────────────
 
-/// D16: `parse_vless_mux_enabled_warns_and_ignores`
+/// D16: `parse_vless_mux_enabled_loads_with_sing_mux`
 ///
-/// `mux: { enabled: true }` → parse succeeds; at least one warn containing "mux".
-/// Class B per ADR-0002: Mux.Cool not implemented; same destination, no muxing.
-/// upstream: `adapter/outbound/vless.go` runs Mux.Cool.
-/// NOT hard-error — user gets a working (non-muxed) connection.
+/// `smux: { enabled: true }` → parse succeeds and the adapter is wired for
+/// sing-mux multiplexing (default protocol smux in this PR; h2mux lands later).  No mux
+/// warn is emitted — the feature is implemented.
+/// Interop note: server must be sing-box / mihomo based (Xray-only servers
+/// speak Mux.Cool, not this protocol).
+#[cfg(feature = "mux")]
 #[tokio::test]
-async fn parse_vless_mux_enabled_warns_and_ignores() {
+async fn parse_vless_mux_enabled_loads_with_sing_mux() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    smux:
+      enabled: true
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    result.expect("mux enabled must not be a hard error");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(
+        mux_warns, 0,
+        "mux is implemented: no mux warn expected; captured lines: {lines:?}"
+    );
+}
+
+/// D16e: unknown mux protocol → proxy rejected with a loud warn (meow's
+/// warn+skip parse semantics; mihomo hard-errors on the same input).
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn parse_vless_mux_unknown_protocol_rejects_proxy() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    mux:
+      enabled: true
+      protocol: not-a-protocol
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("unknown mux protocol must not fail the whole config");
+    assert!(
+        !config.proxies.contains_key("v"),
+        "proxy with unknown mux protocol must be skipped"
+    );
+    let warns = lines
+        .iter()
+        .filter(|l| l.contains("unknown mux protocol"))
+        .count();
+    assert!(
+        warns >= 1,
+        "expected an unknown-mux-protocol warn; {lines:?}"
+    );
+}
+
+/// No-mux builds: an enabled `mux:` block must warn loudly instead of
+/// being silently ignored.
+#[cfg(not(feature = "mux"))]
+#[tokio::test]
+async fn parse_vless_mux_enabled_without_feature_warns() {
     let yaml = r#"
 proxies:
   - name: v
@@ -708,14 +769,100 @@ proxies:
       enabled: true
 "#;
     let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    result.expect("mux enabled must not be a hard error");
-    let warn_count = lines
+    result.expect("mux config must still load without the feature");
+    let warns = lines
+        .iter()
+        .filter(|l| l.contains("compiled without the `mux` feature"))
+        .count();
+    assert!(warns >= 1, "expected a no-mux warn; {lines:?}");
+}
+
+/// D16f: `only-tcp: true` → accepted (UDP stays on the plain proxy path).
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn parse_vless_mux_only_tcp_accepted() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    mux:
+      enabled: true
+      only-tcp: true
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    result.expect("only-tcp mux must load");
+    let mux_warns = lines
         .iter()
         .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
         .count();
+    assert_eq!(mux_warns, 0, "no warn expected; captured lines: {lines:?}");
+}
+
+/// D16g: `statistic` / `brutal-opts` → accepted with a warn each
+/// (upstream fields meow-rs does not implement).
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn parse_vless_mux_unsupported_fields_warn_and_ignore() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    mux:
+      enabled: true
+      statistic: true
+      brutal-opts:
+        enabled: true
+        up: 100
+        down: 100
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    result.expect("unsupported mux fields must not be a hard error");
+    // The config may be parsed more than once during load; assert each
+    // unsupported field warned at least once.
+    let statistic = lines
+        .iter()
+        .filter(|l| l.contains("mux option 'statistic'"))
+        .count();
+    let brutal = lines
+        .iter()
+        .filter(|l| l.contains("mux option 'brutal-opts'"))
+        .count();
     assert!(
-        warn_count >= 1,
-        "at least one WARN about mux must be emitted; captured lines: {lines:?}"
+        statistic >= 1 && brutal >= 1,
+        "expected one warn per unsupported field; {lines:?}"
+    );
+}
+
+/// D16c: explicit `protocol: yamux` → accepted without warn.
+/// D16d: `mux: { enabled: false }` → plain VLESS, no mux, no warn.
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn parse_vless_mux_disabled_loads_plain() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    mux:
+      enabled: false
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    result.expect("mux disabled must load");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(
+        mux_warns, 0,
+        "no mux warn expected; captured lines: {lines:?}"
     );
 }
 

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -692,7 +692,7 @@ proxies:
 /// D16: `parse_vless_mux_enabled_loads_with_sing_mux`
 ///
 /// `smux: { enabled: true }` → parse succeeds and the adapter is wired for
-/// sing-mux multiplexing (default protocol smux in this PR; h2mux lands later).  No mux
+/// sing-mux multiplexing (default protocol h2mux, matching mihomo).  No mux
 /// warn is emitted — the feature is implemented.
 /// Interop note: server must be sing-box / mihomo based (Xray-only servers
 /// speak Mux.Cool, not this protocol).
@@ -1121,5 +1121,32 @@ proxies:
     assert_eq!(
         mux_warns, 0,
         "yamux is implemented: no warn expected; captured lines: {lines:?}"
+    );
+}
+
+/// D16b: explicit `protocol: h2mux` → accepted without warn.
+#[cfg(feature = "mux")]
+#[tokio::test]
+async fn parse_vless_mux_h2mux_accepted() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    mux:
+      enabled: true
+      protocol: h2mux
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    result.expect("h2mux mux must load");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(
+        mux_warns, 0,
+        "h2mux is implemented: no warn expected; captured lines: {lines:?}"
     );
 }

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -991,3 +991,108 @@ proxies:
         "proxy with server > 255 bytes must be skipped (Class A)"
     );
 }
+
+/// D16h: sing-mux on Shadowsocks → accepted (default h2mux).
+#[cfg(all(feature = "mux", feature = "ss"))]
+#[tokio::test]
+async fn parse_ss_mux_singmux_accepted() {
+    let yaml = r#"
+proxies:
+  - name: s
+    type: ss
+    server: example.com
+    port: 8388
+    cipher: aes-128-gcm
+    password: pw
+    mux:
+      enabled: true
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("ss mux must load");
+    assert!(config.proxies.contains_key("s"), "ss proxy must be kept");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(mux_warns, 0, "ss sing-mux is implemented: no warn expected");
+}
+
+/// D16h2: the canonical mihomo `smux:` key on Shadowsocks → accepted
+/// (same block as the legacy `mux:` alias, which stays covered above).
+#[cfg(all(feature = "mux", feature = "ss"))]
+#[tokio::test]
+async fn parse_ss_smux_key_accepted() {
+    let yaml = r#"
+proxies:
+  - name: s
+    type: ss
+    server: example.com
+    port: 8388
+    cipher: aes-128-gcm
+    password: pw
+    smux:
+      enabled: true
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("ss smux: must load");
+    assert!(config.proxies.contains_key("s"), "ss proxy must be kept");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(mux_warns, 0, "smux: key is canonical: no warn expected");
+}
+
+/// D16j: sing-mux on VMess → accepted (default h2mux).
+#[cfg(all(feature = "mux", feature = "vmess"))]
+#[tokio::test]
+async fn parse_vmess_mux_singmux_accepted() {
+    let yaml = r#"
+proxies:
+  - name: m
+    type: vmess
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    cipher: auto
+    mux:
+      enabled: true
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("vmess mux must load");
+    assert!(config.proxies.contains_key("m"), "vmess proxy must be kept");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(
+        mux_warns, 0,
+        "vmess sing-mux is implemented: no warn expected"
+    );
+}
+
+/// D16j2: the canonical mihomo `smux:` key on VMess → accepted
+/// (same block as the legacy `mux:` alias, which stays covered above).
+#[cfg(all(feature = "mux", feature = "vmess"))]
+#[tokio::test]
+async fn parse_vmess_smux_key_accepted() {
+    let yaml = r#"
+proxies:
+  - name: m
+    type: vmess
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    cipher: auto
+    smux:
+      enabled: true
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("vmess smux: must load");
+    assert!(config.proxies.contains_key("m"), "vmess proxy must be kept");
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(mux_warns, 0, "smux: key is canonical: no warn expected");
+}

--- a/crates/meow-listener/src/tun/udp.rs
+++ b/crates/meow-listener/src/tun/udp.rs
@@ -230,8 +230,12 @@ async fn relay_flow(
     // reader loop), downstream packets, and the idle deadline. Reply
     // source addresses are not rewritten: the tun flow is locked to one
     // (src, dst) tuple, so every reply is delivered as coming from `dst`.
-    // A downstream read cancelled by another branch may drop one datagram
-    // — acceptable under UDP delivery semantics.
+    // A downstream read cancelled by another branch may drop the current
+    // datagram: the property holds for VlessUdpReader / MuxPacketConn
+    // (which persist progress), but `relay_flow` is generic over
+    // `Box<dyn ProxyPacketConn>` and Direct / Shadowsocks / Trojan UDP
+    // conns do not carry that invariant.  This is acceptable under UDP
+    // delivery semantics.
     let mut buf = vec![0u8; DATAGRAM_BUF];
     let idle = sleep(udp_timeout);
     tokio::pin!(idle);

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -41,9 +41,9 @@ anytls = ["dep:meow-anytls"]
 # Hysteria2 outbound implemented in-tree on top of Quinn.
 hysteria2 = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:blake2"]
 # sing-mux connection multiplexing for VLESS/Trojan/Shadowsocks/VMess.
-# smux in this PR (tokio-util only); yamux/h2mux deps land in follow-up PRs.
+# smux + yamux in this PR; h2mux deps land in a follow-up PR.
 # Opt-out in `minimal` builds (ADR-0007 binary-size caps).
-mux = ["dep:tokio-util"]
+mux = ["dep:yamux", "dep:tokio-util"]
 # Native client for the `ech-tls-tunnel` SIP003 plugin
 # (https://github.com/shadowsocks/ech-tls-tunnel). Requires ECH on rustls,
 # which pulls aws-lc-rs in via meow-transport.
@@ -55,6 +55,7 @@ meow-dns = { workspace = true }
 meow-transport = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, optional = true }
+yamux = { workspace = true, optional = true }
 meow-anytls = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 h3 = { workspace = true, optional = true }

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-default = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "ech-tls-tunnel", "vmess", "snell", "hysteria2"]
+default = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "ech-tls-tunnel", "vmess", "snell", "hysteria2", "mux"]
 ss = ["dep:shadowsocks"]
 trojan = []
 vless = []
@@ -40,6 +40,10 @@ snell = ["dep:argon2", "dep:aes-gcm"]
 anytls = ["dep:meow-anytls"]
 # Hysteria2 outbound implemented in-tree on top of Quinn.
 hysteria2 = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:blake2"]
+# sing-mux connection multiplexing for VLESS/Trojan/Shadowsocks/VMess.
+# smux in this PR (tokio-util only); yamux/h2mux deps land in follow-up PRs.
+# Opt-out in `minimal` builds (ADR-0007 binary-size caps).
+mux = ["dep:tokio-util"]
 # Native client for the `ech-tls-tunnel` SIP003 plugin
 # (https://github.com/shadowsocks/ech-tls-tunnel). Requires ECH on rustls,
 # which pulls aws-lc-rs in via meow-transport.
@@ -50,6 +54,7 @@ meow-common = { workspace = true }
 meow-dns = { workspace = true }
 meow-transport = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true, optional = true }
 meow-anytls = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 h3 = { workspace = true, optional = true }

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -41,9 +41,9 @@ anytls = ["dep:meow-anytls"]
 # Hysteria2 outbound implemented in-tree on top of Quinn.
 hysteria2 = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:blake2"]
 # sing-mux connection multiplexing for VLESS/Trojan/Shadowsocks/VMess.
-# smux + yamux in this PR; h2mux deps land in a follow-up PR.
+# smux + yamux + h2mux (mihomo's default); Mux.Cool lands in a follow-up PR.
 # Opt-out in `minimal` builds (ADR-0007 binary-size caps).
-mux = ["dep:yamux", "dep:tokio-util"]
+mux = ["dep:h2", "dep:yamux", "dep:tokio-util", "meow-transport/h2"]
 # Native client for the `ech-tls-tunnel` SIP003 plugin
 # (https://github.com/shadowsocks/ech-tls-tunnel). Requires ECH on rustls,
 # which pulls aws-lc-rs in via meow-transport.
@@ -56,6 +56,7 @@ meow-transport = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, optional = true }
 yamux = { workspace = true, optional = true }
+h2 = { version = "0.4", optional = true }
 meow-anytls = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 h3 = { workspace = true, optional = true }

--- a/crates/meow-proxy/src/lib.rs
+++ b/crates/meow-proxy/src/lib.rs
@@ -2,6 +2,8 @@ pub mod direct;
 pub mod group;
 pub mod health;
 pub mod http_adapter;
+#[cfg(feature = "mux")]
+pub mod mux;
 pub mod reject;
 pub mod socks5_adapter;
 pub mod stream_conn;

--- a/crates/meow-proxy/src/mux/address.rs
+++ b/crates/meow-proxy/src/mux/address.rs
@@ -1,0 +1,130 @@
+//! sing `Socksaddr` stream addressing (client side of sing-mux streams).
+//!
+//! The full per-stream request prefix is
+//! `[flags u16 BE][type u8][address][port u16 BE]` — flags 0 for TCP —
+//! matching sing-mux's `EncodeStreamRequest` (protocol.go).  Socksaddr type
+//! bytes: 0x01=IPv4, 0x04=IPv6, 0x03=FQDN (u8 length-prefixed).  Matches
+//! `M.SocksaddrSerializer` in sagernet/sing.
+
+use bytes::{BufMut, BytesMut};
+use std::io;
+use std::net::IpAddr;
+
+const TYPE_IPV4: u8 = 0x01;
+const TYPE_IPV6: u8 = 0x04;
+const TYPE_FQDN: u8 = 0x03;
+
+/// Encode the full TCP stream request: `[flags u16 = 0][socksaddr]`.
+pub fn encode_stream_request(host: &str, port: u16) -> io::Result<Vec<u8>> {
+    encode_stream_request_with_flags(host, port, 0)
+}
+
+/// Encode a stream request with explicit flags (sing-mux flagUDP = 1).
+pub fn encode_stream_request_with_flags(host: &str, port: u16, flags: u16) -> io::Result<Vec<u8>> {
+    let mut out = BytesMut::new();
+    out.put_u16(flags);
+    out.put_slice(&encode_address(host, port)?);
+    Ok(out.to_vec())
+}
+
+/// Encode a destination Socksaddr (without the stream-request flags).
+///
+/// FQDN payloads use a 1-byte length.  Hosts longer than 255 bytes are
+/// invalid as DNS names and cannot be encoded; they are rejected instead
+/// of silently truncating the frame (the server would dial a wrong
+/// address).
+pub fn encode_address(host: &str, port: u16) -> io::Result<Vec<u8>> {
+    let mut out = BytesMut::new();
+    match host.parse::<IpAddr>() {
+        Ok(IpAddr::V4(ip)) => {
+            out.put_u8(TYPE_IPV4);
+            out.put_slice(&ip.octets());
+        }
+        Ok(IpAddr::V6(ip)) => {
+            out.put_u8(TYPE_IPV6);
+            out.put_slice(&ip.octets());
+        }
+        Err(_) => {
+            if host.len() > u8::MAX as usize {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("mux address fqdn exceeds 255 bytes: {host:?}"),
+                ));
+            }
+            let len = host.len() as u8;
+            out.put_u8(TYPE_FQDN);
+            out.put_u8(len);
+            out.put_slice(host.as_bytes());
+        }
+    }
+    out.put_u16(port);
+    Ok(out.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv6Addr;
+
+    #[test]
+    fn ipv4_encoding_matches_sing_layout() {
+        let bytes = encode_address("10.0.2.2", 18081).unwrap();
+        assert_eq!(bytes, [0x01, 10, 0, 2, 2, 0x46, 0xa1]);
+    }
+
+    #[test]
+    fn stream_request_tcp_flags_then_socksaddr() {
+        let bytes = encode_stream_request("10.0.2.2", 18081).unwrap();
+        assert_eq!(bytes, [0x00, 0x00, 0x01, 10, 0, 2, 2, 0x46, 0xa1]);
+    }
+
+    #[test]
+    fn stream_request_udp_flag_matches_sing_mux() {
+        // flagUDP = 1 (sing-mux protocol.go).
+        let bytes = encode_stream_request_with_flags("10.0.2.2", 18081, 1).unwrap();
+        assert_eq!(bytes[0], 0x00);
+        assert_eq!(bytes[1], 0x01);
+    }
+
+    #[test]
+    fn ipv6_encoding() {
+        let ip: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let bytes = encode_address("2001:db8::1", 443).unwrap();
+        assert_eq!(bytes[0], TYPE_IPV6);
+        assert_eq!(&bytes[1..17], &ip.octets());
+        assert_eq!(u16::from_be_bytes([bytes[17], bytes[18]]), 443);
+    }
+
+    #[test]
+    fn fqdn_encoding() {
+        let bytes = encode_address("sp.mux.sing-box.arpa", 444).unwrap();
+        assert_eq!(bytes[0], TYPE_FQDN);
+        assert_eq!(bytes[1] as usize, "sp.mux.sing-box.arpa".len());
+        assert_eq!(
+            &bytes[2..2 + "sp.mux.sing-box.arpa".len()],
+            b"sp.mux.sing-box.arpa"
+        );
+        let port_off = 2 + "sp.mux.sing-box.arpa".len();
+        assert_eq!(
+            u16::from_be_bytes([bytes[port_off], bytes[port_off + 1]]),
+            444
+        );
+    }
+
+    #[test]
+    fn overlong_fqdn_is_rejected_not_truncated() {
+        let host = "a".repeat(256);
+        let err = encode_address(&host, 443).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        let err = encode_stream_request_with_flags(&host, 443, 1).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_takes_ipv6_type() {
+        // ::ffff:10.0.2.2 parses as an IPv6 literal and must encode as such.
+        let bytes = encode_address("::ffff:10.0.2.2", 80).unwrap();
+        assert_eq!(bytes[0], TYPE_IPV6);
+        assert_eq!(bytes.len(), 1 + 16 + 2);
+    }
+}

--- a/crates/meow-proxy/src/mux/client.rs
+++ b/crates/meow-proxy/src/mux/client.rs
@@ -1,0 +1,807 @@
+//! Mux client: bounded pool of mux sessions over one adapter dial path.
+//!
+//! Mirrors metacubex/sing-mux client.go: each session is a physical proxy
+//! connection (dialed to the reserved mux destination); streams are opened
+//! on the session with the fewest streams, new sessions are dialed only when
+//! the configured connection/stream bounds are reached.
+
+use super::packet::MuxPacketConn;
+use super::request::Request;
+use super::smux;
+use super::stream::MuxStreamConn;
+use super::{address, Protocol};
+use meow_common::{MeowError, Metadata, ProxyConn, ProxyPacketConn, Result};
+use std::collections::VecDeque;
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::sync::Mutex;
+
+/// Idle sessions (zero streams) are closed after this long.
+pub const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Maximum time spent establishing one physical mux session while the pool
+/// lock serializes new connections, matching sing-mux's TCPTimeout.
+const SESSION_SETUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Dialer producing one fresh physical connection to the proxy node.  The
+/// connection must already carry the protocol handshake (VLESS/Trojan first
+/// request) targeting the reserved mux destination.
+pub type DialFn =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<Box<dyn ProxyConn>>> + Send>> + Send + Sync>;
+
+/// Mux options, defaults aligned with mihomo's documented values.
+#[derive(Debug, Clone)]
+pub struct MuxOptions {
+    pub protocol: Protocol,
+    pub padding: bool,
+    pub max_connections: usize,
+    pub min_streams: usize,
+    pub max_streams: usize,
+    /// Route UDP through the plain proxy path instead of mux streams
+    /// (mihomo SingMuxOption.OnlyTcp).
+    pub only_tcp: bool,
+}
+
+impl Default for MuxOptions {
+    fn default() -> Self {
+        // smux is the default protocol in this PR; h2mux (mihomo's default)
+        // lands in a follow-up PR.
+        Self {
+            protocol: Protocol::Smux,
+            padding: false,
+            max_connections: 4,
+            min_streams: 4,
+            max_streams: 4,
+            only_tcp: false,
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis() as u64)
+}
+
+/// One protocol session multiplexing streams over one physical connection.
+#[derive(Clone)]
+pub(crate) enum SessionKind {
+    Smux(Arc<smux::Session>),
+}
+
+/// Write the sing-mux per-stream request prefix (flags + Socksaddr
+/// destination).  Mux.Cool has no prefix — its New frame already carries
+/// the destination.
+async fn write_request_prefix<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    host: &str,
+    port: u16,
+    udp: bool,
+) -> io::Result<()> {
+    stream
+        .write_all(&address::encode_stream_request_with_flags(
+            host,
+            port,
+            u16::from(udp),
+        )?)
+        .await?;
+    stream.flush().await
+}
+
+impl SessionKind {
+    /// Open one stream to host:port.  sing-mux sessions write their
+    /// per-stream request prefix here; Mux.Cool encodes the destination
+    /// into the stream's New frame instead.
+    pub(crate) async fn open_stream(
+        &self,
+        host: &str,
+        port: u16,
+        udp: bool,
+    ) -> io::Result<MuxStream> {
+        match self {
+            SessionKind::Smux(session) => {
+                let mut stream =
+                    MuxStream::new(session.open_stream().await.map(MuxStreamKind::Smux)?);
+                write_request_prefix(&mut stream, host, port, udp).await?;
+                Ok(stream)
+            }
+        }
+    }
+
+    pub(crate) fn is_dead(&self) -> bool {
+        match self {
+            SessionKind::Smux(session) => session.is_dead(),
+        }
+    }
+}
+
+/// A stream on either mux protocol, exposed with tokio IO traits.
+///
+/// Carries the sing-mux per-stream response preamble: the server prefixes
+/// its first write on every stream with a status byte (0 = success,
+/// 1 = error + varbin message) — mirroring sing-mux's
+/// `clientConn.readResponse`.
+pub(crate) struct MuxStream {
+    kind: MuxStreamKind,
+    response_pending: bool,
+    /// Sticky: set once the per-stream response status reported a remote
+    /// error; subsequent polls repeat the error instead of reading stray
+    /// varbin message bytes as data.
+    response_failed: bool,
+}
+
+pub(crate) enum MuxStreamKind {
+    Smux(smux::SmuxStream),
+}
+
+impl MuxStreamKind {
+    /// sing-mux prefixes every stream with a response status byte;
+    /// every protocol in this PR is sing-mux, so all streams require it.
+    fn requires_response(&self) -> bool {
+        true
+    }
+}
+
+impl AsyncRead for MuxStreamKind {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            MuxStreamKind::Smux(stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl MuxStream {
+    pub(crate) fn new(kind: MuxStreamKind) -> Self {
+        Self {
+            response_pending: kind.requires_response(),
+            kind,
+            response_failed: false,
+        }
+    }
+
+    /// Consume the per-stream response status byte on first read.
+    fn poll_response(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.response_failed {
+            return Poll::Ready(Err(io::Error::other("mux: remote stream error")));
+        }
+        if !self.response_pending {
+            return Poll::Ready(Ok(()));
+        }
+        let mut byte = [0u8; 1];
+        let mut read_buf = ReadBuf::new(&mut byte);
+        match Pin::new(&mut self.kind).poll_read(cx, &mut read_buf) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(())) => {
+                if read_buf.filled().is_empty() {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "mux: stream closed before response status",
+                    )));
+                }
+                self.response_pending = false;
+                if byte[0] == 0x00 {
+                    Poll::Ready(Ok(()))
+                } else {
+                    // Remote error: a varbin message follows, but the stream
+                    // is dead either way — surface the failure immediately
+                    // and stick to it so the stray message bytes are never
+                    // read as data.
+                    self.response_failed = true;
+                    Poll::Ready(Err(io::Error::other("mux: remote stream error")))
+                }
+            }
+        }
+    }
+}
+
+impl AsyncRead for MuxStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match this.poll_response(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Ready(Ok(())) => {}
+        }
+        Pin::new(&mut this.kind).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for MuxStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut self.get_mut().kind {
+            MuxStreamKind::Smux(stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.get_mut().kind {
+            MuxStreamKind::Smux(stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.get_mut().kind {
+            MuxStreamKind::Smux(stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+pub(crate) struct MuxSession {
+    pub(crate) kind: SessionKind,
+    /// Unified slot counter: each value represents one stream slot held
+    /// by this session — either an in-flight open (reserved by `offer()`
+    /// via CAS, released by `Reservation::drop` on failure/cancel) or an
+    /// established stream (released by `MuxStreamConn::drop`).
+    ///
+    /// A single counter eliminates the read-read race that two separate
+    /// `streams` + `pending` atomics had: `offer()` can check-and-reserve
+    /// with one `compare_exchange`, so the load assessment and the
+    /// increment are one atomic step.
+    pub(crate) streams: AtomicUsize,
+    pub(crate) last_used_ms: AtomicU64,
+}
+
+/// Releases a [`MuxSession`] slot when dropped — the cancellation-safe
+/// counterpart of the reservation `offer()` made via CAS on `streams`.
+struct Reservation(Arc<MuxSession>);
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        self.0.streams.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Shared mux client used by an adapter's dial path.
+pub struct MuxClient {
+    dial: DialFn,
+    options: MuxOptions,
+    sessions: Mutex<VecDeque<Arc<MuxSession>>>,
+}
+
+impl MuxClient {
+    pub fn new(dial: DialFn, options: MuxOptions) -> Arc<Self> {
+        Arc::new(Self {
+            dial,
+            options,
+            sessions: Mutex::new(VecDeque::new()),
+        })
+    }
+
+    /// Whether UDP should use mux rather than the adapter's plain UDP path.
+    pub(crate) fn supports_udp(&self) -> bool {
+        !self.options.only_tcp
+    }
+
+    fn metadata_host(metadata: &Metadata, adapter: &str) -> Result<String> {
+        if !metadata.host.is_empty() {
+            Ok(metadata.host.to_string())
+        } else if let Some(ip) = metadata.dst_ip {
+            Ok(ip.to_string())
+        } else {
+            Err(MeowError::Proxy(format!(
+                "{adapter} mux: metadata has no destination host"
+            )))
+        }
+    }
+
+    /// Shared adapter hook for a muxed TCP dial.
+    pub(crate) async fn open_stream_for(
+        self: &Arc<Self>,
+        metadata: &Metadata,
+        adapter: &str,
+    ) -> Result<MuxStreamConn> {
+        let host = Self::metadata_host(metadata, adapter)?;
+        self.open_stream(&host, metadata.dst_port).await
+    }
+
+    /// Shared adapter hook for UDP.  `None` means `only-tcp` selected the
+    /// adapter's existing plain UDP path.
+    pub(crate) async fn open_packet_stream_for(
+        self: &Arc<Self>,
+        metadata: &Metadata,
+        adapter: &str,
+    ) -> Result<Option<Box<dyn ProxyPacketConn>>> {
+        if !self.supports_udp() {
+            return Ok(None);
+        }
+        let host = Self::metadata_host(metadata, adapter)?;
+        self.open_packet_stream(&host, metadata.dst_port)
+            .await
+            .map(Some)
+    }
+
+    /// Open one multiplexed TCP stream to host:port.  sing-mux writes the
+    /// stream request (flags + Socksaddr destination) before returning;
+    /// Mux.Cool encodes the destination into the stream's New frame.
+    pub async fn open_stream(self: &Arc<Self>, host: &str, port: u16) -> Result<MuxStreamConn> {
+        let (stream, session) = self.open_stream_flags(host, port, false).await?;
+        Ok(MuxStreamConn::new(stream, session))
+    }
+
+    /// Open one multiplexed UDP flow to host:port.  sing-mux carries
+    /// flagUDP and frames datagrams as `[len u16 BE][data]`; Mux.Cool carries
+    /// a per-datagram destination in the frame meta.
+    pub async fn open_packet_stream(
+        self: &Arc<Self>,
+        host: &str,
+        port: u16,
+    ) -> Result<Box<dyn ProxyPacketConn>> {
+        let (stream, session) = self.open_stream_flags(host, port, true).await?;
+        // The conn is bound to the stream request's destination; reads
+        // report it as the datagram source.  Non-IP hosts (domains) get a
+        // placeholder — same convention as the plain VLESS UDP path.
+        let destination = host.parse::<std::net::IpAddr>().ok().map_or_else(
+            || "0.0.0.0:0".parse().expect("static placeholder"),
+            |ip| SocketAddr::new(ip, port),
+        );
+        let kind = stream.kind;
+        Ok(Box::new(MuxPacketConn::new(
+            MuxStream::new(kind),
+            session,
+            destination,
+        )))
+    }
+
+    /// Open a stream (writing its per-stream request: sing-mux prefix or
+    /// Mux.Cool New frame), retrying once on a dead session — the shared
+    /// core of the TCP and UDP open paths.
+    async fn open_stream_flags(
+        self: &Arc<Self>,
+        host: &str,
+        port: u16,
+        udp: bool,
+    ) -> Result<(MuxStream, Arc<MuxSession>)> {
+        let mut last_err = None;
+        for _ in 0..2 {
+            let session = match self.offer().await {
+                Ok(session) => session,
+                Err(e) => return Err(e),
+            };
+            // offer() reserved one slot on `streams` via CAS.  The
+            // guard releases it if the open future is cancelled or the
+            // session rejects the stream.
+            let reservation = Reservation(Arc::clone(&session));
+            match session.kind.open_stream(host, port, udp).await {
+                Ok(stream) => {
+                    // The slot reserved by offer() is now an established
+                    // stream.  Forget the reservation so its Drop doesn't
+                    // decrement — MuxStreamConn::drop will do that when
+                    // the stream is eventually closed.
+                    std::mem::forget(reservation);
+                    // Idle eviction is measured from the last successful open
+                    // (not the last activity): conservative — a long-lived
+                    // stream keeps its session alive via the streams count,
+                    // and zero-stream sessions idle past IDLE_TIMEOUT are
+                    // evicted on the next offer.
+                    session.last_used_ms.store(now_ms(), Ordering::SeqCst);
+                    return Ok((stream, session));
+                }
+                Err(e) => {
+                    // reservation drops here → slot released
+                    last_err = Some(MeowError::Io(e));
+                    continue;
+                }
+            }
+        }
+        Err(last_err.unwrap_or(MeowError::Proxy("mux: failed to open stream".into())))
+    }
+
+    /// Pick an existing session that can take a new request, or dial a new
+    /// one.  Dead sessions are pruned and zero-stream sessions idle past
+    /// `IDLE_TIMEOUT` are evicted.  The returned session has one slot
+    /// reserved for the caller via a CAS on `streams` — the check and the
+    /// increment are a single atomic step, so concurrent offers can never
+    /// overshoot max-streams.
+    async fn offer(self: &Arc<Self>) -> Result<Arc<MuxSession>> {
+        let mut sessions = self.sessions.lock().await;
+        let now = now_ms();
+        sessions.retain(|s| {
+            if s.kind.is_dead() {
+                return false;
+            }
+            let idle = now.saturating_sub(s.last_used_ms.load(Ordering::SeqCst));
+            s.streams.load(Ordering::SeqCst) > 0 || idle < IDLE_TIMEOUT.as_millis() as u64
+        });
+        let options = &self.options;
+        let best = sessions
+            .iter()
+            .min_by_key(|s| s.streams.load(Ordering::SeqCst));
+        if let Some(session) = best {
+            // CAS loop: atomically check the current load and reserve a
+            // slot.  If another thread modifies `streams` between our
+            // load and the CAS, we retry with the updated value.  This
+            // eliminates the read-read race that separate `streams` +
+            // `pending` atomics had — the assessment and the increment
+            // are now one atomic step.
+            loop {
+                let load = session.streams.load(Ordering::SeqCst);
+                let reuse = if load == 0 {
+                    // An idle session always takes the next stream — never
+                    // dial a fresh connection while one is free.
+                    true
+                } else if options.max_connections > 0 {
+                    sessions.len() >= options.max_connections || load < options.min_streams
+                } else {
+                    // max-connections=0: honor min-streams first (sing-mux
+                    // checks minStreams before maxStreams in this branch),
+                    // then fall back to max-streams.  max-streams=0 with
+                    // min-streams=0 keeps the mihomo semantics: one physical
+                    // connection per stream.
+                    load < options.min_streams
+                        || (options.max_streams > 0 && load < options.max_streams)
+                };
+                if !reuse {
+                    break;
+                }
+                match session.streams.compare_exchange(
+                    load,
+                    load + 1,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => return Ok(Arc::clone(session)),
+                    Err(_) => continue,
+                }
+            }
+        }
+        // Bounds reached: dial a fresh session while still holding the
+        // sessions lock so concurrent offers serialize behind this dial and
+        // cannot overshoot max-connections (sing-mux holds its mutex across
+        // offerNew the same way).
+        self.offer_new_locked(&mut sessions).await
+    }
+
+    /// Dial a fresh physical connection and start a new session.  sing-mux
+    /// sessions write the mux request header on top; Mux.Cool needs none —
+    /// the dialer's VLESS CommandMux request already marks the connection.
+    /// Callers must hold the sessions lock.
+    async fn offer_new_locked(
+        self: &Arc<Self>,
+        sessions: &mut VecDeque<Arc<MuxSession>>,
+    ) -> Result<Arc<MuxSession>> {
+        let kind = tokio::time::timeout(SESSION_SETUP_TIMEOUT, self.create_session())
+            .await
+            .map_err(|_| {
+                MeowError::Io(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "mux: session setup timed out",
+                ))
+            })??;
+        let session = Arc::new(MuxSession {
+            kind,
+            // Start at 1: the caller's reservation.  The pool lock is
+            // held, so no concurrent offer can see this session before
+            // the slot is reserved.
+            streams: AtomicUsize::new(1),
+            last_used_ms: AtomicU64::new(now_ms()),
+        });
+        sessions.push_back(Arc::clone(&session));
+        Ok(session)
+    }
+
+    async fn create_session(&self) -> Result<SessionKind> {
+        let mut conn = (self.dial)().await?;
+        let header = Request::new(
+            if self.options.padding { 1 } else { 0 },
+            self.options.protocol as u8,
+            self.options.padding,
+        )
+        .encode();
+        conn.write_all(&header).await.map_err(MeowError::Io)?;
+        conn.flush().await.map_err(MeowError::Io)?;
+        Ok(match self.options.protocol {
+            Protocol::Smux => SessionKind::Smux(Arc::new(
+                smux::Session::client(conn).map_err(MeowError::Io)?,
+            )),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::task::Poll;
+    use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
+
+    /// Minimal AsyncRead+AsyncWrite+ProxyConn newtype over a duplex half.
+    struct TestConn(tokio::io::DuplexStream);
+
+    impl ProxyConn for TestConn {}
+
+    impl AsyncRead for TestConn {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for TestConn {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().0).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+        }
+    }
+
+    /// Mock dialer: each dial yields a duplex half whose far end swallows
+    /// bytes (a minimal mux data sink).
+    async fn mock_mux_client(dials: Arc<AtomicUsize>) -> Arc<MuxClient> {
+        // The mock sink speaks smux frames — pin the protocol explicitly.
+        mock_mux_client_with(
+            dials,
+            MuxOptions {
+                protocol: Protocol::Smux,
+                ..MuxOptions::default()
+            },
+        )
+        .await
+    }
+
+    async fn mock_mux_client_with(dials: Arc<AtomicUsize>, options: MuxOptions) -> Arc<MuxClient> {
+        let dial: DialFn = Arc::new(move || {
+            let dials = Arc::clone(&dials);
+            Box::pin(async move {
+                dials.fetch_add(1, Ordering::SeqCst);
+                let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+                tokio::spawn(async move {
+                    // Drain frames without parsing: the previous version read a
+                    // 10-byte header and extracted a u32 BE "length" from bytes
+                    // 2–5, but smux frames are 8 bytes (u16 LE length at 2–3)
+                    // and yamux frames are 12 bytes.  On a misaligned read the
+                    // u32 can be enormous (e.g. 0x01000000 = 16 MiB when the
+                    // smux version byte 0x01 lands at header[2]), causing a
+                    // huge heap allocation that crashes the Windows runner.
+                    // A fixed-size read-and-discard loop is all a data sink
+                    // needs.
+                    let mut io = server_io;
+                    let mut buf = [0u8; 4096];
+                    loop {
+                        match io.read(&mut buf).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(_) => {}
+                        }
+                    }
+                });
+                Ok(Box::new(TestConn(client_io)) as Box<dyn ProxyConn>)
+            })
+        });
+        MuxClient::new(dial, options)
+    }
+
+    #[tokio::test]
+    async fn streams_pack_into_one_connection_until_bounds() {
+        let dials = Arc::new(AtomicUsize::new(0));
+        let client = mock_mux_client(Arc::clone(&dials)).await;
+        // Default bounds: max-connections=4, min/max-streams=4 — streams
+        // accumulate on the first connection until it reaches max_streams.
+        let mut streams = Vec::new();
+        for _ in 0..4 {
+            streams.push(client.open_stream("a.example", 80).await.unwrap());
+        }
+        assert_eq!(dials.load(Ordering::SeqCst), 1);
+        // Fifth stream exceeds max_streams → second connection.
+        streams.push(client.open_stream("a.example", 80).await.unwrap());
+        assert_eq!(dials.load(Ordering::SeqCst), 2);
+    }
+
+    /// max-connections=0 with max-streams=0 and min-streams=0 keeps the
+    /// mihomo semantics: every stream dials its own physical connection.
+    #[tokio::test]
+    async fn zero_bounds_dial_one_connection_per_stream() {
+        let dials = Arc::new(AtomicUsize::new(0));
+        let options = MuxOptions {
+            protocol: Protocol::Smux,
+            max_connections: 0,
+            min_streams: 0,
+            max_streams: 0,
+            ..MuxOptions::default()
+        };
+        let client = mock_mux_client_with(Arc::clone(&dials), options).await;
+        let mut streams = Vec::new();
+        for _ in 0..3 {
+            streams.push(client.open_stream("a.example", 80).await.unwrap());
+        }
+        assert_eq!(
+            dials.load(Ordering::SeqCst),
+            3,
+            "max-connections=0 + max-streams=0 must dial one connection per stream"
+        );
+        drop(streams);
+    }
+
+    /// Concurrent opens reserve their slots under the pool lock, so the
+    /// per-session stream cap is never overshot by racing offers.
+    #[tokio::test]
+    async fn concurrent_opens_respect_max_streams() {
+        let dials = Arc::new(AtomicUsize::new(0));
+        let options = MuxOptions {
+            protocol: Protocol::Smux,
+            max_connections: 0,
+            min_streams: 4,
+            max_streams: 4,
+            ..MuxOptions::default()
+        };
+        let client = mock_mux_client_with(Arc::clone(&dials), options).await;
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let client = Arc::clone(&client);
+                tokio::spawn(async move {
+                    client
+                        .open_stream(format!("h{i}.example").as_str(), 80)
+                        .await
+                        .unwrap()
+                })
+            })
+            .collect();
+        let mut streams = Vec::new();
+        for handle in handles {
+            streams.push(handle.await.unwrap());
+        }
+        let sessions = client.sessions.lock().await;
+        assert_eq!(
+            sessions.len(),
+            2,
+            "8 concurrent streams at max-streams=4 need 2 sessions"
+        );
+        for session in sessions.iter() {
+            assert_eq!(session.streams.load(Ordering::SeqCst), 4);
+        }
+        drop(streams);
+    }
+
+    /// Stress test for the max-streams overshoot race: with max-streams=1
+    /// every session must end with at most one stream slot.  The original
+    /// design used separate `streams` + `pending` atomics whose sum was
+    /// read with two independent loads — a concurrent open could transition
+    /// between them and make the load appear falsely 0.  The unified
+    /// `streams` counter with CAS-based reservation makes the check-and-
+    /// increment one atomic step, so the overshoot is structurally
+    /// impossible.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn stress_concurrent_opens_never_overshoot_max_streams_one() {
+        for round in 0..200 {
+            let dials = Arc::new(AtomicUsize::new(0));
+            let options = MuxOptions {
+                protocol: Protocol::Smux,
+                max_connections: 0,
+                min_streams: 1,
+                max_streams: 1,
+                ..MuxOptions::default()
+            };
+            let client = mock_mux_client_with(Arc::clone(&dials), options).await;
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let client = Arc::clone(&client);
+                    tokio::spawn(async move {
+                        client
+                            .open_stream(format!("h{i}.example").as_str(), 80)
+                            .await
+                            .unwrap()
+                    })
+                })
+                .collect();
+            let mut streams = Vec::new();
+            for handle in handles {
+                streams.push(handle.await.unwrap());
+            }
+            let sessions = client.sessions.lock().await;
+            for session in sessions.iter() {
+                let streams = session.streams.load(Ordering::SeqCst);
+                assert!(
+                    streams <= 1,
+                    "round {round}: session overshot max-streams=1 with {streams} streams"
+                );
+            }
+            drop(streams);
+        }
+    }
+
+    #[tokio::test]
+    async fn idle_sessions_are_evicted() {
+        let dials = Arc::new(AtomicUsize::new(0));
+        let client = mock_mux_client(Arc::clone(&dials)).await;
+        let s = client.open_stream("a.example", 80).await.unwrap();
+        drop(s);
+        // The zero-stream session stays reusable within IDLE_TIMEOUT.
+        let _s2 = client.open_stream("b.example", 81).await.unwrap();
+        assert_eq!(dials.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn write_error_on_dead_session_falls_back_to_new_dial() {
+        let dials = Arc::new(AtomicUsize::new(0));
+        let client = mock_mux_client(Arc::clone(&dials)).await;
+        let mut s = client.open_stream("a.example", 80).await.unwrap();
+        // Kill the underlying session by shutting the far side: drop the
+        // server task happens implicitly — instead, just verify a second
+        // stream still works after the first session dies.
+        s.shutdown().await.ok();
+        let _s2 = client.open_stream("b.example", 81).await.unwrap();
+        assert!(dials.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_opens_do_not_overshoot_max_connections() {
+        let dials = Arc::new(AtomicUsize::new(0));
+        let options = MuxOptions {
+            protocol: Protocol::Smux,
+            max_connections: 2,
+            min_streams: 1,
+            max_streams: 1,
+            ..MuxOptions::default()
+        };
+        let client = mock_mux_client_with(Arc::clone(&dials), options).await;
+        // Every stream saturates its session, so a racy pool would dial
+        // once per open; holding the lock across the dial must serialize
+        // them onto at most `max_connections` physical connections.
+        let opens = (0..8)
+            .map(|i| {
+                let client = Arc::clone(&client);
+                async move { (i, client.open_stream("a.example", 80).await.unwrap()) }
+            })
+            .collect::<Vec<_>>();
+        let streams = futures::future::join_all(opens).await;
+        assert_eq!(streams.len(), 8);
+        assert_eq!(dials.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn session_setup_timeout_bounds_a_stalled_dial() {
+        let dial: DialFn =
+            Arc::new(|| Box::pin(std::future::pending::<Result<Box<dyn ProxyConn>>>()));
+        let client = MuxClient::new(
+            dial,
+            MuxOptions {
+                protocol: Protocol::Smux,
+                ..MuxOptions::default()
+            },
+        );
+
+        let Err(error) = client.open_stream("a.example", 80).await else {
+            panic!("a stalled dial must time out");
+        };
+        assert!(
+            error.to_string().contains("session setup timed out"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/meow-proxy/src/mux/client.rs
+++ b/crates/meow-proxy/src/mux/client.rs
@@ -9,6 +9,7 @@ use super::packet::MuxPacketConn;
 use super::request::Request;
 use super::smux;
 use super::stream::MuxStreamConn;
+use super::yamux;
 use super::{address, Protocol};
 use meow_common::{MeowError, Metadata, ProxyConn, ProxyPacketConn, Result};
 use std::collections::VecDeque;
@@ -73,6 +74,7 @@ fn now_ms() -> u64 {
 #[derive(Clone)]
 pub(crate) enum SessionKind {
     Smux(Arc<smux::Session>),
+    Yamux(Arc<yamux::Session>),
 }
 
 /// Write the sing-mux per-stream request prefix (flags + Socksaddr
@@ -111,12 +113,19 @@ impl SessionKind {
                 write_request_prefix(&mut stream, host, port, udp).await?;
                 Ok(stream)
             }
+            SessionKind::Yamux(session) => {
+                let mut stream =
+                    MuxStream::new(session.open_stream().await.map(MuxStreamKind::Yamux)?);
+                write_request_prefix(&mut stream, host, port, udp).await?;
+                Ok(stream)
+            }
         }
     }
 
     pub(crate) fn is_dead(&self) -> bool {
         match self {
             SessionKind::Smux(session) => session.is_dead(),
+            SessionKind::Yamux(session) => session.is_dead(),
         }
     }
 }
@@ -138,6 +147,7 @@ pub(crate) struct MuxStream {
 
 pub(crate) enum MuxStreamKind {
     Smux(smux::SmuxStream),
+    Yamux(yamux::Stream),
 }
 
 impl MuxStreamKind {
@@ -156,6 +166,7 @@ impl AsyncRead for MuxStreamKind {
     ) -> Poll<io::Result<()>> {
         match self.get_mut() {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_read(cx, buf),
+            MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_read(cx, buf),
         }
     }
 }
@@ -229,18 +240,21 @@ impl AsyncWrite for MuxStream {
     ) -> Poll<io::Result<usize>> {
         match &mut self.get_mut().kind {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_write(cx, buf),
+            MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match &mut self.get_mut().kind {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_flush(cx),
+            MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_flush(cx),
         }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match &mut self.get_mut().kind {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_shutdown(cx),
+            MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_shutdown(cx),
         }
     }
 }
@@ -512,6 +526,9 @@ impl MuxClient {
             Protocol::Smux => SessionKind::Smux(Arc::new(
                 smux::Session::client(conn).map_err(MeowError::Io)?,
             )),
+            Protocol::Yamux => SessionKind::Yamux(Arc::new(
+                yamux::Session::client(conn).map_err(MeowError::Io)?,
+            )),
         })
     }
 }
@@ -733,6 +750,19 @@ mod tests {
             }
             drop(streams);
         }
+    }
+
+    #[tokio::test]
+    async fn yamux_protocol_pools_streams() {
+        let dials = Arc::new(AtomicUsize::new(0));
+        let options = MuxOptions {
+            protocol: Protocol::Yamux,
+            ..MuxOptions::default()
+        };
+        let client = mock_mux_client_with(Arc::clone(&dials), options).await;
+        let _s1 = client.open_stream("a.example", 80).await.unwrap();
+        let _s2 = client.open_stream("b.example", 80).await.unwrap();
+        assert_eq!(dials.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/meow-proxy/src/mux/client.rs
+++ b/crates/meow-proxy/src/mux/client.rs
@@ -5,6 +5,7 @@
 //! on the session with the fewest streams, new sessions are dialed only when
 //! the configured connection/stream bounds are reached.
 
+use super::h2mux;
 use super::packet::MuxPacketConn;
 use super::request::Request;
 use super::smux;
@@ -51,10 +52,9 @@ pub struct MuxOptions {
 
 impl Default for MuxOptions {
     fn default() -> Self {
-        // smux is the default protocol in this PR; h2mux (mihomo's default)
-        // lands in a follow-up PR.
+        // h2mux is mihomo's default protocol (empty `protocol` maps to it).
         Self {
-            protocol: Protocol::Smux,
+            protocol: Protocol::H2Mux,
             padding: false,
             max_connections: 4,
             min_streams: 4,
@@ -75,6 +75,7 @@ fn now_ms() -> u64 {
 pub(crate) enum SessionKind {
     Smux(Arc<smux::Session>),
     Yamux(Arc<yamux::Session>),
+    H2Mux(Arc<h2mux::Session>),
 }
 
 /// Write the sing-mux per-stream request prefix (flags + Socksaddr
@@ -119,6 +120,12 @@ impl SessionKind {
                 write_request_prefix(&mut stream, host, port, udp).await?;
                 Ok(stream)
             }
+            SessionKind::H2Mux(session) => {
+                let mut stream =
+                    MuxStream::new(session.open_stream().await.map(MuxStreamKind::H2Mux)?);
+                write_request_prefix(&mut stream, host, port, udp).await?;
+                Ok(stream)
+            }
         }
     }
 
@@ -126,6 +133,7 @@ impl SessionKind {
         match self {
             SessionKind::Smux(session) => session.is_dead(),
             SessionKind::Yamux(session) => session.is_dead(),
+            SessionKind::H2Mux(session) => session.is_dead(),
         }
     }
 }
@@ -148,6 +156,7 @@ pub(crate) struct MuxStream {
 pub(crate) enum MuxStreamKind {
     Smux(smux::SmuxStream),
     Yamux(yamux::Stream),
+    H2Mux(h2mux::Stream),
 }
 
 impl MuxStreamKind {
@@ -167,6 +176,7 @@ impl AsyncRead for MuxStreamKind {
         match self.get_mut() {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_read(cx, buf),
             MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_read(cx, buf),
+            MuxStreamKind::H2Mux(stream) => Pin::new(stream).poll_read(cx, buf),
         }
     }
 }
@@ -241,6 +251,7 @@ impl AsyncWrite for MuxStream {
         match &mut self.get_mut().kind {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_write(cx, buf),
             MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_write(cx, buf),
+            MuxStreamKind::H2Mux(stream) => Pin::new(stream).poll_write(cx, buf),
         }
     }
 
@@ -248,6 +259,7 @@ impl AsyncWrite for MuxStream {
         match &mut self.get_mut().kind {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_flush(cx),
             MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_flush(cx),
+            MuxStreamKind::H2Mux(stream) => Pin::new(stream).poll_flush(cx),
         }
     }
 
@@ -255,6 +267,7 @@ impl AsyncWrite for MuxStream {
         match &mut self.get_mut().kind {
             MuxStreamKind::Smux(stream) => Pin::new(stream).poll_shutdown(cx),
             MuxStreamKind::Yamux(stream) => Pin::new(stream).poll_shutdown(cx),
+            MuxStreamKind::H2Mux(stream) => Pin::new(stream).poll_shutdown(cx),
         }
     }
 }
@@ -528,6 +541,9 @@ impl MuxClient {
             )),
             Protocol::Yamux => SessionKind::Yamux(Arc::new(
                 yamux::Session::client(conn).map_err(MeowError::Io)?,
+            )),
+            Protocol::H2Mux => SessionKind::H2Mux(Arc::new(
+                h2mux::Session::client(conn).await.map_err(MeowError::Io)?,
             )),
         })
     }

--- a/crates/meow-proxy/src/mux/h2mux.rs
+++ b/crates/meow-proxy/src/mux/h2mux.rs
@@ -1,0 +1,352 @@
+//! h2mux protocol (mihomo default), client side.
+//!
+//! Mirrors metacubex/sing-mux h2mux.go: the physical connection runs an
+//! HTTP/2 client after the mux request header; each logical stream is one
+//! CONNECT request to `https://localhost`.  The request body carries
+//! client→server bytes as h2 DATA frames, the response body carries
+//! server→client bytes.  No gun/grpc framing — raw passthrough.
+//!
+//! The response is resolved lazily on the first read, mirroring sing-mux's
+//! lateHTTPConn: sing-box's h2mux server defers flushing the 200 headers
+//! until its first response-body write, so awaiting the response before
+//! returning the stream would deadlock (the server waits for our data
+//! before it ever writes).
+
+use bytes::Bytes;
+use http::{Method, Request, StatusCode, Version};
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+pub use meow_transport::h2_common::H2Stream as Stream;
+use meow_transport::h2_common::{RecvState, StatusPolicy};
+
+/// Setup timeout for the CONNECT request/response round trip; mirrors
+/// sing-mux's `TCPTimeout` (5 s).  On expiry the read side fails with
+/// TimedOut (the caller tears the stream down).
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Timeout for acquiring send readiness (h2 `poll_ready`).  Without this,
+/// a peer whose `SETTINGS_MAX_CONCURRENT_STREAMS` is exhausted can park
+/// `open_stream` indefinitely — `RESPONSE_TIMEOUT` only covers the
+/// response, not the open.  Mirrors `SESSION_SETUP_TIMEOUT` (5 s).
+const OPEN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// h2mux session over one physical connection (client role).  The concrete
+/// IO type is erased — the driver task owns the h2 connection.
+pub struct Session {
+    send_request: h2::client::SendRequest<Bytes>,
+    dead: Arc<AtomicBool>,
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl Session {
+    pub async fn client<S>(io: S) -> io::Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let (send_request, connection) =
+            h2::client::handshake(io).await.map_err(io::Error::other)?;
+        let dead = Arc::new(AtomicBool::new(false));
+        let driver_dead = Arc::clone(&dead);
+        // Drive SETTINGS / WINDOW_UPDATE / PING frames; the future resolves
+        // when the physical connection dies.
+        let task = tokio::spawn(async move {
+            let _ = connection.await;
+            driver_dead.store(true, Ordering::SeqCst);
+        });
+        Ok(Self {
+            send_request,
+            dead,
+            _task: task,
+        })
+    }
+
+    /// Open one h2mux stream: a CONNECT request whose body/response body
+    /// form the duplex channel.  Returns immediately — the server may not
+    /// flush its 200 until the first response-body write (see module docs).
+    pub async fn open_stream(&self) -> io::Result<Stream> {
+        let request = Request::builder()
+            .method(Method::CONNECT)
+            .uri("https://localhost")
+            .version(Version::HTTP_2)
+            .body(())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let mut send_request = self.send_request.clone();
+        // h2 requires poll_ready/ready before send_request: sending
+        // without readiness violates the documented contract and is
+        // rejected once MAX_CONCURRENT_STREAMS is exhausted.  A timeout
+        // prevents an exhausted peer from parking open_stream forever.
+        send_request = tokio::time::timeout(OPEN_TIMEOUT, send_request.ready())
+            .await
+            .map_err(|_| io::Error::other("h2mux: timed out waiting for send readiness (open)"))?
+            .map_err(io::Error::other)?;
+        let (response_future, send_stream) = send_request
+            .send_request(request, false)
+            .map_err(io::Error::other)?;
+        Ok(Stream::new(
+            send_stream,
+            RecvState::with_timeout(
+                response_future,
+                RESPONSE_TIMEOUT,
+                StatusPolicy::Exact(StatusCode::OK),
+                "h2mux",
+            ),
+        )
+        .with_remote_no_error_eof())
+    }
+
+    pub fn is_dead(&self) -> bool {
+        self.dead.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        // Aborting the driver task drops the h2 connection and the
+        // underlying socket immediately.  Without this, an evicted idle
+        // session could keep the physical connection (and its fd) alive
+        // until the peer closes it.
+        self._task.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// h2mux echo server over a duplex pipe, mirroring sing-mux's
+    /// h2MuxServerSession: answer every request with 200 and pipe the
+    /// request body into the response body until the request half closes.
+    async fn run_echo_server<S>(io: S) -> tokio::task::JoinHandle<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        tokio::spawn(async move {
+            let Ok(mut connection) = h2::server::handshake(io).await else {
+                return;
+            };
+            // Keep polling accept(): only the connection's poll drives the
+            // codec, so the buffered response frames need it to keep being
+            // polled while per-stream handlers await request data.
+            while let Some(result) = connection.accept().await {
+                let Ok((request, mut respond)) = result else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut body = request.into_body();
+                    let response = http::Response::builder()
+                        .status(StatusCode::OK)
+                        .body(())
+                        .expect("static response");
+                    let Ok(mut send) = respond.send_response(response, false) else {
+                        return;
+                    };
+                    while let Some(chunk) = body.data().await {
+                        let Ok(chunk) = chunk else {
+                            break;
+                        };
+                        let _ = body.flow_control().release_capacity(chunk.len());
+                        if send.send_data(chunk, false).is_err() {
+                            break;
+                        }
+                    }
+                    let _ = send.send_data(Bytes::new(), true);
+                });
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn open_stream_echo_round_trip() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).await.unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        stream.write_all(b"hello h2mux").await.unwrap();
+        let mut resp = [0u8; 11];
+        stream.read_exact(&mut resp).await.unwrap();
+        assert_eq!(&resp, b"hello h2mux");
+    }
+
+    #[tokio::test]
+    async fn two_streams_multiplex_independently() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).await.unwrap());
+
+        let mut a = session.open_stream().await.unwrap();
+        let mut b = session.open_stream().await.unwrap();
+
+        a.write_all(b"AAA").await.unwrap();
+        b.write_all(b"BBB").await.unwrap();
+        let mut buf = [0u8; 3];
+        a.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"AAA");
+        b.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"BBB");
+    }
+
+    #[tokio::test]
+    async fn concurrent_opens_all_succeed() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).await.unwrap());
+
+        let opens = (0..8)
+            .map(|i| {
+                let session = Arc::clone(&session);
+                async move { (i, session.open_stream().await.unwrap()) }
+            })
+            .collect::<Vec<_>>();
+        let streams = futures::future::join_all(opens).await;
+        assert_eq!(streams.len(), 8);
+        for (i, mut stream) in streams {
+            let payload = format!("stream-{i}").into_bytes();
+            stream.write_all(&payload).await.unwrap();
+            let mut resp = vec![0u8; payload.len()];
+            stream.read_exact(&mut resp).await.unwrap();
+            assert_eq!(resp, payload);
+        }
+    }
+
+    /// Live interop probe against a running sing-box VLESS mux inbound
+    /// (127.0.0.1:4411, see target/e2e/mux-interop/).  Run with
+    /// `--ignored` — requires the server and the local web server
+    /// (target/e2e/websrv.py on :18081) to be up.  Exercises the full client
+    /// path: VLESS handshake → mux request header → CONNECT stream →
+    /// stream-request flags + Socksaddr → response status byte → relay.
+    #[tokio::test]
+    #[ignore]
+    #[cfg(all(feature = "mux", feature = "vless"))]
+    async fn live_singbox_vless_probe() {
+        use crate::mux::{DialFn, MuxClient, MuxOptions, Protocol};
+        use crate::vless::header::{Cmd, VlessAddr};
+        use crate::vless::VlessConn;
+        use crate::StreamConn;
+        use meow_common::{MeowError, ProxyConn};
+
+        // b831381d-6324-4d53-ad4f-8cda48b30811
+        const UUID: [u8; 16] = [
+            0xb8, 0x31, 0x38, 0x1d, 0x63, 0x24, 0x4d, 0x53, 0xad, 0x4f, 0x8c, 0xda, 0x48, 0xb3,
+            0x08, 0x11,
+        ];
+        let dial: DialFn = Arc::new(move || {
+            Box::pin(async move {
+                let tcp = tokio::net::TcpStream::connect(("127.0.0.1", 4411))
+                    .await
+                    .map_err(MeowError::Io)?;
+                let addr = VlessAddr::domain(super::super::MUX_DESTINATION_FQDN).unwrap();
+                let conn = VlessConn::new(
+                    Box::new(tcp),
+                    &UUID,
+                    None,
+                    Cmd::Tcp,
+                    super::super::MUX_DESTINATION_PORT,
+                    &addr,
+                )
+                .await?;
+                Ok(Box::new(StreamConn(Box::new(conn))) as Box<dyn ProxyConn>)
+            })
+        });
+        let client = MuxClient::new(
+            dial,
+            MuxOptions {
+                protocol: Protocol::H2Mux,
+                ..MuxOptions::default()
+            },
+        );
+        let mut stream = client.open_stream("127.0.0.1", 18081).await.unwrap();
+        stream
+            .write_all(
+                b"GET /page1.html HTTP/1.1
+Host: 127.0.0.1
+Connection: close
+
+",
+            )
+            .await
+            .unwrap();
+        let mut resp = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut stream, &mut resp)
+            .await
+            .unwrap();
+        assert!(
+            resp.starts_with(b"HTTP/1.1 200"),
+            "unexpected response: {}",
+            String::from_utf8_lossy(&resp[..resp.len().min(120)])
+        );
+    }
+
+    /// After `poll_write` stashes data and returns `Pending` (flow control
+    /// window exhausted), a re-poll with a *different* buffer must be
+    /// rejected with `InvalidInput` — otherwise stale bytes are sent under
+    /// the new buffer's reported length.  This is the changed-buffer guard
+    /// from the #417 review.
+    #[tokio::test]
+    async fn poll_write_rejects_changed_buffer_after_pending() {
+        // Server that accepts the CONNECT, sends 200, and reads the body
+        // very slowly — draining one small chunk per tick so the flow
+        // control window stays nearly exhausted.
+        let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+        let _server = tokio::spawn(async move {
+            let Ok(mut connection) = h2::server::handshake(server_io).await else {
+                return;
+            };
+            while let Some(result) = connection.accept().await {
+                let Ok((request, mut respond)) = result else {
+                    return;
+                };
+                let mut body = request.into_body();
+                let response = http::Response::builder()
+                    .status(StatusCode::OK)
+                    .body(())
+                    .unwrap();
+                let _ = respond.send_response(response, false);
+                // Read one chunk then hold — keeps the stream alive but
+                // stops releasing flow control capacity.
+                if let Some(Ok(chunk)) = body.data().await {
+                    let _ = body.flow_control().release_capacity(chunk.len());
+                }
+                // Keep the body alive (don't drop) so the stream isn't reset.
+                std::mem::forget(body);
+            }
+        });
+
+        let session = Session::client(client_io).await.unwrap();
+        let mut stream = session.open_stream().await.unwrap();
+
+        // Write enough to exhaust the per-stream window (65535 initial).
+        // The server reads one chunk then holds, so after ~65535 bytes
+        // the window is empty and subsequent writes Pending.
+        let fill = vec![0xAA; 65535];
+        if stream.write_all(&fill).await.is_err() {
+            eprintln!("write_all failed — h2 stream closed early, skipping");
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // This write stashes the data and returns Pending (window full).
+        // Timeout interrupts the await, leaving pending_write set.
+        let more = vec![0xBB; 100];
+        let _ = tokio::time::timeout(Duration::from_millis(100), stream.write(&more)).await;
+
+        // Re-poll with a different buffer — the guard must reject it.
+        let different = vec![0xCC; 50];
+        let result = stream.write(&different).await;
+        assert!(
+            result.is_err(),
+            "changed buffer after Pending must be rejected"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::InvalidInput,
+            "expected InvalidInput, got {err}"
+        );
+    }
+}

--- a/crates/meow-proxy/src/mux/mod.rs
+++ b/crates/meow-proxy/src/mux/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod address;
 pub mod client;
+pub mod h2mux;
 pub mod packet;
 pub mod request;
 pub mod smux;
@@ -32,18 +33,20 @@ pub const MUX_DESTINATION_PORT: u16 = 444;
 
 /// Mux protocol identifiers.
 ///
-/// `Smux`/`Yamux` match sing-mux's request-header byte values 0/1.  H2Mux
-/// (byte 2) and Xray Mux.Cool land in follow-up PRs.
+/// `Smux`/`Yamux`/`H2Mux` match sing-mux's request-header byte values 0/1/2.
+/// Xray Mux.Cool lands in a follow-up PR.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Protocol {
     Smux = 0,
     Yamux = 1,
+    H2Mux = 2,
 }
 
 impl Protocol {
     pub fn parse(value: &str) -> Option<Self> {
         match value {
-            "" | "smux" => Some(Protocol::Smux),
+            "" | "h2mux" => Some(Protocol::H2Mux),
+            "smux" => Some(Protocol::Smux),
             "yamux" => Some(Protocol::Yamux),
             _ => None,
         }

--- a/crates/meow-proxy/src/mux/mod.rs
+++ b/crates/meow-proxy/src/mux/mod.rs
@@ -1,0 +1,48 @@
+//! sing-mux compatible connection multiplexing (mihomo-style).
+//!
+//! Implements the client side of the protocol used by mihomo / sing-box:
+//! a single physical proxy connection carries a mux session, and each
+//! logical flow is one mux stream.  Wire format mirrors metacubex/sing-mux:
+//!
+//! * reserved destination `sp.mux.sing-box.arpa:444` in the proxy
+//!   handshake marks the connection as a mux connection (server side);
+//! * after the proxy handshake the client sends a 2-byte (+padding) request
+//!   header picking the mux protocol (smux in this PR; yamux/h2mux land in
+//!   follow-up PRs);
+//! * every stream carries the real destination as a sing-encoded
+//!   `Socksaddr` prefix (see `address`).
+//!
+//! See docs/specs/proxy-mux.md for the full wire specification.
+
+pub mod address;
+pub mod client;
+pub mod packet;
+pub mod request;
+pub mod smux;
+pub mod stream;
+
+pub use client::{DialFn, MuxClient, MuxOptions};
+pub use packet::MuxPacketConn;
+pub use stream::MuxStreamConn;
+
+/// Reserved destination used in the proxy handshake to open a mux session.
+pub const MUX_DESTINATION_FQDN: &str = "sp.mux.sing-box.arpa";
+pub const MUX_DESTINATION_PORT: u16 = 444;
+
+/// Mux protocol identifiers.
+///
+/// `Smux` matches sing-mux's request-header byte value 0.  Yamux/H2Mux
+/// (bytes 1/2) and Xray Mux.Cool land in follow-up PRs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    Smux = 0,
+}
+
+impl Protocol {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "" | "smux" => Some(Protocol::Smux),
+            _ => None,
+        }
+    }
+}

--- a/crates/meow-proxy/src/mux/mod.rs
+++ b/crates/meow-proxy/src/mux/mod.rs
@@ -20,6 +20,7 @@ pub mod packet;
 pub mod request;
 pub mod smux;
 pub mod stream;
+pub mod yamux;
 
 pub use client::{DialFn, MuxClient, MuxOptions};
 pub use packet::MuxPacketConn;
@@ -31,17 +32,19 @@ pub const MUX_DESTINATION_PORT: u16 = 444;
 
 /// Mux protocol identifiers.
 ///
-/// `Smux` matches sing-mux's request-header byte value 0.  Yamux/H2Mux
-/// (bytes 1/2) and Xray Mux.Cool land in follow-up PRs.
+/// `Smux`/`Yamux` match sing-mux's request-header byte values 0/1.  H2Mux
+/// (byte 2) and Xray Mux.Cool land in follow-up PRs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Protocol {
     Smux = 0,
+    Yamux = 1,
 }
 
 impl Protocol {
     pub fn parse(value: &str) -> Option<Self> {
         match value {
             "" | "smux" => Some(Protocol::Smux),
+            "yamux" => Some(Protocol::Yamux),
             _ => None,
         }
     }

--- a/crates/meow-proxy/src/mux/packet.rs
+++ b/crates/meow-proxy/src/mux/packet.rs
@@ -622,7 +622,7 @@ mod tests {
         let client = MuxClient::new(
             dial,
             MuxOptions {
-                protocol: Protocol::Smux,
+                protocol: Protocol::H2Mux,
                 ..MuxOptions::default()
             },
         );

--- a/crates/meow-proxy/src/mux/packet.rs
+++ b/crates/meow-proxy/src/mux/packet.rs
@@ -325,6 +325,89 @@ mod tests {
         assert_eq!(&buf[..n], b"hello-udp");
         assert_eq!(src, "127.0.0.1:53".parse::<SocketAddr>().unwrap());
     }
+
+    /// UDP round trip over a yamux session (parity with the smux test;
+    /// the review flagged yamux UDP as untested).
+    #[tokio::test]
+    async fn udp_datagram_round_trip_over_yamux() {
+        use super::super::yamux;
+        use ::yamux::{Config, Connection, Mode};
+        use tokio_util::compat::TokioAsyncReadCompatExt;
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            let config = Config::default();
+            let io = server_io.compat();
+            let mut connection = Connection::new(io, config, Mode::Server);
+            while let Some(result) =
+                std::future::poll_fn(|cx| connection.poll_next_inbound(cx)).await
+            {
+                let Ok(stream) = result else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    use tokio_util::compat::FuturesAsyncReadCompatExt;
+                    let mut stream = stream.compat();
+                    // Stream request: flags(2) + IPv4 socksaddr(7).
+                    let mut req = [0u8; 9];
+                    if stream.read_exact(&mut req).await.is_err() {
+                        return;
+                    }
+                    assert_eq!(
+                        u16::from_be_bytes([req[0], req[1]]),
+                        1,
+                        "stream request must carry flagUDP"
+                    );
+                    if stream.write_all(&[0x00]).await.is_err() {
+                        return;
+                    }
+                    loop {
+                        let mut len_buf = [0u8; 2];
+                        if stream.read_exact(&mut len_buf).await.is_err() {
+                            return;
+                        }
+                        let len = u16::from_be_bytes(len_buf) as usize;
+                        let mut payload = vec![0u8; len];
+                        if stream.read_exact(&mut payload).await.is_err() {
+                            return;
+                        }
+                        let mut out = bytes::BytesMut::with_capacity(2 + len);
+                        bytes::BufMut::put_u16(&mut out, len as u16);
+                        out.extend_from_slice(&payload);
+                        if stream.write_all(&out).await.is_err() {
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+
+        let session = Arc::new(yamux::Session::client(client_io).unwrap());
+        let yamux_stream = session.open_stream().await.unwrap();
+        let mut stream = MuxStream::new(MuxStreamKind::Yamux(yamux_stream));
+        stream
+            .write_all(&address::encode_stream_request_with_flags("127.0.0.1", 53, 1).unwrap())
+            .await
+            .unwrap();
+        let session_arc = Arc::new(MuxSession {
+            kind: SessionKind::Yamux(session),
+            streams: AtomicUsize::new(1),
+            last_used_ms: AtomicU64::new(0),
+        });
+        let conn = MuxPacketConn::new(
+            stream,
+            session_arc,
+            "127.0.0.1:53".parse::<SocketAddr>().unwrap(),
+        );
+        conn.write_packet(b"yamux-udp", &"127.0.0.1:53".parse().unwrap())
+            .await
+            .unwrap();
+        let mut buf = [0u8; 32];
+        let (n, _src) = conn.read_packet(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"yamux-udp");
+        drop(server);
+    }
     /// Regression: a pending read (no upstream datagram yet) must not
     /// head-of-line block writes — the SOCKS5 UDP relay reads on a
     /// separate task while the client keeps sending.

--- a/crates/meow-proxy/src/mux/packet.rs
+++ b/crates/meow-proxy/src/mux/packet.rs
@@ -1,0 +1,555 @@
+//! UDP-over-mux packet stream (sing-mux clientPacketConn / serverPacketConn).
+//!
+//! A UDP flow is one mux stream opened with the stream-request flagUDP bit;
+//! its payload is length-prefixed datagrams: `[len u16 BE][data]` in both
+//! directions (identical framing to meow's VLESS UDP-over-TCP).  The first
+//! server→client byte is still the stream response status (consumed by
+//! `MuxStream`), and the stream is bound to the destination carried in the
+//! stream request — datagrams carry no per-packet address.
+
+use super::client::{MuxSession, MuxStream};
+use bytes::{BufMut, BytesMut};
+use meow_common::{MeowError, ProxyPacketConn, Result};
+use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+/// One UDP flow multiplexed over a mux stream.  Dropping it half-closes
+/// the stream and decrements the session's stream count.
+pub struct MuxPacketConn {
+    reader: Mutex<PacketReader>,
+    writer: Mutex<PacketWriter>,
+    session: Arc<MuxSession>,
+    /// The destination bound in the stream request; every read reports this
+    /// as the datagram source (no per-packet addressing in sing-mux UDP).
+    destination: SocketAddr,
+}
+
+impl MuxPacketConn {
+    pub(crate) fn new(
+        stream: MuxStream,
+        session: Arc<MuxSession>,
+        destination: SocketAddr,
+    ) -> Self {
+        // Split so a blocked read (no upstream datagram yet) cannot
+        // head-of-line block writes — the SOCKS5 UDP relay runs the
+        // server→client reader on a separate task from client→server
+        // writes, and QUIC-style flows write while waiting for reads.
+        let (reader, writer) = tokio::io::split(stream);
+        Self {
+            reader: Mutex::new(PacketReader::new(reader)),
+            writer: Mutex::new(PacketWriter::new(writer)),
+            session,
+            destination,
+        }
+    }
+}
+
+impl Drop for MuxPacketConn {
+    fn drop(&mut self) {
+        self.session.streams.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+impl MuxPacketConn {
+    /// Write one datagram as `[len u16 BE][data]`.
+    pub async fn write_datagram(&self, data: &[u8]) -> Result<usize> {
+        if data.len() > u16::MAX as usize {
+            return Err(MeowError::Proxy(format!(
+                "mux: UDP packet ({} bytes) exceeds u16 framing",
+                data.len()
+            )));
+        }
+        let mut writer = self.writer.lock().await;
+        writer.write_datagram(data).await.map_err(MeowError::Io)?;
+        Ok(data.len())
+    }
+
+    /// Read one datagram: `[len u16 BE][data]`.  The stream response status
+    /// byte is consumed lazily on the first read by `MuxStream`.
+    pub async fn read_datagram(&self, buf: &mut [u8]) -> Result<usize> {
+        let mut reader = self.reader.lock().await;
+        reader.read_datagram(buf).await
+    }
+}
+
+/// Cancel-safe datagram reader.  Length and payload progress survive a
+/// dropped `read_packet` future (the TUN pump recreates it inside select!).
+struct PacketReader {
+    stream: tokio::io::ReadHalf<MuxStream>,
+    len: [u8; 2],
+    len_pos: usize,
+    payload: Vec<u8>,
+    payload_pos: usize,
+}
+
+impl PacketReader {
+    fn new(stream: tokio::io::ReadHalf<MuxStream>) -> Self {
+        Self {
+            stream,
+            len: [0; 2],
+            len_pos: 0,
+            payload: Vec::new(),
+            payload_pos: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.len_pos = 0;
+        self.payload.clear();
+        self.payload_pos = 0;
+    }
+
+    async fn read_datagram(&mut self, out: &mut [u8]) -> Result<usize> {
+        while self.len_pos < self.len.len() {
+            let read = self
+                .stream
+                .read(&mut self.len[self.len_pos..])
+                .await
+                .map_err(MeowError::Io)?;
+            if read == 0 {
+                return Err(MeowError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "mux: EOF while reading UDP packet length",
+                )));
+            }
+            self.len_pos += read;
+        }
+
+        if self.payload.is_empty() && self.payload_pos == 0 {
+            self.payload
+                .resize(u16::from_be_bytes(self.len) as usize, 0);
+        }
+        while self.payload_pos < self.payload.len() {
+            let read = self
+                .stream
+                .read(&mut self.payload[self.payload_pos..])
+                .await
+                .map_err(MeowError::Io)?;
+            if read == 0 {
+                return Err(MeowError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "mux: EOF while reading UDP packet payload",
+                )));
+            }
+            self.payload_pos += read;
+        }
+
+        let packet_len = self.payload.len();
+        if packet_len > out.len() {
+            self.reset();
+            return Err(MeowError::Proxy(format!(
+                "mux: UDP packet ({packet_len} bytes) exceeds read buffer ({} bytes)",
+                out.len()
+            )));
+        }
+        out[..packet_len].copy_from_slice(&self.payload);
+        self.reset();
+        Ok(packet_len)
+    }
+}
+
+struct PacketWriter {
+    stream: tokio::io::WriteHalf<MuxStream>,
+    /// Cancellation-safe write state: the combined frame (length prefix
+    /// and data) and the byte offset already written. A `write_datagram`
+    /// future dropped mid-write re-enters and resumes from `offset`
+    /// instead of re-writing the length prefix and desyncing the peer
+    /// framing. Mirrors `PacketReader`'s persistent-progress pattern.
+    pending: Option<(bytes::Bytes, usize)>,
+}
+
+impl PacketWriter {
+    fn new(stream: tokio::io::WriteHalf<MuxStream>) -> Self {
+        Self {
+            stream,
+            pending: None,
+        }
+    }
+
+    async fn write_datagram(&mut self, data: &[u8]) -> std::io::Result<()> {
+        // Prepare the combined frame on first entry (or after the
+        // previous one completed).  Owning the bytes is required because
+        // the caller's `&[u8]` may be gone after cancellation.
+        if self.pending.is_none() {
+            let mut frame = BytesMut::with_capacity(2 + data.len());
+            frame.put_u16(data.len() as u16);
+            frame.put_slice(data);
+            self.pending = Some((frame.freeze(), 0));
+        }
+
+        // Write the pending frame to completion, resuming from the
+        // stored offset if a previous call was cancelled mid-write.
+        // Use individual `write` calls (not `write_all`) so each
+        // successful write updates the offset before the next await
+        // point — `write_all` loses its internal progress on
+        // cancellation, which would duplicate already-sent bytes.
+        loop {
+            let (frame, offset) = self.pending.as_ref().unwrap();
+            if *offset >= frame.len() {
+                break;
+            }
+            let n = self.stream.write(&frame[*offset..]).await?;
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "mux: zero-length write during datagram send",
+                ));
+            }
+            self.pending.as_mut().unwrap().1 += n;
+        }
+        self.pending = None;
+        self.stream.flush().await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProxyPacketConn for MuxPacketConn {
+    async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        let n = self.read_datagram(buf).await?;
+        Ok((n, self.destination))
+    }
+
+    async fn write_packet(&self, buf: &[u8], _addr: &SocketAddr) -> Result<usize> {
+        self.write_datagram(buf).await
+    }
+
+    fn local_addr(&self) -> Result<SocketAddr> {
+        Err(MeowError::NotSupported(
+            "MuxPacketConn has no local UDP addr (UDP-over-mux)".into(),
+        ))
+    }
+
+    fn close(&self) -> Result<()> {
+        // The stream half-closes when MuxPacketConn is dropped.
+        Ok(())
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::super::address;
+    use super::super::client::{MuxStreamKind, SessionKind};
+    use super::super::smux;
+    use super::*;
+    use std::net::SocketAddr;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Minimal sing-mux UDP server over a duplex pipe (smux session):
+    /// asserts the stream request carries flagUDP, writes the response
+    /// status byte, then echoes the datagram bytes verbatim.
+    async fn run_udp_server<S>(mut io: S) -> tokio::task::JoinHandle<()>
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+    {
+        tokio::spawn(async move {
+            let mut header = [0u8; 8];
+            let mut first_psh = true;
+            loop {
+                if io.read_exact(&mut header).await.is_err() {
+                    return;
+                }
+                let cmd = header[1];
+                let length = u16::from_le_bytes([header[2], header[3]]) as usize;
+                let sid = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+                let mut payload = vec![0u8; length];
+                if !payload.is_empty() && io.read_exact(&mut payload).await.is_err() {
+                    return;
+                }
+                let mut send = async |cmd: u8, data: &[u8]| {
+                    let mut buf = bytes::BytesMut::with_capacity(8 + data.len());
+                    bytes::BufMut::put_u8(&mut buf, 0x01);
+                    bytes::BufMut::put_u8(&mut buf, cmd);
+                    bytes::BufMut::put_u16_le(&mut buf, data.len() as u16);
+                    bytes::BufMut::put_u32_le(&mut buf, sid);
+                    buf.extend_from_slice(data);
+                    io.write_all(&buf).await
+                };
+                match cmd {
+                    0 => {
+                        let _ = sid;
+                    } // SYN (no response)
+                    2 => {
+                        // PSH
+                        if first_psh {
+                            first_psh = false;
+                            assert_eq!(
+                                u16::from_be_bytes([payload[0], payload[1]]),
+                                1,
+                                "stream request must carry flagUDP"
+                            );
+                            let _ = send(2, &[0x00]).await; // status success
+                        } else {
+                            let _ = send(2, &payload).await; // echo datagram
+                        }
+                    }
+                    1 => {
+                        let _ = send(1, &[]).await;
+                    } // FIN
+                    _ => {}
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn udp_datagram_round_trip_over_smux() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_udp_server(server_io).await;
+        let session = Arc::new(smux::Session::client(client_io).unwrap());
+        let smux_stream = session.open_stream().await.unwrap();
+        let mut stream = MuxStream::new(MuxStreamKind::Smux(smux_stream));
+        stream
+            .write_all(&address::encode_stream_request_with_flags("127.0.0.1", 53, 1).unwrap())
+            .await
+            .unwrap();
+        let session_arc = Arc::new(MuxSession {
+            kind: SessionKind::Smux(session),
+            streams: AtomicUsize::new(1),
+            last_used_ms: AtomicU64::new(0),
+        });
+        let conn = MuxPacketConn::new(
+            stream,
+            session_arc,
+            "127.0.0.1:53".parse::<SocketAddr>().unwrap(),
+        );
+
+        conn.write_packet(b"hello-udp", &"127.0.0.1:53".parse().unwrap())
+            .await
+            .unwrap();
+        let mut buf = [0u8; 32];
+        let (n, src) = conn.read_packet(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"hello-udp");
+        assert_eq!(src, "127.0.0.1:53".parse::<SocketAddr>().unwrap());
+    }
+    /// Regression: a pending read (no upstream datagram yet) must not
+    /// head-of-line block writes — the SOCKS5 UDP relay reads on a
+    /// separate task while the client keeps sending.
+    #[tokio::test]
+    async fn write_not_blocked_by_pending_read() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            let mut io = server_io;
+            let mut header = [0u8; 8];
+            let mut sid = 0u32;
+            let mut psh_count = 0u32;
+            loop {
+                if io.read_exact(&mut header).await.is_err() {
+                    return;
+                }
+                let cmd = header[1];
+                let length = u16::from_le_bytes([header[2], header[3]]) as usize;
+                let frame_sid = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+                let mut payload = vec![0u8; length];
+                if !payload.is_empty() && io.read_exact(&mut payload).await.is_err() {
+                    return;
+                }
+                let mut send = async |cmd: u8, data: &[u8]| {
+                    let mut buf = bytes::BytesMut::with_capacity(8 + data.len());
+                    bytes::BufMut::put_u8(&mut buf, 0x01);
+                    bytes::BufMut::put_u8(&mut buf, cmd);
+                    bytes::BufMut::put_u16_le(&mut buf, data.len() as u16);
+                    bytes::BufMut::put_u32_le(&mut buf, sid);
+                    buf.extend_from_slice(data);
+                    io.write_all(&buf).await
+                };
+                match cmd {
+                    0 => {
+                        sid = frame_sid;
+                    }
+                    2 => {
+                        psh_count += 1;
+                        if psh_count == 2 {
+                            // First datagram bytes arrived: release the
+                            // blocked read with the stream response status.
+                            let _ = send(2, &[0x00]).await;
+                        }
+                        if psh_count >= 2 {
+                            // The length prefix and payload may be split
+                            // across smux frames; echo the byte stream, not
+                            // an assumed one-frame datagram.
+                            let _ = send(2, &payload).await;
+                        }
+                        // First PSH (stream request): stay silent so the
+                        // client's read blocks.
+                    }
+                    _ => {}
+                }
+            }
+        });
+        let session = Arc::new(smux::Session::client(client_io).unwrap());
+        let smux_stream = session.open_stream().await.unwrap();
+        let mut stream = MuxStream::new(MuxStreamKind::Smux(smux_stream));
+        stream
+            .write_all(&address::encode_stream_request_with_flags("127.0.0.1", 53, 1).unwrap())
+            .await
+            .unwrap();
+        let session_arc = Arc::new(MuxSession {
+            kind: SessionKind::Smux(session),
+            streams: AtomicUsize::new(1),
+            last_used_ms: AtomicU64::new(0),
+        });
+        let conn = Arc::new(MuxPacketConn::new(
+            stream,
+            session_arc,
+            "127.0.0.1:53".parse::<SocketAddr>().unwrap(),
+        ));
+        let reader = Arc::clone(&conn);
+        let read_task = tokio::spawn(async move {
+            let mut buf = [0u8; 16];
+            reader.read_packet(&mut buf).await.map(|(n, _)| n)
+        });
+        // Let the reader grab its half and park on the empty stream.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            conn.write_packet(b"x", &"127.0.0.1:53".parse().unwrap())
+                .await
+                .unwrap();
+        })
+        .await
+        .expect("write must not block behind a pending read");
+        let n = tokio::time::timeout(std::time::Duration::from_secs(2), read_task)
+            .await
+            .expect("read must complete after the server responds")
+            .unwrap()
+            .unwrap();
+        assert_eq!(n, 1);
+        drop(server);
+    }
+
+    #[tokio::test]
+    async fn cancelled_read_after_length_prefix_resumes_payload() {
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let (prefix_sent_tx, prefix_sent_rx) = tokio::sync::oneshot::channel();
+        let (continue_tx, continue_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let mut sid = 0;
+            for _ in 0..2 {
+                let mut header = [0u8; 8];
+                server_io.read_exact(&mut header).await.unwrap();
+                sid = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+                let length = u16::from_le_bytes([header[2], header[3]]) as usize;
+                let mut payload = vec![0u8; length];
+                server_io.read_exact(&mut payload).await.unwrap();
+            }
+
+            let mut prefix = bytes::BytesMut::with_capacity(11);
+            bytes::BufMut::put_u8(&mut prefix, 0x01);
+            bytes::BufMut::put_u8(&mut prefix, 0x02);
+            bytes::BufMut::put_u16_le(&mut prefix, 3);
+            bytes::BufMut::put_u32_le(&mut prefix, sid);
+            prefix.extend_from_slice(&[0x00, 0x00, 0x04]);
+            server_io.write_all(&prefix).await.unwrap();
+            let _ = prefix_sent_tx.send(());
+            let _ = continue_rx.await;
+
+            let mut payload = bytes::BytesMut::with_capacity(12);
+            bytes::BufMut::put_u8(&mut payload, 0x01);
+            bytes::BufMut::put_u8(&mut payload, 0x02);
+            bytes::BufMut::put_u16_le(&mut payload, 4);
+            bytes::BufMut::put_u32_le(&mut payload, sid);
+            payload.extend_from_slice(b"pong");
+            server_io.write_all(&payload).await.unwrap();
+        });
+
+        let session = Arc::new(smux::Session::client(client_io).unwrap());
+        let smux_stream = session.open_stream().await.unwrap();
+        let mut stream = MuxStream::new(MuxStreamKind::Smux(smux_stream));
+        stream
+            .write_all(&address::encode_stream_request_with_flags("127.0.0.1", 53, 1).unwrap())
+            .await
+            .unwrap();
+        let session_arc = Arc::new(MuxSession {
+            kind: SessionKind::Smux(session),
+            streams: AtomicUsize::new(1),
+            last_used_ms: AtomicU64::new(0),
+        });
+        let conn = MuxPacketConn::new(
+            stream,
+            session_arc,
+            "127.0.0.1:53".parse::<SocketAddr>().unwrap(),
+        );
+
+        prefix_sent_rx.await.unwrap();
+        let mut buf = [0u8; 8];
+        let cancelled = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            conn.read_datagram(&mut buf),
+        )
+        .await;
+        assert!(
+            cancelled.is_err(),
+            "the first read must wait for the payload"
+        );
+
+        continue_tx.send(()).unwrap();
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            conn.read_datagram(&mut buf),
+        )
+        .await
+        .expect("the resumed read must complete")
+        .unwrap();
+        assert_eq!(&buf[..n], b"pong");
+        server.await.unwrap();
+    }
+
+    /// Live interop probe against a running sing-box VLESS mux inbound
+    /// (127.0.0.1:4411) and the host UDP echo server
+    /// (target/e2e/udp_echo.py on :18082).  Run with `--ignored` —
+    /// requires both servers to be up.  Exercises the full UDP path:
+    /// VLESS handshake → mux request header → flagUDP stream request →
+    /// datagram framing → sing-box direct UDP relay → echo.
+    #[tokio::test]
+    #[ignore]
+    #[cfg(all(feature = "mux", feature = "vless"))]
+    async fn live_singbox_vless_udp_probe() {
+        use crate::mux::{DialFn, MuxClient, MuxOptions, Protocol};
+        use crate::vless::header::{Cmd, VlessAddr};
+        use crate::vless::VlessConn;
+        use crate::StreamConn;
+        use meow_common::{MeowError, ProxyConn};
+
+        // b831381d-6324-4d53-ad4f-8cda48b30811
+        const UUID: [u8; 16] = [
+            0xb8, 0x31, 0x38, 0x1d, 0x63, 0x24, 0x4d, 0x53, 0xad, 0x4f, 0x8c, 0xda, 0x48, 0xb3,
+            0x08, 0x11,
+        ];
+        let dial: DialFn = Arc::new(move || {
+            Box::pin(async move {
+                let tcp = tokio::net::TcpStream::connect(("127.0.0.1", 4411))
+                    .await
+                    .map_err(MeowError::Io)?;
+                let addr = VlessAddr::domain(super::super::MUX_DESTINATION_FQDN).unwrap();
+                let conn = VlessConn::new(
+                    Box::new(tcp),
+                    &UUID,
+                    None,
+                    Cmd::Tcp,
+                    super::super::MUX_DESTINATION_PORT,
+                    &addr,
+                )
+                .await?;
+                Ok(Box::new(StreamConn(Box::new(conn))) as Box<dyn ProxyConn>)
+            })
+        });
+        let client = MuxClient::new(
+            dial,
+            MuxOptions {
+                protocol: Protocol::Smux,
+                ..MuxOptions::default()
+            },
+        );
+        let conn = client.open_packet_stream("127.0.0.1", 18082).await.unwrap();
+        conn.write_packet(b"ping-udp", &"127.0.0.1:18082".parse().unwrap())
+            .await
+            .unwrap();
+        let mut buf = [0u8; 64];
+        let (n, src) = conn.read_packet(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"ping-udp");
+        assert_eq!(src, "127.0.0.1:18082".parse::<SocketAddr>().unwrap());
+    }
+}

--- a/crates/meow-proxy/src/mux/request.rs
+++ b/crates/meow-proxy/src/mux/request.rs
@@ -1,0 +1,156 @@
+//! Mux request header: version / protocol / padding (sing-mux protocol.go).
+
+use bytes::{BufMut, BytesMut};
+use std::io;
+
+pub const VERSION_0: u8 = 0;
+pub const VERSION_1: u8 = 1;
+
+/// Encoded mux request header written right after the proxy handshake.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Request {
+    pub version: u8,
+    pub protocol: u8,
+    pub padding: bool,
+}
+
+impl Request {
+    pub fn new(version: u8, protocol: u8, padding: bool) -> Self {
+        Self {
+            version,
+            protocol,
+            padding,
+        }
+    }
+
+    /// Serialise the header.  When `padding` is set the payload includes
+    /// random padding (length 256 + rand(512), matching sing-mux).
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = BytesMut::with_capacity(3 + 2 + 768);
+        out.put_u8(self.version);
+        out.put_u8(self.protocol);
+        if self.version == VERSION_1 {
+            out.put_u8(u8::from(self.padding));
+            if self.padding {
+                let len: u16 = 256 + (rand::random::<u16>() % 512);
+                out.put_u16(len);
+                let mut pad = vec![0u8; len as usize];
+                for b in &mut pad {
+                    *b = rand::random();
+                }
+                out.put_slice(&pad);
+            }
+        }
+        out.to_vec()
+    }
+
+    /// Parse a request header from the stream prefix.  Returns the parsed
+    /// header and the number of bytes consumed (including padding).
+    pub fn decode(buf: &[u8]) -> io::Result<(Self, usize)> {
+        if buf.len() < 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "mux request too short",
+            ));
+        }
+        let version = buf[0];
+        let protocol = buf[1];
+        let mut consumed = 2;
+        if !(VERSION_0..=VERSION_1).contains(&version) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported mux version: {version}"),
+            ));
+        }
+        // Protocols are smux=0 / yamux=1 / h2mux=2 (sing-mux Protocol* iota).
+        if protocol > 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown mux protocol: {protocol}"),
+            ));
+        }
+        let mut padding = false;
+        if version == VERSION_1 {
+            if buf.len() < consumed + 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "mux padding flag missing",
+                ));
+            }
+            padding = buf[consumed] != 0;
+            consumed += 1;
+            if padding {
+                if buf.len() < consumed + 2 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "mux padding length missing",
+                    ));
+                }
+                let len = u16::from_be_bytes([buf[consumed], buf[consumed + 1]]) as usize;
+                consumed += 2;
+                if buf.len() < consumed + len {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "mux padding truncated",
+                    ));
+                }
+                consumed += len;
+            }
+        }
+        Ok((
+            Request {
+                version,
+                protocol,
+                padding,
+            },
+            consumed,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v0_header_round_trips() {
+        let req = Request::new(VERSION_0, 0, false);
+        let bytes = req.encode();
+        assert_eq!(bytes.len(), 2);
+        let (decoded, consumed) = Request::decode(&bytes).unwrap();
+        assert_eq!(decoded, req);
+        assert_eq!(consumed, 2);
+    }
+
+    #[test]
+    fn v1_no_padding_round_trips() {
+        let req = Request::new(VERSION_1, 1, false);
+        let bytes = req.encode();
+        assert_eq!(bytes.len(), 3);
+        let (decoded, consumed) = Request::decode(&bytes).unwrap();
+        assert_eq!(decoded, req);
+        assert_eq!(consumed, 3);
+    }
+
+    #[test]
+    fn v1_padding_skips_padding_bytes() {
+        let req = Request::new(VERSION_1, 2, true);
+        let bytes = req.encode();
+        assert!(bytes.len() > 3 + 256);
+        let (decoded, consumed) = Request::decode(&bytes).unwrap();
+        assert_eq!(decoded, req);
+        assert_eq!(consumed, bytes.len());
+    }
+
+    #[test]
+    fn rejects_bad_version() {
+        let bytes = [9u8, 0];
+        assert!(Request::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_protocol() {
+        let bytes = [0u8, 7];
+        assert!(Request::decode(&bytes).is_err());
+    }
+}

--- a/crates/meow-proxy/src/mux/smux.rs
+++ b/crates/meow-proxy/src/mux/smux.rs
@@ -1,0 +1,1309 @@
+//! smux protocol (sagernet/smux fork wire format — protocol version 1),
+//! client side.
+//!
+//! This is NOT the upstream xtaci layout: sing-mux/sing-box use the
+//! sagernet fork whose frames are: ver=1, cmd, len u16 LE, stream_id u32 LE, data
+//! (8-byte header, little-endian) and whose version 1 has no window-update
+//! (UPD) flow control — a v1 write just splits into MaxFrameSize frames.
+//! Commands: SYN=0, FIN=1, PSH=2, NOP=3; client stream IDs are odd
+//! (1, 3, 5, ...).  Matches sing-mux's smux usage (DefaultConfig +
+//! KeepAliveDisabled): Version=1, MaxFrameSize=32768, MaxStreamBuffer=64 KiB,
+//! MaxReceiveBuffer=4 MiB.
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use std::collections::HashMap;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::sync::{mpsc, oneshot, Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::{CancellationToken, PollSender};
+
+const CMD_SYN: u8 = 0;
+const CMD_FIN: u8 = 1;
+const CMD_PSH: u8 = 2;
+const CMD_NOP: u8 = 3;
+const SMUX_VERSION: u8 = 1;
+const FRAME_HEADER_LEN: usize = 8;
+
+/// Largest frame payload — sagernet smux MaxFrameSize default (u16 length).
+const MAX_FRAME_SIZE: usize = 32768;
+/// Per-stream channel depth.  The 4 MiB `receive_budget` semaphore bounds
+/// memory; the channel depth only controls how many frames buffer before a
+/// stalled consumer pauses the reader.  A depth of 2 (two max-sized frames)
+/// head-of-line blocks the entire session too easily — one slow tab stalls
+/// every other stream sharing the physical connection.  32 gives real
+/// headroom; the semaphore still caps total buffered memory.
+///
+/// The target architecture is muxcool's `deliver_now` / `Parked` pattern
+/// (PR 6 of this stack): a full queue parks the delivery and pauses the
+/// connection read (session-wide flow control) without blocking writers.
+/// Porting that to smux is a follow-up; this depth raise is the safe
+/// interim fix.
+const STREAM_QUEUE: usize = 32;
+/// Sagernet's default session-wide receive budget.
+const MAX_RECEIVE_BUFFER: usize = 4 * 1024 * 1024;
+/// Bounded outbound queue; stream writes wait when the physical writer lags.
+const OUTBOUND_QUEUE: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Frame {
+    cmd: u8,
+    stream_id: u32,
+    data: Bytes,
+}
+
+impl Frame {
+    #[cfg(test)]
+    fn encode(&self) -> Bytes {
+        encode_frame(self.cmd, self.stream_id, &self.data)
+    }
+
+    fn decode_header(buf: &[u8]) -> io::Result<(u8, usize, u32)> {
+        if buf.len() < FRAME_HEADER_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "smux frame header too short",
+            ));
+        }
+        if buf[0] != SMUX_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported smux version: {}", buf[0]),
+            ));
+        }
+        let cmd = buf[1];
+        let length = u16::from_le_bytes([buf[2], buf[3]]) as usize;
+        let stream_id = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        Ok((cmd, length, stream_id))
+    }
+}
+
+fn encode_frame(cmd: u8, stream_id: u32, data: &[u8]) -> Bytes {
+    // The u16 length field caps single frames; poll_write limits writes to
+    // MAX_FRAME_SIZE, so this only guards future call sites.
+    debug_assert!(
+        data.len() <= u16::MAX as usize,
+        "smux frame payload exceeds u16 length"
+    );
+    let mut out = BytesMut::with_capacity(FRAME_HEADER_LEN + data.len());
+    out.put_u8(SMUX_VERSION);
+    out.put_u8(cmd);
+    out.put_u16_le(data.len() as u16);
+    out.put_u32_le(stream_id);
+    out.put_slice(data);
+    out.freeze()
+}
+
+struct InboundChunk {
+    data: Bytes,
+    /// Releases session receive capacity when the stream consumes or drops
+    /// this chunk.
+    _permit: Option<OwnedSemaphorePermit>,
+}
+
+/// One outbound writer request.  Flush requests travel the SAME bounded
+/// channel as data frames so a flush can never overtake frames the
+/// requesting stream queued earlier (FIFO guarantee).  `Clone` keeps
+/// `PollSender<OutMsg>` usable (its item type must be `Clone`).
+#[derive(Clone)]
+enum OutMsg {
+    Frame(Bytes),
+    /// Acknowledge after the physical transport's buffered data reached
+    /// the wire.  `Arc` keeps the item `Clone` for `PollSender`.
+    Flush(Arc<oneshot::Sender<()>>),
+}
+
+struct SessionState {
+    /// Streams keyed by stream ID; dropping the sender EOFs the stream.
+    streams: Mutex<HashMap<u32, mpsc::Sender<InboundChunk>>>,
+    dead: AtomicBool,
+}
+
+/// smux session over one physical connection (client role).
+pub struct Session {
+    state: Arc<SessionState>,
+    writer_tx: mpsc::Sender<OutMsg>,
+    cancel: CancellationToken,
+    next_stream_id: AtomicU32,
+}
+
+impl Session {
+    /// True once the session is dead (reader/writer task ended or the
+    /// physical connection failed).
+    pub fn is_dead(&self) -> bool {
+        self.state.dead.load(Ordering::SeqCst)
+    }
+
+    /// Start an smux client session over the IO.  A reader task owns the
+    /// read half; a writer task serialises outbound frames.
+    pub fn client<S>(io: S) -> io::Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let (mut reader, mut writer) = tokio::io::split(io);
+        let (writer_tx, mut writer_rx) = mpsc::channel::<OutMsg>(OUTBOUND_QUEUE);
+        let state = Arc::new(SessionState {
+            streams: Mutex::new(HashMap::new()),
+            dead: AtomicBool::new(false),
+        });
+        let receive_budget = Arc::new(Semaphore::new(MAX_RECEIVE_BUFFER));
+        let cancel = CancellationToken::new();
+
+        // Writer task: outbound frames are already encoded, so the hot path
+        // performs no second allocation or payload copy.
+        let writer_state = Arc::clone(&state);
+        let writer_cancel = cancel.clone();
+        tokio::spawn(async move {
+            loop {
+                let msg = tokio::select! {
+                    _ = writer_cancel.cancelled() => break,
+                    msg = writer_rx.recv() => match msg {
+                        Some(msg) => msg,
+                        None => break,
+                    },
+                };
+                match msg {
+                    OutMsg::Frame(frame) => {
+                        let result = tokio::select! {
+                            _ = writer_cancel.cancelled() => break,
+                            result = writer.write_all(&frame) => result,
+                        };
+                        if result.is_err() {
+                            break;
+                        }
+                    }
+                    OutMsg::Flush(ack) => {
+                        // FIFO: every frame queued before this request
+                        // was received first (same channel) and is
+                        // already written — flush the transport now.
+                        // Cancellation must break out even of a stalled
+                        // flush, otherwise a dropped session could keep
+                        // the writer task (and the socket) alive.
+                        let result = tokio::select! {
+                            _ = writer_cancel.cancelled() => break,
+                            result = writer.flush() => result,
+                        };
+                        if result.is_err() {
+                            break;
+                        }
+                        // The channel delivered the sole Arc reference;
+                        // unwrap and ack.  A stray clone would still
+                        // resolve the receiver (with an error) when
+                        // this one drops, never hanging the stream.
+                        let _ = Arc::try_unwrap(ack).map(|sender| sender.send(()));
+                    }
+                }
+            }
+            writer_state.mark_dead().await;
+            writer_cancel.cancel();
+        });
+
+        // Reader task: parse frames, route PSH/FIN to streams.
+        let reader_state = Arc::clone(&state);
+        let reader_cancel = cancel.clone();
+        tokio::spawn(async move {
+            let mut header = [0u8; FRAME_HEADER_LEN];
+            loop {
+                let header_result = tokio::select! {
+                    _ = reader_cancel.cancelled() => break,
+                    result = reader.read_exact(&mut header) => result,
+                };
+                if header_result.is_err() {
+                    break;
+                }
+                let Ok((cmd, length, stream_id)) = Frame::decode_header(&header) else {
+                    break;
+                };
+                let permit = if cmd == CMD_PSH && length > 0 {
+                    let permits = length as u32;
+                    match tokio::select! {
+                        _ = reader_cancel.cancelled() => break,
+                        result = Arc::clone(&receive_budget).acquire_many_owned(permits) => result,
+                    } {
+                        Ok(permit) => Some(permit),
+                        Err(_) => break,
+                    }
+                } else {
+                    None
+                };
+                let mut payload = vec![0u8; length];
+                if !payload.is_empty() {
+                    let payload_result = tokio::select! {
+                        _ = reader_cancel.cancelled() => break,
+                        result = reader.read_exact(&mut payload) => result,
+                    };
+                    if payload_result.is_err() {
+                        break;
+                    }
+                }
+                if reader_state
+                    .handle_frame(
+                        cmd,
+                        stream_id,
+                        InboundChunk {
+                            data: Bytes::from(payload),
+                            _permit: permit,
+                        },
+                        &reader_cancel,
+                    )
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            reader_state.mark_dead().await;
+            reader_cancel.cancel();
+        });
+
+        Ok(Self {
+            state,
+            writer_tx,
+            cancel,
+            next_stream_id: AtomicU32::new(1),
+        })
+    }
+
+    /// Open a new stream.  Client IDs count up by 2 from 1.
+    pub async fn open_stream(self: &Arc<Self>) -> io::Result<SmuxStream> {
+        if self.is_dead() {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "smux session is closed",
+            ));
+        }
+        let id = self.next_stream_id.fetch_add(2, Ordering::Relaxed);
+        let (tx, rx) = mpsc::channel(STREAM_QUEUE);
+        self.state.streams.lock().await.insert(id, tx);
+        // The guard removes the map entry if this future is cancelled
+        // while waiting for outbound capacity — otherwise the id stays
+        // consumed and the entry lingers until a server FIN.
+        let mut guard = MapEntryGuard {
+            state: Arc::clone(&self.state),
+            id,
+            armed: true,
+        };
+        if self
+            .writer_tx
+            .send(OutMsg::Frame(encode_frame(CMD_SYN, id, &[])))
+            .await
+            .is_err()
+        {
+            drop(guard);
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "smux writer gone",
+            ));
+        }
+        guard.disarm();
+        Ok(SmuxStream {
+            id,
+            session: Arc::clone(self),
+            poll_sender: PollSender::new(self.writer_tx.clone()),
+            rx,
+            pending: None,
+            eof: false,
+            fin_sent: false,
+            shutdown_frame: None,
+            flush_rx: None,
+            write_since_flush: false,
+        })
+    }
+}
+
+/// Removes a stream-map entry when dropped while armed — the
+/// cancellation-safe counterpart of `open_stream`'s insert-then-send.
+struct MapEntryGuard {
+    state: Arc<SessionState>,
+    id: u32,
+    armed: bool,
+}
+
+impl MapEntryGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for MapEntryGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let state = Arc::clone(&self.state);
+            let id = self.id;
+            // Detached: drop cannot await the map lock.
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    state.streams.lock().await.remove(&id);
+                });
+            }
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.state.dead.store(true, Ordering::SeqCst);
+        self.cancel.cancel();
+    }
+}
+
+impl SessionState {
+    async fn mark_dead(&self) {
+        if !self.dead.swap(true, Ordering::SeqCst) {
+            // Close every stream.  The read side distinguishes this physical
+            // failure from a peer FIN by consulting `Session::is_dead`.
+            self.streams.lock().await.clear();
+        }
+    }
+
+    async fn handle_frame(
+        &self,
+        cmd: u8,
+        stream_id: u32,
+        chunk: InboundChunk,
+        cancel: &CancellationToken,
+    ) -> io::Result<()> {
+        match cmd {
+            CMD_PSH => {
+                // Data for an unknown stream is dropped rather than killing
+                // the session — an intentional divergence from xtaci (which
+                // closes the connection on protocol violation): the server
+                // may legitimately race a FIN (peer closed, stream removed)
+                // against in-flight PSH frames.
+                let tx = self.streams.lock().await.get(&stream_id).cloned();
+                if let Some(tx) = tx {
+                    tokio::select! {
+                        _ = cancel.cancelled() => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::Interrupted,
+                                "smux session closed",
+                            ));
+                        }
+                        result = tx.send(chunk) => {
+                            let _ = result;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            CMD_FIN => {
+                // Peer half-closed: EOF the read side by dropping the sender.
+                self.streams.lock().await.remove(&stream_id);
+                Ok(())
+            }
+            CMD_NOP => Ok(()),
+            // v1 has no UPD; a server-initiated SYN is unexpected in
+            // client-only usage and unsupported commands are protocol errors.
+            CMD_SYN => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "smux: unexpected SYN from server (client-only usage)",
+            )),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("smux: unknown command {other}"),
+            )),
+        }
+    }
+}
+
+/// One multiplexed stream (AsyncRead + AsyncWrite).
+pub struct SmuxStream {
+    id: u32,
+    session: Arc<Session>,
+    poll_sender: PollSender<OutMsg>,
+    rx: mpsc::Receiver<InboundChunk>,
+    /// Unread remainder of the last chunk handed to poll_read.
+    pending: Option<InboundChunk>,
+    eof: bool,
+    fin_sent: bool,
+    shutdown_frame: Option<Bytes>,
+    /// Pending flush acknowledgement; see `poll_flush`.
+    flush_rx: Option<oneshot::Receiver<()>>,
+    /// Set when a data frame is queued after the current flush request was
+    /// sent: the flush ack then no longer covers every write, so
+    /// `poll_flush` must send another request once the pending one lands.
+    write_since_flush: bool,
+}
+
+impl SmuxStream {
+    fn best_effort_fin(&mut self) {
+        if self.fin_sent {
+            return;
+        }
+        let frame = encode_frame(CMD_FIN, self.id, &[]);
+        match self
+            .session
+            .writer_tx
+            .try_send(OutMsg::Frame(frame.clone()))
+        {
+            Ok(()) => self.fin_sent = true,
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                // The outbound channel is full: queue the FIN
+                // asynchronously instead of dropping it.  Mark fin_sent
+                // now so a later poll_shutdown/drop does not double-send.
+                self.fin_sent = true;
+                let sender = self.session.writer_tx.clone();
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    handle.spawn(async move {
+                        let _ = sender.send(OutMsg::Frame(frame)).await;
+                    });
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                // Session is gone; the connection is closing anyway.
+                self.fin_sent = true;
+            }
+        }
+    }
+}
+
+impl Drop for SmuxStream {
+    fn drop(&mut self) {
+        self.best_effort_fin();
+        // Remove the stream-map entry explicitly.  smux servers (notably
+        // sing-box) may not echo a FIN for a stream the client abandoned,
+        // so waiting for CMD_FIN would leak the entry for the session's
+        // lifetime.  The detached spawn mirrors MapEntryGuard's pattern:
+        // cleanup must not wait on outbound channel capacity.
+        let state = Arc::clone(&self.session.state);
+        let id = self.id;
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                state.streams.lock().await.remove(&id);
+            });
+        }
+    }
+}
+
+impl AsyncRead for SmuxStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        // Every progress path returns Ready immediately: returning Pending
+        // after writing into the caller's ReadBuf would lose those bytes
+        // (the buffer is recreated on the next poll), violating the
+        // AsyncRead contract.  A zero-capacity buffer yields Ready(Ok(()))
+        // per the tokio AsyncRead docs (a Pending here would leave
+        // `read(&mut [])` parked forever).
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        if let Some(mut chunk) = this.pending.take() {
+            let n = chunk.data.len().min(buf.remaining());
+            buf.put_slice(&chunk.data[..n]);
+            chunk.data.advance(n);
+            if !chunk.data.is_empty() {
+                this.pending = Some(chunk);
+            }
+            Poll::Ready(Ok(()))
+        } else if this.eof {
+            Poll::Ready(Ok(()))
+        } else {
+            loop {
+                match this.rx.poll_recv(cx) {
+                    Poll::Ready(Some(mut chunk)) => {
+                        if chunk.data.is_empty() {
+                            // Zero-length PSH frames carry no payload (flush /
+                            // ack signals from the peer); returning Ready with
+                            // an empty ReadBuf would read as EOF to consumers.
+                            continue;
+                        }
+                        let n = chunk.data.len().min(buf.remaining());
+                        buf.put_slice(&chunk.data[..n]);
+                        chunk.data.advance(n);
+                        if !chunk.data.is_empty() {
+                            this.pending = Some(chunk);
+                        }
+                        return Poll::Ready(Ok(()));
+                    }
+                    Poll::Ready(None) => {
+                        this.eof = true;
+                        if this.session.is_dead() {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::BrokenPipe,
+                                "smux session closed",
+                            )));
+                        }
+                        return Poll::Ready(Ok(()));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+        }
+    }
+}
+
+impl AsyncWrite for SmuxStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let this = self.get_mut();
+        if this.session.is_dead() {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "smux session closed",
+            )));
+        }
+        let written = buf.len().min(MAX_FRAME_SIZE);
+        match this.poll_sender.poll_reserve(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(error)) => Poll::Ready(Err(io::Error::other(error.to_string()))),
+            Poll::Ready(Ok(())) => {
+                let frame = encode_frame(CMD_PSH, this.id, &buf[..written]);
+                this.poll_sender
+                    .send_item(OutMsg::Frame(frame))
+                    .map_err(|error| io::Error::other(error.to_string()))?;
+                this.write_since_flush = true;
+                Poll::Ready(Ok(written))
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        // A flush request travels the writer channel behind every frame
+        // this stream queued earlier, so the acknowledgement means those
+        // bytes reached the physical transport (matters for buffered
+        // outer transports like WebSocket).
+        if let Some(rx) = &mut this.flush_rx {
+            match Pin::new(rx).poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(_)) => {
+                    this.flush_rx = None;
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "smux writer gone",
+                    )));
+                }
+                Poll::Ready(Ok(())) => {
+                    this.flush_rx = None;
+                    if !this.write_since_flush {
+                        return Poll::Ready(Ok(()));
+                    }
+                    // Data was queued after the flush request went out:
+                    // fall through and send another flush so the ack
+                    // covers those writes too.
+                }
+            }
+        }
+        match this.poll_sender.poll_reserve(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(error)) => Poll::Ready(Err(io::Error::other(error.to_string()))),
+            Poll::Ready(Ok(())) => {
+                let (tx, rx) = oneshot::channel();
+                this.poll_sender
+                    .send_item(OutMsg::Flush(Arc::new(tx)))
+                    .map_err(|error| io::Error::other(error.to_string()))?;
+                // Every write queued before this request is now covered.
+                this.write_since_flush = false;
+                // Poll the fresh receiver once to register the waker
+                // before parking.
+                let mut rx = rx;
+                match Pin::new(&mut rx).poll(cx) {
+                    Poll::Pending => {
+                        this.flush_rx = Some(rx);
+                        Poll::Pending
+                    }
+                    Poll::Ready(Err(_)) => Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "smux writer gone",
+                    ))),
+                    Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                }
+            }
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if this.fin_sent {
+            return Poll::Ready(Ok(()));
+        }
+        let frame = this
+            .shutdown_frame
+            .take()
+            .unwrap_or_else(|| encode_frame(CMD_FIN, this.id, &[]));
+        match this.poll_sender.poll_reserve(cx) {
+            Poll::Pending => {
+                this.shutdown_frame = Some(frame);
+                Poll::Pending
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(io::Error::other(error.to_string()))),
+            Poll::Ready(Ok(())) => {
+                this.poll_sender
+                    .send_item(OutMsg::Frame(frame))
+                    .map_err(|error| io::Error::other(error.to_string()))?;
+                this.fin_sent = true;
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn frame_wire_layout_matches_sagernet_smux() {
+        // SYN on stream 1: [ver=1][cmd=SYN][len=0 u16 LE][sid=1 u32 LE].
+        let frame = Frame {
+            cmd: CMD_SYN,
+            stream_id: 1,
+            data: Bytes::new(),
+        };
+        let buf = frame.encode();
+        assert_eq!(&buf[..], &[0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]);
+
+        // PSH with 3 bytes on stream 3.
+        let frame = Frame {
+            cmd: CMD_PSH,
+            stream_id: 3,
+            data: Bytes::from_static(b"abc"),
+        };
+        let buf = frame.encode();
+        assert_eq!(
+            &buf[..],
+            &[0x01, 0x02, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00, b'a', b'b', b'c']
+        );
+
+        let (cmd, length, sid) = Frame::decode_header(&buf[..FRAME_HEADER_LEN]).unwrap();
+        assert_eq!(cmd, CMD_PSH);
+        assert_eq!(length, 3);
+        assert_eq!(sid, 3);
+    }
+
+    /// Minimal smux server over a duplex pipe (same sagernet v1 codec):
+    /// echoes PSH payloads back on the same stream and answers FIN with FIN.
+    async fn run_echo_server<S>(mut io: S) -> tokio::task::JoinHandle<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        tokio::spawn(async move {
+            let mut header = [0u8; FRAME_HEADER_LEN];
+            loop {
+                if io.read_exact(&mut header).await.is_err() {
+                    return;
+                }
+                let Ok((cmd, length, stream_id)) = Frame::decode_header(&header) else {
+                    return;
+                };
+                let mut payload = vec![0u8; length];
+                if !payload.is_empty() && io.read_exact(&mut payload).await.is_err() {
+                    return;
+                }
+                match cmd {
+                    CMD_PSH => {
+                        let echoed = payload.clone();
+                        let mut buf = BytesMut::with_capacity(FRAME_HEADER_LEN + echoed.len());
+                        buf.put_u8(SMUX_VERSION);
+                        buf.put_u8(CMD_PSH);
+                        buf.put_u16_le(echoed.len() as u16);
+                        buf.put_u32_le(stream_id);
+                        buf.put_slice(&echoed);
+                        if io.write_all(&buf).await.is_err() {
+                            return;
+                        }
+                    }
+                    CMD_FIN => {
+                        let mut buf = BytesMut::with_capacity(FRAME_HEADER_LEN);
+                        buf.put_u8(SMUX_VERSION);
+                        buf.put_u8(CMD_FIN);
+                        buf.put_u16_le(0);
+                        buf.put_u32_le(stream_id);
+                        if io.write_all(&buf).await.is_err() {
+                            return;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn open_stream_echo_round_trip() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        stream.write_all(b"hello smux").await.unwrap();
+        let mut resp = [0u8; 10];
+        stream.read_exact(&mut resp).await.unwrap();
+        assert_eq!(&resp, b"hello smux");
+    }
+
+    #[tokio::test]
+    async fn two_streams_multiplex_independently() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).unwrap());
+
+        let mut a = session.open_stream().await.unwrap();
+        let mut b = session.open_stream().await.unwrap();
+
+        a.write_all(b"AAA").await.unwrap();
+        b.write_all(b"BBB").await.unwrap();
+        let mut buf = [0u8; 3];
+        a.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"AAA");
+        b.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"BBB");
+    }
+
+    #[tokio::test]
+    async fn large_write_splits_into_max_frame_chunks() {
+        let (client_io, server_io) = tokio::io::duplex(1 << 20);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        // 2.5 × MaxFrameSize — must arrive as 3 PSH frames and echo back
+        // byte-identical.
+        let payload = vec![0x5au8; MAX_FRAME_SIZE * 2 + MAX_FRAME_SIZE / 2];
+        stream.write_all(&payload).await.unwrap();
+        let mut resp = vec![0u8; payload.len()];
+        stream.read_exact(&mut resp).await.unwrap();
+        assert_eq!(resp, payload);
+    }
+
+    /// A zero-length PSH frame carries no payload (flush / ack signal):
+    /// it must be skipped, not delivered as an empty read, which consumers
+    /// (the tunnel relay) treat as EOF.
+    #[tokio::test]
+    async fn zero_length_psh_frame_does_not_read_as_eof() {
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+        let server = tokio::spawn(async move {
+            let mut hdr = [0u8; FRAME_HEADER_LEN];
+            server_io.read_exact(&mut hdr).await.unwrap(); // client SYN
+            let stream_id = u32::from_le_bytes([hdr[4], hdr[5], hdr[6], hdr[7]]);
+            server_io
+                .write_all(&encode_frame(CMD_PSH, stream_id, &[]))
+                .await
+                .unwrap();
+            server_io
+                .write_all(&encode_frame(CMD_PSH, stream_id, b"ok"))
+                .await
+                .unwrap();
+        });
+        stream.write_all(b"x").await.unwrap();
+        let mut buf = [0u8; 4];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), stream.read(&mut buf))
+            .await
+            .expect("read must not hang")
+            .expect("zero-length PSH must not read as EOF");
+        assert_eq!(n, 2);
+        assert_eq!(&buf[..2], b"ok");
+        drop(stream);
+        drop(session);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn half_close_sends_fin_and_eofs_peer() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        stream.write_all(b"ping").await.unwrap();
+        stream.shutdown().await.unwrap();
+        let mut resp = Vec::new();
+        stream.read_to_end(&mut resp).await.unwrap();
+        assert_eq!(&resp[..], b"ping");
+    }
+
+    #[tokio::test]
+    async fn physical_eof_is_reported_as_an_error() {
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+        let server = tokio::spawn(async move {
+            let mut syn = [0u8; FRAME_HEADER_LEN];
+            server_io.read_exact(&mut syn).await.unwrap();
+        });
+        server.await.unwrap();
+
+        let mut buf = [0u8; 1];
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.read(&mut buf))
+            .await
+            .expect("physical EOF must wake the stream")
+            .expect_err("physical EOF must not look like a clean FIN");
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    #[tokio::test]
+    async fn poll_flush_round_trips_through_writer() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            let mut io = server_io;
+            let mut buf = [0u8; 64];
+            let _ = io.read(&mut buf).await;
+        });
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+        stream.write_all(b"abc").await.unwrap();
+        // The flush request travels the writer channel behind the data
+        // frames and is acknowledged only after the transport flushed.
+        tokio::time::timeout(std::time::Duration::from_secs(1), stream.flush())
+            .await
+            .expect("flush must complete")
+            .unwrap();
+        drop(stream);
+        drop(session);
+        server.await.unwrap();
+    }
+
+    /// IO with independent write and flush gates: the writer can be
+    /// parked inside `poll_flush` while later writes are queued, which is
+    /// the exact interleaving that exposes a flush-contract bug.
+    struct FlushGatedIo {
+        inner: tokio::io::DuplexStream,
+        write_open: Arc<AtomicBool>,
+        flush_open: Arc<AtomicBool>,
+        write_waker: Arc<std::sync::Mutex<Option<std::task::Waker>>>,
+        flush_waker: Arc<std::sync::Mutex<Option<std::task::Waker>>>,
+        write_polled: Arc<AtomicBool>,
+        flush_polled: Arc<AtomicBool>,
+    }
+
+    impl AsyncRead for FlushGatedIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for FlushGatedIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let this = self.get_mut();
+            if this.write_open.load(Ordering::SeqCst) {
+                return Pin::new(&mut this.inner).poll_write(cx, buf);
+            }
+            this.write_polled.store(true, Ordering::SeqCst);
+            *this.write_waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            let this = self.get_mut();
+            if this.flush_open.load(Ordering::SeqCst) {
+                return Pin::new(&mut this.inner).poll_flush(cx);
+            }
+            this.flush_polled.store(true, Ordering::SeqCst);
+            *this.flush_waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+        }
+    }
+
+    /// Regression: a second flush issued while a first flush is still
+    /// pending must cover data written after the first flush request.
+    /// Current code returns the first flush's ack and silently leaves the
+    /// later data unflushed.
+    #[tokio::test]
+    async fn second_flush_must_cover_data_written_while_first_flush_pending() {
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let write_open = Arc::new(AtomicBool::new(true));
+        let flush_open = Arc::new(AtomicBool::new(false));
+        let write_waker = Arc::new(std::sync::Mutex::new(None));
+        let flush_waker = Arc::new(std::sync::Mutex::new(None));
+        let write_polled = Arc::new(AtomicBool::new(false));
+        let flush_polled = Arc::new(AtomicBool::new(false));
+        let session = Arc::new(
+            Session::client(FlushGatedIo {
+                inner: client_io,
+                write_open: Arc::clone(&write_open),
+                flush_open: Arc::clone(&flush_open),
+                write_waker: Arc::clone(&write_waker),
+                flush_waker: Arc::clone(&flush_waker),
+                write_polled: Arc::clone(&write_polled),
+                flush_polled: Arc::clone(&flush_polled),
+            })
+            .unwrap(),
+        );
+        let mut stream = session.open_stream().await.unwrap();
+
+        // D1 is written and the first flush request is queued behind it.
+        stream.write_all(b"abc").await.unwrap();
+        let waker = futures::task::noop_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+        let first_poll = Pin::new(&mut stream).poll_flush(&mut cx);
+        assert!(first_poll.is_pending(), "first flush must be pending");
+
+        // Wait until the writer is parked inside the transport flush.
+        for _ in 0..100 {
+            if flush_polled.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            flush_polled.load(Ordering::SeqCst),
+            "writer must be parked in poll_flush"
+        );
+
+        // D2 is queued AFTER the first flush request.
+        stream.write_all(b"def").await.unwrap();
+
+        // Before releasing the first flush, close the write gate so the
+        // writer will block when it later tries to write D2.
+        write_open.store(false, Ordering::SeqCst);
+
+        // Release the first flush.
+        flush_open.store(true, Ordering::SeqCst);
+        if let Some(w) = flush_waker.lock().unwrap().take() {
+            w.wake();
+        }
+
+        // The second flush must NOT complete while D2 is still unflushed:
+        // the first flush's ack only covers D1.
+        let waker = futures::task::noop_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+        let second_poll = Pin::new(&mut stream).poll_flush(&mut cx);
+        assert!(
+            second_poll.is_pending(),
+            "second flush must stay pending until D2 is flushed"
+        );
+
+        // Release the write gate: the writer drains D2, and only then may
+        // the second flush complete.
+        write_open.store(true, Ordering::SeqCst);
+        if let Some(w) = write_waker.lock().unwrap().take() {
+            w.wake();
+        }
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            std::future::poll_fn(|cx| Pin::new(&mut stream).poll_flush(cx)),
+        )
+        .await
+        .expect("second flush must not hang")
+        .expect("second flush must succeed");
+
+        // The transport must have received both D1 and D2.
+        let mut hdr = [0u8; FRAME_HEADER_LEN];
+        server_io.read_exact(&mut hdr).await.unwrap();
+        let (cmd, length, _sid) = Frame::decode_header(&hdr).unwrap();
+        assert_eq!(cmd, CMD_SYN, "first frame must be the stream SYN");
+        assert_eq!(length, 0);
+        server_io.read_exact(&mut hdr).await.unwrap();
+        let (cmd, length, _sid) = Frame::decode_header(&hdr).unwrap();
+        assert_eq!(cmd, CMD_PSH, "second frame must be D1");
+        let mut payload = vec![0u8; length];
+        server_io.read_exact(&mut payload).await.unwrap();
+        assert_eq!(&payload, b"abc");
+        server_io.read_exact(&mut hdr).await.unwrap();
+        let (cmd, length, _sid) = Frame::decode_header(&hdr).unwrap();
+        assert_eq!(cmd, CMD_PSH, "third frame must be D2");
+        let mut payload = vec![0u8; length];
+        server_io.read_exact(&mut payload).await.unwrap();
+        assert_eq!(&payload, b"def");
+
+        // Cleanup: release the write gate and drain.
+        write_open.store(true, Ordering::SeqCst);
+        if let Some(w) = write_waker.lock().unwrap().take() {
+            w.wake();
+        }
+        drop(stream);
+        drop(session);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let mut buf = [0u8; 64];
+            loop {
+                match server_io.read(&mut buf).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+            }
+        })
+        .await;
+    }
+
+    /// IO whose write half stays Pending until the test releases it —
+    /// parks the session writer deterministically so the bounded
+    /// outbound channel can be filled (a plain small duplex cannot: the
+    /// writer drains it too fast, and duplex(0) reads EOF instantly).
+    /// `polled` records that the write half parked, so tests can top
+    /// the channel up AFTER the writer stopped consuming; the stored
+    /// waker lets the test wake the parked write on release.
+    struct GatedIo {
+        inner: tokio::io::DuplexStream,
+        open: Arc<AtomicBool>,
+        waker: Arc<std::sync::Mutex<Option<std::task::Waker>>>,
+        polled: Arc<AtomicBool>,
+    }
+
+    impl AsyncRead for GatedIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for GatedIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let this = self.get_mut();
+            if this.open.load(Ordering::SeqCst) {
+                return Pin::new(&mut this.inner).poll_write(cx, buf);
+            }
+            this.polled.store(true, Ordering::SeqCst);
+            *this.waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+        }
+    }
+
+    /// Regression: an open cancelled while the outbound channel is full
+    /// must not leave its stream-map entry behind.
+    #[tokio::test]
+    async fn cancelled_open_removes_stream_map_entry() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let open = Arc::new(AtomicBool::new(false));
+        let waker = Arc::new(std::sync::Mutex::new(None));
+        let polled = Arc::new(AtomicBool::new(false));
+        let session = Arc::new(
+            Session::client(GatedIo {
+                inner: client_io,
+                open: Arc::clone(&open),
+                waker: Arc::clone(&waker),
+                polled: Arc::clone(&polled),
+            })
+            .unwrap(),
+        );
+        // Park the writer on a first frame (gate closed), then keep the
+        // queue topped up: the parked write consumed one slot that must
+        // be refilled for the SYN send to stay Pending.
+        let filler = OutMsg::Frame(encode_frame(CMD_PSH, 0xFFFF, &[1]));
+        session.writer_tx.try_send(filler.clone()).unwrap();
+        while session.writer_tx.capacity() > 0 {
+            session.writer_tx.try_send(filler.clone()).unwrap();
+        }
+        loop {
+            while session.writer_tx.capacity() > 0 {
+                session.writer_tx.try_send(filler.clone()).unwrap();
+            }
+            if polled.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let opened =
+            tokio::time::timeout(std::time::Duration::from_millis(50), session.open_stream()).await;
+        assert!(opened.is_err(), "open must wait for outbound capacity");
+        // The cancellation guard removes the entry asynchronously.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            session.state.streams.lock().await.is_empty(),
+            "the cancelled open must not leave its stream-map entry"
+        );
+        // Release the parked write and drain so the session can shut
+        // down cleanly.
+        open.store(true, Ordering::SeqCst);
+        if let Some(w) = waker.lock().unwrap().take() {
+            w.wake();
+        }
+        let drain = tokio::spawn(async move {
+            let mut io = server_io;
+            let mut buf = [0u8; 64];
+            loop {
+                match io.read(&mut buf).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+            }
+        });
+        drop(session);
+        drain.await.unwrap();
+    }
+
+    /// Regression: dropping a stream while the outbound channel is full
+    /// must not silently lose the FIN frame.  `best_effort_fin` uses
+    /// `try_send`; when the channel is full the FIN is dropped and the
+    /// server never learns the stream closed.
+    #[tokio::test]
+    async fn dropped_stream_under_backpressure_still_sends_fin() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let open = Arc::new(AtomicBool::new(false));
+        let waker = Arc::new(std::sync::Mutex::new(None));
+        let polled = Arc::new(AtomicBool::new(false));
+        let session = Arc::new(
+            Session::client(GatedIo {
+                inner: client_io,
+                open: Arc::clone(&open),
+                waker: Arc::clone(&waker),
+                polled: Arc::clone(&polled),
+            })
+            .unwrap(),
+        );
+        // Open a stream first: its SYN is queued and the writer parks on
+        // it (gate closed).
+        let stream = session.open_stream().await.unwrap();
+        let sid = stream.id;
+        // Keep the channel topped up so the FIN try_send must fail.
+        let filler = OutMsg::Frame(encode_frame(CMD_PSH, 0xFFFF, &[1]));
+        while session.writer_tx.capacity() > 0 {
+            session.writer_tx.try_send(filler.clone()).unwrap();
+        }
+        loop {
+            while session.writer_tx.capacity() > 0 {
+                session.writer_tx.try_send(filler.clone()).unwrap();
+            }
+            if polled.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        // Drop the stream while the channel is full: try_send(FIN) fails.
+        drop(stream);
+        // Release the writer and collect every frame the server sees.
+        open.store(true, Ordering::SeqCst);
+        if let Some(w) = waker.lock().unwrap().take() {
+            w.wake();
+        }
+        let mut seen_fin_for_sid = false;
+        let mut io = server_io;
+        let mut hdr = [0u8; FRAME_HEADER_LEN];
+        let mut payload = [0u8; 64];
+        let drain = async {
+            loop {
+                if io.read_exact(&mut hdr).await.is_err() {
+                    break;
+                }
+                let Ok((cmd, length, frame_sid)) = Frame::decode_header(&hdr) else {
+                    break;
+                };
+                if length > 0 && io.read_exact(&mut payload[..length]).await.is_err() {
+                    break;
+                }
+                if cmd == CMD_FIN && frame_sid == sid {
+                    seen_fin_for_sid = true;
+                }
+            }
+        };
+        // The writer drains the channel and then idles; EOF never comes
+        // while the session is alive, so bound the observation window.
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), drain).await;
+        assert!(
+            seen_fin_for_sid,
+            "server must receive FIN for the dropped stream even under backpressure"
+        );
+        drop(session);
+    }
+
+    #[tokio::test]
+    async fn outbound_queue_applies_backpressure() {
+        let (client_io, _server_io) = tokio::io::duplex(1);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+        let payload = vec![0x5a; MAX_FRAME_SIZE * (OUTBOUND_QUEUE + 2)];
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            stream.write_all(&payload),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "a blocked physical writer must backpressure streams"
+        );
+    }
+
+    struct DropTrackedIo {
+        inner: tokio::io::DuplexStream,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Drop for DropTrackedIo {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    impl AsyncRead for DropTrackedIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for DropTrackedIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+        }
+    }
+
+    #[tokio::test]
+    async fn dropping_idle_session_releases_physical_io() {
+        let (client_io, _server_io) = tokio::io::duplex(64 * 1024);
+        let dropped = Arc::new(AtomicBool::new(false));
+        let session = Session::client(DropTrackedIo {
+            inner: client_io,
+            dropped: Arc::clone(&dropped),
+        })
+        .unwrap();
+        drop(session);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !dropped.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropping an idle session must stop its tasks and release the fd");
+    }
+}

--- a/crates/meow-proxy/src/mux/stream.rs
+++ b/crates/meow-proxy/src/mux/stream.rs
@@ -1,0 +1,59 @@
+//! `MuxStreamConn`: ProxyConn wrapper around one smux stream.
+
+use super::client::{MuxSession, MuxStream};
+use meow_common::ProxyConn;
+use std::io;
+use std::pin::Pin;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// One multiplexed logical connection.  Dropping it sends FIN (best effort)
+/// and decrements the session's stream count.
+pub struct MuxStreamConn {
+    inner: MuxStream,
+    session: Arc<MuxSession>,
+}
+
+impl MuxStreamConn {
+    pub(crate) fn new(inner: MuxStream, session: Arc<MuxSession>) -> Self {
+        Self { inner, session }
+    }
+}
+
+impl Drop for MuxStreamConn {
+    fn drop(&mut self) {
+        self.session.streams.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+impl ProxyConn for MuxStreamConn {}
+
+impl AsyncRead for MuxStreamConn {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for MuxStreamConn {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}

--- a/crates/meow-proxy/src/mux/yamux.rs
+++ b/crates/meow-proxy/src/mux/yamux.rs
@@ -1,0 +1,256 @@
+//! yamux protocol (hashicorp/go-yamux wire format), client side, via the
+//! libp2p `yamux` crate which interoperates with hashicorp yamux on the
+//! wire.
+//!
+//! yamux 0.14 has no split Control: the `Connection` state machine must be
+//! polled continuously to drive reads (data/FIN delivery to streams) AND to
+//! open outbound streams.  One driver task owns the connection and polls a
+//! hand-rolled state machine each wake-up: drain queued open requests, serve
+//! one `poll_new_outbound`, drive one `poll_next_inbound`, then park (all
+//! wakers — request channel, stream-open ack, socket — stay registered).
+//! The crate speaks the `futures` IO traits; tokio-util compat bridges to
+//! tokio's AsyncRead/AsyncWrite.
+
+use std::collections::VecDeque;
+use std::io;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
+
+/// tokio io bridged to the futures IO traits the yamux crate consumes
+/// (\`TokioAsyncReadCompatExt::compat\`).
+type FutIo<S> = tokio_util::compat::Compat<S>;
+
+struct OpenRequest {
+    respond: oneshot::Sender<std::result::Result<yamux::Stream, yamux::ConnectionError>>,
+}
+
+/// yamux session over one physical connection (client role).  The
+/// concrete IO type is erased — only the driver task owns the connection.
+pub struct Session {
+    open_tx: mpsc::UnboundedSender<OpenRequest>,
+    dead: Arc<AtomicBool>,
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl Session {
+    pub fn client<S>(io: S) -> io::Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        // yamux 0.14 dropped the per-stream open/close timeout knobs;
+        // sing-mux sets both to 5 s — acceptable divergence.
+        let config = yamux::Config::default();
+        let io: FutIo<S> = io.compat();
+        let mut connection = yamux::Connection::new(io, config, yamux::Mode::Client);
+        let (open_tx, mut open_rx) = mpsc::unbounded_channel::<OpenRequest>();
+        let dead = Arc::new(AtomicBool::new(false));
+        let driver_dead = Arc::clone(&dead);
+        let task = tokio::spawn(async move {
+            // Queued open requests wait here in FIFO order; every request
+            // keeps its own oneshot so none can be dropped by a newer one.
+            let mut pending_opens: VecDeque<OpenRequest> = VecDeque::new();
+            std::future::poll_fn(|cx| {
+                loop {
+                    // Drain queued open requests.
+                    while let Poll::Ready(item) = open_rx.poll_recv(cx) {
+                        match item {
+                            Some(request) => pending_opens.push_back(request),
+                            // All callers gone: shut the driver down.
+                            None => return Poll::Ready(()),
+                        }
+                    }
+                    // Serve stream opens until the connection reports
+                    // Pending; looping here keeps the queue moving without
+                    // waiting for an external wake-up.
+                    if !pending_opens.is_empty() {
+                        match connection.poll_new_outbound(cx) {
+                            Poll::Ready(result) => {
+                                let request = pending_opens.pop_front().expect("checked non-empty");
+                                let _ = request.respond.send(result);
+                                continue;
+                            }
+                            Poll::Pending => {}
+                        }
+                    }
+                    // Drive inbound: data/FIN delivery plus connection teardown.
+                    match connection.poll_next_inbound(cx) {
+                        // Server-initiated streams are not expected in proxy
+                        // mux; drop them (reset) and keep driving.
+                        Poll::Ready(Some(Ok(stream))) => {
+                            tracing::debug!("yamux: server-initiated stream dropped (reset)");
+                            drop(stream);
+                            continue;
+                        }
+                        Poll::Ready(Some(Err(_))) | Poll::Ready(None) => return Poll::Ready(()),
+                        Poll::Pending => {}
+                    }
+                    return Poll::Pending;
+                }
+            })
+            .await;
+            driver_dead.store(true, Ordering::SeqCst);
+        });
+        Ok(Self {
+            open_tx,
+            dead,
+            _task: task,
+        })
+    }
+
+    pub async fn open_stream(&self) -> io::Result<Stream> {
+        let (respond, response) = oneshot::channel();
+        self.open_tx
+            .send(OpenRequest { respond })
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "yamux driver gone"))?;
+        let stream = response
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "yamux driver dropped request"))?
+            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, format!("yamux open: {e}")))?;
+        Ok(Stream::from(stream))
+    }
+
+    pub fn is_dead(&self) -> bool {
+        self.dead.load(Ordering::SeqCst)
+    }
+}
+
+/// One yamux stream, exposed with tokio IO traits.
+pub struct Stream {
+    inner: tokio_util::compat::Compat<yamux::Stream>,
+}
+
+impl From<yamux::Stream> for Stream {
+    fn from(stream: yamux::Stream) -> Self {
+        Self {
+            inner: stream.compat(),
+        }
+    }
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// yamux echo server over a duplex pipe (crate-native server mode).
+    async fn run_echo_server<S>(io: S) -> tokio::task::JoinHandle<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        tokio::spawn(async move {
+            let config = yamux::Config::default();
+            let io = io.compat();
+            let mut connection = yamux::Connection::new(io, config, yamux::Mode::Server);
+            loop {
+                match std::future::poll_fn(|cx| connection.poll_next_inbound(cx)).await {
+                    Some(Ok(stream)) => {
+                        tokio::spawn(async move {
+                            let mut stream = stream.compat();
+                            let mut buf = vec![0u8; 4096];
+                            loop {
+                                match stream.read(&mut buf).await {
+                                    Ok(0) | Err(_) => break,
+                                    Ok(n) => {
+                                        if stream.write_all(&buf[..n]).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    Some(Err(_)) | None => return,
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn open_stream_echo_round_trip() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        stream.write_all(b"hello yamux").await.unwrap();
+        let mut resp = [0u8; 11];
+        stream.read_exact(&mut resp).await.unwrap();
+        assert_eq!(&resp, b"hello yamux");
+    }
+
+    #[tokio::test]
+    async fn two_streams_multiplex_independently() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).unwrap());
+
+        let mut a = session.open_stream().await.unwrap();
+        let mut b = session.open_stream().await.unwrap();
+
+        a.write_all(b"AAA").await.unwrap();
+        b.write_all(b"BBB").await.unwrap();
+        let mut buf = [0u8; 3];
+        a.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"AAA");
+        b.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"BBB");
+    }
+
+    #[tokio::test]
+    async fn concurrent_opens_all_succeed() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let _server = run_echo_server(server_io).await;
+        let session = Arc::new(Session::client(client_io).unwrap());
+
+        // Open many streams at once: the driver must queue every request
+        // instead of dropping earlier ones for later arrivals.
+        let opens = (0..8)
+            .map(|i| {
+                let session = Arc::clone(&session);
+                async move { (i, session.open_stream().await.unwrap()) }
+            })
+            .collect::<Vec<_>>();
+        let streams = futures::future::join_all(opens).await;
+        assert_eq!(streams.len(), 8);
+        for (i, mut stream) in streams {
+            let payload = format!("stream-{i}").into_bytes();
+            stream.write_all(&payload).await.unwrap();
+            let mut resp = vec![0u8; payload.len()];
+            stream.read_exact(&mut resp).await.unwrap();
+            assert_eq!(resp, payload);
+        }
+    }
+}

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -51,16 +51,25 @@ enum PluginKind {
     EchTlsTunnel(EchTlsTunnelConfig, TlsLayer),
 }
 
-pub struct ShadowsocksAdapter {
-    name: SmolStr,
+/// Dial-relevant SS state, shared (Arc) between the adapter and any mux
+/// session so the SIP003 plugin handle stays alive for both.
+struct SsCore {
     server: SmolStr,
     port: u16,
     server_config: ServerConfig,
     context: shadowsocks::context::SharedContext,
+    plugin: PluginKind,
+}
+
+pub struct ShadowsocksAdapter {
+    name: SmolStr,
+    core: Arc<SsCore>,
     addr_str: SmolStr,
     support_udp: bool,
-    plugin: PluginKind,
     health: ProxyHealth,
+    /// sing-mux compatible connection multiplexing (optional).
+    #[cfg(feature = "mux")]
+    mux: Option<Arc<crate::mux::MuxClient>>,
 }
 
 impl ShadowsocksAdapter {
@@ -141,17 +150,138 @@ impl ShadowsocksAdapter {
             None => PluginKind::None,
         };
 
-        Ok(Self {
-            name: SmolStr::from(name),
+        let core = Arc::new(SsCore {
             server: SmolStr::from(server),
             port,
             server_config,
             context,
+            plugin,
+        });
+
+        Ok(Self {
+            name: SmolStr::from(name),
+            core,
             addr_str,
             support_udp: udp,
-            plugin,
             health: ProxyHealth::new(),
+            #[cfg(feature = "mux")]
+            mux: None,
         })
+    }
+
+    /// Enable sing-mux compatible connection multiplexing.  The session's
+    /// SS stream targets the reserved mux destination; the server must be a
+    /// sing-box / mihomo SS inbound with multiplex enabled (a plain
+    /// ss-server does not speak sing-mux).  Xray Mux.Cool is VLESS-only.
+    #[cfg(feature = "mux")]
+    pub fn with_mux(mut self, options: crate::mux::MuxOptions) -> Self {
+        use crate::mux::{MuxClient, MUX_DESTINATION_FQDN, MUX_DESTINATION_PORT};
+        use std::sync::Arc as StdArc;
+
+        let core = Arc::clone(&self.core);
+        let dial: crate::mux::DialFn = StdArc::new(move || {
+            let core = Arc::clone(&core);
+            Box::pin(async move {
+                let addr = Address::DomainNameAddress(
+                    MUX_DESTINATION_FQDN.to_string(),
+                    MUX_DESTINATION_PORT,
+                );
+                core.dial_tcp_stream(addr).await
+            })
+        });
+        self.mux = Some(MuxClient::new(dial, options));
+        self
+    }
+}
+
+impl SsCore {
+    /// Dial a raw (or plugin-transported) TCP stream to the SS server and
+    /// wrap it in the SS crypto codec for the given target address.
+    async fn dial_tcp_stream(&self, addr: Address) -> Result<Box<dyn ProxyConn>> {
+        match &self.plugin {
+            PluginKind::Obfs(obfs) => {
+                // Open a raw TCP connection to the SS server, wrap it in the
+                // simple-obfs codec, then layer the SS crypto stream on top.
+                let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+                    .await
+                    .map_err(|e| MeowError::Proxy(format!("ss obfs tcp connect: {e}")))?;
+                let _ = tcp.set_nodelay(true);
+                match obfs.clone() {
+                    BuiltinObfs::Http { host } => {
+                        let wrapped = HttpObfs::new(tcp, host, self.port);
+                        let stream = ProxyClientStream::from_stream(
+                            Arc::clone(&self.context),
+                            wrapped,
+                            &self.server_config,
+                            addr,
+                        );
+                        Ok(Box::new(SsConn(stream)))
+                    }
+                    BuiltinObfs::Tls { server } => {
+                        let wrapped = TlsObfs::new(tcp, server);
+                        let stream = ProxyClientStream::from_stream(
+                            Arc::clone(&self.context),
+                            wrapped,
+                            &self.server_config,
+                            addr,
+                        );
+                        Ok(Box::new(SsConn(stream)))
+                    }
+                }
+            }
+            PluginKind::V2ray(cfg, tls) => {
+                let transport =
+                    v2ray_plugin::dial(cfg, tls.as_ref(), &self.server, self.port).await?;
+                let stream = ProxyClientStream::from_stream(
+                    Arc::clone(&self.context),
+                    transport,
+                    &self.server_config,
+                    addr,
+                );
+                Ok(Box::new(SsConn(stream)))
+            }
+            #[cfg(feature = "ech-tls-tunnel")]
+            PluginKind::EchTlsTunnel(cfg, tls) => {
+                let transport = ech_tls_tunnel::dial(cfg, tls, &self.server, self.port).await?;
+                let stream = ProxyClientStream::from_stream(
+                    Arc::clone(&self.context),
+                    transport,
+                    &self.server_config,
+                    addr,
+                );
+                Ok(Box::new(SsConn(stream)))
+            }
+            PluginKind::None | PluginKind::External(_) => {
+                // Hand-roll the TCP connect so the installed
+                // `meow_common::SocketProtector` sees the fd before connect —
+                // otherwise the upstream `shadowsocks` crate would dial this
+                // stream internally via plain tokio and the Android
+                // `VpnService.protect(fd)` hook would never fire, so the
+                // outbound socket would loop back into our own VPN tunnel.
+                //
+                // For `PluginKind::External`, `tcp_external_addr` returns the
+                // SIP003 plugin's local listener (typically 127.0.0.1:<port>),
+                // so the connect is loopback and `protect()` is harmless;
+                // for `PluginKind::None` it's the remote SS server. Dispatch
+                // on the variant so domain-name servers also go through the
+                // installed `HostResolver` (system DNS would loop the
+                // lookup through the VPN on Android).
+                let tcp = match self.server_config.tcp_external_addr() {
+                    ServerAddr::SocketAddr(sa) => meow_common::connect_tcp(*sa).await,
+                    ServerAddr::DomainName(host, port) => {
+                        meow_common::connect_tcp_host(host, *port).await
+                    }
+                }
+                .map_err(|e| MeowError::Proxy(format!("ss tcp connect: {e}")))?;
+                let stream = ProxyClientStream::from_stream(
+                    Arc::clone(&self.context),
+                    tcp,
+                    &self.server_config,
+                    addr,
+                );
+                Ok(Box::new(SsConn(stream)))
+            }
+        }
     }
 }
 
@@ -371,107 +501,57 @@ impl ProxyAdapter for ShadowsocksAdapter {
     }
 
     fn support_udp(&self) -> bool {
-        self.support_udp
+        // With mux enabled, UDP rides the mux TCP session (unless
+        // `only-tcp` forces the plain path) — mirrors mihomo's
+        // SingMux.SupportUDP.
+        self.support_udp || {
+            #[cfg(feature = "mux")]
+            {
+                self.mux.as_ref().is_some_and(|mux| mux.supports_udp())
+            }
+            #[cfg(not(feature = "mux"))]
+            {
+                false
+            }
+        }
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
         let addr = parse_address(metadata);
         debug!("SS connecting to {} via {}", addr, self.addr_str);
 
-        match &self.plugin {
-            PluginKind::Obfs(obfs) => {
-                // Open a raw TCP connection to the SS server, wrap it in the
-                // simple-obfs codec, then layer the SS crypto stream on top.
-                let tcp = meow_common::connect_tcp_host(&self.server, self.port)
-                    .await
-                    .map_err(|e| MeowError::Proxy(format!("ss obfs tcp connect: {e}")))?;
-                let _ = tcp.set_nodelay(true);
-                match obfs.clone() {
-                    BuiltinObfs::Http { host } => {
-                        let wrapped = HttpObfs::new(tcp, host, self.port);
-                        let stream = ProxyClientStream::from_stream(
-                            Arc::clone(&self.context),
-                            wrapped,
-                            &self.server_config,
-                            addr,
-                        );
-                        Ok(Box::new(SsConn(stream)))
-                    }
-                    BuiltinObfs::Tls { server } => {
-                        let wrapped = TlsObfs::new(tcp, server);
-                        let stream = ProxyClientStream::from_stream(
-                            Arc::clone(&self.context),
-                            wrapped,
-                            &self.server_config,
-                            addr,
-                        );
-                        Ok(Box::new(SsConn(stream)))
-                    }
-                }
-            }
-            PluginKind::V2ray(cfg, tls) => {
-                let transport =
-                    v2ray_plugin::dial(cfg, tls.as_ref(), &self.server, self.port).await?;
-                let stream = ProxyClientStream::from_stream(
-                    Arc::clone(&self.context),
-                    transport,
-                    &self.server_config,
-                    addr,
-                );
-                Ok(Box::new(SsConn(stream)))
-            }
-            #[cfg(feature = "ech-tls-tunnel")]
-            PluginKind::EchTlsTunnel(cfg, tls) => {
-                let transport = ech_tls_tunnel::dial(cfg, tls, &self.server, self.port).await?;
-                let stream = ProxyClientStream::from_stream(
-                    Arc::clone(&self.context),
-                    transport,
-                    &self.server_config,
-                    addr,
-                );
-                Ok(Box::new(SsConn(stream)))
-            }
-            PluginKind::None | PluginKind::External(_) => {
-                // Hand-roll the TCP connect so the installed
-                // `meow_common::SocketProtector` sees the fd before connect —
-                // otherwise the upstream `shadowsocks` crate would dial this
-                // stream internally via plain tokio and the Android
-                // `VpnService.protect(fd)` hook would never fire, so the
-                // outbound socket would loop back into our own VPN tunnel.
-                //
-                // For `PluginKind::External`, `tcp_external_addr` returns the
-                // SIP003 plugin's local listener (typically 127.0.0.1:<port>),
-                // so the connect is loopback and `protect()` is harmless;
-                // for `PluginKind::None` it's the remote SS server. Dispatch
-                // on the variant so domain-name servers also go through the
-                // installed `HostResolver` (system DNS would loop the
-                // lookup through the VPN on Android).
-                let tcp = match self.server_config.tcp_external_addr() {
-                    ServerAddr::SocketAddr(sa) => meow_common::connect_tcp(*sa).await,
-                    ServerAddr::DomainName(host, port) => {
-                        meow_common::connect_tcp_host(host, *port).await
-                    }
-                }
-                .map_err(|e| MeowError::Proxy(format!("ss tcp connect: {e}")))?;
-                let stream = ProxyClientStream::from_stream(
-                    Arc::clone(&self.context),
-                    tcp,
-                    &self.server_config,
-                    addr,
-                );
-                Ok(Box::new(SsConn(stream)))
-            }
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            let conn = mux.open_stream_for(metadata, "ss").await?;
+            return Ok(Box::new(conn));
         }
+
+        self.core.dial_tcp_stream(addr).await
     }
 
-    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        if matches!(self.plugin, PluginKind::V2ray(..)) {
+    #[cfg_attr(not(feature = "mux"), allow(unused_variables))]
+    async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            if mux.supports_udp() {
+                debug!(
+                    "SS mux UDP connecting to {} via {}",
+                    metadata.remote_address(),
+                    self.addr_str
+                );
+            }
+            if let Some(conn) = mux.open_packet_stream_for(metadata, "ss").await? {
+                return Ok(conn);
+            }
+        }
+
+        if matches!(self.core.plugin, PluginKind::V2ray(..)) {
             return Err(MeowError::NotSupported(
                 "v2ray-plugin does not support UDP relay".into(),
             ));
         }
         #[cfg(feature = "ech-tls-tunnel")]
-        if matches!(self.plugin, PluginKind::EchTlsTunnel(..)) {
+        if matches!(self.core.plugin, PluginKind::EchTlsTunnel(..)) {
             return Err(MeowError::NotSupported(
                 "ech-tls-tunnel does not support UDP relay".into(),
             ));
@@ -486,7 +566,7 @@ impl ProxyAdapter for ShadowsocksAdapter {
         // `udp_external_addr` returns a literal `SocketAddr` for the standard
         // path and the SIP003 plugin's local listener for external plugins
         // (where the connect is loopback — protect is harmless).
-        let candidates = match self.server_config.udp_external_addr() {
+        let candidates = match self.core.server_config.udp_external_addr() {
             ServerAddr::SocketAddr(sa) => vec![*sa],
             ServerAddr::DomainName(host, port) => meow_common::resolve_host_all(host, *port)
                 .await
@@ -529,8 +609,8 @@ impl ProxyAdapter for ShadowsocksAdapter {
         };
         let socket = ProxySocket::<TokioUdpDatagram>::from_socket(
             UdpSocketType::Client,
-            Arc::clone(&self.context),
-            &self.server_config,
+            Arc::clone(&self.core.context),
+            &self.core.server_config,
             TokioUdpDatagram(udp),
         );
         debug!("SS UDP connected via {}", remote);

--- a/crates/meow-proxy/src/trojan.rs
+++ b/crates/meow-proxy/src/trojan.rs
@@ -24,8 +24,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::sync::Mutex;
 use tracing::debug;
 
+#[cfg(feature = "mux")]
+use crate::mux::{MuxClient, MuxOptions};
 use crate::stream_conn::StreamConn;
 use crate::transport_to_proxy_err;
+use std::sync::Arc;
 
 /// SOCKS5-style command bytes used inside the Trojan request header.
 const CMD_CONNECT: u8 = 0x01;
@@ -46,7 +49,10 @@ pub struct TrojanAdapter {
     hex_password: SmolStr,
     support_udp: bool,
     health: ProxyHealth,
-    tls_layer: TlsLayer,
+    tls_layer: Arc<TlsLayer>,
+    /// sing-mux compatible connection multiplexing (optional).
+    #[cfg(feature = "mux")]
+    mux: Option<Arc<MuxClient>>,
 }
 
 impl TrojanAdapter {
@@ -87,8 +93,66 @@ impl TrojanAdapter {
             hex_password: SmolStr::from(hex_password),
             support_udp: udp,
             health: ProxyHealth::new(),
-            tls_layer,
+            tls_layer: Arc::new(tls_layer),
+            #[cfg(feature = "mux")]
+            mux: None,
         }
+    }
+
+    /// Enable sing-mux compatible connection multiplexing.  The Trojan
+    /// request header on the shared connection targets the reserved mux
+    /// destination (\`sp.mux.sing-box.arpa:444\`); the server switches the
+    /// connection into mux mode on seeing it.
+    #[cfg(feature = "mux")]
+    pub fn with_mux(mut self, options: MuxOptions) -> Self {
+        use crate::mux::{MUX_DESTINATION_FQDN, MUX_DESTINATION_PORT};
+
+        let server = self.server.clone();
+        let port = self.port;
+        let hex_password = self.hex_password.clone();
+        let tls_layer = Arc::clone(&self.tls_layer);
+
+        let dial: crate::mux::DialFn = Arc::new(move || {
+            let server = server.clone();
+            let hex_password = hex_password.clone();
+            let tls_layer = Arc::clone(&tls_layer);
+            Box::pin(async move {
+                // Build the mux-destination request header.
+                let mut hdr_buf = [0u8; TROJAN_HEADER_BUF_SIZE];
+                let pw = hex_password.as_bytes();
+                let mut pos = 0;
+                hdr_buf[..pw.len()].copy_from_slice(pw);
+                pos += pw.len();
+                hdr_buf[pos..pos + 2].copy_from_slice(b"\r\n");
+                pos += 2;
+                hdr_buf[pos] = CMD_CONNECT;
+                pos += 1;
+                hdr_buf[pos] = ATYP_DOMAIN;
+                pos += 1;
+                let fqdn = MUX_DESTINATION_FQDN.as_bytes();
+                hdr_buf[pos] = u8::try_from(fqdn.len()).expect("static mux fqdn fits u8");
+                pos += 1;
+                hdr_buf[pos..pos + fqdn.len()].copy_from_slice(fqdn);
+                pos += fqdn.len();
+                hdr_buf[pos..pos + 2].copy_from_slice(&MUX_DESTINATION_PORT.to_be_bytes());
+                pos += 2;
+                hdr_buf[pos..pos + 2].copy_from_slice(b"\r\n");
+                pos += 2;
+                let header = &hdr_buf[..pos];
+
+                let tcp = meow_common::connect_tcp_host(&server, port)
+                    .await
+                    .map_err(MeowError::Io)?;
+                let mut stream = tls_layer
+                    .connect(Box::new(tcp))
+                    .await
+                    .map_err(transport_to_proxy_err)?;
+                stream.write_all(header).await.map_err(MeowError::Io)?;
+                Ok(Box::new(StreamConn(stream)) as Box<dyn ProxyConn>)
+            })
+        });
+        self.mux = Some(MuxClient::new(dial, options));
+        self
     }
 
     fn build_header<'a>(
@@ -384,7 +448,19 @@ impl ProxyAdapter for TrojanAdapter {
     }
 
     fn support_udp(&self) -> bool {
-        self.support_udp
+        // With mux enabled, UDP rides the mux TCP session (unless
+        // `only-tcp` forces the plain path) — mirrors mihomo's
+        // SingMux.SupportUDP.
+        self.support_udp || {
+            #[cfg(feature = "mux")]
+            {
+                self.mux.as_ref().is_some_and(|mux| mux.supports_udp())
+            }
+            #[cfg(not(feature = "mux"))]
+            {
+                false
+            }
+        }
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
@@ -393,11 +469,31 @@ impl ProxyAdapter for TrojanAdapter {
             metadata.remote_address(),
             self.addr_str
         );
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            let conn = mux.open_stream_for(metadata, "trojan").await?;
+            return Ok(Box::new(conn));
+        }
         let stream = self.open_tls_with_header(metadata, CMD_CONNECT).await?;
         Ok(Box::new(StreamConn(stream)))
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        // Mux UDP rides the mux TCP session and does not depend on the
+        // node's `udp:` flag — check it before the plain-path gate.
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            if mux.supports_udp() {
+                debug!(
+                    "Trojan mux UDP connecting to {} via {}",
+                    metadata.remote_address(),
+                    self.addr_str
+                );
+            }
+            if let Some(conn) = mux.open_packet_stream_for(metadata, "trojan").await? {
+                return Ok(conn);
+            }
+        }
         if !self.support_udp {
             return Err(MeowError::NotSupported(
                 "Trojan UDP is disabled for this proxy (set `udp: true`)".into(),

--- a/crates/meow-proxy/src/vless/conn.rs
+++ b/crates/meow-proxy/src/vless/conn.rs
@@ -82,7 +82,7 @@ impl VlessConn {
     /// Like [`Self::new`], but defers the request header to the first
     /// write so a wrapping Vision layer can pad it together with the first
     /// payload (xray expects the request inside the first Vision record).
-    #[cfg(feature = "vless-vision")]
+    #[cfg(any(feature = "mux", feature = "vless-vision"))]
     pub async fn new_deferred(
         stream: Box<dyn Stream>,
         uuid_bytes: &[u8; 16],
@@ -626,7 +626,7 @@ mod tests {
         assert_eq!(&hdr[1..17], &TEST_UUID, "uuid must match");
     }
 
-    #[cfg(feature = "vless-vision")]
+    #[cfg(any(feature = "mux", feature = "vless-vision"))]
     #[tokio::test]
     async fn deferred_header_handles_one_byte_partial_writes() {
         let (client, mut server) = duplex(1024);
@@ -656,7 +656,7 @@ mod tests {
         assert_eq!(response, [b'!']);
     }
 
-    #[cfg(feature = "vless-vision")]
+    #[cfg(any(feature = "mux", feature = "vless-vision"))]
     #[tokio::test]
     async fn deferred_header_is_flushed_before_server_first_read() {
         let (client, mut server) = duplex(1024);

--- a/crates/meow-proxy/src/vless/conn.rs
+++ b/crates/meow-proxy/src/vless/conn.rs
@@ -9,14 +9,14 @@
 
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use meow_common::{MeowError, ProxyConn, ProxyPacketConn, Result};
 use meow_transport::Stream;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 
-use super::header::{decode_response, encode_request, Cmd, VlessAddr};
+use super::header::{encode_request, Cmd, VlessAddr};
 
 // ─── VlessConn ────────────────────────────────────────────────────────────────
 
@@ -29,6 +29,23 @@ pub struct VlessConn {
     pub(crate) inner: Box<dyn Stream>,
     /// `true` until the 2-byte response header has been consumed.
     pub(crate) response_pending: bool,
+    /// Partial response-header read progress.  Cancel-safe: a Pending
+    /// between the two header bytes must not lose the byte already
+    /// consumed (a local buffer would shift the whole stream by one byte).
+    pub(crate) response_buf: [u8; 2],
+    pub(crate) response_pos: usize,
+    /// Scratch buffer for the response addon bytes (usually empty).
+    pub(crate) response_addon: Vec<u8>,
+    /// Pre-encoded request header, written ahead of the first payload.
+    /// `Some` only for deferred-header connections (Vision): the request
+    /// must ride inside the first Vision-padded record, matching
+    /// mihomo/xray, so it is emitted on the first write instead of during
+    /// construction.
+    pub(crate) header_pending: Option<Bytes>,
+    /// Set once the deferred header has reached the inner stream and cleared
+    /// after the next flush.  A read-first protocol must flush the request
+    /// before waiting for the server response.
+    pub(crate) header_needs_flush: bool,
 }
 
 impl VlessConn {
@@ -54,13 +71,101 @@ impl VlessConn {
         Ok(Self {
             inner: stream,
             response_pending: true,
+            response_buf: [0; 2],
+            response_pos: 0,
+            response_addon: Vec::new(),
+            header_pending: None,
+            header_needs_flush: false,
         })
     }
 
+    /// Like [`Self::new`], but defers the request header to the first
+    /// write so a wrapping Vision layer can pad it together with the first
+    /// payload (xray expects the request inside the first Vision record).
+    #[cfg(feature = "vless-vision")]
+    pub async fn new_deferred(
+        stream: Box<dyn Stream>,
+        uuid_bytes: &[u8; 16],
+        flow: Option<&str>,
+        cmd: Cmd,
+        dst_port: u16,
+        addr: &VlessAddr,
+    ) -> Result<Self> {
+        let mut buf = BytesMut::new();
+        encode_request(&mut buf, uuid_bytes, flow, cmd, dst_port, addr);
+        Ok(Self {
+            inner: stream,
+            response_pending: true,
+            response_buf: [0; 2],
+            response_pos: 0,
+            response_addon: Vec::new(),
+            header_pending: Some(buf.freeze()),
+            header_needs_flush: false,
+        })
+    }
+
+    /// Write a deferred request header before the caller's first payload.
+    /// Header-only progress may continue inside one poll; payload progress is
+    /// reported immediately so `AsyncWrite` never returns `Pending` or
+    /// `Ok(0)` after consuming caller bytes.
+    fn poll_write_deferred(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        loop {
+            let Some(header) = self.header_pending.take() else {
+                return Pin::new(&mut *self.inner).poll_write(cx, buf);
+            };
+            let header_len = header.len();
+            let mut combined = BytesMut::with_capacity(header_len + buf.len());
+            combined.extend_from_slice(&header);
+            combined.extend_from_slice(buf);
+            match Pin::new(&mut *self.inner).poll_write(cx, &combined) {
+                Poll::Pending => {
+                    self.header_pending = Some(header);
+                    return Poll::Pending;
+                }
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Ready(Ok(0)) => {
+                    self.header_pending = Some(header);
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "vless: failed to write deferred request header",
+                    )));
+                }
+                Poll::Ready(Ok(written)) if written < header_len => {
+                    self.header_pending = Some(header.slice(written..));
+                }
+                Poll::Ready(Ok(written)) => {
+                    self.header_needs_flush = true;
+                    let payload_written = written - header_len;
+                    if payload_written > 0 || buf.is_empty() {
+                        return Poll::Ready(Ok(payload_written));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Ensure a deferred request is sent and flushed before reading or
+    /// shutting down.  This is the server-first path used by SMTP, IMAP,
+    /// MySQL and similar protocols that do not write application data first.
+    fn poll_flush_deferred_header(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        while self.header_pending.is_some() {
+            let written = ready!(self.poll_write_deferred(cx, &[]))?;
+            debug_assert_eq!(written, 0);
+        }
+        if self.header_needs_flush {
+            ready!(Pin::new(&mut *self.inner).poll_flush(cx))?;
+            self.header_needs_flush = false;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    // Called only from the Vision wrapper (vless-vision feature).
+    #[cfg_attr(not(feature = "vless-vision"), allow(dead_code))]
     pub(crate) fn enable_raw_read_passthrough(&mut self) -> bool {
         meow_transport::enable_raw_read_passthrough(&mut *self.inner)
     }
 
+    #[cfg_attr(not(feature = "vless-vision"), allow(dead_code))]
     pub(crate) fn enable_raw_write_passthrough(&mut self) -> bool {
         meow_transport::enable_raw_write_passthrough(&mut *self.inner)
     }
@@ -74,21 +179,17 @@ impl AsyncRead for VlessConn {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        // Lazily consume the response header on first read.
-        if self.response_pending {
-            // Use a pinned future to read the 2-byte response header.
-            let inner = &mut self.inner;
-            // We need to read version(1) + addon_length(1).
-            // For simplicity, we do a synchronous-style poll loop here.
-            // Read the two header bytes using poll_read directly.
-            let mut hdr_buf = [0u8; 2];
-            let mut hdr_read = 0;
-            loop {
-                if hdr_read >= 2 {
-                    break;
-                }
-                let mut tmp = ReadBuf::new(&mut hdr_buf[hdr_read..]);
-                match Pin::new(&mut *inner).poll_read(cx, &mut tmp) {
+        // Lazily consume the response header on first read.  Progress lives
+        // in self (response_buf/response_pos): a Pending between the two
+        // header bytes must keep the byte already consumed — a local buffer
+        // would lose it and shift the whole stream by one byte.
+        let this = &mut *self;
+        ready!(this.poll_flush_deferred_header(cx))?;
+        if this.response_pending {
+            while this.response_pos < 2 {
+                let pos = this.response_pos;
+                let mut tmp = ReadBuf::new(&mut this.response_buf[pos..]);
+                match Pin::new(&mut *this.inner).poll_read(cx, &mut tmp) {
                     Poll::Ready(Ok(())) => {
                         let n = tmp.filled().len();
                         if n == 0 {
@@ -97,30 +198,31 @@ impl AsyncRead for VlessConn {
                                 "vless: server closed before response header",
                             )));
                         }
-                        hdr_read += n;
+                        this.response_pos += n;
                     }
                     Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                     Poll::Pending => return Poll::Pending,
                 }
             }
-            let version = hdr_buf[0];
-            let addon_length = hdr_buf[1] as usize;
+            let version = this.response_buf[0];
+            let addon_length = this.response_buf[1] as usize;
             if version != 0x00 {
                 return Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("vless: version mismatch: expected 0x00, got {version:#04x}"),
                 )));
             }
-            // Discard addon bytes if any
+            // Discard addon bytes if any — also cancel-safe: progress
+            // counts against the persistent response_pos, and the scratch
+            // buffer survives Pending.
             if addon_length > 0 {
-                let mut discard = vec![0u8; addon_length];
-                let mut disc_read = 0;
-                loop {
-                    if disc_read >= addon_length {
-                        break;
-                    }
-                    let mut tmp = ReadBuf::new(&mut discard[disc_read..]);
-                    match Pin::new(&mut *inner).poll_read(cx, &mut tmp) {
+                if this.response_addon.len() != addon_length {
+                    this.response_addon = vec![0u8; addon_length];
+                }
+                while this.response_pos - 2 < addon_length {
+                    let pos = this.response_pos - 2;
+                    let mut tmp = ReadBuf::new(&mut this.response_addon[pos..]);
+                    match Pin::new(&mut *this.inner).poll_read(cx, &mut tmp) {
                         Poll::Ready(Ok(())) => {
                             let n = tmp.filled().len();
                             if n == 0 {
@@ -129,14 +231,15 @@ impl AsyncRead for VlessConn {
                                     "vless: EOF during addon discard",
                                 )));
                             }
-                            disc_read += n;
+                            this.response_pos += n;
                         }
                         Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                         Poll::Pending => return Poll::Pending,
                     }
                 }
             }
-            self.response_pending = false;
+            this.response_pending = false;
+            this.response_addon = Vec::new();
             tracing::debug!("VLESS: response header consumed lazily");
         }
         Pin::new(&mut self.inner).poll_read(cx, buf)
@@ -145,19 +248,24 @@ impl AsyncRead for VlessConn {
 
 impl AsyncWrite for VlessConn {
     fn poll_write(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
+        let this = self.get_mut();
+        this.poll_write_deferred(cx, buf)
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        ready!(this.poll_flush_deferred_header(cx))?;
+        Pin::new(&mut *this.inner).poll_flush(cx)
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        ready!(this.poll_flush_deferred_header(cx))?;
+        Pin::new(&mut *this.inner).poll_shutdown(cx)
     }
 }
 
@@ -170,7 +278,11 @@ impl ProxyConn for VlessConn {}
 /// A VLESS UDP connection over TCP.
 ///
 /// Each datagram is framed as `u16_be(length) + data`.  The VLESS request
-/// header (cmd=0x02) is sent on construction; the response header is consumed.
+/// header (cmd=0x02) is sent on construction; the response header is
+/// consumed **lazily** on the first read — xray/sing-vmess only write it
+/// together with the first reply datagram, so eager consumption during
+/// construction would deadlock (server waits for the first datagram before
+/// answering, client waits for the answer before sending it).
 ///
 /// The stream is split into independent read/write halves, each behind its
 /// own `Mutex`, so a `read_packet` parked waiting for a server datagram never
@@ -179,8 +291,169 @@ impl ProxyConn for VlessConn {}
 /// lock any flow needing interleaved sends while a recv is pending (QUIC,
 /// WireGuard, games) stalled after the first packet.
 pub struct VlessPacketConn {
-    reader: tokio::sync::Mutex<tokio::io::ReadHalf<Box<dyn Stream>>>,
+    reader: tokio::sync::Mutex<VlessUdpReader>,
     writer: tokio::sync::Mutex<tokio::io::WriteHalf<Box<dyn Stream>>>,
+}
+
+/// Cancel-safe UDP reader.  The response header, the per-datagram length
+/// prefix and the payload all persist their read progress across dropped
+/// `read_packet` futures — the TUN pump recreates its read inside
+/// `select!`, and a lost half-read would desynchronise the UDP-over-TCP
+/// framing forever.
+struct VlessUdpReader {
+    stream: tokio::io::ReadHalf<Box<dyn Stream>>,
+    /// VLESS response header `[version][addon_length]`; `hdr_pos < 2`
+    /// means the response phase is still active.
+    hdr: [u8; 2],
+    hdr_pos: usize,
+    /// True once the response header (and any addon bytes) were consumed.
+    header_done: bool,
+    /// Per-datagram length prefix, big-endian.
+    len: [u8; 2],
+    len_pos: usize,
+    /// Datagram payload (or the response addon bytes mid-discard).
+    payload: Vec<u8>,
+    payload_pos: usize,
+}
+
+impl VlessUdpReader {
+    fn new(stream: tokio::io::ReadHalf<Box<dyn Stream>>) -> Self {
+        Self {
+            stream,
+            hdr: [0; 2],
+            hdr_pos: 0,
+            header_done: false,
+            len: [0; 2],
+            len_pos: 0,
+            payload: Vec::new(),
+            payload_pos: 0,
+        }
+    }
+
+    /// Reset the per-datagram state for the next packet (the response
+    /// header is read exactly once and stays consumed).
+    fn reset_datagram(&mut self) {
+        self.len_pos = 0;
+        self.payload.clear();
+        self.payload_pos = 0;
+    }
+
+    async fn read_packet(&mut self, buf: &mut [u8]) -> Result<(usize, std::net::SocketAddr)> {
+        use tokio::io::AsyncReadExt;
+        // Phase 1: response header [version][addon_length], consumed
+        // lazily on the first read (it rides with the first reply
+        // datagram).  Progress persists so a cancelled read resumes
+        // instead of shifting the stream by the lost bytes.
+        if !self.header_done {
+            while self.hdr_pos < self.hdr.len() {
+                let n = self
+                    .stream
+                    .read(&mut self.hdr[self.hdr_pos..])
+                    .await
+                    .map_err(MeowError::Io)?;
+                if n == 0 {
+                    return Err(MeowError::Proxy(
+                        "vless: server closed after header — check UUID and server config".into(),
+                    ));
+                }
+                self.hdr_pos += n;
+            }
+            let version = self.hdr[0];
+            let addon_length = self.hdr[1] as usize;
+            if version != 0x00 {
+                // upstream: closes silently. NOT silent — we surface the reason.
+                tracing::warn!(
+                    version = %format!("{:#04x}", version),
+                    "vless: response version mismatch (expected 0x00) — \
+                     check UUID and whether a TLS layer is required"
+                );
+                return Err(MeowError::Proxy(format!(
+                    "vless: version mismatch: expected 0x00, got {version:#04x}"
+                )));
+            }
+            if addon_length > 0 {
+                // Discard the addon bytes (UDP sends none; keep the same
+                // tolerance as the TCP path) with persistent progress.
+                // Only reset when the size changes: a cancelled
+                // `read_packet` future re-enters here with `header_done`
+                // still false, and resetting `payload_pos` to 0 would
+                // re-read `addon_length` bytes, eating the head of the
+                // first datagram and desyncing the UDP framing.
+                if self.payload.len() != addon_length {
+                    self.payload.resize(addon_length, 0);
+                    self.payload_pos = 0;
+                }
+                while self.payload_pos < self.payload.len() {
+                    let n = self
+                        .stream
+                        .read(&mut self.payload[self.payload_pos..])
+                        .await
+                        .map_err(MeowError::Io)?;
+                    if n == 0 {
+                        return Err(MeowError::Proxy(
+                            "vless: server closed mid response-header addon".into(),
+                        ));
+                    }
+                    self.payload_pos += n;
+                }
+                self.payload.clear();
+                self.payload_pos = 0;
+            }
+            self.header_done = true;
+        }
+        // Phase 2: per-datagram `u16_be(len)`.
+        while self.len_pos < self.len.len() {
+            let n = self
+                .stream
+                .read(&mut self.len[self.len_pos..])
+                .await
+                .map_err(MeowError::Io)?;
+            if n == 0 {
+                return Err(MeowError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "vless: EOF while reading UDP packet length",
+                )));
+            }
+            self.len_pos += n;
+        }
+        // Phase 3: payload (sized once per datagram; partial progress
+        // survives cancellation).
+        if self.payload.is_empty() && self.payload_pos == 0 {
+            self.payload
+                .resize(u16::from_be_bytes(self.len) as usize, 0);
+        }
+        while self.payload_pos < self.payload.len() {
+            let n = self
+                .stream
+                .read(&mut self.payload[self.payload_pos..])
+                .await
+                .map_err(MeowError::Io)?;
+            if n == 0 {
+                return Err(MeowError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "vless: EOF while reading UDP packet payload",
+                )));
+            }
+            self.payload_pos += n;
+        }
+        let packet_len = self.payload.len();
+        if packet_len > buf.len() {
+            // The oversized payload was fully drained into the internal
+            // buffer, so the stream framing stays aligned for the next
+            // read — surface the error only after the drain.
+            self.reset_datagram();
+            return Err(MeowError::Proxy(format!(
+                "vless: UDP packet ({packet_len} bytes) exceeds read buffer ({} bytes)",
+                buf.len()
+            )));
+        }
+        buf[..packet_len].copy_from_slice(&self.payload);
+        self.reset_datagram();
+        // Return a placeholder source address (connection-oriented
+        // UDP-over-TCP has no per-datagram source addr).
+        let placeholder: std::net::SocketAddr = "0.0.0.0:0".parse().unwrap();
+        Ok((packet_len, placeholder))
+    }
 }
 
 impl VlessPacketConn {
@@ -197,12 +470,9 @@ impl VlessPacketConn {
         stream.write_all(&buf).await.map_err(MeowError::Io)?;
         stream.flush().await.map_err(MeowError::Io)?;
 
-        // Read and discard the response header.
-        decode_response(&mut stream).await?;
-
         let (reader, writer) = tokio::io::split(stream);
         Ok(Self {
-            reader: tokio::sync::Mutex::new(reader),
+            reader: tokio::sync::Mutex::new(VlessUdpReader::new(reader)),
             writer: tokio::sync::Mutex::new(writer),
         })
     }
@@ -221,31 +491,13 @@ impl ProxyPacketConn for VlessPacketConn {
         Ok(buf.len())
     }
 
-    /// Read a UDP packet: consume `u16_be(len)` then `len` bytes.
+    /// Read a UDP packet: consume `u16_be(len)` then `len` bytes.  The
+    /// VLESS response header is consumed lazily on the first read (it rides
+    /// with the first reply datagram).  All progress is persistent, so a
+    /// cancelled future resumes from where it stopped.
     async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, std::net::SocketAddr)> {
-        use tokio::io::AsyncReadExt;
         let mut reader = self.reader.lock().await;
-        let mut len_buf = [0u8; 2];
-        reader
-            .read_exact(&mut len_buf)
-            .await
-            .map_err(MeowError::Io)?;
-        let pkt_len = u16::from_be_bytes(len_buf) as usize;
-        if pkt_len > buf.len() {
-            return Err(MeowError::Proxy(format!(
-                "vless: UDP packet ({} bytes) exceeds read buffer ({} bytes)",
-                pkt_len,
-                buf.len()
-            )));
-        }
-        reader
-            .read_exact(&mut buf[..pkt_len])
-            .await
-            .map_err(MeowError::Io)?;
-        // Return a placeholder source address (connection-oriented UDP-over-TCP
-        // has no per-datagram source addr).
-        let placeholder: std::net::SocketAddr = "0.0.0.0:0".parse().unwrap();
-        Ok((pkt_len, placeholder))
+        reader.read_packet(buf).await
     }
 
     fn local_addr(&self) -> Result<std::net::SocketAddr> {
@@ -265,7 +517,44 @@ impl ProxyPacketConn for VlessPacketConn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
+
+    struct ChunkedStream {
+        inner: tokio::io::DuplexStream,
+        max_write: usize,
+    }
+
+    impl AsyncRead for ChunkedStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for ChunkedStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let this = self.get_mut();
+            let count = buf.len().min(this.max_write);
+            Pin::new(&mut this.inner).poll_write(cx, &buf[..count])
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+        }
+    }
 
     /// Test UUID: b831381d-6324-4d53-ad4f-8cda48b30811
     const TEST_UUID: [u8; 16] = [
@@ -335,6 +624,62 @@ mod tests {
         assert_eq!(hdr[0], 0x00, "version byte must be 0x00");
         // uuid must match
         assert_eq!(&hdr[1..17], &TEST_UUID, "uuid must match");
+    }
+
+    #[cfg(feature = "vless-vision")]
+    #[tokio::test]
+    async fn deferred_header_handles_one_byte_partial_writes() {
+        let (client, mut server) = duplex(1024);
+        tokio::spawn(async move {
+            let mut request = vec![0u8; 26 + 4];
+            server.read_exact(&mut request).await.unwrap();
+            assert_eq!(&request[26..], b"ping");
+            server.write_all(&[0x00, 0x00, b'!']).await.unwrap();
+        });
+
+        let mut conn = VlessConn::new_deferred(
+            Box::new(ChunkedStream {
+                inner: client,
+                max_write: 1,
+            }),
+            &TEST_UUID,
+            None,
+            Cmd::Tcp,
+            80,
+            &VlessAddr::Ipv4([1, 2, 3, 4]),
+        )
+        .await
+        .unwrap();
+        conn.write_all(b"ping").await.unwrap();
+        let mut response = [0u8; 1];
+        conn.read_exact(&mut response).await.unwrap();
+        assert_eq!(response, [b'!']);
+    }
+
+    #[cfg(feature = "vless-vision")]
+    #[tokio::test]
+    async fn deferred_header_is_flushed_before_server_first_read() {
+        let (client, mut server) = duplex(1024);
+        tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x00, 0x00]).await.unwrap();
+            server.write_all(b"banner").await.unwrap();
+        });
+
+        let mut conn = VlessConn::new_deferred(
+            Box::new(client),
+            &TEST_UUID,
+            None,
+            Cmd::Tcp,
+            25,
+            &VlessAddr::Ipv4([1, 2, 3, 4]),
+        )
+        .await
+        .unwrap();
+        let mut banner = [0u8; 6];
+        conn.read_exact(&mut banner).await.unwrap();
+        assert_eq!(&banner, b"banner");
     }
 
     // ─── F2: payload round-trip ───────────────────────────────────────────────
@@ -581,6 +926,50 @@ mod tests {
         assert_eq!(echoed, b"ping");
     }
 
+    // ─── F8b: lazy response header (xray/sing-vmess semantics) ───────────────
+
+    /// The server answers the VLESS response header only together with the
+    /// first reply datagram.  `VlessPacketConn::new` must return without
+    /// waiting for it (eager consumption deadlocks: the server waits for the
+    /// first datagram before answering, the client waits for the answer
+    /// before sending that datagram).
+    #[tokio::test]
+    async fn vless_packet_conn_handles_lazy_response_header() {
+        use tokio::io::AsyncWriteExt;
+
+        let (client, server) = duplex(4096);
+        tokio::spawn(async move {
+            let mut s = server;
+            let mut hdr = vec![0u8; 26];
+            s.read_exact(&mut hdr).await.unwrap();
+            // NO response header yet — wait for the first datagram frame.
+            let mut len = [0u8; 2];
+            s.read_exact(&mut len).await.unwrap();
+            let n = u16::from_be_bytes(len) as usize;
+            let mut payload = vec![0u8; n];
+            s.read_exact(&mut payload).await.unwrap();
+            // First server write = response header + echoed datagram frame.
+            s.write_all(&[0x00, 0x00]).await.unwrap();
+            s.write_all(&len).await.unwrap();
+            s.write_all(&payload).await.unwrap();
+        });
+
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .expect("VlessPacketConn::new");
+
+        let dst = "8.8.8.8:53".parse().unwrap();
+        conn.write_packet(b"ping", &dst).await.unwrap();
+        let mut buf = [0u8; 8];
+        let (n, _src) = conn.read_packet(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"ping");
+    }
+
     // ─── F7: UDP cmd byte is 0x02 ─────────────────────────────────────────────
 
     /// Guards against copy-paste of the TCP path without flipping the cmd byte.
@@ -612,5 +1001,179 @@ mod tests {
         let hdr = rx.await.expect("header");
         // cmd byte at offset 18 (version=1 + uuid=16 + addon_length=1)
         assert_eq!(hdr[18], 0x02, "UDP cmd must be 0x02, not 0x01");
+    }
+
+    // ─── F6: UDP reader cancellation safety ─────────────────────────────────
+
+    /// A read cancelled halfway through the response header must resume
+    /// instead of shifting the stream: the next read sees the full
+    /// datagram.
+    #[tokio::test]
+    async fn udp_read_survives_cancellation_mid_response() {
+        let (client, mut server) = duplex(1024);
+        let (go_tx, go_rx) = tokio::sync::oneshot::channel::<()>();
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x00]).await.unwrap(); // first header byte only
+            let _ = go_rx.await;
+            server
+                .write_all(&[0x00, 0x00, 0x04, b'p', b'o', b'n', b'g'])
+                .await
+                .unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                conn.read_packet(&mut buf)
+            )
+            .await
+            .is_err(),
+            "the read must wait for the second response byte"
+        );
+        go_tx.send(()).unwrap();
+        let (n, _) = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            conn.read_packet(&mut buf),
+        )
+        .await
+        .expect("the resumed read must complete")
+        .unwrap();
+        assert_eq!(&buf[..n], b"pong");
+        server_task.await.unwrap();
+    }
+
+    /// A read cancelled halfway through a datagram payload must resume
+    /// the same datagram.
+    #[tokio::test]
+    async fn udp_read_survives_cancellation_mid_payload() {
+        let (client, mut server) = duplex(1024);
+        let (go_tx, go_rx) = tokio::sync::oneshot::channel::<()>();
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            // Full response + length prefix + half the payload.
+            server
+                .write_all(&[0x00, 0x00, 0x00, 0x04, b'p', b'o'])
+                .await
+                .unwrap();
+            let _ = go_rx.await;
+            server.write_all(b"ng").await.unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                conn.read_packet(&mut buf)
+            )
+            .await
+            .is_err(),
+            "the read must wait for the rest of the payload"
+        );
+        go_tx.send(()).unwrap();
+        let (n, _) = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            conn.read_packet(&mut buf),
+        )
+        .await
+        .expect("the resumed read must complete")
+        .unwrap();
+        assert_eq!(&buf[..n], b"pong");
+        server_task.await.unwrap();
+    }
+
+    /// Response version mismatch → hard error naming the problem (the
+    /// shared decode_response behavior, now owned by the UDP reader).
+    #[tokio::test]
+    async fn udp_response_version_mismatch_errors() {
+        let (client, mut server) = duplex(1024);
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x01, 0x00]).await.unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        let err = conn.read_packet(&mut buf).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("version mismatch"),
+            "error must mention the version mismatch, got: {msg}"
+        );
+        server_task.await.unwrap();
+    }
+
+    /// Non-zero addon_length: the addon bytes are discarded and the next
+    /// datagram reads aligned.
+    #[tokio::test]
+    async fn udp_response_addon_is_discarded() {
+        let (client, mut server) = duplex(1024);
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server
+                .write_all(&[0x00, 0x02, 0xAA, 0xBB, 0x00, 0x04, b'p', b'o', b'n', b'g'])
+                .await
+                .unwrap();
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        let (n, _) = conn.read_packet(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"pong");
+        server_task.await.unwrap();
+    }
+
+    /// A response truncated mid-header must error cleanly, not panic.
+    #[tokio::test]
+    async fn udp_truncated_response_errors() {
+        let (client, mut server) = duplex(1024);
+        let server_task = tokio::spawn(async move {
+            let mut request = vec![0u8; 26];
+            server.read_exact(&mut request).await.unwrap();
+            server.write_all(&[0x00]).await.unwrap();
+            drop(server);
+        });
+        let conn = VlessPacketConn::new(
+            Box::new(client),
+            &TEST_UUID,
+            53,
+            &VlessAddr::Ipv4([8, 8, 8, 8]),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 16];
+        assert!(conn.read_packet(&mut buf).await.is_err());
+        server_task.await.unwrap();
     }
 }

--- a/crates/meow-proxy/src/vless/header.rs
+++ b/crates/meow-proxy/src/vless/header.rs
@@ -31,8 +31,7 @@
 // upstream SHA: xray-core/xray-core (2024) — pin on first Vision integration
 
 use bytes::{BufMut, BytesMut};
-use meow_common::{MeowError, Metadata, Result};
-use tokio::io::AsyncReadExt;
+use meow_common::Metadata;
 
 // ─── Address type ─────────────────────────────────────────────────────────────
 
@@ -109,19 +108,8 @@ pub(crate) fn encode_request(
     // uuid (16 bytes, binary form)
     dst.put_slice(uuid_bytes);
 
-    // addon
-    // NOT prost — two hardcoded bytes + string copy (spec §Addon encoding).
-    match flow {
-        Some("xtls-rprx-vision") => {
-            dst.put_u8(18); // addon_length = 18
-            dst.put_u8(0x0A); // protobuf field 1, wire type 2
-            dst.put_u8(0x10); // varint 16  (len("xtls-rprx-vision") = 16)
-            dst.put_slice(b"xtls-rprx-vision");
-        }
-        _ => {
-            dst.put_u8(0x00); // addon_length = 0
-        }
-    }
+    // addon (shared with the Mux request encoder below)
+    put_flow_addon(dst, flow);
 
     // command
     dst.put_u8(cmd as u8);
@@ -148,55 +136,26 @@ pub(crate) fn encode_request(
     }
 }
 
-// ─── Response decoder ─────────────────────────────────────────────────────────
-
-/// Read and discard the VLESS response header from `stream`.
+/// Append the flow addon block (length byte + protobuf blob, if any).
 ///
-/// Returns `Err` if version != 0x00 (logs `warn!` before returning).
-///
-/// upstream: transport/vless/conn.go::ReadResponseHeader
-pub(crate) async fn decode_response<S>(stream: &mut S) -> Result<()>
-where
-    S: AsyncReadExt + Unpin,
-{
-    let mut hdr = [0u8; 2]; // version + addon_length
-    stream.read_exact(&mut hdr).await.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::UnexpectedEof {
-            MeowError::Proxy(
-                "vless: server closed after header — check UUID and server config".into(),
-            )
-        } else {
-            MeowError::Io(e)
+/// NOT prost — two hardcoded bytes + string copy (spec §Addon encoding).
+fn put_flow_addon(dst: &mut BytesMut, flow: Option<&str>) {
+    match flow {
+        Some("xtls-rprx-vision") => {
+            dst.put_u8(18); // addon_length = 18
+            dst.put_u8(0x0A); // protobuf field 1, wire type 2
+            dst.put_u8(0x10); // varint 16  (len("xtls-rprx-vision") = 16)
+            dst.put_slice(b"xtls-rprx-vision");
         }
-    })?;
-
-    let version = hdr[0];
-    let addon_length = hdr[1] as usize;
-
-    if version != 0x00 {
-        // upstream: closes silently. NOT silent — we surface the reason.
-        // Class B per ADR-0002: connection goes to same destination, but user
-        // may be missing TLS or have the wrong UUID.
-        tracing::warn!(
-            version = %format!("{:#04x}", version),
-            "vless: response version mismatch (expected 0x00) — \
-             check UUID and whether a TLS layer is required"
-        );
-        return Err(MeowError::Proxy(format!(
-            "vless: version mismatch: expected 0x00, got {version:#04x}"
-        )));
+        _ => {
+            dst.put_u8(0x00); // addon_length = 0
+        }
     }
-
-    if addon_length > 0 {
-        let mut discard = vec![0u8; addon_length];
-        stream
-            .read_exact(&mut discard)
-            .await
-            .map_err(MeowError::Io)?;
-    }
-
-    Ok(())
 }
+
+// The VLESS response header `[version][addon_length][addon…]` is consumed
+// by `VlessConn::poll_read` (TCP) and `VlessUdpReader::read_packet` (UDP)
+// with persistent, cancellation-safe progress in `vless/conn.rs`.
 
 // ─── Unit tests (§A, §B) ─────────────────────────────────────────────────────
 
@@ -449,144 +408,15 @@ mod tests {
         // Send a valid response header back.
         server.write_all(&[0x00, 0x00]).await.unwrap();
 
-        // decode_response must succeed.
-        decode_response(&mut client)
+        // The response header round-trips as [version=0][addon_length=0].
+        let mut resp = [0u8; 2];
+        tokio::io::AsyncReadExt::read_exact(&mut client, &mut resp)
             .await
             .expect("round-trip decode ok");
+        assert_eq!(resp, [0x00, 0x00]);
     }
 
-    // ─── B1: response version 0 ok ───────────────────────────────────────────
-
-    #[tokio::test]
-    async fn response_decode_version_zero_ok() {
-        use tokio::io::duplex;
-        use tokio::io::AsyncWriteExt;
-
-        let (mut client, mut server) = duplex(64);
-        server.write_all(&[0x00, 0x00]).await.unwrap();
-        decode_response(&mut client)
-            .await
-            .expect("version 0 must succeed");
-    }
-
-    // ─── B2: response with non-zero addon_length ──────────────────────────────
-
-    /// version=0, addon_length=2, addon bytes read+discarded.
-    /// Guards against ignoring addon_length and misaligning subsequent reads.
-    #[tokio::test]
-    async fn response_decode_version_zero_with_addon() {
-        use tokio::io::duplex;
-        use tokio::io::AsyncWriteExt;
-
-        let (mut client, mut server) = duplex(64);
-        server.write_all(&[0x00, 0x02, 0xAA, 0xBB]).await.unwrap();
-        decode_response(&mut client)
-            .await
-            .expect("version 0 with addon must succeed");
-
-        // Confirm the stream is now aligned: next byte (if any) is payload, not addon.
-        // No further bytes queued, so just assert decode succeeded.
-    }
-
-    // ─── B3: version mismatch warns + errors ─────────────────────────────────
-
-    /// Input [0x01, 0x00] → Err; tracing shows a warn with "version" or "mismatch".
-    /// upstream: transport/vless/conn.go closes silently.
-    /// NOT silent — we surface the reason for debugging.
-    #[test]
-    fn response_decode_version_mismatch_warns_and_errors() {
-        use std::sync::{Arc, Mutex};
-        use tokio::io::duplex;
-        use tracing_subscriber::fmt::MakeWriter;
-
-        // Capture warnings.
-        let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let line_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
-
-        #[derive(Clone)]
-        struct CapWriter(Arc<Mutex<Vec<String>>>, Arc<Mutex<String>>);
-        impl std::io::Write for CapWriter {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                let s = String::from_utf8_lossy(buf).to_string();
-                let mut lb = self.1.lock().unwrap();
-                lb.push_str(&s);
-                if lb.contains('\n') {
-                    let mut log = self.0.lock().unwrap();
-                    for line in lb.split('\n') {
-                        let t = line.trim();
-                        if !t.is_empty() {
-                            log.push(t.to_string());
-                        }
-                    }
-                    lb.clear();
-                }
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-        impl<'a> MakeWriter<'a> for CapWriter {
-            type Writer = Self;
-            fn make_writer(&'a self) -> Self {
-                self.clone()
-            }
-        }
-
-        let cap = CapWriter(Arc::clone(&captured), line_buf);
-        let sub = tracing_subscriber::fmt()
-            .with_writer(cap)
-            .with_ansi(false)
-            .with_level(true)
-            .finish();
-
-        let result = tracing::subscriber::with_default(sub, || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .unwrap();
-            rt.block_on(async {
-                let (mut client, mut server) = duplex(64);
-                tokio::io::AsyncWriteExt::write_all(&mut server, &[0x01, 0x00])
-                    .await
-                    .unwrap();
-                decode_response(&mut client).await
-            })
-        });
-
-        assert!(result.is_err(), "version mismatch must return Err");
-        let err_str = result.unwrap_err().to_string();
-        assert!(
-            err_str.contains("version") || err_str.contains("mismatch"),
-            "error must mention version mismatch, got: {err_str}"
-        );
-
-        let logs = captured.lock().unwrap();
-        let warn_count = logs
-            .iter()
-            .filter(|l| l.contains("WARN") && (l.contains("version") || l.contains("mismatch")))
-            .count();
-        assert_eq!(
-            warn_count, 1,
-            "exactly one warn must be emitted; got: {:?}",
-            *logs
-        );
-    }
-
-    // ─── B4: truncated buffer → clean Err, no panic ──────────────────────────
-
-    #[tokio::test]
-    async fn response_decode_truncated_buffer_errors() {
-        use tokio::io::duplex;
-        use tokio::io::AsyncWriteExt;
-
-        let (mut client, mut server) = duplex(64);
-        // Only send version byte, close before addon_length.
-        server.write_all(&[0x00]).await.unwrap();
-        drop(server); // EOF after 1 byte
-        let result = decode_response(&mut client).await;
-        assert!(
-            result.is_err(),
-            "truncated response must return Err, not panic"
-        );
-    }
+    // Response-header decode coverage (B1-B4) lives with the consumers
+    // now: `vless/conn.rs` tests `VlessUdpReader` for version mismatch,
+    // addon discard and truncated-header errors.
 }

--- a/crates/meow-proxy/src/vless/vision.rs
+++ b/crates/meow-proxy/src/vless/vision.rs
@@ -545,10 +545,17 @@ impl AsyncWrite for VisionConn {
             return Poll::Pending;
         }
 
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
         if !this.write_padding {
             return Pin::new(&mut this.inner).poll_write(cx, buf);
         }
-        this.build_write_frame(buf);
+        // The padding frame carries u16 content/padding length fields:
+        // chunk large writes so those fields cannot wrap and
+        // desynchronise the peer's vision decoder.
+        let chunk_len = buf.len().min(16 * 1024);
+        this.build_write_frame(&buf[..chunk_len]);
         match this.drain_pending_write(cx) {
             Poll::Ready(Ok(Some(n))) => Poll::Ready(Ok(n)),
             Poll::Ready(Ok(None)) => Poll::Ready(Ok(0)),

--- a/crates/meow-proxy/src/vless_adapter.rs
+++ b/crates/meow-proxy/src/vless_adapter.rs
@@ -23,15 +23,15 @@ use meow_common::{
 use smol_str::SmolStr;
 use tracing::debug;
 
+#[cfg(feature = "mux")]
+use crate::mux::{MuxClient, MuxOptions};
 use crate::stream_conn::StreamConn;
 use crate::transport_chain::TransportChain;
 use crate::vless::{addr_from_metadata, Cmd, VlessConn, VlessPacketConn};
+use std::sync::Arc;
 
 #[cfg(feature = "vless-vision")]
 use crate::vless::VisionConn;
-
-#[cfg(feature = "vless-encryption")]
-use std::sync::Arc;
 
 #[cfg(feature = "vless-encryption")]
 use crate::vless::encryption::ClientInstance;
@@ -57,7 +57,10 @@ pub struct VlessAdapter {
     uuid_bytes: [u8; 16],
     flow: Option<VlessFlow>,
     udp: bool,
-    transport: TransportChain,
+    transport: Arc<TransportChain>,
+    /// sing-mux compatible connection multiplexing (optional).
+    #[cfg(feature = "mux")]
+    mux: Option<Arc<MuxClient>>,
     /// VLESS post-quantum Encryption (`mlkem768x25519plus`), applied below the
     /// VLESS header exchange once per dial. `None` for plain VLESS.
     #[cfg(feature = "vless-encryption")]
@@ -88,11 +91,87 @@ impl VlessAdapter {
             uuid_bytes,
             flow,
             udp,
-            transport,
+            transport: Arc::new(transport),
+            #[cfg(feature = "mux")]
+            mux: None,
             #[cfg(feature = "vless-encryption")]
             encryption: None,
             health: ProxyHealth::new(),
         }
+    }
+
+    /// Enable connection multiplexing.  sing-mux (smux in this PR; yamux/h2mux
+    /// land in follow-up PRs) shares one connection pool: the session's VLESS
+    /// request targets the reserved mux destination
+    /// (sp.mux.sing-box.arpa:444) and a mux request header follows; the server
+    /// must be sing-box / mihomo with multiplex enabled.
+    #[cfg(feature = "mux")]
+    pub fn with_mux(mut self, options: MuxOptions) -> Self {
+        use crate::mux::{MuxClient, MUX_DESTINATION_FQDN, MUX_DESTINATION_PORT};
+        use crate::vless::header::VlessAddr;
+        use std::sync::Arc as StdArc;
+
+        let server = self.server.clone();
+        let port = self.port;
+        let uuid_bytes = self.uuid_bytes;
+        let transport = StdArc::clone(&self.transport);
+        let flow = self.flow;
+        #[cfg(feature = "vless-encryption")]
+        let encryption = self.encryption.clone();
+
+        let dial: crate::mux::DialFn = StdArc::new(move || {
+            let server = server.clone();
+            let transport = StdArc::clone(&transport);
+            #[cfg(feature = "vless-encryption")]
+            let encryption = encryption.clone();
+            Box::pin(async move {
+                let tcp = meow_common::connect_tcp_host(&server, port)
+                    .await
+                    .map_err(MeowError::Io)?;
+                let stream = transport.connect(Box::new(tcp)).await?;
+                #[cfg(feature = "vless-encryption")]
+                let stream = match &encryption {
+                    Some(encryption) => encryption.handshake(stream).await?,
+                    None => stream,
+                };
+                let flow_str = match flow {
+                    #[cfg(feature = "vless-vision")]
+                    Some(VlessFlow::XtlsRprxVision) => Some("xtls-rprx-vision"),
+                    _ => None,
+                };
+                let addr = VlessAddr::domain(MUX_DESTINATION_FQDN).expect("static mux fqdn");
+                #[cfg(feature = "vless-vision")]
+                // Defense-in-depth: parse_vless rejects vision+mux at config
+                // time; this guards programmatic construction.  Match on
+                // flow_str (which is Some only for the Vision variant) rather
+                // than flow.is_some(), so a future second flow variant does
+                // not silently build a VisionConn.
+                if flow_str.is_some() {
+                    let vless = VlessConn::new_deferred(
+                        stream,
+                        &uuid_bytes,
+                        flow_str,
+                        Cmd::Tcp,
+                        MUX_DESTINATION_PORT,
+                        &addr,
+                    )
+                    .await?;
+                    return Ok(Box::new(VisionConn::new(vless, uuid_bytes)) as Box<dyn ProxyConn>);
+                }
+                let conn = VlessConn::new(
+                    stream,
+                    &uuid_bytes,
+                    flow_str,
+                    Cmd::Tcp,
+                    MUX_DESTINATION_PORT,
+                    &addr,
+                )
+                .await?;
+                Ok(Box::new(StreamConn(Box::new(conn))) as Box<dyn ProxyConn>)
+            })
+        });
+        self.mux = Some(MuxClient::new(dial, options));
+        self
     }
 
     /// Attach a VLESS Encryption client (`encryption: mlkem768x25519plus…`).
@@ -135,7 +214,19 @@ impl ProxyAdapter for VlessAdapter {
     }
 
     fn support_udp(&self) -> bool {
-        self.udp
+        // With mux enabled, UDP rides the mux TCP session (unless
+        // `only-tcp` forces the plain path) — mirrors mihomo's
+        // SingMux.SupportUDP.
+        self.udp || {
+            #[cfg(feature = "mux")]
+            {
+                self.mux.as_ref().is_some_and(|mux| mux.supports_udp())
+            }
+            #[cfg(not(feature = "mux"))]
+            {
+                false
+            }
+        }
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
@@ -145,6 +236,12 @@ impl ProxyAdapter for VlessAdapter {
             self.addr_str,
             self.flow
         );
+
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            let conn = mux.open_stream_for(metadata, "vless").await?;
+            return Ok(Box::new(conn));
+        }
 
         let stream = self.dial_stream().await?;
         let addr = addr_from_metadata(metadata);
@@ -164,11 +261,12 @@ impl ProxyAdapter for VlessAdapter {
             }
         };
 
-        // Vision must wrap the connection BEFORE the request header is sent:
-        // xray expects the VLESS request inside the first Vision-padded record
-        // (mihomo wires it the same way), so the header is deferred to the
-        // first write through the Vision layer.
         let conn = match self.flow {
+            // Vision must wrap the connection BEFORE the request header is
+            // sent: xray expects the VLESS request inside the first
+            // Vision-padded record (mihomo wires it the same way), so the
+            // header is deferred to the first write through the Vision
+            // layer.
             #[cfg(feature = "vless-vision")]
             Some(VlessFlow::XtlsRprxVision) => {
                 let vless = VlessConn::new_deferred(
@@ -199,6 +297,20 @@ impl ProxyAdapter for VlessAdapter {
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            if mux.supports_udp() {
+                debug!(
+                    "VLESS mux UDP connecting to {} via {}",
+                    metadata.remote_address(),
+                    self.addr_str
+                );
+            }
+            if let Some(conn) = mux.open_packet_stream_for(metadata, "vless").await? {
+                return Ok(conn);
+            }
+        }
+
         // Vision is TCP-only; UDP always uses plain VlessConn regardless of flow.
         debug!(
             "VLESS UDP connecting to {} via {}",

--- a/crates/meow-proxy/src/vless_adapter.rs
+++ b/crates/meow-proxy/src/vless_adapter.rs
@@ -164,21 +164,38 @@ impl ProxyAdapter for VlessAdapter {
             }
         };
 
-        let conn = VlessConn::new(
-            stream,
-            &self.uuid_bytes,
-            flow_str,
-            Cmd::Tcp,
-            metadata.dst_port,
-            &addr,
-        )
-        .await?;
-
-        match self.flow {
+        // Vision must wrap the connection BEFORE the request header is sent:
+        // xray expects the VLESS request inside the first Vision-padded record
+        // (mihomo wires it the same way), so the header is deferred to the
+        // first write through the Vision layer.
+        let conn = match self.flow {
             #[cfg(feature = "vless-vision")]
-            Some(VlessFlow::XtlsRprxVision) => Ok(Box::new(VisionConn::new(conn, self.uuid_bytes))),
-            _ => Ok(Box::new(StreamConn(Box::new(conn)))),
-        }
+            Some(VlessFlow::XtlsRprxVision) => {
+                let vless = VlessConn::new_deferred(
+                    stream,
+                    &self.uuid_bytes,
+                    flow_str,
+                    Cmd::Tcp,
+                    metadata.dst_port,
+                    &addr,
+                )
+                .await?;
+                Box::new(VisionConn::new(vless, self.uuid_bytes)) as Box<dyn ProxyConn>
+            }
+            _ => {
+                let conn = VlessConn::new(
+                    stream,
+                    &self.uuid_bytes,
+                    flow_str,
+                    Cmd::Tcp,
+                    metadata.dst_port,
+                    &addr,
+                )
+                .await?;
+                Box::new(StreamConn(Box::new(conn)))
+            }
+        };
+        Ok(conn)
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {

--- a/crates/meow-proxy/src/vmess/header.rs
+++ b/crates/meow-proxy/src/vmess/header.rs
@@ -78,11 +78,10 @@ pub struct SealedHeader {
 ///
 /// Returns (encrypted_header_bytes, req_key, req_iv, resp_v) for the caller
 /// to derive body cipher keys.
-pub fn seal_request_header(
+fn seal_header(
     cmd_key: &[u8; 16],
     security: Security,
-    metadata: &Metadata,
-    is_udp: bool,
+    cmd: HeaderCmd<'_>,
 ) -> Result<SealedHeader, String> {
     let mut rng = rand::rng();
 
@@ -101,9 +100,7 @@ pub fn seal_request_header(
     let auth_id = build_auth_id(cmd_key, &mut rng);
 
     // 2) Build plaintext header
-    let plaintext = build_header_plaintext(
-        &req_key, &req_iv, resp_v, security, metadata, is_udp, &mut rng,
-    )?;
+    let plaintext = build_header_plaintext(&req_key, &req_iv, resp_v, security, cmd, &mut rng)?;
 
     // 3) Derive header encryption keys
     let header_key = kdf16(cmd_key, &[b"VMess Header AEAD Key", &auth_id, &conn_nonce]);
@@ -168,6 +165,22 @@ pub fn seal_request_header(
         req_iv,
         resp_v,
     })
+}
+
+/// Seal a VMess request header carrying the given destination and the TCP
+/// or UDP command byte.
+pub fn seal_request_header(
+    cmd_key: &[u8; 16],
+    security: Security,
+    metadata: &Metadata,
+    is_udp: bool,
+) -> Result<SealedHeader, String> {
+    let cmd = if is_udp {
+        HeaderCmd::Udp(metadata)
+    } else {
+        HeaderCmd::Tcp(metadata)
+    };
+    seal_header(cmd_key, security, cmd)
 }
 
 /// Response body key/iv for AEAD VMess, derived from the request body
@@ -252,17 +265,27 @@ fn build_auth_id(cmd_key: &[u8; 16], rng: &mut impl RngCore) -> [u8; 16] {
     block
 }
 
+/// The header destination: `None` for CommandMux (no port/address follows
+/// the command byte — mirrors sing-vmess `if command != CommandMux`).
+#[derive(Clone, Copy)]
+enum HeaderCmd<'a> {
+    Tcp(&'a Metadata),
+    Udp(&'a Metadata),
+}
+
 fn build_header_plaintext(
     req_key: &[u8; 16],
     req_iv: &[u8; 16],
     resp_v: u8,
     security: Security,
-    metadata: &Metadata,
-    is_udp: bool,
+    cmd: HeaderCmd<'_>,
     rng: &mut impl RngCore,
 ) -> Result<Vec<u8>, String> {
     let padding_len = (rng.next_u32() % 16) as u8;
-    let cmd = if is_udp { CMD_UDP } else { CMD_TCP };
+    let (cmd_byte, metadata) = match cmd {
+        HeaderCmd::Tcp(m) => (CMD_TCP, Some(m)),
+        HeaderCmd::Udp(m) => (CMD_UDP, Some(m)),
+    };
 
     let mut buf = Vec::with_capacity(64);
     buf.push(0x01); // version
@@ -272,13 +295,15 @@ fn build_header_plaintext(
     buf.push(OPT_STANDARD); // opts: S=1
     buf.push((padding_len << 4) | security.to_nibble()); // p(4) || sec(4)
     buf.push(0x00); // reserved
-    buf.push(cmd);
+    buf.push(cmd_byte);
 
-    // Port (big-endian, BEFORE addr_type)
-    buf.extend_from_slice(&metadata.dst_port.to_be_bytes());
+    if let Some(metadata) = metadata {
+        // Port (big-endian, BEFORE addr_type)
+        buf.extend_from_slice(&metadata.dst_port.to_be_bytes());
 
-    // Address encoding
-    encode_address(&mut buf, metadata)?;
+        // Address encoding
+        encode_address(&mut buf, metadata)?;
+    }
 
     // Padding
     if padding_len > 0 {
@@ -582,8 +607,7 @@ mod tests {
             &req_iv,
             0x42,
             Security::Aes128Gcm,
-            &meta,
-            false,
+            HeaderCmd::Tcp(&meta),
             &mut rng,
         )
         .unwrap();

--- a/crates/meow-proxy/src/vmess/mod.rs
+++ b/crates/meow-proxy/src/vmess/mod.rs
@@ -8,6 +8,7 @@ use meow_common::{
     AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
 };
 use smol_str::SmolStr;
+use std::sync::Arc;
 use tracing::debug;
 
 use crate::transport_chain::TransportChain;
@@ -21,8 +22,11 @@ pub struct VmessAdapter {
     cmd_key: [u8; 16],
     security: Security,
     udp: bool,
-    transport: TransportChain,
+    transport: Arc<TransportChain>,
     health: ProxyHealth,
+    /// sing-mux compatible connection multiplexing (optional).
+    #[cfg(feature = "mux")]
+    mux: Option<Arc<crate::mux::MuxClient>>,
 }
 
 impl VmessAdapter {
@@ -43,21 +47,104 @@ impl VmessAdapter {
             cmd_key: header::cmd_key(&uuid_bytes),
             security,
             udp,
-            transport,
+            transport: Arc::new(transport),
             health: ProxyHealth::new(),
+            #[cfg(feature = "mux")]
+            mux: None,
         }
     }
 
-    async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
-            .await
-            .map_err(MeowError::Io)?;
-        let _ = tcp.set_nodelay(true);
-        self.transport
-            .connect(Box::new(tcp))
-            .await
-            .map_err(|e| MeowError::Proxy(format!("vmess transport: {e}")))
+    /// Enable sing-mux compatible connection multiplexing (smux in this PR;
+    /// yamux/h2mux land in follow-up PRs). The session's VMess request targets
+    /// the reserved mux destination (sp.mux.sing-box.arpa:444); the server must
+    /// be sing-box / mihomo with multiplex enabled on the VMess inbound.
+    #[cfg(feature = "mux")]
+    pub fn with_mux(mut self, options: crate::mux::MuxOptions) -> Self {
+        use crate::mux::{MuxClient, MUX_DESTINATION_FQDN, MUX_DESTINATION_PORT};
+        use std::sync::Arc as StdArc;
+
+        let transport = Arc::clone(&self.transport);
+        let server = self.server.clone();
+        let cmd_key = self.cmd_key;
+        let security = self.security;
+        let port = self.port;
+
+        let dial: crate::mux::DialFn = StdArc::new(move || {
+            let transport = Arc::clone(&transport);
+            let server = server.clone();
+            Box::pin(async move {
+                let metadata = Metadata {
+                    host: MUX_DESTINATION_FQDN.into(),
+                    dst_port: MUX_DESTINATION_PORT,
+                    ..Default::default()
+                };
+                let sealed = header::seal_request_header(&cmd_key, security, &metadata, false)
+                    .map_err(MeowError::Proxy)?;
+                dial_vmess(&transport, &server, port, sealed, security).await
+            })
+        });
+        self.mux = Some(MuxClient::new(dial, options));
+        self
     }
+
+    /// Dial a raw TCP + transport-chain stream to the VMess server, run the
+    /// VMess request header exchange for the given destination, and return
+    /// the encrypted duplex.
+    async fn dial_to(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        let sealed = header::seal_request_header(&self.cmd_key, self.security, metadata, false)
+            .map_err(MeowError::Proxy)?;
+        dial_vmess(
+            &self.transport,
+            &self.server,
+            self.port,
+            sealed,
+            self.security,
+        )
+        .await
+    }
+}
+
+/// Dial a raw TCP + transport-chain stream to the VMess server, run the
+/// VMess request header exchange for the given destination, and return the
+/// encrypted duplex.  Shared by the plain dial path and the sing-mux
+/// session dialer (which targets the reserved mux destination).
+async fn dial_vmess(
+    transport: &TransportChain,
+    server: &str,
+    port: u16,
+    sealed: header::SealedHeader,
+    security: Security,
+) -> Result<Box<dyn ProxyConn>> {
+    use tokio::io::AsyncWriteExt;
+
+    let tcp = meow_common::connect_tcp_host(server, port)
+        .await
+        .map_err(MeowError::Io)?;
+    let _ = tcp.set_nodelay(true);
+    let mut stream = transport
+        .connect(Box::new(tcp))
+        .await
+        .map_err(|e| MeowError::Proxy(format!("vmess transport: {e}")))?;
+
+    stream
+        .write_all(&sealed.bytes)
+        .await
+        .map_err(MeowError::Io)?;
+
+    let read_cipher =
+        body::BodyCipher::new(security, &sealed.req_key, &sealed.req_iv, sealed.resp_v);
+    let write_cipher =
+        body::BodyCipher::new(security, &sealed.req_key, &sealed.req_iv, sealed.resp_v);
+
+    let duplex = conn::spawn_vmess_relay(
+        stream,
+        read_cipher,
+        write_cipher,
+        sealed.req_key,
+        sealed.req_iv,
+        sealed.resp_v,
+    );
+    Ok(Box::new(crate::stream_conn::StreamConn(Box::new(duplex))))
 }
 
 #[async_trait]
@@ -75,7 +162,19 @@ impl ProxyAdapter for VmessAdapter {
     }
 
     fn support_udp(&self) -> bool {
-        self.udp
+        // With mux enabled, UDP rides the mux TCP session (unless
+        // `only-tcp` forces the plain path) — mirrors mihomo's
+        // SingMux.SupportUDP.
+        self.udp || {
+            #[cfg(feature = "mux")]
+            {
+                self.mux.as_ref().is_some_and(|mux| mux.supports_udp())
+            }
+            #[cfg(not(feature = "mux"))]
+            {
+                false
+            }
+        }
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
@@ -85,43 +184,31 @@ impl ProxyAdapter for VmessAdapter {
             self.addr_str
         );
 
-        let stream = self.dial_stream().await?;
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            let conn = mux.open_stream_for(metadata, "vmess").await?;
+            return Ok(Box::new(conn));
+        }
 
-        let sealed = header::seal_request_header(&self.cmd_key, self.security, metadata, false)
-            .map_err(MeowError::Proxy)?;
-
-        use tokio::io::AsyncWriteExt;
-        let mut stream = stream;
-        stream
-            .write_all(&sealed.bytes)
-            .await
-            .map_err(MeowError::Io)?;
-
-        let read_cipher = body::BodyCipher::new(
-            self.security,
-            &sealed.req_key,
-            &sealed.req_iv,
-            sealed.resp_v,
-        );
-        let write_cipher = body::BodyCipher::new(
-            self.security,
-            &sealed.req_key,
-            &sealed.req_iv,
-            sealed.resp_v,
-        );
-
-        let duplex = conn::spawn_vmess_relay(
-            stream,
-            read_cipher,
-            write_cipher,
-            sealed.req_key,
-            sealed.req_iv,
-            sealed.resp_v,
-        );
-        Ok(Box::new(crate::stream_conn::StreamConn(Box::new(duplex))))
+        self.dial_to(metadata).await
     }
 
-    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+    #[cfg_attr(not(feature = "mux"), allow(unused_variables))]
+    async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        #[cfg(feature = "mux")]
+        if let Some(mux) = &self.mux {
+            if mux.supports_udp() {
+                debug!(
+                    "VMess mux UDP connecting to {} via {}",
+                    metadata.remote_address(),
+                    self.addr_str
+                );
+            }
+            if let Some(conn) = mux.open_packet_stream_for(metadata, "vmess").await? {
+                return Ok(conn);
+            }
+        }
+
         Err(MeowError::NotSupported(
             "vmess UDP relay not yet implemented".into(),
         ))

--- a/crates/meow-transport/src/h2.rs
+++ b/crates/meow-transport/src/h2.rs
@@ -7,16 +7,10 @@
 //!
 //! upstream: transport/vmess/h2.go
 
-use std::io;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
 use async_trait::async_trait;
-use bytes::Bytes;
 use rand::seq::IndexedRandom as _;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use crate::h2_common::RecvState;
+use crate::h2_common::{H2Stream, RecvState};
 use crate::{Result, Stream, Transport, TransportError};
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -38,7 +32,6 @@ pub struct H2Config {
     /// rejects an empty list at parse time (Class A divergence, hard error).
     pub hosts: Vec<String>,
 }
-
 impl Default for H2Config {
     fn default() -> Self {
         Self {
@@ -96,6 +89,14 @@ impl Transport for H2Layer {
             let _ = conn.await;
         });
 
+        // h2 requires poll_ready/ready before send_request: sending
+        // without readiness is rejected once MAX_CONCURRENT_STREAMS is
+        // exhausted.
+        h2 = h2
+            .ready()
+            .await
+            .map_err(|e| TransportError::H2(e.to_string()))?;
+
         // Open the h2 stream; `end_of_stream = false` — we will stream data.
         let (response_future, send_stream) = h2
             .send_request(request, false)
@@ -111,133 +112,3 @@ impl Transport for H2Layer {
         )))
     }
 }
-
-// ─── H2Stream ────────────────────────────────────────────────────────────────
-
-/// A raw bidirectional stream over a single HTTP/2 request/response pair.
-///
-/// Unlike [`GunStream`] in `grpc.rs`, no gun framing is applied — bytes pass
-/// through the h2 DATA frames verbatim.
-struct H2Stream {
-    send: h2::SendStream<Bytes>,
-    /// Response body, resolved on the first read (see [`RecvState`]).
-    recv: RecvState,
-    /// Buffered payload bytes from the most recently received DATA frame.
-    read_buf: Bytes,
-    /// Pre-encoded payload stashed while we wait for h2 send-window capacity.
-    /// Set on the first `poll_write` for a given `buf`; cleared after
-    /// `send_data` succeeds.  Ensures `reserve_capacity` is called exactly
-    /// once per logical write.
-    pending_write: Option<Bytes>,
-}
-
-impl H2Stream {
-    fn new(send: h2::SendStream<Bytes>, recv: RecvState) -> Self {
-        Self {
-            send,
-            recv,
-            read_buf: Bytes::new(),
-            pending_write: None,
-        }
-    }
-}
-
-impl AsyncRead for H2Stream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        let this = self.get_mut();
-
-        loop {
-            // Drain any buffered bytes from the last DATA frame first.
-            if !this.read_buf.is_empty() {
-                let n = this.read_buf.len().min(buf.remaining());
-                buf.put_slice(&this.read_buf[..n]);
-                let _ = this.read_buf.split_to(n);
-                return Poll::Ready(Ok(()));
-            }
-
-            // Fetch the next DATA frame from the h2 receive stream. Resolving
-            // the response is part of the read path, not of `connect()`; see
-            // `h2_common::RecvState`.
-            match this.recv.poll_ready(cx) {
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Ready(Ok(())) => {}
-            }
-            let recv = this.recv.stream().expect("poll_ready resolved Ok");
-            match recv.poll_data(cx) {
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(None) => return Poll::Ready(Ok(())), // clean EOF
-                Poll::Ready(Some(Err(e))) => {
-                    return Poll::Ready(Err(io::Error::other(e)));
-                }
-                Poll::Ready(Some(Ok(bytes))) => {
-                    // Release flow-control window back to the sender.
-                    let _ = recv.flow_control().release_capacity(bytes.len());
-                    this.read_buf = bytes;
-                    // loop → drain read_buf
-                }
-            }
-        }
-    }
-}
-
-impl AsyncWrite for H2Stream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        let this = self.get_mut();
-
-        // Stash the payload exactly once per logical write.  If pending_write
-        // is already set, a previous poll returned Pending; capacity has been
-        // reserved — do not encode or reserve again.
-        if this.pending_write.is_none() {
-            let data = Bytes::copy_from_slice(buf);
-            this.send.reserve_capacity(data.len());
-            this.pending_write = Some(data);
-        }
-
-        // Wait for the h2 send window to open.
-        match this.send.poll_capacity(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(None) => {
-                this.pending_write = None;
-                Poll::Ready(Err(io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    "h2: send stream closed",
-                )))
-            }
-            Poll::Ready(Some(Err(e))) => {
-                this.pending_write = None;
-                Poll::Ready(Err(io::Error::other(e)))
-            }
-            Poll::Ready(Some(Ok(_capacity))) => {
-                let data = this.pending_write.take().expect("set above");
-                this.send.send_data(data, false).map_err(io::Error::other)?;
-                Poll::Ready(Ok(buf.len()))
-            }
-        }
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // h2 DATA frames are pushed into the h2 connection immediately on
-        // send_data; there is no write-side buffer to flush.
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let this = self.get_mut();
-        // Send empty DATA + EOS flag to signal end of the request stream.
-        this.send
-            .send_data(Bytes::new(), true)
-            .map_err(io::Error::other)?;
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl Unpin for H2Stream {}

--- a/crates/meow-transport/src/h2_common.rs
+++ b/crates/meow-transport/src/h2_common.rs
@@ -1,73 +1,298 @@
-//! Shared HTTP/2 plumbing for the `grpc` (gun) and `h2` transports.
-//!
-//! Both transports open a single long-lived `POST` and use its request/response
-//! bodies as a bidirectional byte stream. The one thing they must *not* do is
-//! wait for the server's response HEADERS before handing the stream to the
-//! proxy codec: xray's `Tun` gRPC handler and mihomo's h2 handler both block
-//! reading the client's first DATA frame before they write anything, and Go's
-//! `grpc-go` only flushes response headers on the first `SendMsg`. A client
-//! that awaits the response first therefore deadlocks — the tunnel comes up,
-//! the REALITY/TLS handshake succeeds, and then nothing ever moves (issue
-//! #377).
-//!
-//! [`RecvState`] defers that await to the first read, which is what upstream
-//! does (`transport/gun/gun.go` resolves the response inside `Read`).
+//! Shared raw HTTP/2 stream plumbing for the h2 transport and sing-h2mux.
 
+use bytes::Bytes;
+use http::StatusCode;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-/// Receive half of a client-initiated h2 request, resolved lazily on first read.
-pub(crate) enum RecvState {
-    /// Response HEADERS not seen yet.
+/// Accepted response status for a lazily resolved HTTP/2 body.
+#[derive(Clone, Copy)]
+pub enum StatusPolicy {
+    Success,
+    Exact(StatusCode),
+}
+
+enum RecvInner {
     Pending(h2::client::ResponseFuture),
-    /// Response received and accepted; body stream ready.
     Ready(h2::RecvStream),
-    /// Response resolved to an error (transport failure or non-2xx status).
     Failed,
 }
 
-impl RecvState {
-    pub(crate) fn new(response: h2::client::ResponseFuture) -> Self {
-        Self::Pending(response)
-    }
+/// Receive half of a client-initiated h2 request, resolved lazily on first
+/// read so servers that wait for request DATA cannot deadlock setup.
+pub struct RecvState {
+    inner: RecvInner,
+    timeout: Option<Pin<Box<tokio::time::Sleep>>>,
+    status: StatusPolicy,
+    label: &'static str,
+}
 
-    /// Drive the response future far enough that [`Self::stream`] returns the
-    /// body. Once this resolves `Ready(Ok(()))` the state is [`Self::Ready`].
-    pub(crate) fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        match self {
-            Self::Ready(_) => Poll::Ready(Ok(())),
-            Self::Failed => Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "h2: response stream already failed",
-            ))),
-            Self::Pending(future) => match Pin::new(future).poll(cx) {
-                Poll::Pending => Poll::Pending,
-                Poll::Ready(Ok(response)) => {
-                    let status = response.status();
-                    if !status.is_success() {
-                        *self = Self::Failed;
-                        return Poll::Ready(Err(io::Error::other(format!(
-                            "h2: server answered with status {status}, expected 2xx"
-                        ))));
-                    }
-                    *self = Self::Ready(response.into_body());
-                    Poll::Ready(Ok(()))
-                }
-                Poll::Ready(Err(e)) => {
-                    *self = Self::Failed;
-                    Poll::Ready(Err(io::Error::other(e)))
-                }
-            },
+impl RecvState {
+    pub fn new(response: h2::client::ResponseFuture) -> Self {
+        Self {
+            inner: RecvInner::Pending(response),
+            timeout: None,
+            status: StatusPolicy::Success,
+            label: "h2",
         }
     }
 
-    /// The body stream. Only `Some` after [`Self::poll_ready`] resolved `Ok`.
-    pub(crate) fn stream(&mut self) -> Option<&mut h2::RecvStream> {
-        match self {
-            Self::Ready(recv) => Some(recv),
+    pub fn with_timeout(
+        response: h2::client::ResponseFuture,
+        timeout: Duration,
+        status: StatusPolicy,
+        label: &'static str,
+    ) -> Self {
+        Self {
+            inner: RecvInner::Pending(response),
+            timeout: Some(Box::pin(tokio::time::sleep(timeout))),
+            status,
+            label,
+        }
+    }
+
+    fn accepts(&self, status: StatusCode) -> bool {
+        match self.status {
+            StatusPolicy::Success => status.is_success(),
+            StatusPolicy::Exact(expected) => status == expected,
+        }
+    }
+
+    /// Drive the response future far enough that [`Self::stream`] returns the
+    /// body. Once this resolves `Ready(Ok(()))`, the body is retained.
+    pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.inner {
+            RecvInner::Ready(_) => return Poll::Ready(Ok(())),
+            RecvInner::Failed => {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    format!("{}: response stream already failed", self.label),
+                )))
+            }
+            RecvInner::Pending(future) => match Pin::new(future).poll(cx) {
+                Poll::Pending => {}
+                Poll::Ready(Ok(response)) => {
+                    let status = response.status();
+                    if !self.accepts(status) {
+                        self.inner = RecvInner::Failed;
+                        return Poll::Ready(Err(io::Error::other(format!(
+                            "{}: unexpected response status {status}",
+                            self.label
+                        ))));
+                    }
+                    self.inner = RecvInner::Ready(response.into_body());
+                    self.timeout = None;
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Ready(Err(error)) => {
+                    self.inner = RecvInner::Failed;
+                    return Poll::Ready(Err(io::Error::other(error)));
+                }
+            },
+        }
+
+        if let Some(timeout) = &mut self.timeout {
+            if timeout.as_mut().poll(cx).is_ready() {
+                self.inner = RecvInner::Failed;
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("{}: response timeout", self.label),
+                )));
+            }
+        }
+        Poll::Pending
+    }
+
+    pub fn stream(&mut self) -> Option<&mut h2::RecvStream> {
+        match &mut self.inner {
+            RecvInner::Ready(stream) => Some(stream),
             _ => None,
         }
     }
 }
+
+/// Raw bidirectional bytes over one HTTP/2 request/response pair.
+pub struct H2Stream {
+    send: h2::SendStream<Bytes>,
+    recv: RecvState,
+    read_buf: Bytes,
+    /// Pre-encoded payload stashed while waiting for h2 send-window
+    /// capacity, plus the number of bytes already handed to the
+    /// connection.  Only the ungranted remainder is ever sent, so a
+    /// peer that stops reading applies real backpressure instead of
+    /// growing h2's internal buffer.
+    pending_write: Option<(Bytes, usize)>,
+    remote_no_error_is_eof: bool,
+    eos_sent: bool,
+}
+
+impl H2Stream {
+    pub fn new(send: h2::SendStream<Bytes>, recv: RecvState) -> Self {
+        Self {
+            send,
+            recv,
+            read_buf: Bytes::new(),
+            pending_write: None,
+            remote_no_error_is_eof: false,
+            eos_sent: false,
+        }
+    }
+
+    pub fn with_remote_no_error_eof(mut self) -> Self {
+        self.remote_no_error_is_eof = true;
+        self
+    }
+
+    fn best_effort_eos(&mut self) {
+        if !self.eos_sent {
+            self.eos_sent = true;
+            let _ = self.send.send_data(Bytes::new(), true);
+        }
+    }
+}
+
+impl Drop for H2Stream {
+    fn drop(&mut self) {
+        self.best_effort_eos();
+    }
+}
+
+impl AsyncRead for H2Stream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        // A zero-capacity buffer yields Ready(Ok(())) per the tokio
+        // AsyncRead docs (a Pending here would leave `read(&mut [])`
+        // parked forever).
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        loop {
+            if !this.read_buf.is_empty() {
+                let count = this.read_buf.len().min(buf.remaining());
+                buf.put_slice(&this.read_buf[..count]);
+                let _ = this.read_buf.split_to(count);
+                return Poll::Ready(Ok(()));
+            }
+            match this.recv.poll_ready(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) => {}
+            }
+            let recv = this.recv.stream().expect("poll_ready resolved Ok");
+            match recv.poll_data(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(Ok(())),
+                Poll::Ready(Some(Err(error))) => {
+                    if this.remote_no_error_is_eof
+                        && error.is_reset()
+                        && error.is_remote()
+                        && error.reason() == Some(h2::Reason::NO_ERROR)
+                    {
+                        return Poll::Ready(Ok(()));
+                    }
+                    return Poll::Ready(Err(io::Error::other(error)));
+                }
+                Poll::Ready(Some(Ok(bytes))) => {
+                    let _ = recv.flow_control().release_capacity(bytes.len());
+                    this.read_buf = bytes;
+                }
+            }
+        }
+    }
+}
+
+impl AsyncWrite for H2Stream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let this = self.get_mut();
+        // Stash the payload exactly once per logical write.  If
+        // pending_write is set, a previous poll returned Pending and
+        // capacity has been reserved — do not copy or reserve again.
+        // A Pending poll must be retried with the same buffer; reject a
+        // changed buffer rather than silently sending stale bytes under
+        // its reported length.  The comparison is offset-aware: after a
+        // partial send, write_all advances the buffer by the consumed
+        // amount, so the incoming buf matches &data[offset..].
+        if let Some((data, offset)) = &this.pending_write {
+            if buf != &data[*offset..] {
+                this.pending_write = None;
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "h2: write buffer changed after Pending; \
+                     AsyncWrite requires retrying with the same buffer",
+                )));
+            }
+        } else {
+            let data = Bytes::copy_from_slice(buf);
+            this.send.reserve_capacity(data.len());
+            this.pending_write = Some((data, 0));
+        }
+        match this.send.poll_capacity(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => {
+                this.pending_write = None;
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "h2: send stream closed",
+                )))
+            }
+            Poll::Ready(Some(Err(error))) => {
+                this.pending_write = None;
+                Poll::Ready(Err(io::Error::other(error)))
+            }
+            Poll::Ready(Some(Ok(capacity))) => {
+                let (data, offset) = this.pending_write.as_mut().expect("set above");
+                let remaining = data.len() - *offset;
+                // poll_capacity may grant less than the reserved amount
+                // (the peer's flow-control window); send only the
+                // granted prefix and keep the rest pending.
+                let allowed = capacity.min(remaining);
+                if allowed == 0 {
+                    // Unreachable: poll_capacity yields Some(Ok(n)) with
+                    // n > 0, and remaining == 0 implies pending_write was
+                    // already cleared.  Re-register the waker defensively
+                    // so a future code change cannot park this task forever.
+                    debug_assert!(allowed > 0, "h2: zero capacity grant with remaining data");
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                let chunk = data.slice(*offset..*offset + allowed);
+                let chunk_len = chunk.len();
+                if let Err(error) = this.send.send_data(chunk, false) {
+                    this.pending_write = None;
+                    return Poll::Ready(Err(io::Error::other(error)));
+                }
+                *offset += chunk_len;
+                if *offset >= data.len() {
+                    this.pending_write = None;
+                }
+                Poll::Ready(Ok(chunk_len))
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().best_effort_eos();
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Unpin for H2Stream {}

--- a/crates/meow-transport/src/lib.rs
+++ b/crates/meow-transport/src/lib.rs
@@ -38,7 +38,7 @@ mod reality_tls;
 pub mod ws;
 
 #[cfg(any(feature = "grpc", feature = "h2"))]
-mod h2_common;
+pub mod h2_common;
 
 #[cfg(feature = "grpc")]
 pub mod grpc;

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -430,10 +430,19 @@ impl AsyncWrite for RealityTlsStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        if let Poll::Ready(done) = self.drain_pending_write(cx) {
-            done?;
-        } else {
-            return Poll::Pending;
+        // Drain any in-flight record first.  If the drain is still
+        // Pending, nothing from the incoming `buf` has been consumed —
+        // return Pending so the caller retries with the same buffer.
+        // If the drain completes, fall through to seal the new buffer
+        // rather than reporting the *old* record's length against the
+        // new buffer (AsyncWrite does not guarantee the same buffer is
+        // presented after a Pending).
+        if self.write_pending.is_some() {
+            match self.drain_pending_write(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {} // drained — fall through
+            }
         }
 
         if buf.is_empty() {
@@ -444,14 +453,23 @@ impl AsyncWrite for RealityTlsStream {
             return Pin::new(&mut self.inner).poll_write(cx, buf);
         }
 
+        // TLS records carry a u16 length: chunk large writes into
+        // standard 16 KiB records instead of letting the length field
+        // wrap (which would desynchronise the peer's TLS reader).
+        let chunk_len = buf.len().min(16 * 1024);
         let frame = self
             .write_key
-            .seal(TLS_RECORD_APPLICATION_DATA, buf)
+            .seal(TLS_RECORD_APPLICATION_DATA, &buf[..chunk_len])
             .map_err(transport_io_error)?;
         self.write_pending = Some(StreamPendingWrite { frame, pos: 0 });
+        // The record is buffered; report chunk_len immediately whether
+        // or not the drain completes now.  The next poll_write /
+        // poll_flush / poll_shutdown drains it.  Returning Pending here
+        // would be unsafe: the sealed record's plaintext length would
+        // be reported against whatever buffer arrives on the next poll.
         match self.drain_pending_write(cx) {
-            Poll::Ready(Ok(())) | Poll::Pending => Poll::Ready(Ok(buf.len())),
             Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            _ => Poll::Ready(Ok(chunk_len)),
         }
     }
 
@@ -553,9 +571,17 @@ fn build_reality_client_hello(
         .duration_since(UNIX_EPOCH)
         .map_err(|e| TransportError::Tls(format!("system clock before UNIX_EPOCH: {e}")))?
         .as_secs() as u32;
+    // Auth payload layout must match the server's expectation.  The first
+    // three bytes are the REALITY ClientVer triple.  sing-box hardcodes
+    // [1, 8, 1] (common/tls/reality_client.go:186-188); xray-core uses its
+    // own version bytes (transport/internet/reality/reality.go:143-145).
+    // Neither server validates these bytes — they are part of the 16-byte
+    // AES-GCM auth payload, and the server only checks the short_id and
+    // timestamp after decryption.  Using sing-box's value is the safe
+    // interop choice: it works with both sing-box and xray servers.
     reality_plain[0] = 1;
     reality_plain[1] = 8;
-    reality_plain[2] = 2;
+    reality_plain[2] = 1;
     reality_plain[3] = 0;
     reality_plain[4..8].copy_from_slice(&unix.to_be_bytes());
     reality_plain[8..16].copy_from_slice(&reality.short_id);
@@ -1063,6 +1089,11 @@ impl RecordKey {
         body.push(inner_type);
 
         let record_len = body.len() + 16;
+        if record_len > u16::MAX as usize {
+            return Err(TransportError::Tls(format!(
+                "TLS record exceeds u16 length: {record_len}"
+            )));
+        }
         let mut header = Vec::with_capacity(5);
         header.push(TLS_RECORD_APPLICATION_DATA);
         header.extend_from_slice(&[0x03, 0x03]);
@@ -1435,11 +1466,145 @@ mod tests {
         assert!(extract_ed25519_spki(&spki[2..]).is_none());
     }
 
+    // ─── Split + concurrent direction polling (mux regression) ───────────────
+
+    /// Deterministic chunk bytes for a (seq, len) pair.
+    fn chunk(seq: u32, len: usize) -> Vec<u8> {
+        let mut state = seq.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            out.push((state >> 24) as u8);
+        }
+        out
+    }
+
+    /// Invariant test backing the mux corruption investigation: the REALITY
+    /// record layer, driven through tokio split (read and write halves
+    /// polled from two tasks concurrently), must preserve data byte-exact.
+    /// The stress-era corruption was traced to the mux layer's stored-future
+    /// write (a Pending re-poll re-framed the same chunk, duplicating it),
+    /// NOT to this layer — this test locks that conclusion in: if split
+    /// driving ever corrupts here, the layer needs its own fix.
+    /// (see proxy-mux.md §6)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn split_concurrent_read_write_preserves_data() {
+        let (client_io, server_io) = tokio::io::duplex(512 * 1024);
+        let secret = [0x5Au8; 32];
+
+        let client_stream = RealityTlsStream {
+            inner: Box::new(client_io),
+            read_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            write_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            read_raw_passthrough: false,
+            write_raw_passthrough: false,
+            read_plain: VecDeque::new(),
+            read_state: StreamReadState::Header {
+                buf: [0; 5],
+                pos: 0,
+            },
+            write_pending: None,
+        };
+        let server_stream = RealityTlsStream {
+            inner: Box::new(server_io),
+            read_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            write_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            read_raw_passthrough: false,
+            write_raw_passthrough: false,
+            read_plain: VecDeque::new(),
+            read_state: StreamReadState::Header {
+                buf: [0; 5],
+                pos: 0,
+            },
+            write_pending: None,
+        };
+
+        // Server: read [u32 LE len][data] plaintext frames, echo them back.
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let mut s = server_stream;
+            loop {
+                let mut len_b = [0u8; 4];
+                if s.read_exact(&mut len_b).await.is_err() {
+                    return;
+                }
+                let len = u32::from_le_bytes(len_b) as usize;
+                if len == 0 {
+                    return;
+                }
+                let mut data = vec![0u8; len];
+                if s.read_exact(&mut data).await.is_err() {
+                    return;
+                }
+                if s.write_all(&len_b).await.is_err()
+                    || s.write_all(&data).await.is_err()
+                    || s.flush().await.is_err()
+                {
+                    return;
+                }
+            }
+        });
+
+        let (rd, wr) = tokio::io::split(Box::new(client_stream) as Box<dyn Stream>);
+
+        // Reader task: verify every echoed chunk against the deterministic
+        // generator — any corruption shows up as a mismatch.
+        let reader = tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut rd = rd;
+            let mut seq = 0u32;
+            let mut bad = 0u32;
+            let mut count = 0u32;
+            loop {
+                let mut len_b = [0u8; 4];
+                if rd.read_exact(&mut len_b).await.is_err() {
+                    return (count, bad);
+                }
+                let len = u32::from_le_bytes(len_b) as usize;
+                if len == 0 {
+                    return (count, bad);
+                }
+                let mut data = vec![0u8; len];
+                if rd.read_exact(&mut data).await.is_err() {
+                    return (count, bad);
+                }
+                if data != chunk(seq, len) {
+                    bad += 1;
+                }
+                count += 1;
+                seq += 1;
+            }
+        });
+
+        // Writer task: full-duplex pressure against the parked reader.
+        let write_task = tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let mut wr = wr;
+            for seq in 0..2000u32 {
+                let len = 1 + ((seq.wrapping_mul(2_654_435_761)) % 8192) as usize;
+                let data = chunk(seq, len);
+                let mut frame = Vec::with_capacity(4 + len);
+                frame.extend_from_slice(&(len as u32).to_le_bytes());
+                frame.extend_from_slice(&data);
+                if wr.write_all(&frame).await.is_err() || wr.flush().await.is_err() {
+                    return;
+                }
+            }
+            let _ = wr.write_all(&[0u8; 4]).await;
+            let _ = wr.flush().await;
+        });
+        write_task.await.unwrap();
+
+        let (count, bad) = reader.await.unwrap();
+        assert_eq!(bad, 0, "corrupted echoes under concurrent split polling");
+        assert_eq!(count, 2000, "all chunks must be echoed");
+    }
+
     // ─── Reality ClientHello session_id seal ──────────────────────────────────
 
     /// The 32-byte session_id must decrypt, under the key/nonce/AAD a real
     /// Reality server reconstructs, to the authentication payload
-    /// (`[1, 8, 2, 0] || timestamp || short_id`). Asserting the plaintext —
+    /// (`[1, 8, 1, 0] || timestamp || short_id`). Asserting the plaintext —
     /// not just the length — is what proves the server could authenticate us.
     #[test]
     fn reality_client_hello_session_id_decrypts_to_auth_payload() {
@@ -1479,7 +1644,12 @@ mod tests {
             .decrypt_in_place_detached(nonce, &aad, &mut buf, Tag::from_slice(tag))
             .expect("session_id must decrypt under the server-derived key");
 
-        assert_eq!(&buf[0..4], &[1, 8, 2, 0], "reality auth header");
+        // ClientVer triple [1, 8, 1] — sing-box's hardcoded value
+        // (common/tls/reality_client.go:186-188). Neither sing-box nor
+        // xray servers validate these bytes; they are part of the
+        // AES-GCM auth payload and the server only checks short_id
+        // and timestamp after decryption.
+        assert_eq!(&buf[0..4], &[1, 8, 1, 0], "reality auth header");
         assert_eq!(&buf[8..16], &reality.short_id, "short_id echoed");
     }
 
@@ -1502,5 +1672,114 @@ mod tests {
         let mut buf = vec![0u8; 50];
         buf[0] = HS_CLIENT_HELLO; // wrong handshake type
         assert!(parse_server_hello(&buf).is_err());
+    }
+
+    // ─── poll_write changed-buffer safety ─────────────────────────────────────
+
+    /// A mock inner stream whose first `poll_write` returns `Pending`
+    /// (after self-waking) so that `drain_pending_write` can't complete
+    /// on the initial seal.  Subsequent calls accept all bytes.
+    struct PendingOnce {
+        pending: bool,
+        written: Vec<u8>,
+    }
+
+    impl AsyncRead for PendingOnce {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for PendingOnce {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            if self.pending {
+                self.pending = false;
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            self.written.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl Unpin for PendingOnce {}
+
+    /// After `poll_write` seals a record and the inner stream returns
+    /// `Pending`, the caller is told `Ok(chunk_len)` immediately (the
+    /// record is buffered).  A *second* `poll_write` with a different
+    /// buffer must drain the pending record first, then seal and report
+    /// the *new* buffer's length — never the old record's length.
+    ///
+    /// This is the changed-buffer hazard from the #413 review: before
+    /// the fix the top path returned `Ok(consumed)` (the old record's
+    /// plaintext length) against whatever buffer arrived, sending stale
+    /// bytes while claiming the new buffer was consumed.
+    #[test]
+    fn poll_write_reports_new_chunk_len_after_pending_drain() {
+        let secret = [0x5Au8; 32];
+        let mut stream = RealityTlsStream {
+            inner: Box::new(PendingOnce {
+                pending: true,
+                written: Vec::new(),
+            }),
+            read_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            write_key: RecordKey::new(CipherSuite::Aes128GcmSha256, &secret),
+            read_raw_passthrough: false,
+            write_raw_passthrough: false,
+            read_plain: VecDeque::new(),
+            read_state: StreamReadState::Header {
+                buf: [0; 5],
+                pos: 0,
+            },
+            write_pending: None,
+        };
+
+        use tokio::io::AsyncWriteExt;
+
+        // First write: 10 bytes.  Inner returns Pending → drain returns
+        // Pending → poll_write returns Ok(10) with the record buffered.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let n = stream.write(&[0xAA; 10]).await.unwrap();
+            assert_eq!(n, 10, "first write: chunk_len reported immediately");
+        });
+
+        // The pending record is buffered (not fully drained).
+        assert!(
+            stream.write_pending.is_some(),
+            "record buffered after Pending drain"
+        );
+
+        // Second write: 5 different bytes.  The top path drains the
+        // pending record (inner now accepts), then seals the new buffer.
+        // Must report 5 (the new chunk_len), NOT 10 (the old record).
+        rt.block_on(async {
+            let n = stream.write(&[0xBB; 5]).await.unwrap();
+            assert_eq!(n, 5, "second write: new chunk_len, not old record's length");
+        });
+
+        // The pending record from the second write should also be
+        // drainable (inner accepts everything now).
+        assert!(
+            stream.write_pending.is_none(),
+            "second record drained on this call"
+        );
     }
 }

--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -202,10 +202,10 @@ proxies:
 | `flow: xtls-rprx-direct` / `xtls-rprx-splice` | Accepted (deprecated upstream) | Hard parse error — use `xtls-rprx-vision` instead. |
 | `encryption: mlkem768x25519plus…` (post-quantum Encryption) | Accepted | Supported with the `vless-encryption` feature (in `full`); otherwise a hard parse error naming the feature. |
 | `encryption:` any other non-`""`/`"none"` value | Accepted | Hard parse error — VLESS defines no other body cipher. |
-| `mux: {enabled: true}` | Multiplexes | Warn-once, ignored. |
+| `smux: {enabled: true}` | Multiplexes | Implemented as sing-mux (smux/yamux/h2mux; default h2mux) for sing-box/mihomo servers, plus Xray Mux.Cool (`protocol: muxcool`, VLESS/VMess) for Xray servers. Legacy `mux:` remains accepted. |
 | `tls: false` with no outer encryption | Accepted silently | Warn-once at load — traffic is plaintext. |
 
-**Deferred:** VLESS inbound and Mux.Cool.
+**Deferred:** VLESS inbound.
 
 ### HTTP CONNECT outbound
 

--- a/docs/specs/proxy-mux.md
+++ b/docs/specs/proxy-mux.md
@@ -1,0 +1,294 @@
+# proxy-mux: Connection Multiplexing (sing-mux + Xray Mux.Cool)
+
+Status: sing-mux (smux / yamux / h2mux) and **Xray Mux.Cool**
+(`protocol: muxcool`) are fully implemented, unit-tested. sing-mux
+applies to VLESS / Trojan / Shadowsocks / VMess outbounds; muxcool
+applies to VLESS and VMess (CommandMux signaling in both request
+headers). Interop matrix:
+
+- sing-mux ↔ sing-box v1.13.18 (VLESS plaintext / Trojan+TLS / Reality /
+  Reality+Vision inbounds with multiplex enabled) works both ways;
+- muxcool ↔ local sing-box (plaintext / Reality / Reality+Vision, TCP+UDP)
+  works;
+- muxcool ↔ **real Xray node** (example-xray-node, VLESS Reality+Vision)
+  works — on the same node sing-mux does not interoperate (Xray only speaks
+  Mux.Cool).
+  (follow-up, closing the mux gap from the gap analysis)
+Reference implementations: mihomo Alpha
+(adapter/outbound/singmux.go, listener/sing/sing.go), metacubex/sing-mux,
+sagernet/sing-mux, sagernet/smux (smux frame format), metacubex/sing v0.5.7
+(address codec); Mux.Cool follows xray-core common/mux
+(frame.go / writer.go / session.go) and sing-vmess mux.go.
+
+## Goal
+
+Real multiplexing the mihomo way: provide
+`smux: {enabled, protocol, max-connections, min-streams, max-streams, padding, statistic, only-tcp}`
+(aligned with SingMuxOption) on VLESS / Trojan / Shadowsocks / VMess
+outbounds, multiplexing many logical streams over **one physical node
+connection** and eliminating the per-stream node TCP+TLS+protocol handshake
+cost (measured 500-700ms per new connection @140ms RTT). The legacy `mux:`
+key remains accepted for compatibility; configuring both keys warns and prefers the canonical `smux:`.
+
+## Wire Protocols (confirmed field-by-field from the sources)
+
+### 1. Physical connection setup (VLESS / Trojan / SS / VMess)
+
+1. Client TCP(+TLS) to the node and performs the protocol handshake with
+   **destination = the reserved mux FQDN** `sp.mux.sing-box.arpa:444`:
+   VLESS and VMess carry the address in their request header; Trojan does
+   not but writes the reserved FQDN anyway for parity; SS carries no wire
+   address at all (the destination is irrelevant to the cipher stream —
+   the server detects multiplexing by sniffing the mux request header).
+2. The mux request header (see §2) is written **immediately after** the
+   handshake, in the same write batch.
+3. The server recognizes the mux request header → switches into the mux
+   service; the VLESS 2-byte response header (`[version, addons_len]`) is
+   **lazily prefixed to the first downstream write** by the server, so the
+   client strips it on its first read (meow-rs's `VlessConn` already has
+   lazy `response_pending` consumption, which fits naturally).
+
+### 2. Mux request header (protocol negotiation)
+
+| Field | Length | Meaning |
+|---|---|---|
+| version | u8 | 0 or 1 |
+| protocol | u8 | 0=smux, 1=yamux, 2=h2mux (mihomo default h2mux) |
+| padding | u8 | present only when version==1; 1=enabled |
+| padding_len | u16 BE | only when padding=1; value = 256 + rand(512) |
+| padding bytes | n | random padding |
+
+### 3. Sessions (one per physical connection, chosen by protocol)
+
+- **smux**: note — sing-mux uses the **sagernet/smux fork**, whose frame
+  format differs from upstream xtaci:
+  [ver=1][cmd][len u16 LE][stream_id u32 LE][data] (8-byte header,
+  little-endian). cmd: SYN=0, FIN=1, PSH=2, NOP=3 (UPD=4 only in v2). v1
+  has **no window-update flow control** — the write side splits into
+  MaxFrameSize=32768 frames (u16 length cap). Config =
+  smux.DefaultConfig() + KeepAliveDisabled=true (Version=1,
+  MaxFrameSize=32768, MaxStreamBuffer=64KiB, MaxReceiveBuffer=4MiB).
+- **yamux**: hashicorp yamux (interoperates with libp2p rust-yamux);
+  StreamClose/OpenTimeout = 5s.
+- **h2mux** (mihomo default): sing's custom layer over HTTP/2
+  (sing-mux/h2mux.go). Each stream = one CONNECT request to
+  https://localhost (no :scheme/:path); request-body DATA frames =
+  client→server, response-body DATA frames = server→client. The **server
+  flushes the 200 lazily**: the 200 HEADERS go on the wire only with the
+  first response-body write, so the client **must not block waiting for
+  the 200** — sing-mux uses lateHTTPConn (write side usable immediately,
+  read side waits for setup) — meow-rs likewise parses the response lazily
+  on the first read with a 5s (TCPTimeout) cap. On stream close sing-box
+  sends RST_STREAM(NO_ERROR), treated as a clean EOF (the Go client maps
+  it to io.EOF the same way). The sing-box *server* reaps idle h2mux
+  sessions after 30s (h2mux.go idleTimeout).
+
+### 4. Per-stream addressing (StreamRequest / StreamResponse)
+
+After opening a stream, the client's first write is the **stream request**
+(protocol.go EncodeStreamRequest):
+[flags u16 BE][type u8][addr][port u16 BE], flags=0 for TCP (flagUDP=1 for
+UDP streams). Socksaddr types: 0x01=IPv4(4B), 0x03=FQDN(len u8 + bytes),
+0x04=IPv6(16B). The server reads the address and dials the real target for
+that stream.
+
+**Every stream's first downstream write carries a status byte**
+(serverConn.Write): [status u8], 0=success; 1=error followed by a varbin
+length-prefixed error message. The client strips the status byte on its
+first read (sing-mux clientConn.readResponse); meow-rs handles it uniformly
+in the MuxStream layer for all three protocols.
+
+**UDP streams**: a stream whose flags set flagUDP(1) is a UDP stream, bound
+to the destination in the stream request; afterwards both directions are
+[len u16 BE][data] datagram frames (the same framing as meow's VLESS
+UDP-over-TCP), with no per-packet addresses. The server handles them via
+serverPacketConn. meow-rs's `MuxPacketConn` implements this framing;
+`only-tcp: true` routes UDP over the plain non-mux path instead. The
+`statistic`/`brutal-opts` fields are not supported yet (each gets a warn
+on parse; brutal is Linux-only upstream).
+
+### 5. Client session management (aligned with sing-mux client.go)
+
+- `openStream`: pick the session with the fewest streams among
+  `CanTakeNewRequest` sessions; if none, `offerNew` (fresh physical
+  connection + handshake + session).
+- Bounds: when maxConnections>0, decide by connection count / per-connection
+  minStreams; otherwise by global maxStreams.
+- Connection failure / closed session → retry at most 2 times; the
+  *client* pool evicts zero-stream sessions after a 60s idle timeout
+  (meow-rs `IDLE_TIMEOUT`, mirroring sing-mux Service IdleTimeout).
+- padding mode uses version=1; TCPTimeout=5s caps connection setup.
+
+### 6. Xray Mux.Cool (`protocol: muxcool`, VLESS + VMess)
+
+Mux.Cool is Xray's frame multiplexing protocol (same lineage as
+v2ray-plugin's mux) and is **completely unrelated** to sing-mux: there is
+**no** mux request header — the session signaling is the VLESS request
+header itself.
+
+**Signaling**: the session connection's VLESS request header carries
+command = 0x03 (CommandMux) and **omits** the port/address (xray
+encoding.go::EncodeRequestHeader skips the address for CommandMux;
+sing-vmess vless/protocol.go::ReadRequest likewise skips parsing). The
+2-byte VLESS response header `[version, addons_len]` is still consumed
+lazily (VlessConn logic unchanged). Under Vision the request header rides
+inside the first Vision record together with the first mux frame
+(VlessConn::new_mux_deferred, same as the sing-mux path).
+
+**Frame format** (xray common/mux/frame.go, all big-endian):
+
+```text
+meta_len   u16 BE    length of the meta block
+meta:
+  session_id u16 BE  stream id — client-allocated (incrementing from 1),
+                      echoed back by the server
+  status     u8      1=New 2=Keep 3=End 4=KeepAlive
+  option     u8      bit1=Data, bit2=Error
+  (New frames, and Keep frames carrying a UDP destination:)
+    network u8       1=TCP 2=UDP
+    port    u16 BE
+    atype   u8       0x01 IPv4 | 0x02 domain | 0x03 IPv6
+    address ...      VMess address layout (port first)
+payload_len u16 BE   present only when option&Data
+payload             payload_len bytes
+```
+
+End frames carry no payload_len; KeepAlive frames use sid=0 (unbound). The
+server **never opens streams** (responses echo the client's sid). Optional
+trailing meta bytes on New frames (xray's fullcone source info, UDP
+GlobalID) are not sent by us, and both server implementations discard
+unknown trailing meta bytes.
+
+**Stream semantics**:
+
+- TCP streams: New frame (meta-only) opens the stream → Keep+Data frames
+  carry data in both directions (≤ 8KiB per frame, matching xray writer.go
+  chunking) → End frame (sent on shutdown or drop; EndGuard guarantees
+  exactly-once). Server End → clean EOF; with the Error option → error.
+- UDP streams: New frame with network=UDP opens the stream; Keep frames in
+  both directions carry a **per-datagram destination** in the meta
+  (aligned with sing-vmess serverMuxPacketConn); the read side parses the
+  source address back out, and frames without an address fall back to the
+  stream's bound destination.
+- Session: a **single driver task** owns the connection and polls both
+  directions from that one task (the same discipline as h2mux's h2 driver)
+  — outbound frames go to the driver over a bounded channel (PollSender
+  poll-based backpressure), inbound frames are read and demuxed by the
+  driver's state machine (bounded 32-deep per-stream channel). **Inbound
+  delivery never blocks the driver**: a frame hitting a full queue parks
+  (at most one) and pauses the connection read (session-wide flow control,
+  TCP window semantics); consumers wake the driver via the space Notify
+  whenever they drain a slot (notify_one's permit semantics cover the
+  arm-before-check window; an unconditional loop-top retry is the
+  fallback). Blocking delivery would deadlock a write-then-read consumer
+  (its writes wait on outbound capacity while the driver waits on inbound
+  capacity) — a dedicated regression test covers this (1MiB full-duplex
+  loop, the old design deadlocks 100%). End frames remove the stream entry
+  before the terminal event parks (no stale senders); session ids never
+  wrap around (a recycled id would collide with a live stream's frames).
+  30s KeepAlive (sid=0).
+  **Key lesson (root-caused to the exact mechanism)**: an earlier stream
+  write path used a stored future — poll_write returned Pending while a
+  write future was in flight, and on completion the future fell through and
+  re-framed the **current buffer** (the relay's HalfCopy does not advance
+  pos on Pending and re-polls with the same buffer) → the same chunk was
+  written twice → duplicated bytes inside the stream → end-to-end TLS record
+  desync (bursts of schannel failures with zero protocol-layer errors and
+  intact small HTTP responses — extremely stealthy). Plaintext loopback
+  writes rarely hit Pending so it never triggered; TLS burst writes often
+  did, worst under 12-stream lock contention on one session (100% repro).
+  Fix: stream writes enqueue frames to the session driver task (PollSender
+  poll-based backpressure, no stored future — duplication is structurally
+  impossible); additionally the VlessConn lazy response-header consumption
+  became persistent state (same class of cancel-safety hazard). 12-way
+  concurrent stress after the fix: 0 failures (local 780/780, real Xray
+  612/612).
+
+**Server compatibility**: Xray-core VLESS and VMess inbounds (native);
+sing-box / mihomo VLESS and VMess inbounds (sing-vmess
+HandleMuxConnection on CommandMux, same frame lineage, no inbound config
+needed). Note: the `v1.mux.cool` magic destination (port 666) is the
+legacy v2ray address trick — sing-vmess defines it (`MuxDestination`) but
+never uses it; modern signaling is the CommandMux byte in the request
+header, which is what meow-rs sends.
+
+## meow-rs Architecture Mapping
+
+```
+crates/meow-proxy/src/mux/
+  mod.rs        Protocol (+MuxCool), MuxClient (session pool + offer/offerNew + idle sweep)
+  request.rs    §2 sing-mux request header encode/decode (incl. padding)
+  address.rs    §4 stream request codec (flags + sing Socksaddr)
+  smux.rs       smux session + stream (sagernet fork frame format, self-implemented)
+  yamux.rs      yamux wrapper (on the libp2p yamux crate)
+  h2mux.rs      h2mux session + stream (h2 crate: CONNECT stream = bidirectional bodies)
+  muxcool.rs    §6 Mux.Cool: frame codec (pure functions) + session + TCP stream + UDP PacketConn
+  packet.rs     MuxPacketConn: UDP stream (flagUDP + [len u16 BE][data] datagram frames)
+  stream.rs     MuxStreamConn: ProxyConn wrapper (pin-projection of the !Unpin inner stream,
+                modeled after anytls AnytlsConn)
+```
+
+- Integration points: `vless_adapter::dial_tcp`, `trojan::dial_tcp`,
+  `shadowsocks_adapter::dial_tcp` and `vmess::VmessAdapter::dial_tcp` —
+  when mux is enabled they call `mux_client.open_stream(dest)` instead of
+  dialing a fresh connection; each adapter's `with_mux` builds a
+  `DialFn` that performs the plain protocol handshake targeting
+  `sp.mux.sing-box.arpa:444` (SS shares its dial state with the mux
+  session through an `Arc`-wrapped core so SIP003 plugin handles stay
+  alive).
+- Config parsing: the canonical `smux:` block (plus legacy `mux:` alias) is
+  parsed, default protocol=h2mux matching mihomo; smux/yamux/h2mux all
+  implemented; unknown protocols reject the node with meow's warn+skip
+  semantics (mihomo hard-errors on the same input).
+- Build gating: the `mux` Cargo feature (meow-proxy/meow-config/meow-app,
+  on by default, excluded from `minimal`). A no-mux build reading an
+  enabled mux block warns that the option was ignored.
+- Health checks / URLTest: delay probes over mux streams naturally reuse
+  the same session.
+
+## Interop Boundaries (important)
+
+- `protocol: smux|yamux|h2mux` (default h2mux): applies to VLESS /
+  Trojan / Shadowsocks / VMess. The server must be sing-box / mihomo
+  based with `multiplex` enabled on the matching inbound (a plain
+  ss-server does not speak sing-mux). **Xray servers are incompatible** —
+  Xray only speaks Mux.Cool; use `protocol: muxcool` (VLESS/VMess) there.
+- `protocol: muxcool` (VLESS / VMess): the server is Xray-core, or a
+  sing-box / mihomo VLESS / VMess inbound (whose sing-vmess server handles
+  CommandMux natively, no inbound config needed). Do not use on Trojan or
+  Shadowsocks nodes.
+- Both protocol families share one MuxClient pool and the same min/max
+  bounds; all protocol differences are contained in the SessionKind arms
+  and the with_mux dial closure — zero branching in the adapter layer.
+- **Pool defaults**: meow defaults to `max-connections=4, min-streams=4,
+  max-streams=4`. mihomo's `smux:` block defaults to `0/0/0`, which makes
+  sing-mux apply `minStreams = 8` upstream. A user copying a mihomo config
+  with explicit zeros gets one physical connection per stream (mihomo
+  semantics); a user relying on implicit defaults gets meow's 4/4/4 pooling
+  rather than mihomo's 0/0/0.
+
+## Test Plan
+
+1. Unit: request header/padding codec; Socksaddr codec round trips; smux
+   frame codec (wire byte assertions), SYN/FIN/PSH state machine, large
+   write frame splitting (in-memory duplex both-ends exercise); MuxClient
+   offer/offerNew/min-max bounds and concurrency caps (mock dialer);
+   yamux/h2mux concurrent open + echo.
+2. Integration (done; scripts under target/e2e/mux-interop/):
+   - sing-mux: local sing-box v1.13.18 VLESS (plaintext) / Trojan (TLS) /
+     Shadowsocks / VMess inbounds with multiplex enabled — meow curls the
+     local websrv through h2mux/smux/yamux with 200, gstatic 204 (h2 +
+     http/1.1) and UDP echo round trips; 6 concurrent curls share one
+     physical connection. live_singbox_vless_probe (#[ignore]) is kept as
+     a repeatable interop regression.
+   - muxcool: the same sing-box inbounds (CommandMux needs no inbound
+     config) — plaintext VLESS (TCP 204/200 + UDP echo), Reality (204),
+     Reality+Vision (204 + UDP echo; configs meow-muxcool.yml /
+     meow-reality-muxcool.yml / meow-rv-muxcool.yml) all pass.
+3. Physical device: a real Xray node (example-xray-node, VLESS
+   Reality+Vision, config meow-real-muxcool.yml) with `protocol: muxcool`
+   passes 204 (h2 + http/1.1), and 4 consecutive connections reuse one
+   physical session (the log shows a single VLESS response-header
+   consumption); sing-mux against the same node fails (code=000) —
+   confirming the two protocol families are mutually incompatible and must
+   be chosen by server type.

--- a/docs/specs/proxy-vless-test-plan.md
+++ b/docs/specs/proxy-vless-test-plan.md
@@ -50,7 +50,7 @@ divergence. ADR-0002 Class cite (A or B) per `feedback_adr_0002_class_cite.md`.
 | 3 | `reality-opts` present — upstream routes Reality | A | Not implemented; silent ignore = plain-TLS to Reality-expecting server, no diagnostic. Hard-error with roadmap pointer. |
 | 4 | Unknown `flow` value — upstream ignores | A | Unknown flow may skip expected security processing. Hard-error. |
 | 5 | `encryption: <non-none>` — upstream hard-errors too | — | Match (both hard-error). Not a divergence. |
-| 6 | `mux: { enabled: true }` — upstream runs Mux.Cool | B | Not implemented; warn-once, ignore. Same destination. |
+| 6 | `mux: { enabled: true }` — sing-mux multiplexing | B | Implemented (default h2mux; smux/yamux also supported) for sing-box/mihomo servers; Xray Mux.Cool (`protocol: muxcool`) for Xray servers. |
 | 7 | `flow: xtls-rprx-vision` + `udp: true` — upstream UDP uses plain VLESS silently | B | Warn-once at load; UDP still routes same destination with outer-TLS. Not Class A (crypto unchanged). |
 
 ---

--- a/docs/specs/proxy-vless.md
+++ b/docs/specs/proxy-vless.md
@@ -62,8 +62,11 @@ Out of scope:
   message.
 - **VLESS inbound** — not shipping a VLESS server; subscription
   clients only.
-- **Mux.Cool** (`mux: { enabled: true }`) — same defer as VMess;
-  warn-ignore.
+- **mux** (`mux: { enabled: true }`) — implemented as sing-mux compatible
+  multiplexing (default h2mux, matching mihomo; smux and yamux also
+  supported; unknown protocols are rejected with warn+skip) for
+  sing-box / mihomo servers, plus Xray Mux.Cool (`protocol: muxcool`,
+  VLESS/VMess-only) for Xray servers. See `docs/specs/proxy-mux.md`.
 - **`encryption` field enforcement.** Upstream VLESS always sets
   `encryption: none`; the field is present for forward compat. Accept
   any value that is `""` or `"none"` silently; hard-error on anything


### PR DESCRIPTION
### Description

This is the fifth layer of the #394 stack. It adds h2mux, the third sing-mux protocol, and extracts the shared raw HTTP/2 stream state needed by the implementation.

The change adds h2mux session and stream handling, dispatches sing-mux protocol byte `2`, and wires the h2 feature and optional dependencies. The empty/default mux protocol becomes h2mux, matching mihomo. The `minimal` build remains free of mux dependencies.

Stack position:

- Base: `pr4-mux-yamux` (`3023ca3`)
- Next: `pr6-mux-muxcool`

### How did you test this change?

Given mux is enabled without an explicit protocol, when configuration is parsed, h2mux is selected as the default.

Given `protocol: smux` or `protocol: yamux`, when configuration is parsed, the explicit protocol remains respected.

Given an HTTP/2 peer that delays response headers until request DATA, when the first application write is made, the connection does not deadlock waiting for response headers.

Given an H2 write is Pending and the caller changes the buffer, when the write is polled again, stale bytes are not sent and the changed-buffer contract violation is rejected.

The branch was checked with repository formatting, all three clippy feature modes, a locked workspace check, affected crate tests, and configuration integration tests.
End-to-end smoke results for this layer's protocol(s) are recorded in PR6 (`How did you test this change?`): VLESS/Trojan/Shadowsocks/VMess × smux/yamux/h2mux against a local sing-box 1.13.13 multiplex inbound, plus UDP via the repository's live probes.


### Key points

The shared H2 state is extracted in `meow-transport` so h2mux and the existing H2 transport use the same response and write-cancellation invariants. Changing the empty/default protocol is intentionally delayed until h2mux exists in the stack.

### Notes for reviewers

Review the shared H2 state transitions before the h2mux session adapter. This PR should be reviewed incrementally against `pr4-mux-yamux`.

After this PR, smux, yamux, and h2mux complete the sing-mux family. Xray Mux.Cool is a separate VLESS/VMess-specific implementation in PR6.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @aimkiray will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

Part of the stacked mux implementation tracked in #412.
> **Stack note:** branches are submitted from the fork, so each PR targets `main` (GitHub does not support cross-fork stacked bases). The stack order is preserved by the branch names and commit ancestry: PR1 -> PR2 (on pr1-vless-deferred) -> PR3 (on pr2-mux-smux) -> PR4 (on pr3-mux-ss-vmess) -> PR5 (on pr4-mux-yamux) -> PR6 (on pr5-mux-h2mux). Reviewers can read each layer as the incremental commits on top of the previous branch.
