### PR TITLE
feat(anytls): implement UDP relay over udp-over-tcp v2

### DIFF
--- a/crates/meow-anytls/src/server/udp_proxy.rs
+++ b/crates/meow-anytls/src/server/udp_proxy.rs
@@ -1,20 +1,37 @@
 //! UDP over TCP proxy implementation
 //!
-//! Implements sing-box udp-over-tcp v2 protocol (Connect format)
+//! Implements the sing-box udp-over-tcp v2 protocol, both the Connect and the
+//! Bind (non-connect) format.
 //!
 //! # Protocol Format
 //!
 //! ## Request (sent once at stream start):
 //! ```text
 //! | isConnect | ATYP | Address | Port |
-//! | u8 (=1)   | u8   | variable| u16be|
+//! | u8        | u8   | variable| u16be|
 //! ```
 //!
-//! ## Data packets (Connect format, isConnect=1):
+//! ## Data packets, Connect format (isConnect=1):
 //! ```text
 //! | Length | Data     |
 //! | u16be  | variable |
 //! ```
+//!
+//! ## Data packets, Bind format (isConnect=0):
+//! ```text
+//! | ATYP | Address | Port  | Length | Data     |
+//! | u8   | variable| u16be | u16be  | variable |
+//! ```
+//!
+//! Beware the asymmetry between the two address encodings: the *request*
+//! address uses the SOCKS5 family bytes (`M.SocksaddrSerializer` upstream:
+//! 0x01 IPv4 / 0x03 domain / 0x04 IPv6) while every *per-packet* address in
+//! Bind format uses uot's own table (`uot.AddrParser`: 0x00 IPv4 / 0x01 IPv6 /
+//! 0x02 domain). Sharing one table between them is silently wrong on the wire.
+//!
+//! Bind format is what mihomo's AnyTLS outbound speaks (`uot.NewLazyConn` with
+//! `IsConnect` left false), so it is the format meow's own `AnytlsAdapter`
+//! sends; Connect format is kept for clients that ask for it.
 //!
 //! Reference: <https://github.com/SagerNet/sing-box/blob/dev-next/docs/configuration/shared/udp-over-tcp.md>
 
@@ -30,6 +47,45 @@ use tracing::{field, info_span};
 
 const MAX_UDP_PACKET_SIZE: usize = 65535;
 
+/// SOCKS5 address-family bytes — the initial request header only.
+const SOCKS5_ATYP_IPV4: u8 = 0x01;
+const SOCKS5_ATYP_DOMAIN: u8 = 0x03;
+const SOCKS5_ATYP_IPV6: u8 = 0x04;
+
+/// `uot.AddrParser` address-family bytes — Bind-format per-packet headers.
+const UOT_ATYP_IPV4: u8 = 0x00;
+const UOT_ATYP_IPV6: u8 = 0x01;
+const UOT_ATYP_DOMAIN: u8 = 0x02;
+
+/// A wire destination before any name resolution.
+///
+/// Kept unresolved so the Bind-format request address — which the peer sends
+/// but the server never routes on — does not cost a DNS round-trip.
+#[derive(Debug, Clone)]
+enum AddrSpec {
+    Ip(SocketAddr),
+    Domain(String, u16),
+}
+
+impl AddrSpec {
+    /// Resolve to a socket address, hitting the shared DNS cache for domains.
+    async fn resolve(&self) -> Result<SocketAddr> {
+        match self {
+            AddrSpec::Ip(addr) => Ok(*addr),
+            AddrSpec::Domain(host, port) => resolve_host_with_cache(host, *port).await,
+        }
+    }
+}
+
+impl std::fmt::Display for AddrSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddrSpec::Ip(addr) => write!(f, "{}", addr),
+            AddrSpec::Domain(host, port) => write!(f, "{}:{}", host, port),
+        }
+    }
+}
+
 /// Handle UDP over TCP stream
 ///
 /// Target address should be "sp.v2.udp-over-tcp.arpa"
@@ -37,8 +93,9 @@ const MAX_UDP_PACKET_SIZE: usize = 65535;
 /// # Protocol
 ///
 /// sing-box udp-over-tcp v2:
-/// 1. First, read initial request containing target address (SOCKS5 format)
-/// 2. Then, each packet: Length (2 bytes BE) + Payload
+/// 1. First, read the initial request: isConnect + target address (SOCKS5 format)
+/// 2. Then, each packet: Length (2 bytes BE) + Payload, prefixed by a uot
+///    address when the request asked for Bind format (isConnect=0)
 /// 3. Bidirectional forwarding between Stream and UDP socket
 ///
 /// Reference: <https://github.com/SagerNet/sing-box/blob/dev-next/docs/configuration/shared/udp-over-tcp.md>
@@ -61,22 +118,40 @@ pub async fn handle_udp_over_tcp(stream: Arc<Stream>) -> Result<()> {
     let reader = stream.reader();
     let mut reader_guard = reader.lock().await;
 
-    // Step 1: Read initial request (contains target address)
-    // Format: SOCKS5 address (ATYP + Address + Port)
-    let target_addr = match read_initial_request(&mut reader_guard).await {
-        Ok(addr) => addr,
+    // Step 1: Read initial request (isConnect + target address)
+    // Format: isConnect + SOCKS5 address (ATYP + Address + Port)
+    let (is_connect, target_spec) = match read_initial_request(&mut reader_guard).await {
+        Ok(request) => request,
         Err(e) => {
             tracing::error!("[UDP] Failed to read initial request: {}", e);
             return Err(e);
         }
     };
-    udp_span.record("target", field::display(target_addr));
+    udp_span.record("target", field::display(&target_spec));
 
-    tracing::debug!("[UDP] Target UDP address: {}", target_addr);
+    tracing::debug!(
+        "[UDP] {} format, target UDP address: {}",
+        if is_connect { "Connect" } else { "Bind" },
+        target_spec
+    );
 
     drop(reader_guard);
 
+    // Only Connect format pins a single destination for the whole stream; in
+    // Bind format the request address is informational and every packet
+    // carries its own, so resolving it here would be a pointless DNS lookup.
+    let connect_target = if is_connect {
+        Some(target_spec.resolve().await?)
+    } else {
+        None
+    };
+
     // Step 2: Create UDP socket (bind to any available port)
+    //
+    // IPv4-only: Bind format lets the client name an arbitrary destination per
+    // packet, so an IPv6 target fails at `send_to`. Acceptable here because
+    // this server is a test/fork artifact — meow itself ships no anytls
+    // inbound — but it is the first thing to change if that stops being true.
     let udp_socket = UdpSocket::bind("0.0.0.0:0").await.map_err(|e| {
         tracing::error!("[UDP] Failed to create UDP socket: {}", e);
         AnyTlsError::Io(e)
@@ -99,7 +174,7 @@ pub async fn handle_udp_over_tcp(stream: Arc<Stream>) -> Result<()> {
         result = stream_to_udp(
             &stream,
             &udp_socket,
-            &target_addr,
+            connect_target.as_ref(),
             Arc::clone(&packets_stream_to_udp),
             Arc::clone(&bytes_stream_to_udp)
         ) => {
@@ -111,7 +186,7 @@ pub async fn handle_udp_over_tcp(stream: Arc<Stream>) -> Result<()> {
         result = udp_to_stream(
             &stream,
             &udp_socket,
-            &target_addr,
+            is_connect,
             Arc::clone(&packets_udp_to_stream),
             Arc::clone(&bytes_udp_to_stream)
         ) => {
@@ -148,8 +223,9 @@ pub async fn handle_udp_over_tcp(stream: Arc<Stream>) -> Result<()> {
 /// | u8        | u8   | variable| u16be|
 /// ```
 ///
-/// Returns the target SocketAddr
-async fn read_initial_request(reader: &mut StreamReader) -> Result<SocketAddr> {
+/// Returns `(is_connect, destination)`. The address is left unresolved: in
+/// Bind format the server never routes on it.
+async fn read_initial_request(reader: &mut StreamReader) -> Result<(bool, AddrSpec)> {
     // Read isConnect (1 byte)
     let mut is_connect_buf = [0u8; 1];
     reader
@@ -157,116 +233,157 @@ async fn read_initial_request(reader: &mut StreamReader) -> Result<SocketAddr> {
         .await
         .map_err(AnyTlsError::Io)?;
 
-    let is_connect = is_connect_buf[0];
+    // Upstream writes a Go bool, so anything non-zero means Connect.
+    let is_connect = is_connect_buf[0] != 0;
 
-    if is_connect != 1 {
-        // We only support connect format (isConnect=1)
-        return Err(AnyTlsError::Protocol(format!(
-            "Unsupported UDP over TCP format: isConnect={}",
-            is_connect
-        )));
-    }
+    let destination = read_socks5_addr(reader).await?;
 
-    tracing::debug!("[UDP] Using Connect format (isConnect=1)");
+    Ok((is_connect, destination))
+}
 
-    // Read ATYP (1 byte)
+/// Read a SOCKS5-serialized address (`M.SocksaddrSerializer` upstream).
+///
+/// Used by the initial request only — per-packet headers use
+/// [`read_uot_addr`], whose family bytes differ.
+async fn read_socks5_addr(reader: &mut StreamReader) -> Result<AddrSpec> {
     let mut atyp_buf = [0u8; 1];
     reader
         .read_exact(&mut atyp_buf)
         .await
         .map_err(AnyTlsError::Io)?;
 
-    let atyp = atyp_buf[0];
-
-    match atyp {
-        0x01 => {
-            // IPv4: 4 bytes IP + 2 bytes port
-            let mut ip_buf = [0u8; 4];
-            reader
-                .read_exact(&mut ip_buf)
-                .await
-                .map_err(AnyTlsError::Io)?;
-
-            let mut port_buf = [0u8; 2];
-            reader
-                .read_exact(&mut port_buf)
-                .await
-                .map_err(AnyTlsError::Io)?;
-
-            let ip = std::net::Ipv4Addr::from(ip_buf);
-            let port = u16::from_be_bytes(port_buf);
-
-            Ok(SocketAddr::from((ip, port)))
-        }
-        0x04 => {
-            // IPv6: 16 bytes IP + 2 bytes port
-            let mut ip_buf = [0u8; 16];
-            reader
-                .read_exact(&mut ip_buf)
-                .await
-                .map_err(AnyTlsError::Io)?;
-
-            let mut port_buf = [0u8; 2];
-            reader
-                .read_exact(&mut port_buf)
-                .await
-                .map_err(AnyTlsError::Io)?;
-
-            let ip = std::net::Ipv6Addr::from(ip_buf);
-            let port = u16::from_be_bytes(port_buf);
-
-            Ok(SocketAddr::from((ip, port)))
-        }
-        0x03 => {
-            // Domain: length (1 byte) + domain + 2 bytes port
-            let mut len_buf = [0u8; 1];
-            reader
-                .read_exact(&mut len_buf)
-                .await
-                .map_err(AnyTlsError::Io)?;
-
-            let domain_len = len_buf[0] as usize;
-            if domain_len == 0 || domain_len > 255 {
-                return Err(AnyTlsError::Protocol("Invalid domain length".into()));
-            }
-
-            let mut domain_buf = vec![0u8; domain_len];
-            reader
-                .read_exact(&mut domain_buf)
-                .await
-                .map_err(AnyTlsError::Io)?;
-
-            let domain = String::from_utf8(domain_buf)
-                .map_err(|e| AnyTlsError::Protocol(format!("Invalid domain name: {}", e)))?;
-
-            let mut port_buf = [0u8; 2];
-            reader
-                .read_exact(&mut port_buf)
-                .await
-                .map_err(AnyTlsError::Io)?;
-
-            let port = u16::from_be_bytes(port_buf);
-
-            // Resolve domain name with caching and timeout
-            let addr = resolve_host_with_cache(&domain, port).await?;
-
-            Ok(addr)
-        }
-        _ => Err(AnyTlsError::Protocol(format!(
+    match atyp_buf[0] {
+        SOCKS5_ATYP_IPV4 => read_ipv4_addr(reader).await,
+        SOCKS5_ATYP_IPV6 => read_ipv6_addr(reader).await,
+        SOCKS5_ATYP_DOMAIN => read_domain_addr(reader).await,
+        other => Err(AnyTlsError::Protocol(format!(
             "Unknown address type: {}",
-            atyp
+            other
         ))),
     }
 }
 
+/// Read a uot-serialized address (`uot.AddrParser` upstream).
+///
+/// Prefixes every Bind-format packet. Note the family bytes differ from the
+/// SOCKS5 ones used by the request header.
+async fn read_uot_addr(reader: &mut StreamReader) -> Result<AddrSpec> {
+    let mut atyp_buf = [0u8; 1];
+    reader
+        .read_exact(&mut atyp_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    match atyp_buf[0] {
+        UOT_ATYP_IPV4 => read_ipv4_addr(reader).await,
+        UOT_ATYP_IPV6 => read_ipv6_addr(reader).await,
+        UOT_ATYP_DOMAIN => read_domain_addr(reader).await,
+        other => Err(AnyTlsError::Protocol(format!(
+            "Unknown uot address type: {}",
+            other
+        ))),
+    }
+}
+
+/// IPv4: 4 bytes IP + 2 bytes port.
+async fn read_ipv4_addr(reader: &mut StreamReader) -> Result<AddrSpec> {
+    let mut ip_buf = [0u8; 4];
+    reader
+        .read_exact(&mut ip_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let port = read_port(reader).await?;
+    Ok(AddrSpec::Ip(SocketAddr::from((
+        std::net::Ipv4Addr::from(ip_buf),
+        port,
+    ))))
+}
+
+/// IPv6: 16 bytes IP + 2 bytes port.
+async fn read_ipv6_addr(reader: &mut StreamReader) -> Result<AddrSpec> {
+    let mut ip_buf = [0u8; 16];
+    reader
+        .read_exact(&mut ip_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let port = read_port(reader).await?;
+    Ok(AddrSpec::Ip(SocketAddr::from((
+        std::net::Ipv6Addr::from(ip_buf),
+        port,
+    ))))
+}
+
+/// Domain: length (1 byte) + domain + 2 bytes port.
+async fn read_domain_addr(reader: &mut StreamReader) -> Result<AddrSpec> {
+    let mut len_buf = [0u8; 1];
+    reader
+        .read_exact(&mut len_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let domain_len = len_buf[0] as usize;
+    if domain_len == 0 {
+        return Err(AnyTlsError::Protocol("Invalid domain length".into()));
+    }
+
+    let mut domain_buf = vec![0u8; domain_len];
+    reader
+        .read_exact(&mut domain_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+
+    let domain = String::from_utf8(domain_buf)
+        .map_err(|e| AnyTlsError::Protocol(format!("Invalid domain name: {}", e)))?;
+
+    let port = read_port(reader).await?;
+    Ok(AddrSpec::Domain(domain, port))
+}
+
+async fn read_port(reader: &mut StreamReader) -> Result<u16> {
+    let mut port_buf = [0u8; 2];
+    reader
+        .read_exact(&mut port_buf)
+        .await
+        .map_err(AnyTlsError::Io)?;
+    Ok(u16::from_be_bytes(port_buf))
+}
+
+/// Append a uot-serialized address (`uot.AddrParser` upstream).
+///
+/// IPv4-mapped IPv6 addresses are unmapped first, matching upstream's
+/// `Socksaddr` normalization, so a dual-stack socket's `recv_from` peer does
+/// not reach the client as `::ffff:a.b.c.d`.
+fn encode_uot_addr(buf: &mut BytesMut, addr: &SocketAddr) {
+    match addr.ip() {
+        std::net::IpAddr::V4(v4) => {
+            buf.put_u8(UOT_ATYP_IPV4);
+            buf.put_slice(&v4.octets());
+        }
+        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => {
+                buf.put_u8(UOT_ATYP_IPV4);
+                buf.put_slice(&v4.octets());
+            }
+            None => {
+                buf.put_u8(UOT_ATYP_IPV6);
+                buf.put_slice(&v6.octets());
+            }
+        },
+    }
+    buf.put_u16(addr.port());
+}
+
 /// Stream → UDP: Read packets from Stream, decode and send to UDP
 ///
-/// Protocol: Each packet is Length (2 bytes BE) + Payload
-/// The payload is pure UDP data (target address already known from initial request)
+/// Connect format: each packet is Length (2 bytes BE) + Payload, all bound for
+/// `connect_target`. Bind format (`connect_target` is `None`): each packet is
+/// prefixed by its own uot address, resolved per packet.
 async fn stream_to_udp(
     stream: &Stream,
     udp: &UdpSocket,
-    target_addr: &SocketAddr,
+    connect_target: Option<&SocketAddr>,
     packets_counter: Arc<AtomicU>,
     bytes_counter: Arc<AtomicU>,
 ) -> Result<()> {
@@ -277,11 +394,41 @@ async fn stream_to_udp(
     tracing::debug!("[UDP] Stream → UDP task started for stream {}", stream_id);
 
     loop {
+        // Bind format carries a destination per packet; Connect format pinned
+        // it once in the initial request.
+        let target_addr = match connect_target {
+            Some(addr) => *addr,
+            None => match read_uot_addr(&mut reader_guard).await {
+                Ok(spec) => match spec.resolve().await {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        // A single unresolvable destination must not kill the
+                        // whole association, but the length-prefixed payload
+                        // still has to be drained to stay frame-aligned.
+                        tracing::warn!("[UDP] Dropping packet for unresolvable target: {}", e);
+                        match read_udp_packet(&mut reader_guard).await {
+                            Ok(_) => continue,
+                            Err(e) if is_eof(&e) => break,
+                            Err(e) => return Err(e),
+                        }
+                    }
+                },
+                Err(e) => {
+                    if is_eof(&e) {
+                        tracing::debug!("[UDP] Stream closed (EOF), stopping Stream → UDP");
+                        break;
+                    }
+                    tracing::error!("[UDP] Failed to read packet address: {}", e);
+                    return Err(e);
+                }
+            },
+        };
+
         // Read one UDP packet (Length + Payload format)
         let payload = match read_udp_packet(&mut reader_guard).await {
             Ok(data) => data,
             Err(e) => {
-                if e.to_string().contains("UnexpectedEof") || e.to_string().contains("EOF") {
+                if is_eof(&e) {
                     tracing::debug!("[UDP] Stream closed (EOF), stopping Stream → UDP");
                     break;
                 }
@@ -301,7 +448,7 @@ async fn stream_to_udp(
             target_addr
         );
 
-        // Send to UDP (target address already known from initial request)
+        // Send to UDP (target from the initial request or this packet's header)
         let sent = udp.send_to(&payload, target_addr).await?;
 
         if sent != payload.len() {
@@ -316,13 +463,13 @@ async fn stream_to_udp(
 
 /// UDP → Stream: Read from UDP, encode and send to Stream
 ///
-/// Protocol: Each packet is Length (2 bytes BE) + Payload
-/// The payload is pure UDP data (source address info might be embedded, but for simplicity
-/// we just send the data since the connection is already established)
+/// Connect format: each packet is Length (2 bytes BE) + Payload — the client
+/// already knows the peer. Bind format: the source address is prefixed in uot
+/// encoding so the client can demultiplex.
 async fn udp_to_stream(
     stream: &Stream,
     udp: &UdpSocket,
-    _target_addr: &SocketAddr,
+    is_connect: bool,
     packets_counter: Arc<AtomicU>,
     bytes_counter: Arc<AtomicU>,
 ) -> Result<()> {
@@ -344,10 +491,11 @@ async fn udp_to_stream(
 
         tracing::trace!("[UDP] UDP → Stream: {} bytes from {}", len, addr);
 
-        // Encode: Length (2 bytes BE) + Payload
-        // Note: According to sing-box protocol, the payload is just the UDP data
-        // The source address info is not included in each packet (connection is established)
-        let packet = encode_udp_packet_simple(&buf[..len])?;
+        let packet = if is_connect {
+            encode_udp_packet_simple(&buf[..len])?
+        } else {
+            encode_udp_packet_from(&buf[..len], &addr)?
+        };
 
         // Send to Stream using the send_data method
         if let Err(e) = stream.send_data(packet) {
@@ -356,6 +504,16 @@ async fn udp_to_stream(
         }
         packets_counter.fetch_add(1, Ordering::Relaxed);
         bytes_counter.fetch_add(len as Uint, Ordering::Relaxed);
+    }
+}
+
+/// Whether a read error means the peer closed the stream rather than a real
+/// protocol fault. `StreamReader::read_exact` reports a short read as
+/// `UnexpectedEof`.
+fn is_eof(err: &AnyTlsError) -> bool {
+    match err {
+        AnyTlsError::Io(e) => e.kind() == std::io::ErrorKind::UnexpectedEof,
+        _ => false,
     }
 }
 
@@ -415,6 +573,37 @@ fn encode_udp_packet_simple(payload: &[u8]) -> Result<Bytes> {
 
     // Write payload
     buf.put_slice(payload);
+
+    Ok(buf.freeze())
+}
+
+/// Encode a Bind-format UDP packet.
+///
+/// Format: | uot address | Length (2 bytes BE) | Payload |
+///
+/// One anytls data frame carries a `u16` length and the codec truncates
+/// silently on overflow, so the whole framed packet — not just the payload —
+/// has to fit. The largest header is 19 bytes (IPv6) + 2 for the length, which
+/// still leaves room for a maximum-size UDP datagram.
+fn encode_udp_packet_from(payload: &[u8], from: &SocketAddr) -> Result<Bytes> {
+    if payload.len() > MAX_UDP_PACKET_SIZE {
+        return Err(AnyTlsError::Protocol(format!(
+            "UDP packet too large: {} bytes",
+            payload.len()
+        )));
+    }
+
+    let mut buf = BytesMut::with_capacity(payload.len() + 21);
+    encode_uot_addr(&mut buf, from);
+    buf.put_u16(payload.len() as u16);
+    buf.put_slice(payload);
+
+    if buf.len() > MAX_UDP_PACKET_SIZE {
+        return Err(AnyTlsError::Protocol(format!(
+            "Framed UDP packet too large: {} bytes",
+            buf.len()
+        )));
+    }
 
     Ok(buf.freeze())
 }

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -556,8 +556,11 @@ fn parse_direct(
 /// Parse a `type: anytls` proxy block into an [`AnytlsAdapter`].
 ///
 /// Required fields: `server`, `port`, `password`. Optional: `sni`,
-/// `skip-cert-verify`. Closes the parser side of issue #75; the wire
+/// `skip-cert-verify`, `udp`. Closes the parser side of issue #75; the wire
 /// protocol itself is provided by the `anytls-rs` crate.
+///
+/// `udp` defaults to `false`, matching mihomo's `AnyTLSOption.UDP` (the
+/// adapter then relays datagrams over udp-over-tcp v2).
 ///
 /// # Hard errors (Class A per ADR-0002)
 ///
@@ -584,8 +587,12 @@ fn parse_anytls(
         .get("skip-cert-verify")
         .and_then(serde_yaml::Value::as_bool)
         .unwrap_or(false);
+    let udp = config
+        .get("udp")
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(false);
 
-    meow_proxy::AnytlsAdapter::new(name, server, port, password, sni, skip_cert_verify)
+    meow_proxy::AnytlsAdapter::new(name, server, port, password, sni, skip_cert_verify, udp)
 }
 
 /// Parse a `type: hysteria2` proxy block.
@@ -2221,6 +2228,21 @@ tls: true
             "name: jp\ntype: anytls\nserver: 1.2.3.4\nport: 443\npassword: secret\nsni: example.com\nskip-cert-verify: true\n",
         );
         assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    /// mihomo's `AnyTLSOption.UDP` is `omitempty`/false by default; only an
+    /// explicit `udp: true` advertises datagram support to the tunnel.
+    #[cfg(feature = "anytls")]
+    #[tokio::test]
+    async fn parse_anytls_udp_is_opt_in() {
+        let off =
+            anytls_config("name: jp\ntype: anytls\nserver: 1.2.3.4\nport: 443\npassword: secret\n");
+        assert!(!parse_proxy(&off).unwrap().support_udp());
+
+        let on = anytls_config(
+            "name: jp\ntype: anytls\nserver: 1.2.3.4\nport: 443\npassword: secret\nudp: true\n",
+        );
+        assert!(parse_proxy(&on).unwrap().support_udp());
     }
 
     #[cfg(feature = "anytls")]

--- a/crates/meow-proxy/src/anytls_adapter.rs
+++ b/crates/meow-proxy/src/anytls_adapter.rs
@@ -3,21 +3,25 @@
 //! Thin wrapper over the `anytls-rs` crate's `Client`. The protocol itself
 //! — TLS handshake, password auth, session multiplexing, padding scheme —
 //! lives upstream; this file only translates between meow-rs's `ProxyAdapter`
-//! trait and `anytls_rs`'s `Client::create_proxy_stream` / `Session` API.
+//! trait and `anytls_rs`'s `Client::create_proxy_stream` / `Session` API,
+//! plus the sing-box udp-over-tcp v2 framing that carries UDP (see the `uot`
+//! section below).
 //!
-//! Live integration tests are not included: they would require a running
-//! anytls server. Parser-level tests cover config validation.
+//! `tests/anytls_integration.rs` covers TCP and UDP end to end against an
+//! in-process `anytls_rs::server::Server`; no external anytls server needed.
 
 use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use anytls_rs::client::Client as AnytlsClient;
+use anytls_rs::client::UDP_OVER_TCP_MAGIC_ADDR;
 use anytls_rs::padding::PaddingFactory;
 use anytls_rs::protocol::{Command, Frame};
-use anytls_rs::session::{Session, Stream as AnytlsStream};
+use anytls_rs::session::{Session, Stream as AnytlsStream, StreamReader};
 use async_trait::async_trait;
 use bytes::Bytes;
 use parking_lot::Mutex;
@@ -35,6 +39,7 @@ pub struct AnytlsAdapter {
     addr: String,
     health: ProxyHealth,
     client: AnytlsClient,
+    udp: bool,
 }
 
 impl AnytlsAdapter {
@@ -45,6 +50,9 @@ impl AnytlsAdapter {
     /// `None` to default to `server`. When `skip_cert_verify` is set, the TLS
     /// stack accepts any certificate — useful for self-signed dev servers and
     /// matches the `skip-cert-verify` semantics of the trojan/vless adapters.
+    /// `udp` mirrors mihomo's `udp:` option (`AnyTLSOption.UDP`, default
+    /// `false`): when unset, [`ProxyAdapter::support_udp`] reports `false` and
+    /// the tunnel routes UDP elsewhere.
     pub fn new(
         name: &str,
         server: &str,
@@ -52,6 +60,7 @@ impl AnytlsAdapter {
         password: &str,
         sni: Option<&str>,
         skip_cert_verify: bool,
+        udp: bool,
     ) -> std::result::Result<Self, String> {
         // Bridge meow_common's outbound-socket hooks (resolver-aware TCP
         // dialer + Android `SocketProtector`) into anytls-rs's separate
@@ -83,6 +92,7 @@ impl AnytlsAdapter {
             addr: server_addr,
             health: ProxyHealth::new(),
             client,
+            udp,
         })
     }
 }
@@ -102,9 +112,7 @@ impl ProxyAdapter for AnytlsAdapter {
     }
 
     fn support_udp(&self) -> bool {
-        // UDP is supported by the protocol (udp-over-tcp v2), but the upstream
-        // crate's UDP path requires a separate API. Wire it up in a follow-up.
-        false
+        self.udp
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
@@ -118,10 +126,28 @@ impl ProxyAdapter for AnytlsAdapter {
         Ok(Box::new(AnytlsConn::new(stream, session)))
     }
 
-    async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        Err(MeowError::Proxy(
-            "anytls: UDP not implemented yet".to_string(),
-        ))
+    /// Open a udp-over-tcp v2 relay stream (issue #75 follow-up).
+    ///
+    /// Mirrors mihomo `adapter/outbound/anytls.go: ListenPacketContext`: a
+    /// plain proxy stream to the magic destination, then sing-box's `uot`
+    /// framing on top of it. The uot request is written lazily together with
+    /// the first datagram, exactly as upstream's `uot.NewLazyConn` does.
+    async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        if !self.udp {
+            return Err(MeowError::NotSupported(
+                "anytls: UDP is disabled for this proxy (set `udp: true`)".to_string(),
+            ));
+        }
+        let (stream, session) = self
+            .client
+            .create_proxy_stream((UDP_OVER_TCP_MAGIC_ADDR.to_string(), 0))
+            .await
+            .map_err(|e| MeowError::Proxy(format!("anytls udp dial: {e}")))?;
+        Ok(Box::new(AnytlsPacketConn::new(
+            stream,
+            session,
+            encode_uot_request(metadata),
+        )))
     }
 
     fn health(&self) -> &ProxyHealth {
@@ -302,6 +328,299 @@ impl Drop for AnytlsConn {
 
 impl ProxyConn for AnytlsConn {}
 
+// ─── udp-over-tcp v2 (sing-box `uot`) ────────────────────────────────────────
+//
+// AnyTLS carries UDP the same way sing-box and mihomo do: a normal proxy
+// stream opened to the magic destination `sp.v2.udp-over-tcp.arpa:0`, then
+// sing-box's `uot` framing inside it.
+//
+//   request (once, before the first datagram):
+//       | isConnect | ATYP | Address | Port  |
+//       | u8        | u8   | var     | u16be |   ← SOCKS5 family bytes
+//
+//   datagram (repeated, non-connect mode):
+//       | ATYP | Address | Port  | Length | Payload |
+//       | u8   | var     | u16be | u16be  | var     |   ← uot family bytes
+//
+// Beware the asymmetry: upstream serializes the *request* address with
+// `M.SocksaddrSerializer` (SOCKS5 bytes 0x01/0x03/0x04) but every *per-packet*
+// address with `uot.AddrParser` (its own 0x00/0x01/0x02). Reusing one table
+// for both is silently wrong on the wire.
+//
+// Like mihomo we run in non-connect mode (`uot.Request{Destination: …}` leaves
+// `IsConnect` false), so each datagram carries its own address and replies
+// carry the real source address — which is what `ProxyPacketConn` needs to
+// hand back to the SOCKS5/TUN listeners.
+//
+// upstream: sing `common/uot/{protocol,conn,server}.go`,
+// mihomo `adapter/outbound/anytls.go: ListenPacketContext`
+
+/// SOCKS5 address-family bytes — the **request** header only.
+const SOCKS5_ATYP_IPV4: u8 = 0x01;
+const SOCKS5_ATYP_DOMAIN: u8 = 0x03;
+const SOCKS5_ATYP_IPV6: u8 = 0x04;
+
+/// `uot.AddrParser` address-family bytes — every **per-packet** header.
+const UOT_ATYP_IPV4: u8 = 0x00;
+const UOT_ATYP_IPV6: u8 = 0x01;
+const UOT_ATYP_DOMAIN: u8 = 0x02;
+
+/// One anytls data frame carries a `u16` length, so a datagram plus its uot
+/// header must fit in 64 KiB. The largest possible IPv6 header is
+/// ATYP(1) + addr(16) + port(2) + length(2) = 21 bytes, which still leaves
+/// room for a maximum-size (65507-byte) UDP payload.
+const MAX_UOT_FRAME: usize = u16::MAX as usize;
+
+/// Encode the one-shot uot request: `isConnect = 0` followed by the session's
+/// nominal destination in SOCKS5 form. In non-connect mode the server ignores
+/// this address (it routes per packet), but upstream still sends it and its
+/// serializer rejects an empty address, so mirror mihomo and send the
+/// resolved destination — falling back to the hostname when the metadata has
+/// no IP yet.
+fn encode_uot_request(metadata: &Metadata) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(24);
+    buf.push(0); // isConnect = false
+    match metadata.dst_ip {
+        Some(IpAddr::V4(v4)) => {
+            buf.push(SOCKS5_ATYP_IPV4);
+            buf.extend_from_slice(&v4.octets());
+        }
+        Some(IpAddr::V6(v6)) => match v6.to_ipv4_mapped() {
+            Some(v4) => {
+                buf.push(SOCKS5_ATYP_IPV4);
+                buf.extend_from_slice(&v4.octets());
+            }
+            None => {
+                buf.push(SOCKS5_ATYP_IPV6);
+                buf.extend_from_slice(&v6.octets());
+            }
+        },
+        None => {
+            // No resolved IP: send the hostname, truncated to the 255-byte
+            // ceiling the length prefix allows. An empty host degrades to
+            // 0.0.0.0 rather than an unencodable address.
+            let host = metadata.host.as_bytes();
+            if host.is_empty() || host.len() > 255 {
+                buf.push(SOCKS5_ATYP_IPV4);
+                buf.extend_from_slice(&Ipv4Addr::UNSPECIFIED.octets());
+            } else {
+                buf.push(SOCKS5_ATYP_DOMAIN);
+                buf.push(host.len() as u8);
+                buf.extend_from_slice(host);
+            }
+        }
+    }
+    buf.extend_from_slice(&metadata.dst_port.to_be_bytes());
+    buf
+}
+
+/// Append a per-packet uot address header (`uot.AddrParser` bytes).
+fn encode_uot_addr(buf: &mut Vec<u8>, addr: &SocketAddr) {
+    match addr.ip() {
+        IpAddr::V4(v4) => {
+            buf.push(UOT_ATYP_IPV4);
+            buf.extend_from_slice(&v4.octets());
+        }
+        // Upstream unmaps before serializing, so a `::ffff:a.b.c.d` peer goes
+        // out as plain IPv4 rather than as an IPv6 address the server would
+        // then have to unmap itself.
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => {
+                buf.push(UOT_ATYP_IPV4);
+                buf.extend_from_slice(&v4.octets());
+            }
+            None => {
+                buf.push(UOT_ATYP_IPV6);
+                buf.extend_from_slice(&v6.octets());
+            }
+        },
+    }
+    buf.extend_from_slice(&addr.port().to_be_bytes());
+}
+
+/// Read a per-packet uot address header.
+///
+/// Domain-form replies are best-effort, matching `trojan.rs`: an IP literal is
+/// parsed, anything else degrades to `0.0.0.0:<port>`. Servers echo the IP
+/// form here — the FQDN branch exists because the serializer allows it.
+async fn read_uot_addr(reader: &mut StreamReader) -> Result<SocketAddr> {
+    let mut atyp = [0u8; 1];
+    reader.read_exact(&mut atyp).await.map_err(MeowError::Io)?;
+    let ip = match atyp[0] {
+        UOT_ATYP_IPV4 => {
+            let mut octets = [0u8; 4];
+            reader
+                .read_exact(&mut octets)
+                .await
+                .map_err(MeowError::Io)?;
+            IpAddr::V4(Ipv4Addr::from(octets))
+        }
+        UOT_ATYP_IPV6 => {
+            let mut octets = [0u8; 16];
+            reader
+                .read_exact(&mut octets)
+                .await
+                .map_err(MeowError::Io)?;
+            IpAddr::V6(Ipv6Addr::from(octets))
+        }
+        UOT_ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            reader.read_exact(&mut len).await.map_err(MeowError::Io)?;
+            let mut domain = vec![0u8; len[0] as usize];
+            reader
+                .read_exact(&mut domain)
+                .await
+                .map_err(MeowError::Io)?;
+            std::str::from_utf8(&domain)
+                .ok()
+                .and_then(|d| d.parse::<IpAddr>().ok())
+                .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+        }
+        other => {
+            return Err(MeowError::Proxy(format!(
+                "anytls udp: unknown uot address type {other:#x}"
+            )))
+        }
+    };
+    let mut port = [0u8; 2];
+    reader.read_exact(&mut port).await.map_err(MeowError::Io)?;
+    Ok(SocketAddr::new(ip, u16::from_be_bytes(port)))
+}
+
+/// UDP-over-AnyTLS packet connection.
+///
+/// Each datagram becomes exactly one anytls data frame, so the framing the
+/// server reassembles never interleaves with another task's packet. Reads
+/// borrow the stream's own reader mutex; writes are serialized by the
+/// `pending_request` mutex, which doubles as the lazy-request slot.
+struct AnytlsPacketConn {
+    stream: Arc<AnytlsStream>,
+    session: Arc<Session>,
+    stream_id: u32,
+    /// uot request, sent coalesced with the first datagram (upstream
+    /// `uot.NewLazyConn`); `None` once it has gone out.
+    pending_request: tokio::sync::Mutex<Option<Vec<u8>>>,
+    fin_sent: AtomicBool,
+}
+
+impl AnytlsPacketConn {
+    fn new(stream: Arc<AnytlsStream>, session: Arc<Session>, request: Vec<u8>) -> Self {
+        let stream_id = stream.id();
+        Self {
+            stream,
+            session,
+            stream_id,
+            pending_request: tokio::sync::Mutex::new(Some(request)),
+            fin_sent: AtomicBool::new(false),
+        }
+    }
+
+    /// Idempotent per-stream FIN, identical in intent to [`AnytlsConn::fin_stream`]:
+    /// release the server's UDP socket and the session's stream-map entry
+    /// without tearing down the pooled session.
+    fn fin_stream(&self) {
+        if self.fin_sent.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let session = Arc::clone(&self.session);
+        let stream_id = self.stream_id;
+        handle.spawn(async move {
+            let _ = session
+                .write_control_frame(Frame::control(Command::Fin, stream_id))
+                .await;
+        });
+    }
+}
+
+#[async_trait]
+impl ProxyPacketConn for AnytlsPacketConn {
+    async fn read_packet(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        let mut reader = self.stream.reader().lock().await;
+
+        let addr = read_uot_addr(&mut reader).await?;
+
+        let mut len_bytes = [0u8; 2];
+        reader
+            .read_exact(&mut len_bytes)
+            .await
+            .map_err(MeowError::Io)?;
+        let length = u16::from_be_bytes(len_bytes) as usize;
+
+        // Copy what fits and drain the rest, so an undersized caller buffer
+        // truncates one datagram instead of desynchronizing the stream.
+        let to_copy = length.min(buf.len());
+        if to_copy > 0 {
+            reader
+                .read_exact(&mut buf[..to_copy])
+                .await
+                .map_err(MeowError::Io)?;
+        }
+        if length > to_copy {
+            let mut sink = vec![0u8; length - to_copy];
+            reader.read_exact(&mut sink).await.map_err(MeowError::Io)?;
+        }
+        Ok((to_copy, addr))
+    }
+
+    async fn write_packet(&self, buf: &[u8], addr: &SocketAddr) -> Result<usize> {
+        let mut pending = self.pending_request.lock().await;
+
+        let request_len = pending.as_ref().map_or(0, Vec::len);
+        let mut frame = Vec::with_capacity(request_len + 21 + buf.len());
+        if let Some(request) = pending.as_ref() {
+            frame.extend_from_slice(request);
+        }
+        encode_uot_addr(&mut frame, addr);
+        let Ok(length) = u16::try_from(buf.len()) else {
+            return Err(MeowError::Proxy(format!(
+                "anytls udp: packet too large ({} > {})",
+                buf.len(),
+                u16::MAX
+            )));
+        };
+        frame.extend_from_slice(&length.to_be_bytes());
+        frame.extend_from_slice(buf);
+
+        // The anytls frame header is a `u16` too, and the codec truncates
+        // silently rather than erroring — reject instead of corrupting.
+        if frame.len() > MAX_UOT_FRAME {
+            return Err(MeowError::Proxy(format!(
+                "anytls udp: framed packet too large ({} > {MAX_UOT_FRAME})",
+                frame.len()
+            )));
+        }
+
+        self.session
+            .write_data_frame(self.stream_id, Bytes::from(frame))
+            .await
+            .map_err(|e| MeowError::Proxy(format!("anytls udp write: {e}")))?;
+        *pending = None;
+        Ok(buf.len())
+    }
+
+    fn local_addr(&self) -> Result<SocketAddr> {
+        // Diagnostics only: the datagrams ride a multiplexed TLS stream, there
+        // is no local UDP socket to report.
+        Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
+    }
+
+    fn close(&self) -> Result<()> {
+        self.fin_stream();
+        Ok(())
+    }
+}
+
+impl Drop for AnytlsPacketConn {
+    fn drop(&mut self) {
+        // NAT eviction drops the boxed conn without calling `close()`, so FIN
+        // here too; `fin_stream` is idempotent across both paths.
+        self.fin_stream();
+    }
+}
+
 fn build_server_name(value: &str) -> std::result::Result<ServerName<'static>, String> {
     let normalized = value.trim().trim_start_matches('[').trim_end_matches(']');
     if normalized.is_empty() {
@@ -445,4 +764,133 @@ fn install_anytls_bridges() {
             anytls_rs::set_socket_protector(Arc::new(Bridge));
         }
     });
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use meow_common::Network;
+
+    fn reader_over(bytes: &[u8]) -> StreamReader {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        tx.send(Bytes::copy_from_slice(bytes)).unwrap();
+        StreamReader::new(0, rx)
+    }
+
+    fn metadata_for(host: &str, ip: Option<IpAddr>, port: u16) -> Metadata {
+        Metadata {
+            network: Network::Udp,
+            host: smol_str::SmolStr::from(host),
+            dst_ip: ip,
+            dst_port: port,
+            ..Default::default()
+        }
+    }
+
+    /// The request header uses SOCKS5 family bytes, *not* the uot ones.
+    #[test]
+    fn request_encodes_socks5_family_bytes() {
+        let v4 = encode_uot_request(&metadata_for("", Some("8.8.8.8".parse().unwrap()), 53));
+        assert_eq!(v4, vec![0, SOCKS5_ATYP_IPV4, 8, 8, 8, 8, 0, 53]);
+
+        let v6 = encode_uot_request(&metadata_for(
+            "",
+            Some("2001:4860:4860::8888".parse().unwrap()),
+            53,
+        ));
+        assert_eq!(v6[0], 0, "isConnect must be false (Bind format)");
+        assert_eq!(v6[1], SOCKS5_ATYP_IPV6);
+        assert_eq!(v6.len(), 1 + 1 + 16 + 2);
+
+        let domain = encode_uot_request(&metadata_for("example.com", None, 443));
+        assert_eq!(domain[0], 0);
+        assert_eq!(domain[1], SOCKS5_ATYP_DOMAIN);
+        assert_eq!(domain[2], 11);
+        assert_eq!(&domain[3..14], b"example.com");
+        assert_eq!(u16::from_be_bytes([domain[14], domain[15]]), 443);
+    }
+
+    /// A resolved IPv4-mapped destination goes out as plain IPv4, matching
+    /// upstream's `Socksaddr` normalization.
+    #[test]
+    fn request_unmaps_v4_mapped_destination() {
+        let mapped = encode_uot_request(&metadata_for(
+            "",
+            Some("::ffff:1.2.3.4".parse().unwrap()),
+            8080,
+        ));
+        assert_eq!(mapped, vec![0, SOCKS5_ATYP_IPV4, 1, 2, 3, 4, 0x1f, 0x90]);
+    }
+
+    /// Metadata with neither an IP nor a host must still produce an address
+    /// the upstream serializer accepts.
+    #[test]
+    fn request_falls_back_to_unspecified_without_address() {
+        let empty = encode_uot_request(&metadata_for("", None, 1234));
+        assert_eq!(empty, vec![0, SOCKS5_ATYP_IPV4, 0, 0, 0, 0, 0x04, 0xd2]);
+    }
+
+    /// Per-packet headers use the uot family bytes — 0x00/0x01, not SOCKS5's
+    /// 0x01/0x04. Getting this wrong is silent on the wire.
+    #[test]
+    fn packet_header_encodes_uot_family_bytes() {
+        let mut buf = Vec::new();
+        encode_uot_addr(&mut buf, &"1.2.3.4:80".parse().unwrap());
+        assert_eq!(buf, vec![UOT_ATYP_IPV4, 1, 2, 3, 4, 0, 80]);
+
+        let mut buf = Vec::new();
+        encode_uot_addr(&mut buf, &"[::1]:80".parse().unwrap());
+        assert_eq!(buf[0], UOT_ATYP_IPV6);
+        assert_eq!(buf.len(), 1 + 16 + 2);
+
+        // v4-mapped peers are unmapped, as upstream does before serializing.
+        let mut buf = Vec::new();
+        encode_uot_addr(&mut buf, &"[::ffff:1.2.3.4]:80".parse().unwrap());
+        assert_eq!(buf, vec![UOT_ATYP_IPV4, 1, 2, 3, 4, 0, 80]);
+    }
+
+    #[tokio::test]
+    async fn read_uot_addr_round_trips_encode() {
+        for addr in ["1.2.3.4:53", "[2001:db8::1]:443"] {
+            let addr: SocketAddr = addr.parse().unwrap();
+            let mut buf = Vec::new();
+            encode_uot_addr(&mut buf, &addr);
+            let mut reader = reader_over(&buf);
+            assert_eq!(read_uot_addr(&mut reader).await.unwrap(), addr);
+        }
+    }
+
+    /// Domain-form replies degrade to `0.0.0.0:<port>` unless the "domain" is
+    /// an IP literal — same best-effort rule as `trojan.rs`.
+    #[tokio::test]
+    async fn read_uot_addr_handles_domain_form() {
+        let mut wire = vec![UOT_ATYP_DOMAIN, 11];
+        wire.extend_from_slice(b"example.com");
+        wire.extend_from_slice(&443u16.to_be_bytes());
+        let mut reader = reader_over(&wire);
+        assert_eq!(
+            read_uot_addr(&mut reader).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 443)
+        );
+
+        let mut wire = vec![UOT_ATYP_DOMAIN, 7];
+        wire.extend_from_slice(b"1.2.3.4");
+        wire.extend_from_slice(&53u16.to_be_bytes());
+        let mut reader = reader_over(&wire);
+        assert_eq!(
+            read_uot_addr(&mut reader).await.unwrap(),
+            "1.2.3.4:53".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_uot_addr_rejects_unknown_family() {
+        let mut reader = reader_over(&[0x09, 0, 0, 0, 0, 0, 0]);
+        let Err(err) = read_uot_addr(&mut reader).await else {
+            panic!("unknown address family must error");
+        };
+        assert!(
+            err.to_string().contains("unknown uot address type"),
+            "{err}"
+        );
+    }
 }

--- a/crates/meow-proxy/tests/anytls_integration.rs
+++ b/crates/meow-proxy/tests/anytls_integration.rs
@@ -107,6 +107,7 @@ async fn anytls_round_trip_through_upstream_server() {
         PASSWORD,
         Some("localhost"),
         true,
+        true,
     )
     .expect("adapter must build");
 
@@ -158,6 +159,7 @@ async fn anytls_concurrent_dials_each_get_independent_streams() {
             PASSWORD,
             Some("localhost"),
             true,
+            true,
         )
         .expect("adapter must build"),
     );
@@ -204,6 +206,7 @@ async fn anytls_sequential_writes_same_connection() {
         PASSWORD,
         Some("localhost"),
         true,
+        true,
     )
     .expect("adapter must build");
 
@@ -246,6 +249,7 @@ async fn anytls_rejects_wrong_password() {
         "WRONG-PASSWORD",
         Some("localhost"),
         true,
+        true,
     )
     .expect("adapter must build");
 
@@ -282,4 +286,151 @@ async fn anytls_rejects_wrong_password() {
             );
         }
     }
+}
+
+// ─── UDP over AnyTLS (sing-box udp-over-tcp v2, Bind format) ─────────────────
+
+/// Local UDP echo server. Returns its bound `127.0.0.1:port`.
+async fn start_udp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = sock.local_addr().unwrap();
+    let h = tokio::spawn(async move {
+        let mut buf = vec![0u8; 2048];
+        while let Ok((n, peer)) = sock.recv_from(&mut buf).await {
+            if sock.send_to(&buf[..n], peer).await.is_err() {
+                break;
+            }
+        }
+    });
+    (addr, h)
+}
+
+fn udp_metadata(dst: SocketAddr) -> Metadata {
+    Metadata {
+        network: Network::Udp,
+        host: smol_str::SmolStr::from(dst.ip().to_string()),
+        dst_ip: Some(dst.ip()),
+        dst_port: dst.port(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn anytls_udp_round_trip_through_upstream_server() {
+    install_crypto_provider();
+
+    let (echo_addr, _echo_h) = start_udp_echo_server().await;
+    let (cert, key) = self_signed_cert();
+    let (server_addr, _server_h) = start_anytls_server(cert, key).await;
+
+    let adapter = AnytlsAdapter::new(
+        "test-anytls-udp",
+        &server_addr.ip().to_string(),
+        server_addr.port(),
+        PASSWORD,
+        Some("localhost"),
+        true,
+        true,
+    )
+    .expect("adapter must build");
+
+    let conn = timeout(T, adapter.dial_udp(&udp_metadata(echo_addr)))
+        .await
+        .expect("dial_udp must not stall")
+        .expect("dial_udp must succeed end-to-end");
+
+    let payload = b"meow<>anytls udp round-trip";
+    let sent = timeout(T, conn.write_packet(payload, &echo_addr))
+        .await
+        .expect("write_packet must not stall")
+        .expect("write_packet must succeed");
+    assert_eq!(sent, payload.len());
+
+    let mut buf = vec![0u8; 2048];
+    let (n, from) = timeout(T, conn.read_packet(&mut buf))
+        .await
+        .expect("read_packet must not stall")
+        .expect("read_packet must succeed");
+    assert_eq!(&buf[..n], payload, "echoed payload must match");
+    // Bind format carries the real source per packet — if the reply header
+    // were mis-encoded this would come back as 0.0.0.0:0 or garbage.
+    assert_eq!(from, echo_addr, "reply must carry the peer address");
+}
+
+#[tokio::test]
+async fn anytls_udp_routes_each_packet_to_its_own_destination() {
+    // Bind format (isConnect=0) means the destination travels with every
+    // datagram rather than being pinned at handshake. Two echo servers on one
+    // packet conn prove that path, and that replies are attributed correctly.
+    install_crypto_provider();
+
+    let (echo_a, _a_h) = start_udp_echo_server().await;
+    let (echo_b, _b_h) = start_udp_echo_server().await;
+    let (cert, key) = self_signed_cert();
+    let (server_addr, _server_h) = start_anytls_server(cert, key).await;
+
+    let adapter = AnytlsAdapter::new(
+        "test-anytls-udp-multi",
+        &server_addr.ip().to_string(),
+        server_addr.port(),
+        PASSWORD,
+        Some("localhost"),
+        true,
+        true,
+    )
+    .expect("adapter must build");
+
+    let conn = timeout(T, adapter.dial_udp(&udp_metadata(echo_a)))
+        .await
+        .expect("dial_udp must not stall")
+        .expect("dial_udp must succeed");
+
+    timeout(T, conn.write_packet(b"to-a", &echo_a))
+        .await
+        .expect("write a must not stall")
+        .expect("write a");
+    timeout(T, conn.write_packet(b"to-b", &echo_b))
+        .await
+        .expect("write b must not stall")
+        .expect("write b");
+
+    // Replies may arrive in either order; key them by source address.
+    let mut seen = std::collections::HashMap::new();
+    let mut buf = vec![0u8; 2048];
+    for _ in 0..2 {
+        let (n, from) = timeout(T, conn.read_packet(&mut buf))
+            .await
+            .expect("read_packet must not stall")
+            .expect("read_packet must succeed");
+        seen.insert(from, buf[..n].to_vec());
+    }
+
+    assert_eq!(seen.get(&echo_a).map(Vec::as_slice), Some(&b"to-a"[..]));
+    assert_eq!(seen.get(&echo_b).map(Vec::as_slice), Some(&b"to-b"[..]));
+}
+
+#[tokio::test]
+async fn anytls_udp_is_refused_when_not_enabled() {
+    install_crypto_provider();
+
+    let (echo_addr, _echo_h) = start_udp_echo_server().await;
+    let (cert, key) = self_signed_cert();
+    let (server_addr, _server_h) = start_anytls_server(cert, key).await;
+
+    let adapter = AnytlsAdapter::new(
+        "test-anytls-udp-off",
+        &server_addr.ip().to_string(),
+        server_addr.port(),
+        PASSWORD,
+        Some("localhost"),
+        true,
+        false,
+    )
+    .expect("adapter must build");
+
+    assert!(!adapter.support_udp(), "udp: false must not advertise UDP");
+    let Err(err) = adapter.dial_udp(&udp_metadata(echo_addr)).await else {
+        panic!("dial_udp must be refused when `udp` is off");
+    };
+    assert!(err.to_string().contains("udp: true"), "msg: {err}");
 }

--- a/crates/meow-proxy/tests/anytls_leak.rs
+++ b/crates/meow-proxy/tests/anytls_leak.rs
@@ -135,6 +135,7 @@ async fn anytls_repeated_dials_do_not_leak_fds() {
         PASSWORD,
         Some("localhost"),
         true,
+        true,
     )
     .expect("adapter must build");
 

--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -58,7 +58,7 @@ cause problems; items marked ~ work with caveats; items marked ✓ work.
 | `proxies:` — SOCKS5 outbound | ✓ | Full parity (M1.B-4). |
 | `proxies:` — Snell | ✓ | v3/v4/v5, UDP-over-TCP, optional HTTP/TLS obfs. |
 | `proxies:` — Hysteria2 | ✓ | QUIC TCP/UDP, Salamander obfs, port hopping, bandwidth hints. |
-| `proxies:` — AnyTLS | ✓ | In the `full` bundle, and therefore in the release binaries; excluded from `minimal`. |
+| `proxies:` — AnyTLS | ✓ | TCP + UDP (udp-over-tcp v2, opt in with `udp: true`). In the `full` bundle, and therefore in the release binaries; excluded from `minimal`. |
 | `proxies:` — TUIC / WireGuard / SSH | ✗ | Not implemented. |
 | `proxy-groups:` — selector, url-test, fallback | ✓ | Fully supported. |
 | `proxy-groups:` — load-balance | ✓ | round-robin + consistent-hashing (M1.C-1). |

--- a/website/guide/proxies.md
+++ b/website/guide/proxies.md
@@ -230,6 +230,7 @@ Obfuscated-TLS outbound (requires the `anytls` feature).
 | `password` | string | ✓ | — | |
 | `sni` | string | | — | |
 | `skip-cert-verify` | bool | | `false` | |
+| `udp` | bool | | `false` | Enable UDP relay (sing-box udp-over-tcp v2) |
 
 ---
 


### PR DESCRIPTION
## Problem

`AnytlsAdapter::dial_udp` was a stub returning `"anytls: UDP not implemented yet"` and `support_udp()` hard-returned `false`, so any UDP flow routed to an anytls outbound (QUIC/HTTP-3, games, non-`:53` DNS) failed to dial.

AnyTLS has no datagram channel — it's one TLS connection over TCP by design, since that's the whole camouflage premise. So UDP has to be framed inside a stream, exactly as Trojan does. AnyTLS uses sing-box's udp-over-tcp v2 (`uot`): a normal proxy stream to `sp.v2.udp-over-tcp.arpa:0` with `uot` framing inside it. All the plumbing already existed (`create_proxy_stream`, `write_data_frame`, `Stream::reader`); only the framing layer was missing.

## The wire-format trap

`uot` serializes the **request** address with the SOCKS5 family bytes (`0x01` IPv4 / `0x03` domain / `0x04` IPv6) but every **per-packet** address with its own table (`0x00` IPv4 / `0x01` IPv6 / `0x02` domain). Sharing one table between them raises no error — just a server that mis-routes. Hence the explicit constants and unit tests asserting each byte.

Verified against `sing@v0.5.1/common/uot/{protocol,conn,server}.go` and mihomo `adapter/outbound/anytls.go`.

## Changes

**Client — `meow-proxy/src/anytls_adapter.rs`**

- New `AnytlsPacketConn` implementing `ProxyPacketConn`, modelled on `TrojanPacketConn`. Runs **Bind format** (`isConnect = 0`), matching mihomo's `uot.NewLazyConn(c, uot.Request{Destination: …})`, so each datagram carries its own destination and each reply carries the real source address — what the SOCKS5-UDP and TUN listeners hand back to the client.
- The uot request is written coalesced with the first datagram, as upstream's lazy conn does; the mutex holding it doubles as the write serializer.
- One datagram = one anytls data frame, so a packet can never be split or interleaved with another task's. `FrameCodec::encode` writes `len as u16` and truncates **silently**, so oversized frames are rejected rather than corrupted.
- `close()` and `Drop` both FIN the stream (idempotent), same as `AnytlsConn` — NAT eviction drops the boxed conn without calling `close()`, and #201 item 4 showed the server-side socket leaks without a FIN.

**Config — `meow-config/src/proxy_parser.rs`**

`udp:` flag, **default `false`**, matching mihomo's `AnyTLSOption.UDP` and every other adapter here except hysteria2. Existing configs need `udp: true` added to opt in.

**Server — `meow-anytls/src/server/udp_proxy.rs`**

Accepts `isConnect = 0` instead of rejecting it, so the in-tree server is sing-box-compatible rather than half-compatible and can serve the integration test. Connect format unchanged byte-for-byte.

No new TCP connections: `dial_udp` uses the same pooled-session path as `dial_tcp`, so each UDP association is a stream on the existing connection.

## Tests

- 7 unit tests over the codec: both family tables, v4-mapped unmapping, domain fallback, unknown family, request fallbacks.
- 3 integration tests against an in-process `anytls_rs::server::Server` — round trip with source-address assertion, two destinations over one packet conn (proves per-packet routing actually works), and refusal when `udp` is off. No external anytls server needed.

Full regression bar green: `cargo fmt --check`, all three clippy configurations, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --lib` (1042 tests), plus the anytls integration and leak suites.

## Follow-up (not in this PR)

mihomo exposes `idle-session-check-interval`, `idle-session-timeout`, `min-idle-session`, and `disable-reuse`; `parse_anytls` accepts none of them and the pool is hardwired to `SessionPoolConfig::default()`. `Client` already has a constructor taking a pool config, so it's a parser-and-threading job.

Refs #75.