### PR TITLE
fix(dns): resolve proxy server hostnames with the configured DNS

### DIFF
--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -777,12 +777,25 @@ async fn run(
     // failure mode; the Android `SocketProtector` is installed separately by
     // the JNI bridge.
     //
-    // Only when `dns.enable` is true: with DNS off, `config.dns.resolver` is
-    // a stub pointing at a hard-coded upstream, and forcing every proxy dial
-    // through it would be worse than the OS resolver the user asked for.
-    // Clearing otherwise keeps a config reload from leaving a stale hook
-    // installed.
-    if config.dns.enabled {
+    // On desktop this is gated on `dns.enable`: with DNS off,
+    // `config.dns.resolver` is a stub pointing at a hard-coded upstream, and
+    // forcing every proxy dial through it would be worse than the OS resolver
+    // the user asked for. Clearing otherwise keeps a config reload from
+    // leaving a stale hook installed.
+    //
+    // The VPN platforms are the exception and install it unconditionally.
+    // There the hook is not a DNS-quality choice but a correctness one: it is
+    // the only thing keeping proxy-server lookups off libc `getaddrinfo`,
+    // whose sockets bypass `VpnService.protect(fd)` / the NE tunnel's
+    // exclusion and therefore loop the query back through our own tunnel.
+    // Android installed it unconditionally before proxy-server resolution
+    // moved cross-platform; gating it on `dns.enable` there would resurrect
+    // that loop for `dns.enable: false` configs (the very case
+    // `socket_protect::resolve_addrs` warns about). The stub upstream is a
+    // worse resolver than the OS one, but a reachable one beats a lookup that
+    // deadlocks against the tunnel carrying it.
+    const VPN_PLATFORM: bool = cfg!(any(target_os = "android", target_os = "ios"));
+    if config.dns.enabled || VPN_PLATFORM {
         meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(Arc::clone(
             &config.dns.resolver,
         ))));

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -796,9 +796,12 @@ async fn run(
     // deadlocks against the tunnel carrying it.
     const VPN_PLATFORM: bool = cfg!(any(target_os = "android", target_os = "ios"));
     if config.dns.enabled || VPN_PLATFORM {
-        meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(Arc::clone(
-            &config.dns.resolver,
-        ))));
+        meow_common::set_host_resolver(Arc::new(
+            meow_dns::ResolverHostHook::new_with_proxy_resolver(
+                Arc::clone(&config.dns.resolver),
+                config.dns.proxy_resolver.clone(),
+            ),
+        ));
     } else {
         meow_common::clear_host_resolver();
     }

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -765,19 +765,29 @@ async fn run(
     // Keep a resolver clone for the auto-update task before it moves into the tunnel.
     let resolver = Arc::clone(&config.dns.resolver);
 
-    // Android: install the resolver as the global host-resolver hook used
-    // by `meow_common::connect_tcp_host` / `resolve_host`. Without this,
-    // proxy adapters dialling by hostname would fall back to libc's
-    // `getaddrinfo`, whose DNS sockets bypass `VpnService.protect(fd)` —
-    // so on a VPN-active device DNS would route through our own tunnel
-    // and loop. See `meow-common/src/socket_protect.rs` for the full
-    // failure mode. The `SocketProtector` itself is installed separately
-    // by the JNI bridge.
-    #[cfg(target_os = "android")]
-    {
+    // Install the configured resolver as the global host-resolver hook used
+    // by `meow_common::connect_tcp_host` / `resolve_host`, so a proxy node's
+    // own server hostname is resolved by the DNS in the config — matching
+    // mihomo, and matching what `DirectAdapter` already does for destination
+    // hostnames. Without it the proxy adapters fall back to libc's
+    // `getaddrinfo`, which ignores `dns:` entirely (wrong nameserver,
+    // wrong `hosts:` entries) and, on a VPN-active device, opens DNS sockets
+    // that bypass `VpnService.protect(fd)` so the query loops back through
+    // our own tunnel. See `meow-common/src/socket_protect.rs` for the full
+    // failure mode; the Android `SocketProtector` is installed separately by
+    // the JNI bridge.
+    //
+    // Only when `dns.enable` is true: with DNS off, `config.dns.resolver` is
+    // a stub pointing at a hard-coded upstream, and forcing every proxy dial
+    // through it would be worse than the OS resolver the user asked for.
+    // Clearing otherwise keeps a config reload from leaving a stale hook
+    // installed.
+    if config.dns.enabled {
         meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(Arc::clone(
             &config.dns.resolver,
         ))));
+    } else {
+        meow_common::clear_host_resolver();
     }
 
     // Create the tunnel (core routing engine)

--- a/crates/meow-common/src/socket_protect.rs
+++ b/crates/meow-common/src/socket_protect.rs
@@ -69,6 +69,20 @@ pub trait HostResolver: Send + Sync {
     async fn resolve_all(&self, host: &str) -> io::Result<Vec<IpAddr>> {
         self.resolve(host).await.map(|ip| vec![ip])
     }
+
+    /// Resolve `host` using only answers the implementation already holds —
+    /// static mappings, warm cache — without any lookup that could itself
+    /// need an outbound dial.
+    ///
+    /// Consulted instead of [`Self::resolve_all`] when the hook is re-entered
+    /// — a nameserver that dials a proxy to answer a query, for the very
+    /// hostname that proxy is reached at. `None` means "nothing known", and the
+    /// caller falls through to the system resolver. The default answers
+    /// nothing, which is always safe.
+    fn resolve_all_local(&self, host: &str) -> Option<Vec<IpAddr>> {
+        let _ = host;
+        None
+    }
 }
 
 static RESOLVER: RwLock<Option<Arc<dyn HostResolver>>> = RwLock::new(None);
@@ -89,6 +103,29 @@ pub fn clear_host_resolver() {
 /// Snapshot of the currently-installed host resolver.
 pub fn host_resolver() -> Option<Arc<dyn HostResolver>> {
     RESOLVER.read().clone()
+}
+
+tokio::task_local! {
+    /// Set for the duration of a [`HostResolver`] call made from
+    /// [`resolve_addrs`]. See [`in_host_resolver`] for why.
+    static IN_HOST_RESOLVER: ();
+}
+
+/// True when the current task is already inside a [`HostResolver`] call.
+///
+/// The hook is backed by meow-rs's own `meow_dns::Resolver`, and a nameserver
+/// may be tagged `#PROXY` — i.e. answering the query means dialing a proxy,
+/// which means resolving *that* proxy's server hostname, which re-enters the
+/// hook. If the two hostnames coincide (the usual case: the proxy carrying
+/// DNS is the one being dialed) the resolver's single-flight `inflight` map
+/// would make the inner lookup wait on the outer one, deadlocking the dial
+/// until it times out. Detecting the re-entry and falling back to the system
+/// resolver for the inner lookup breaks the cycle. The whole chain — hook →
+/// resolver → DNS client → proxy dial → hook — runs on one task, so a
+/// task-local is a precise fence: unrelated concurrent dials keep using the
+/// configured DNS.
+fn in_host_resolver() -> bool {
+    IN_HOST_RESOLVER.try_with(|()| ()).is_ok()
 }
 
 // ─── System-resolver result cache (Android / iOS only) ─────────────────────
@@ -311,6 +348,8 @@ async fn connect_tcp_iface_bound(addr: SocketAddr) -> io::Result<TcpStream> {
 ///    don't loop the query back through our own tunnel. Consulted
 ///    independently of whether a `SocketProtector` is installed — iOS uses
 ///    the resolver hook without a protector.
+///    Skipped when the call is itself nested inside a hook call (see
+///    [`in_host_resolver`]).
 /// 3. Short-TTL cache of prior system-resolver results (Android / iOS only)
 ///    → collapses a wake-time burst of dials to one `getaddrinfo`.
 /// 4. System resolver (`tokio::net::lookup_host`), result cached.
@@ -321,18 +360,26 @@ async fn resolve_addrs(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
         return Ok(vec![SocketAddr::new(ip, port)]);
     }
 
-    if let Some(r) = host_resolver() {
-        let ips = r.resolve_all(host).await?;
-        if ips.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("resolve: no address for {host}:{port}"),
-            ));
+    match host_resolver() {
+        Some(r) if in_host_resolver() => {
+            // Re-entered: answer from what the hook already knows, and only
+            // fall through to the system resolver when it knows nothing.
+            if let Some(ips) = r.resolve_all_local(host) {
+                if !ips.is_empty() {
+                    return Ok(ips
+                        .into_iter()
+                        .map(|ip| SocketAddr::new(ip, port))
+                        .collect());
+                }
+            }
+            tracing::debug!(
+                host,
+                "resolve: re-entrant host-resolver call (a DNS upstream dials through a \
+                 proxy) — using the system resolver for this hop to avoid a lookup cycle"
+            );
         }
-        return Ok(ips
-            .into_iter()
-            .map(|ip| SocketAddr::new(ip, port))
-            .collect());
+        Some(r) => return resolve_via_hook(r.as_ref(), host, port).await,
+        None => {}
     }
 
     if let Some(cached) = sys_cache_get(host, port) {
@@ -359,6 +406,27 @@ async fn resolve_addrs(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
     }
     sys_cache_put(host, &addrs);
     Ok(addrs)
+}
+
+/// Run one [`HostResolver`] lookup with [`IN_HOST_RESOLVER`] set, so a dial
+/// made while answering it takes the system-resolver path instead of
+/// re-entering the hook.
+async fn resolve_via_hook(
+    r: &dyn HostResolver,
+    host: &str,
+    port: u16,
+) -> io::Result<Vec<SocketAddr>> {
+    let ips = IN_HOST_RESOLVER.scope((), r.resolve_all(host)).await?;
+    if ips.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("resolve: no address for {host}:{port}"),
+        ));
+    }
+    Ok(ips
+        .into_iter()
+        .map(|ip| SocketAddr::new(ip, port))
+        .collect())
 }
 
 /// Dial an outbound TCP stream to `host:port`. The hostname is resolved
@@ -890,5 +958,115 @@ mod tests {
 
         clear_host_resolver();
         assert!(host_resolver().is_none());
+    }
+
+    /// Stands in for a `#PROXY`-tagged nameserver: answering a lookup means
+    /// dialing a proxy, which resolves that proxy's own server hostname.
+    struct ReentrantResolver {
+        calls: AtomicUsize,
+        inner: parking_lot::Mutex<Option<io::Result<Vec<SocketAddr>>>>,
+    }
+    #[async_trait]
+    impl HostResolver for ReentrantResolver {
+        async fn resolve(&self, host: &str) -> io::Result<IpAddr> {
+            self.resolve_all(host).await.map(|ips| ips[0])
+        }
+
+        async fn resolve_all(&self, _host: &str) -> io::Result<Vec<IpAddr>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            // The nested dial the DNS upstream would make.
+            *self.inner.lock() = Some(resolve_host_all("localhost", 53).await);
+            Ok(vec![IpAddr::from([203, 0, 113, 7])])
+        }
+    }
+
+    #[tokio::test]
+    async fn nested_dial_inside_the_hook_uses_the_system_resolver() {
+        let _g = LOCK.lock().await;
+        clear_host_resolver();
+        let r = Arc::new(ReentrantResolver {
+            calls: AtomicUsize::new(0),
+            inner: parking_lot::Mutex::new(None),
+        });
+        set_host_resolver(Arc::clone(&r) as Arc<dyn HostResolver>);
+
+        let addrs = resolve_host_all("proxy.example", 443)
+            .await
+            .expect("outer lookup answered by the hook");
+        assert_eq!(addrs, vec![SocketAddr::from(([203, 0, 113, 7], 443))]);
+
+        // One hook call, not two: the nested dial must not re-enter it, or a
+        // real resolver's single-flight map would deadlock the pair.
+        assert_eq!(r.calls.load(Ordering::SeqCst), 1);
+        let inner = r.inner.lock().take().expect("nested dial ran");
+        let inner = inner.expect("system resolver answered the nested dial");
+        assert!(
+            inner.iter().all(|a| a.ip().is_loopback()),
+            "nested dial must come from the system resolver, got {inner:?}"
+        );
+
+        clear_host_resolver();
+    }
+
+    /// Same nesting, but the hook knows the inner host statically (a `hosts:`
+    /// entry or a warm cache line), so the system resolver is never reached.
+    struct LocalAnswerResolver {
+        local_calls: AtomicUsize,
+        inner: parking_lot::Mutex<Option<io::Result<Vec<SocketAddr>>>>,
+    }
+    #[async_trait]
+    impl HostResolver for LocalAnswerResolver {
+        async fn resolve(&self, host: &str) -> io::Result<IpAddr> {
+            self.resolve_all(host).await.map(|ips| ips[0])
+        }
+
+        async fn resolve_all(&self, _host: &str) -> io::Result<Vec<IpAddr>> {
+            *self.inner.lock() = Some(resolve_host_all("node.example", 8388).await);
+            Ok(vec![IpAddr::from([203, 0, 113, 7])])
+        }
+
+        fn resolve_all_local(&self, _host: &str) -> Option<Vec<IpAddr>> {
+            self.local_calls.fetch_add(1, Ordering::SeqCst);
+            Some(vec![IpAddr::from([192, 0, 2, 55])])
+        }
+    }
+
+    #[tokio::test]
+    async fn nested_dial_prefers_the_hooks_local_answer() {
+        let _g = LOCK.lock().await;
+        clear_host_resolver();
+        let r = Arc::new(LocalAnswerResolver {
+            local_calls: AtomicUsize::new(0),
+            inner: parking_lot::Mutex::new(None),
+        });
+        set_host_resolver(Arc::clone(&r) as Arc<dyn HostResolver>);
+
+        resolve_host_all("proxy.example", 443).await.unwrap();
+
+        assert_eq!(r.local_calls.load(Ordering::SeqCst), 1);
+        let inner = r.inner.lock().take().unwrap().unwrap();
+        assert_eq!(
+            inner,
+            vec![SocketAddr::from(([192, 0, 2, 55], 8388))],
+            "the nested hop must take the hook's local answer, not the OS resolver"
+        );
+
+        clear_host_resolver();
+    }
+
+    #[tokio::test]
+    async fn hook_applies_again_after_the_nested_scope_ends() {
+        let _g = LOCK.lock().await;
+        clear_host_resolver();
+        let r = FixedResolver::new(IpAddr::from([198, 51, 100, 4]));
+        set_host_resolver(Arc::clone(&r) as Arc<dyn HostResolver>);
+
+        for _ in 0..2 {
+            let addrs = resolve_host_all("node.example", 8388).await.unwrap();
+            assert_eq!(addrs, vec![SocketAddr::from(([198, 51, 100, 4], 8388))]);
+        }
+        assert_eq!(r.count(), 2, "the guard must not leak across calls");
+
+        clear_host_resolver();
     }
 }

--- a/crates/meow-config/src/dns_parser.rs
+++ b/crates/meow-config/src/dns_parser.rs
@@ -9,7 +9,7 @@ use meow_dns::upstream::{NameServerEntry, NameServerUrl};
 use meow_dns::{DnsClient, HostOrIp, Resolver};
 use meow_trie::DomainTrie;
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::warn;
@@ -41,6 +41,7 @@ pub async fn parse_dns(
                 resolver,
                 listen_addr: None,
                 enabled: false,
+                proxy_resolver: None,
             });
         }
     };
@@ -52,6 +53,8 @@ pub async fn parse_dns(
     let fallback_urls = parse_nameserver_entries(dns.fallback.as_deref().unwrap_or(&[]))?;
     let default_ns_urls =
         parse_nameserver_entries(dns.default_nameserver.as_deref().unwrap_or(&[]))?;
+    let proxy_ns_urls =
+        parse_nameserver_entries(dns.proxy_server_nameserver.as_deref().unwrap_or(&[]))?;
 
     let mode = match dns.enhanced_mode.as_deref() {
         Some("fake-ip") => DnsMode::FakeIp,
@@ -65,6 +68,46 @@ pub async fn parse_dns(
     if use_hosts && use_system_hosts {
         merge_system_hosts(&mut hosts).await;
     }
+
+    // mihomo `proxy-server-nameserver`: a dedicated resolver used only for
+    // proxy server hostnames (dns.Config.ProxyServer → ProxyServerHostResolver).
+    // Normal mode — proxy server domains must never get fake IPs — and no
+    // fallback/policy; hostname URLs bootstrap via default-nameserver exactly
+    // like the main list. Hosts entries still apply (mihomo checks its global
+    // hosts table before consulting any resolver), so it gets its own copy of
+    // the hosts trie — DomainTrie is not Clone, hence the rebuild.
+    let proxy_resolver = if proxy_ns_urls.is_empty() {
+        None
+    } else {
+        for (nameserver, proxy) in circular_proxy_tags(&proxy_ns_urls, proxy_registry) {
+            warn!(
+                "dns.proxy-server-nameserver '{nameserver}' is tagged #{proxy}, but '{proxy}' is \
+                 itself reached by hostname — resolving that hostname is what this nameserver \
+                 exists to do, so the lookup re-enters the resolver, is fenced to hosts: + cache, \
+                 and falls through to the system resolver on a miss. Pin the node's server in \
+                 hosts:, give it an IP-literal server:, or drop the #{proxy} tag."
+            );
+        }
+        let mut proxy_hosts = build_hosts_trie(raw.hosts.as_ref())?;
+        if use_hosts && use_system_hosts {
+            merge_system_hosts(&mut proxy_hosts).await;
+        }
+        Some(Arc::new(
+            Resolver::new_with_bootstrap_with_proxies(
+                proxy_ns_urls,
+                vec![],
+                default_ns_urls.clone(),
+                DnsMode::Normal,
+                proxy_hosts,
+                use_hosts,
+                None,
+                None,
+                proxy_registry,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("proxy-server-nameserver: {e}"))?,
+        ))
+    };
 
     // Build nameserver-policy if configured.
     let policy = if let Some(nsp_map) = &dns.nameserver_policy {
@@ -127,6 +170,7 @@ pub async fn parse_dns(
         resolver: Arc::new(resolver),
         listen_addr,
         enabled: true,
+        proxy_resolver,
     })
 }
 
@@ -192,6 +236,54 @@ async fn install_fakeip(
     };
     resolver.set_fakeip_skipper(Skipper::new(&patterns, skipper_mode));
     Ok(())
+}
+
+/// `#PROXY`-tagged `dns.proxy-server-nameserver` entries whose proxy cannot be
+/// dialled without this very resolver, as `(nameserver, proxy name)` pairs.
+///
+/// A tag here is legitimate when the named node has an IP-literal `server:` —
+/// `meow_common::resolve_addrs` short-circuits literals, so the hook is never
+/// re-entered and the nameserver is genuinely reached through the proxy. It is
+/// circular when the node is reached by hostname: resolving *that* hostname
+/// routes back into this resolver, trips the re-entrancy fence, and degrades to
+/// `resolve_ips_local` (hosts: + warm cache) with a silent system-resolver
+/// fallback on a miss. Groups report an empty `addr()` because the member is
+/// only chosen at dial time, so they count as circular too.
+///
+/// Unknown proxy names are skipped — `Resolver::new_with_bootstrap_with_proxies`
+/// already rejects those with `BootstrapError::UnknownProxy`.
+fn circular_proxy_tags(
+    entries: &[NameServerEntry],
+    proxy_registry: &HashMap<smol_str::SmolStr, Arc<dyn meow_common::Proxy>>,
+) -> Vec<(String, String)> {
+    entries
+        .iter()
+        .filter_map(|entry| {
+            let name = entry.proxy.as_deref()?;
+            let proxy = proxy_registry.get(name)?;
+            if is_ip_literal_addr(proxy.addr()) {
+                return None;
+            }
+            Some((entry.url.to_string(), name.to_string()))
+        })
+        .collect()
+}
+
+/// True when a `ProxyAdapter::addr()` string (`"<server>:<port>"`) carries an
+/// IP literal rather than a hostname. Anything unparseable is treated as a
+/// literal so a shape we do not recognise cannot manufacture a false warning.
+fn is_ip_literal_addr(addr: &str) -> bool {
+    if addr.is_empty() {
+        // Groups: member — and therefore its server — unknown until dial time.
+        return false;
+    }
+    if addr.parse::<SocketAddr>().is_ok() || addr.parse::<IpAddr>().is_ok() {
+        return true;
+    }
+    let host = addr.rsplit_once(':').map_or(addr, |(h, _)| h);
+    let host = host.strip_prefix('[').unwrap_or(host);
+    let host = host.strip_suffix(']').unwrap_or(host);
+    host.parse::<IpAddr>().is_ok()
 }
 
 /// Parse nameserver strings into `NameServerEntry`s — every entry must
@@ -765,6 +857,46 @@ mod tests {
         assert!(trie.search("example.com").is_none());
     }
 
+    #[tokio::test]
+    async fn proxy_server_nameserver_builds_dedicated_resolver() {
+        let raw: RawConfig = serde_yaml::from_str(
+            "dns:\n  enable: true\n  nameserver:\n    - 1.1.1.1\n  proxy-server-nameserver:\n    - 223.5.5.5\n",
+        )
+        .unwrap();
+        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None)
+            .await
+            .unwrap();
+        assert!(
+            cfg.proxy_resolver.is_some(),
+            "proxy-server-nameserver must build a dedicated resolver"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_proxy_server_nameserver_leaves_proxy_resolver_none() {
+        let raw: RawConfig =
+            serde_yaml::from_str("dns:\n  enable: true\n  nameserver:\n    - 1.1.1.1\n").unwrap();
+        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None)
+            .await
+            .unwrap();
+        assert!(cfg.proxy_resolver.is_none());
+    }
+
+    #[tokio::test]
+    async fn proxy_server_nameserver_ignored_when_dns_disabled() {
+        // mihomo: ProxyServerHostResolver is nil whenever the DNS section is
+        // off — proxy server hostnames fall back to the system resolver.
+        let raw: RawConfig = serde_yaml::from_str(
+            "dns:\n  enable: false\n  proxy-server-nameserver:\n    - 223.5.5.5\n",
+        )
+        .unwrap();
+        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None)
+            .await
+            .unwrap();
+        assert!(!cfg.enabled);
+        assert!(cfg.proxy_resolver.is_none());
+    }
+
     #[test]
     fn build_hosts_trie_single_ip() {
         let mut map = HashMap::new();
@@ -1031,6 +1163,8 @@ mod tests {
     /// these tests only care whether the adapter handle reached the client.
     struct PolicyStubProxy {
         health: meow_common::ProxyHealth,
+        /// `"<server>:<port>"`, or empty to stand in for a group.
+        addr: String,
     }
 
     #[async_trait::async_trait]
@@ -1045,7 +1179,7 @@ mod tests {
             meow_common::AdapterType::Direct
         }
         fn addr(&self) -> &str {
-            ""
+            &self.addr
         }
         fn support_udp(&self) -> bool {
             false
@@ -1089,6 +1223,7 @@ mod tests {
             "Proxy".into(),
             Arc::new(PolicyStubProxy {
                 health: meow_common::ProxyHealth::new(),
+                addr: String::new(),
             }),
         );
         let value = crate::raw::RawNspValue::One("tcp://8.8.8.8#Proxy".to_string());
@@ -1130,5 +1265,68 @@ mod tests {
             .expect("tls entry with SNI fragment builds");
         assert_eq!(resolvers.len(), 1);
         assert!(!resolvers[0].is_proxied());
+    }
+
+    // --- proxy-server-nameserver `#PROXY` circularity ---------------------
+
+    fn stub_registry(
+        entries: &[(&str, &str)],
+    ) -> HashMap<smol_str::SmolStr, Arc<dyn meow_common::Proxy>> {
+        entries
+            .iter()
+            .map(|(name, addr)| {
+                let proxy: Arc<dyn meow_common::Proxy> = Arc::new(PolicyStubProxy {
+                    health: meow_common::ProxyHealth::new(),
+                    addr: (*addr).to_string(),
+                });
+                (smol_str::SmolStr::from(*name), proxy)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn ip_literal_addr_detection() {
+        assert!(is_ip_literal_addr("1.2.3.4:443"));
+        assert!(is_ip_literal_addr("[2001:db8::1]:443"));
+        assert!(is_ip_literal_addr("2001:db8::1"));
+        assert!(!is_ip_literal_addr("node.example:443"));
+        // Groups report no address at all.
+        assert!(!is_ip_literal_addr(""));
+    }
+
+    #[test]
+    fn proxy_tag_on_hostname_node_is_circular() {
+        let entries = parse_nameserver_entries(&["223.5.5.5#JP".to_string()]).unwrap();
+        let registry = stub_registry(&[("JP", "node.example:443")]);
+        assert_eq!(
+            circular_proxy_tags(&entries, &registry),
+            vec![("udp://223.5.5.5:53".to_string(), "JP".to_string())]
+        );
+    }
+
+    #[test]
+    fn proxy_tag_on_ip_literal_node_is_fine() {
+        // The hook short-circuits IP literals, so this tag never re-enters
+        // the resolver — it works exactly as written and must not warn.
+        let entries = parse_nameserver_entries(&["223.5.5.5#JP".to_string()]).unwrap();
+        let registry = stub_registry(&[("JP", "1.2.3.4:443")]);
+        assert!(circular_proxy_tags(&entries, &registry).is_empty());
+    }
+
+    #[test]
+    fn proxy_tag_on_group_is_circular() {
+        let entries = parse_nameserver_entries(&["223.5.5.5#Auto".to_string()]).unwrap();
+        let registry = stub_registry(&[("Auto", "")]);
+        assert_eq!(circular_proxy_tags(&entries, &registry).len(), 1);
+    }
+
+    #[test]
+    fn untagged_and_unknown_proxy_entries_are_skipped() {
+        let entries =
+            parse_nameserver_entries(&["223.5.5.5".to_string(), "8.8.8.8#NoSuchProxy".to_string()])
+                .unwrap();
+        // Unknown names are the bootstrap builder's error to raise, not ours.
+        let registry = stub_registry(&[("JP", "node.example:443")]);
+        assert!(circular_proxy_tags(&entries, &registry).is_empty());
     }
 }

--- a/crates/meow-config/src/dns_parser.rs
+++ b/crates/meow-config/src/dns_parser.rs
@@ -40,6 +40,7 @@ pub async fn parse_dns(
             return Ok(DnsConfig {
                 resolver,
                 listen_addr: None,
+                enabled: false,
             });
         }
     };
@@ -125,6 +126,7 @@ pub async fn parse_dns(
     Ok(DnsConfig {
         resolver: Arc::new(resolver),
         listen_addr,
+        enabled: true,
     })
 }
 

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -88,6 +88,11 @@ pub struct GeneralConfig {
 pub struct DnsConfig {
     pub resolver: Arc<Resolver>,
     pub listen_addr: Option<SocketAddr>,
+    /// `dns.enable` from the config. False means `resolver` is the stub
+    /// built for `DirectAdapter` (a single hard-coded upstream), not the
+    /// user's DNS — callers that would otherwise impose it process-wide,
+    /// such as the `meow_common::HostResolver` hook, must not install it.
+    pub enabled: bool,
 }
 
 /// Listener protocol type — mirrors the `type:` field in the YAML `listeners:` array.

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -93,6 +93,10 @@ pub struct DnsConfig {
     /// user's DNS — callers that would otherwise impose it process-wide,
     /// such as the `meow_common::HostResolver` hook, must not install it.
     pub enabled: bool,
+    /// Dedicated resolver built from `dns.proxy-server-nameserver` (mihomo
+    /// `ProxyServerHostResolver`). `None` when the option is unset or DNS is
+    /// disabled — proxy server hostnames then resolve via `resolver`.
+    pub proxy_resolver: Option<Arc<Resolver>>,
 }
 
 /// Listener protocol type — mirrors the `type:` field in the YAML `listeners:` array.

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -297,6 +297,10 @@ pub struct RawDns {
     pub default_nameserver: Option<Vec<String>>,
     pub nameserver: Option<Vec<String>>,
     pub fallback: Option<Vec<String>>,
+    /// Nameservers used exclusively to resolve proxy server hostnames
+    /// (mihomo `proxy-server-nameserver`). When set, proxy adapters resolve
+    /// their `server:` through these instead of the main `nameserver` list.
+    pub proxy_server_nameserver: Option<Vec<String>>,
     pub fake_ip_filter: Option<Vec<String>>,
     /// If false, the hosts trie lookup is skipped entirely at query time.
     pub use_hosts: Option<bool>,

--- a/crates/meow-dns/src/host_resolver_hook.rs
+++ b/crates/meow-dns/src/host_resolver_hook.rs
@@ -26,20 +26,47 @@ use crate::Resolver;
 /// `Resolver::resolve_ips` — i.e. the same path `DirectAdapter` uses, so
 /// hosts file entries and fake-IP rules behave consistently between the
 /// direct outbound and the socket-protect dial path.
+///
+/// When `dns.proxy-server-nameserver` is configured, `proxy_resolver` is
+/// `Some` and takes over exclusively (mihomo `ProxyServerHostResolver`):
+/// proxy server hostnames resolve only through those nameservers — there is
+/// no fallback to the main resolver on failure, matching mihomo's
+/// `LookupIPWithResolver`, which never retries a failed preferred resolver
+/// against the default one.
 pub struct ResolverHostHook {
     resolver: Arc<Resolver>,
+    proxy_resolver: Option<Arc<Resolver>>,
 }
 
 impl ResolverHostHook {
     pub fn new(resolver: Arc<Resolver>) -> Self {
-        Self { resolver }
+        Self {
+            resolver,
+            proxy_resolver: None,
+        }
+    }
+
+    pub fn new_with_proxy_resolver(
+        resolver: Arc<Resolver>,
+        proxy_resolver: Option<Arc<Resolver>>,
+    ) -> Self {
+        Self {
+            resolver,
+            proxy_resolver,
+        }
+    }
+
+    /// The resolver proxy server hostnames go through: the dedicated
+    /// `proxy-server-nameserver` resolver when configured, else the main one.
+    fn active(&self) -> &Arc<Resolver> {
+        self.proxy_resolver.as_ref().unwrap_or(&self.resolver)
     }
 }
 
 #[async_trait]
 impl HostResolver for ResolverHostHook {
     async fn resolve(&self, host: &str) -> io::Result<IpAddr> {
-        self.resolver.resolve_ip(host).await.ok_or_else(|| {
+        self.active().resolve_ip(host).await.ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("meow-dns resolver: no address for {host}"),
@@ -48,7 +75,7 @@ impl HostResolver for ResolverHostHook {
     }
 
     async fn resolve_all(&self, host: &str) -> io::Result<Vec<IpAddr>> {
-        self.resolver.resolve_ips(host).await.ok_or_else(|| {
+        self.active().resolve_ips(host).await.ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("meow-dns resolver: no address for {host}"),
@@ -57,6 +84,63 @@ impl HostResolver for ResolverHostHook {
     }
 
     fn resolve_all_local(&self, host: &str) -> Option<Vec<IpAddr>> {
-        self.resolver.resolve_ips_local(host)
+        self.active().resolve_ips_local(host)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolver::HostEntry;
+    use meow_common::DnsMode;
+    use meow_trie::DomainTrie;
+
+    /// A resolver that answers only from its hosts trie — never touches the
+    /// network, so tests stay offline.
+    fn hosts_only_resolver(entries: &[(&str, &str)]) -> Arc<Resolver> {
+        let mut trie = DomainTrie::new();
+        for (host, ip) in entries {
+            assert!(trie.insert(
+                host,
+                HostEntry::Addresses(vec![ip.parse().expect("valid IP literal")]),
+            ));
+        }
+        Arc::new(Resolver::new(vec![], vec![], DnsMode::Normal, trie, true))
+    }
+
+    #[tokio::test]
+    async fn without_proxy_resolver_uses_main_resolver() {
+        let main = hosts_only_resolver(&[("node.example", "192.0.2.1")]);
+        let hook = ResolverHostHook::new(main);
+        let ip = hook.resolve("node.example").await.unwrap();
+        assert_eq!(ip, "192.0.2.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[tokio::test]
+    async fn proxy_resolver_takes_precedence_over_main() {
+        let main = hosts_only_resolver(&[("node.example", "192.0.2.1")]);
+        let proxy = hosts_only_resolver(&[("node.example", "192.0.2.2")]);
+        let hook = ResolverHostHook::new_with_proxy_resolver(main, Some(proxy));
+
+        let ip = hook.resolve("node.example").await.unwrap();
+        assert_eq!(ip, "192.0.2.2".parse::<IpAddr>().unwrap());
+
+        let all = hook.resolve_all("node.example").await.unwrap();
+        assert_eq!(all, vec!["192.0.2.2".parse::<IpAddr>().unwrap()]);
+
+        let local = hook.resolve_all_local("node.example").unwrap();
+        assert_eq!(local, vec!["192.0.2.2".parse::<IpAddr>().unwrap()]);
+    }
+
+    #[tokio::test]
+    async fn proxy_resolver_miss_does_not_fall_back_to_main() {
+        // mihomo LookupIPWithResolver: a configured ProxyServerHostResolver
+        // is authoritative — failure never retries the default resolver.
+        let main = hosts_only_resolver(&[("node.example", "192.0.2.1")]);
+        let proxy = hosts_only_resolver(&[]);
+        let hook = ResolverHostHook::new_with_proxy_resolver(main, Some(proxy));
+
+        assert!(hook.resolve("node.example").await.is_err());
+        assert!(hook.resolve_all_local("node.example").is_none());
     }
 }

--- a/crates/meow-dns/src/host_resolver_hook.rs
+++ b/crates/meow-dns/src/host_resolver_hook.rs
@@ -55,4 +55,8 @@ impl HostResolver for ResolverHostHook {
             )
         })
     }
+
+    fn resolve_all_local(&self, host: &str) -> Option<Vec<IpAddr>> {
+        self.resolver.resolve_ips_local(host)
+    }
 }

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -860,6 +860,35 @@ impl Resolver {
         self.lookup_actual_all(lookup_host).await
     }
 
+    /// [`Self::resolve_ips`] restricted to answers this resolver already
+    /// holds — the `hosts:` trie and the DNS cache. Never queries an
+    /// upstream, so it can never dial a proxy.
+    ///
+    /// This is the answer offered when the host-resolver hook is re-entered
+    /// (a `#PROXY` nameserver dialing the very proxy whose server hostname
+    /// is being looked up). Going upstream there would re-enter the resolver
+    /// and stall on its own single-flight entry; returning what is already
+    /// known keeps `hosts:` mappings and warm cache entries authoritative
+    /// for proxy-server hostnames even on that path.
+    pub fn resolve_ips_local(&self, host: &str) -> Option<Vec<IpAddr>> {
+        let lookup_host = if self.use_hosts {
+            match self.lookup_hosts_entry(host) {
+                Some(HostsLookup::Addresses(ips)) if !ips.is_empty() => {
+                    return Some(ips.clone());
+                }
+                Some(HostsLookup::Alias(alias)) => alias,
+                _ => host,
+            }
+        } else {
+            host
+        };
+        let ips = self.cache.get(lookup_host)?;
+        if ips.is_empty() {
+            return None;
+        }
+        Some(ips.to_vec())
+    }
+
     pub async fn resolve_ip(&self, host: &str) -> Option<IpAddr> {
         self.resolve_ips(host).await?.into_iter().next()
     }
@@ -1392,6 +1421,51 @@ mod tests {
             .put("cached.test", &ips, Duration::from_secs(60));
 
         assert_eq!(resolver.resolve_ips("cached.test").await, Some(ips));
+    }
+
+    #[test]
+    fn resolve_ips_local_answers_from_hosts_and_cache_only() {
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
+        let via_hosts = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+        hosts.insert("node.test", vec![via_hosts].into());
+        hosts.insert("alias.test", HostEntry::Alias("cached.test".into()));
+        let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, true);
+
+        let via_cache = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 3));
+        resolver
+            .cache
+            .put("cached.test", &[via_cache], Duration::from_secs(60));
+
+        assert_eq!(
+            resolver.resolve_ips_local("node.test"),
+            Some(vec![via_hosts])
+        );
+        assert_eq!(
+            resolver.resolve_ips_local("cached.test"),
+            Some(vec![via_cache])
+        );
+        assert_eq!(
+            resolver.resolve_ips_local("alias.test"),
+            Some(vec![via_cache]),
+            "a hosts alias must resolve through to the cached target"
+        );
+        assert_eq!(
+            resolver.resolve_ips_local("unknown.test"),
+            None,
+            "an unknown host must not trigger an upstream query"
+        );
+    }
+
+    #[test]
+    fn resolve_ips_local_ignores_hosts_when_use_hosts_is_off() {
+        let mut hosts: DomainTrie<HostEntry> = DomainTrie::new();
+        hosts.insert(
+            "node.test",
+            vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))].into(),
+        );
+        let resolver = Resolver::new(vec![], vec![], DnsMode::Normal, hosts, false);
+
+        assert_eq!(resolver.resolve_ips_local("node.test"), None);
     }
 
     #[test]

--- a/docs/adr/0012-dns-via-proxy.md
+++ b/docs/adr/0012-dns-via-proxy.md
@@ -59,6 +59,8 @@ DNS-over-proxy creates one hard loop hazard:
 **Mitigation rules** (enforced at config-parse time, hard error per ADR-0002 Class A — silent breakage in DNS is a privacy failure):
 
 1. **Proxy-server hostnames must never resolve through a `#PROXY` client.** When the resolver dials a proxy adapter, it must use a *bootstrap* resolver that has no `#PROXY` entries. This is the same bootstrap path that already resolves `dns.google` for an encrypted upstream today (`resolver.rs:354–382`).
+
+   *Implemented as a runtime fence rather than a retained bootstrap pool.* Since proxy-server hostnames now resolve through the `meow_common::HostResolver` hook (i.e. through this resolver) on every platform, the cycle is detected where it forms: `resolve_addrs` marks its task while the hook runs, and a dial made under that mark — which is exactly a `#PROXY` upstream dialing its own proxy — is answered by `Resolver::resolve_ips_local` (`hosts:` trie + DNS cache, never an upstream query), falling through to the system resolver when nothing is known. This holds the invariant without keeping the throwaway bootstrap clients alive past construction, and without which the resolver's single-flight `inflight` entry would make the inner lookup wait on the outer one.
 2. **Direct cycle detection**: if proxy `A` declares `dns: <anything>#A`, reject the config at load.
 3. **Indirect cycles** (A→B→A) are detected by walking the proxy `dns:` graph at config load. A cycle is a Class A error.
 

--- a/website/guide/dns.md
+++ b/website/guide/dns.md
@@ -110,6 +110,34 @@ dns:
   same domain keeps its fake IP across restarts.
 - Flush at runtime with `POST /cache/fakeip/flush`.
 
+## Proxy server hostnames
+
+When `enable: true`, a proxy node's own `server:` hostname is resolved by this resolver
+— not by the operating system. So `nameserver`, `nameserver-policy`, `fallback` and the
+top-level `hosts:` map all apply to the proxy upstream itself, exactly as they do to
+destination domains:
+
+```yaml
+hosts:
+  hk.example.com: 203.0.113.9   # pins the node, no lookup at all
+
+proxies:
+  - { name: HK, type: trojan, server: hk.example.com, port: 443, password: … }
+```
+
+FakeIP never applies here: proxy dials always take the real address, whatever
+`enhanced-mode` is set to.
+
+With `enable: false` the resolver is an internal stub, so proxy hostnames keep going to
+the OS resolver — set `enable: true` if you want the config's DNS to own them.
+
+::: tip `#PROXY` nameservers
+A nameserver tagged `#PROXY` has to dial that proxy to answer a query. If the query *is*
+for that proxy's own server hostname, meow-rs would be waiting on itself, so this one hop
+falls back to the `hosts:` map and the DNS cache, then to the OS resolver. Pinning such
+nodes in `hosts:` (or configuring them by IP) keeps them off the OS resolver entirely.
+:::
+
 ## Caching
 
 - **Forward cache** (name → IP) honors response TTL (min 10s) in a sharded LRU.

--- a/website/guide/dns.md
+++ b/website/guide/dns.md
@@ -26,6 +26,7 @@ still used internally so rules and proxies can resolve names.
 | `nameserver` | list | `[]` | Primary upstreams (defaults to `8.8.8.8` if empty) |
 | `fallback` | list | `[]` | Fallback upstreams (gated by `fallback-filter`) |
 | `default-nameserver` | list | `[]` | Bootstrap servers to resolve DoT/DoH hostnames |
+| `proxy-server-nameserver` | list | `[]` | Dedicated upstreams for proxy server hostnames; when unset they use `nameserver` |
 | `nameserver-policy` | map | — | Per-domain upstream routing |
 | `fallback-filter` | block | — | When to use `fallback` |
 | `fake-ip-range` | string | `198.18.0.1/16` | Fake-IP CIDR pool |
@@ -134,11 +135,43 @@ Android and iOS builds are the exception: there the OS resolver's sockets would 
 back through the VPN tunnel and deadlock, so node hostnames always go through the
 built-in resolver, `enable` or not.
 
+### Dedicated upstreams for nodes
+
+`proxy-server-nameserver` gives node hostnames their own upstreams, separate from the
+ones serving ordinary traffic. The usual reason is bootstrapping: the main `nameserver`
+is somewhere the proxy has to reach first, so the nodes themselves need a resolver that
+is reachable without a working tunnel.
+
+```yaml
+dns:
+  enable: true
+  nameserver: ["https://1.1.1.1/dns-query"]   # for destination domains
+  proxy-server-nameserver: [223.5.5.5]        # for the nodes' own server:
+```
+
+It is a self-contained resolver, so a few things differ from the main one:
+
+- **No fallback to `nameserver`.** Once configured it is authoritative for node
+  hostnames; if it cannot answer, the dial fails rather than retrying elsewhere.
+- **`nameserver-policy`, `fallback` and `fallback-filter` do not apply** — only the
+  listed upstreams are consulted.
+- **`hosts:` still wins**, so a pinned node never reaches these upstreams at all.
+- **Always `normal` mode**, so a node can never be handed a fake IP.
+- **`default-nameserver` still bootstraps it**, so a DoT/DoH entry here needs a plain
+  IP-literal bootstrap server just like one in `nameserver`.
+- **Ignored when `enable: false`**, along with the rest of the `dns` block.
+
 ::: tip `#PROXY` nameservers
 A nameserver tagged `#PROXY` has to dial that proxy to answer a query. If the query *is*
 for that proxy's own server hostname, meow-rs would be waiting on itself, so this one hop
 falls back to the `hosts:` map and the DNS cache, then to the OS resolver. Pinning such
 nodes in `hosts:` (or configuring them by IP) keeps them off the OS resolver entirely.
+
+Tagging a `proxy-server-nameserver` entry is the sharpest form of this: resolving node
+hostnames is the job you just gave it, so `proxy-server-nameserver: [223.5.5.5#HK]` can
+only work when `HK` itself needs no lookup — an IP-literal `server:`, or one pinned in
+`hosts:`. meow-rs warns at startup when the tagged node is reached by hostname (or is a
+group, whose member is only picked at dial time).
 :::
 
 ## Caching

--- a/website/guide/dns.md
+++ b/website/guide/dns.md
@@ -129,7 +129,10 @@ FakeIP never applies here: proxy dials always take the real address, whatever
 `enhanced-mode` is set to.
 
 With `enable: false` the resolver is an internal stub, so proxy hostnames keep going to
-the OS resolver — set `enable: true` if you want the config's DNS to own them.
+the OS resolver — set `enable: true` if you want the config's DNS to own them. The
+Android and iOS builds are the exception: there the OS resolver's sockets would route
+back through the VPN tunnel and deadlock, so node hostnames always go through the
+built-in resolver, `enable` or not.
 
 ::: tip `#PROXY` nameservers
 A nameserver tagged `#PROXY` has to dial that proxy to answer a query. If the query *is*


### PR DESCRIPTION
A proxy node's own `server:` hostname was resolved by libc `getaddrinfo` on every
platform but Android, so `dns:`, `nameserver-policy` and `hosts:` had no effect on
the proxy upstream itself — only on destination domains, which `DirectAdapter`
already routes through the configured `Resolver`. mihomo resolves proxy server
domains with its own DNS; this closes that gap, then fixes a regression the move
introduced and adds the option mihomo pairs with it.

### 1. Resolve node hostnames with the configured DNS (`ccb227b`)

The plumbing already existed — `meow_common::connect_tcp_host` consults an installed
`HostResolver`, every adapter dials through it, and `meow_dns::ResolverHostHook` backs
it with the configured resolver. It was just installed under
`#[cfg(target_os = "android")]`. Install it everywhere, gated on `dns.enable`.

Fake-IP is not a hazard: `Resolver::resolve_ips` is the real-address path, so a proxy
dial never gets a synthesised address whatever the mode.

The one real hazard is ADR-0012's loop — a `#PROXY` nameserver has to dial that proxy
to answer a query, and if the query is for that proxy's own server hostname the lookup
stalls on the resolver's single-flight entry. `resolve_addrs` now fences the hook call
with a task-local (the whole chain runs on one task, so unrelated concurrent dials are
unaffected), and a dial under the fence is answered by the new
`Resolver::resolve_ips_local`: `hosts:` trie plus DNS cache, never an upstream query.

### 2. Keep the hook installed on Android and iOS (`974c921`)

Gating on `dns.enable` is right on desktop but a regression on the VPN platforms, where
the hook is not a DNS-quality choice but a correctness one: `getaddrinfo`'s sockets
bypass `VpnService.protect(fd)` / the NE tunnel's exclusion and loop the query back
through our own tunnel. A `dns.enable: false` config on Android went from working to
deadlocking on every hostname node. Gate on `config.dns.enabled || VPN_PLATFORM`.

### 3. `dns.proxy-server-nameserver` (`7d7f830`)

mihomo's `ProxyServerHostResolver`: a dedicated resolver for node hostnames, for the
bootstrapping case where the main `nameserver` is somewhere the proxy has to reach
first. Deliberately narrow, matching upstream — no fallback to the main resolver, no
policy/fallback/fallback-filter, always `normal` mode, `hosts:` still wins,
`default-nameserver` still bootstraps it, absent when `dns.enable` is false.

A `#PROXY` tag on such an entry warns rather than errors: it is circular in spirit, but
`resolve_addrs` short-circuits IP literals, so `223.5.5.5#HK` works exactly as written
when `HK` has a literal `server:` or a `hosts:` pin. The warning fires only on the shape
that actually degrades — a tagged node reached by hostname, or a group.

## Verification

Unit tests cover the config surface, the hook's precedence and no-fallback rule, and the
four circularity cases. Beyond that, driven end-to-end against a real 167-node
subscription config (which already ships `proxy-server-nameserver`), with two stub
nameservers on loopback and a forced dial through a hostname node:

- **With `proxy-server-nameserver`** — the node's A and AAAA queries arrive at the
  dedicated stub; the main-nameserver stub sees nothing.
- **Without it** — the same queries arrive at the main-nameserver stub instead.
- **As shipped** (`proxy-server-nameserver` pointing at meow's own DNS listener) — the
  lookup goes through the local server and out to the configured upstream, no loop.
- **`#PROXY` tag on a hostname node** — warning fires; on an IP-literal node it stays
  silent.

Regression bar green: `fmt --check`, all three clippy configurations, `cargo test --lib`,
`RUSTDOCFLAGS="-D warnings" cargo doc`.

## Known gaps (not addressed here)

- `PUT /configs` never re-parses `dns:`, so changes to these options need a restart.
- Provider / subscription / geodata fetches still use the system resolver — observed
  during verification, where the geodata auto-update dials before the hook is installed.