### PR TITLE
fix(config): cap direct HTTP fetch body size in rule-provider and geodata

### DIFF
--- a/crates/meow-config/src/geodata.rs
+++ b/crates/meow-config/src/geodata.rs
@@ -129,7 +129,7 @@ pub async fn download_and_replace(
         if !status.is_success() {
             return Err(anyhow!("HTTP {status} fetching {url}"));
         }
-        resp.bytes().await?.to_vec()
+        internal_http::response_bytes_with_limit(resp).await?
     };
 
     if let Some(parent) = dest.parent() {

--- a/crates/meow-config/src/internal_http.rs
+++ b/crates/meow-config/src/internal_http.rs
@@ -34,23 +34,42 @@ const READ_TIMEOUT: Duration = Duration::from_secs(60);
 const USER_AGENT: &str = concat!("clash.meta/", env!("CARGO_PKG_VERSION"));
 pub(crate) const MAX_BODY_BYTES: usize = 256 * 1024 * 1024; // 256 MiB hard ceiling
 
-pub(crate) async fn response_text_with_limit(resp: reqwest::Response) -> Result<String> {
+/// Consume `resp`'s body into a `Vec<u8>`, rejecting it before or during the
+/// read if it exceeds `MAX_BODY_BYTES`.
+///
+/// Checks `Content-Length` up front when present, then streams the body and
+/// bails as soon as the accumulated length would cross the cap — so a
+/// dishonest or absent `Content-Length` can't be used to smuggle an
+/// oversized body past the precheck.
+pub(crate) async fn response_bytes_with_limit(resp: reqwest::Response) -> Result<Vec<u8>> {
+    response_bytes_capped(resp, MAX_BODY_BYTES).await
+}
+
+/// Same as [`response_bytes_with_limit`] but with the cap as a parameter, so
+/// tests can exercise the precheck and streaming-cap paths against a small
+/// limit instead of transferring hundreds of megabytes.
+async fn response_bytes_capped(resp: reqwest::Response, limit: usize) -> Result<Vec<u8>> {
     if resp
         .content_length()
-        .is_some_and(|length| length > MAX_BODY_BYTES as u64)
+        .is_some_and(|length| length > limit as u64)
     {
-        bail!("response exceeds max body size ({MAX_BODY_BYTES} bytes)");
+        bail!("response exceeds max body size ({limit} bytes)");
     }
 
     let mut bytes = Vec::new();
     let mut stream = resp.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
-        if chunk.len() > MAX_BODY_BYTES.saturating_sub(bytes.len()) {
-            bail!("response exceeds max body size ({MAX_BODY_BYTES} bytes)");
+        if chunk.len() > limit.saturating_sub(bytes.len()) {
+            bail!("response exceeds max body size ({limit} bytes)");
         }
         bytes.extend_from_slice(&chunk);
     }
+    Ok(bytes)
+}
+
+pub(crate) async fn response_text_with_limit(resp: reqwest::Response) -> Result<String> {
+    let bytes = response_bytes_with_limit(resp).await?;
     String::from_utf8(bytes).map_err(|e| anyhow!("response body is not UTF-8: {e}"))
 }
 
@@ -373,5 +392,61 @@ mod tests {
             err.to_string().contains("timed out"),
             "expected connect timeout, got: {err}"
         );
+    }
+
+    /// Spawns a bare TCP server on `127.0.0.1` that writes `raw_response`
+    /// verbatim to the first connection it accepts, then returns its URL.
+    async fn spawn_raw_http_server(raw_response: &'static [u8]) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 1024];
+            // Drain (part of) the request so the exchange is well-formed;
+            // the response below doesn't depend on what was sent.
+            let _ = stream.read(&mut buf).await;
+            let _ = stream.write_all(raw_response).await;
+            let _ = stream.shutdown().await;
+        });
+        format!("http://{addr}/")
+    }
+
+    // Regression test for issue #431: a dishonest (or merely huge)
+    // Content-Length must be rejected before any of the body is read.
+    #[tokio::test]
+    async fn response_bytes_capped_rejects_oversize_content_length() {
+        let url =
+            spawn_raw_http_server(b"HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\n\r\nshort").await;
+        let resp = reqwest::get(&url).await.unwrap();
+        let err = response_bytes_capped(resp, 16).await.unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds max body size"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // Regression test for issue #431: with no (or an absent) Content-Length
+    // — e.g. chunked encoding — the streaming cap must still catch an
+    // oversized body instead of buffering it in full.
+    #[tokio::test]
+    async fn response_bytes_capped_rejects_oversize_stream_without_content_length() {
+        let url = spawn_raw_http_server(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n10\r\n0123456789abcdef\r\n0\r\n\r\n",
+        )
+        .await;
+        let resp = reqwest::get(&url).await.unwrap();
+        let err = response_bytes_capped(resp, 8).await.unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds max body size"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn response_bytes_capped_accepts_body_within_limit() {
+        let url = spawn_raw_http_server(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello").await;
+        let resp = reqwest::get(&url).await.unwrap();
+        let bytes = response_bytes_capped(resp, 16).await.unwrap();
+        assert_eq!(bytes, b"hello");
     }
 }

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -627,7 +627,7 @@ pub(crate) async fn fetch_http_async(url: &str, proxy: Option<&Arc<dyn Proxy>>) 
         .build()?;
     let resp = client.get(url).send().await?;
     let status = resp.status();
-    let bytes = resp.bytes().await?;
+    let bytes = internal_http::response_bytes_with_limit(resp).await?;
     if !status.is_success() {
         return Err(anyhow!(
             "HTTP {}: {}",
@@ -638,7 +638,7 @@ pub(crate) async fn fetch_http_async(url: &str, proxy: Option<&Arc<dyn Proxy>>) 
                 .collect::<String>()
         ));
     }
-    Ok(bytes.to_vec())
+    Ok(bytes)
 }
 
 fn write_cache(path: &Path, bytes: &[u8]) {


### PR DESCRIPTION
Fixes #431

## Root cause

`fetch_http_async()`'s no-proxy branch in `crates/meow-config/src/rule_provider.rs` and `download_and_replace()`'s no-proxy branch in `crates/meow-config/src/geodata.rs` each built a bare `reqwest::Client` and called `resp.bytes().await` with no `Content-Length` precheck and no incremental cap, buffering the entire response body in memory regardless of size. The proxied paths (`internal_http::fetch_via_proxy`) were already capped at the crate's 256 MiB `MAX_BODY_BYTES` ceiling — this was the direct-fetch path issue #282 missed.

A rule-provider or geodata `url:` pointed at a hostile, compromised, or (for plain `http://`) on-path-MITM'd server responding with a multi-gigabyte body would get fully buffered before any size check, OOM-killing the process. This is worse on the memory-constrained targets meow-rs ships to (OpenWrt routers, Raspberry Pi, mobile), and it's not a one-shot: `RuleProvider::refresh()` retries it on every `interval:` tick, and the prefetch path runs it at startup and on every config reload.

## Fix

Added `internal_http::response_bytes_with_limit()`, a `Vec<u8>`-returning sibling of the existing `response_text_with_limit()` (now expressed as this plus a UTF-8 conversion). Same defense as the proxied path: reject early if `Content-Length` exceeds `MAX_BODY_BYTES`, then stream the body and bail as soon as the accumulated length would cross the cap (so a dishonest/absent `Content-Length` can't smuggle an oversized body past the precheck). Bytes rather than `String` because rule providers accept the binary `.mrs` format and geodata fetches `.mmdb`/`.dat`, neither of which is guaranteed to be UTF-8.

Wired it into both previously-unbounded direct branches:
- `rule_provider.rs::fetch_http_async` (no-proxy branch)
- `geodata.rs::download_and_replace` (no-proxy branch)

## Verification

- New unit tests in `internal_http::tests` (via a `response_bytes_capped(resp, limit)` helper parameterized on the cap, so tests don't need to transfer hundreds of MB against the real 256 MiB constant):
  - `response_bytes_capped_rejects_oversize_content_length` — dishonest/oversized `Content-Length` is rejected before any body bytes are read.
  - `response_bytes_capped_rejects_oversize_stream_without_content_length` — chunked response with no `Content-Length` but an oversized decoded body is rejected during streaming.
  - `response_bytes_capped_accepts_body_within_limit` — a normal, in-limit body still round-trips correctly.
- Full regression bar, all green:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo clippy --all-targets --no-default-features -- -D warnings`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
  - `cargo test --lib` (all crates, including the 3 new `meow-config` tests above)

No `Metadata`/`ConnectionInfo`/`UdpSession`/DNS `CacheEntry`/`ReverseEntry` types touched, and no relay hot-path code touched, so no byte-count/allocation deltas apply.