### PR TITLE
fix(udp): atomically claim the NAT key and gate eviction on session identity

### DIFF
--- a/crates/meow-tunnel/src/udp.rs
+++ b/crates/meow-tunnel/src/udp.rs
@@ -175,7 +175,14 @@ pub async fn handle_udp(
     if let Some(session) = existing {
         if let Err(e) = session.conn.write_packet(data, &dst_addr).await {
             debug!("UDP write error for {} -> {}: {}", src, dst_addr, e);
-            tunnel.nat_table.remove(&key);
+            // Compare-and-remove: evict only the session that actually failed.
+            // While this write was parked a concurrent slow path may have
+            // replaced the entry with a fresh healthy session; an
+            // unconditional `remove()` would tear that replacement down and
+            // force the next packet to redial (issue #432).
+            tunnel
+                .nat_table
+                .remove_if(&key, |_, s| Arc::ptr_eq(s, &session));
         } else {
             session.touch();
         }
@@ -214,12 +221,45 @@ pub async fn handle_udp(
 
     match proxy.dial_udp(&metadata).await {
         Ok(conn) => {
-            if let Err(e) = conn.write_packet(data, &dst_addr).await {
-                warn!("UDP initial write error for {} -> {}: {}", src, dst_addr, e);
-                return;
-            }
             let session = Arc::new(UdpSession::new(conn, Arc::from(proxy.name())));
-            tunnel.nat_table.insert(key, session);
+            // Claim the key atomically before the first write. The dial above
+            // is a long await with the key unclaimed, so two concurrent
+            // handle_udp calls for the same brand-new (src, dst) can both
+            // reach this point; a blind `insert` here made the second call
+            // silently drop — and thereby close — the first session with the
+            // reply to its datagram still in flight (issue #432).
+            // `entry().or_insert_with()` takes the shard write lock but has no
+            // `.await` inside, and the guard is dropped before the write
+            // below, so this cannot reintroduce the guard-across-await
+            // deadlock fixed in 1454ef2.
+            let winner = Arc::clone(
+                tunnel
+                    .nat_table
+                    .entry(key)
+                    .or_insert_with(|| Arc::clone(&session))
+                    .value(),
+            );
+            if !Arc::ptr_eq(&winner, &session) {
+                // Lost the claim: a concurrent call installed its session
+                // first. Close the redundant conn and carry this datagram on
+                // the winner, so exactly one upstream flow ever sees traffic.
+                debug!(
+                    "UDP concurrent session create for {} -> {}: folding into winner",
+                    src, dst_addr
+                );
+                if let Err(e) = session.conn.close() {
+                    debug!(
+                        "UDP close of redundant conn for {} -> {}: {}",
+                        src, dst_addr, e
+                    );
+                }
+            }
+            if let Err(e) = winner.conn.write_packet(data, &dst_addr).await {
+                warn!("UDP initial write error for {} -> {}: {}", src, dst_addr, e);
+                tunnel
+                    .nat_table
+                    .remove_if(&key, |_, s| Arc::ptr_eq(s, &winner));
+            }
         }
         Err(e) => {
             warn!("UDP dial error for {} -> {}: {}", src, dst_addr, e);
@@ -230,8 +270,39 @@ pub async fn handle_udp(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tunnel::Tunnel;
     use async_trait::async_trait;
     use meow_common::error::Result as MeowResult;
+    use meow_common::{
+        AdapterType, DelayHistory, DnsMode, MeowError, Network, Proxy, ProxyConn, ProxyHealth,
+        TunnelMode,
+    };
+    use smol_str::SmolStr;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::sync::Mutex;
+
+    fn mk_tunnel() -> Tunnel {
+        let resolver = Arc::new(meow_dns::Resolver::new(
+            vec![],
+            vec![],
+            DnsMode::Normal,
+            meow_trie::DomainTrie::new(),
+            false,
+        ));
+        Tunnel::new(resolver)
+    }
+
+    fn mk_metadata(src: SocketAddr, dst: SocketAddr) -> Metadata {
+        Metadata {
+            network: Network::Udp,
+            src_ip: Some(src.ip()),
+            src_port: src.port(),
+            dst_ip: Some(dst.ip()),
+            dst_port: dst.port(),
+            ..Default::default()
+        }
+    }
 
     struct NoopPacketConn;
 
@@ -337,19 +408,7 @@ mod tests {
     /// fails the test instead of hanging CI if that pattern is reintroduced.
     #[tokio::test(start_paused = false)]
     async fn fast_path_write_failure_evicts_without_deadlock() {
-        use crate::tunnel::Tunnel;
-        use meow_common::{DnsMode, Metadata, Network};
-        use meow_dns::Resolver;
-        use meow_trie::DomainTrie;
-
-        let resolver = Arc::new(Resolver::new(
-            vec![],
-            vec![],
-            DnsMode::Normal,
-            DomainTrie::new(),
-            false,
-        ));
-        let tunnel = Tunnel::new(resolver);
+        let tunnel = mk_tunnel();
 
         // Literal-IP destination so pre_resolve is a no-op and the NAT key is
         // deterministic. Insert a session whose upstream write always fails.
@@ -364,18 +423,9 @@ mod tests {
             )),
         );
 
-        let metadata = Metadata {
-            network: Network::Udp,
-            src_ip: Some(src.ip()),
-            src_port: src.port(),
-            dst_ip: Some(dst.ip()),
-            dst_port: dst.port(),
-            ..Default::default()
-        };
-
         tokio::time::timeout(
             Duration::from_secs(2),
-            handle_udp(tunnel.inner(), b"ping", src, metadata),
+            handle_udp(tunnel.inner(), b"ping", src, mk_metadata(src, dst)),
         )
         .await
         .expect("handle_udp must not deadlock on a fast-path write failure");
@@ -383,6 +433,223 @@ mod tests {
         assert!(
             tunnel.inner().nat_table.get(&key).is_none(),
             "a session with a dead upstream must be evicted"
+        );
+    }
+
+    /// Packet conn that records every write and whether it has been closed,
+    /// via handles shared with the test body.
+    struct RecordingPacketConn {
+        writes: Arc<AtomicUsize>,
+        closed: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl ProxyPacketConn for RecordingPacketConn {
+        async fn read_packet(&self, _buf: &mut [u8]) -> MeowResult<(usize, SocketAddr)> {
+            Ok((0, "0.0.0.0:0".parse().unwrap()))
+        }
+        async fn write_packet(&self, buf: &[u8], _addr: &SocketAddr) -> MeowResult<usize> {
+            self.writes.fetch_add(1, Ordering::SeqCst);
+            Ok(buf.len())
+        }
+        fn local_addr(&self) -> MeowResult<SocketAddr> {
+            Ok("0.0.0.0:0".parse().unwrap())
+        }
+        fn close(&self) -> MeowResult<()> {
+            self.closed.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Mock proxy whose `dial_udp` sleeps before returning, widening the
+    /// dial-then-insert window so two concurrent `handle_udp` calls for the
+    /// same (src, dst) both reach the NAT insert. Hands out
+    /// [`RecordingPacketConn`]s and keeps their (writes, closed) handles.
+    struct SlowDialProxy {
+        dials: AtomicUsize,
+        conns: Mutex<Vec<(Arc<AtomicUsize>, Arc<AtomicBool>)>>,
+        health: ProxyHealth,
+    }
+
+    impl SlowDialProxy {
+        fn new() -> Self {
+            Self {
+                dials: AtomicUsize::new(0),
+                conns: Mutex::new(Vec::new()),
+                health: ProxyHealth::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ProxyAdapter for SlowDialProxy {
+        fn name(&self) -> &str {
+            "slow-mock"
+        }
+        fn adapter_type(&self) -> AdapterType {
+            AdapterType::Direct
+        }
+        fn addr(&self) -> &str {
+            ""
+        }
+        fn support_udp(&self) -> bool {
+            true
+        }
+        async fn dial_tcp(&self, _metadata: &Metadata) -> MeowResult<Box<dyn ProxyConn>> {
+            Err(MeowError::NotSupported("slow-mock: tcp".into()))
+        }
+        async fn dial_udp(&self, _metadata: &Metadata) -> MeowResult<Box<dyn ProxyPacketConn>> {
+            self.dials.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let writes = Arc::new(AtomicUsize::new(0));
+            let closed = Arc::new(AtomicBool::new(false));
+            self.conns
+                .lock()
+                .unwrap()
+                .push((Arc::clone(&writes), Arc::clone(&closed)));
+            Ok(Box::new(RecordingPacketConn { writes, closed }))
+        }
+        fn health(&self) -> &ProxyHealth {
+            &self.health
+        }
+    }
+
+    impl Proxy for SlowDialProxy {
+        fn alive(&self) -> bool {
+            true
+        }
+        fn alive_for_url(&self, _url: &str) -> bool {
+            true
+        }
+        fn last_delay(&self) -> u16 {
+            0
+        }
+        fn last_delay_for_url(&self, _url: &str) -> u16 {
+            0
+        }
+        fn delay_history(&self) -> Vec<DelayHistory> {
+            Vec::new()
+        }
+    }
+
+    /// Regression for issue #432 (slow path): two concurrent `handle_udp`
+    /// calls for the same brand-new (src, dst) both miss the NAT table and
+    /// both dial (the check-then-act window), but the atomic claim must fold
+    /// them into exactly one surviving session — the loser's conn is closed
+    /// without ever carrying traffic, and the loser's datagram is re-sent on
+    /// the winner. Before the fix the second blind `insert` silently dropped
+    /// the first session with its datagram's reply in flight.
+    #[tokio::test(start_paused = true)]
+    async fn concurrent_first_packets_fold_into_single_session() {
+        let tunnel = mk_tunnel();
+        tunnel.set_mode(TunnelMode::Global);
+        let proxy = Arc::new(SlowDialProxy::new());
+        let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
+        proxies.insert(
+            SmolStr::new_static("GLOBAL"),
+            Arc::clone(&proxy) as Arc<dyn Proxy>,
+        );
+        tunnel.update_proxies(proxies);
+
+        let src = SocketAddr::from(([127, 0, 0, 1], 6666));
+        let dst = SocketAddr::from(([198, 51, 100, 8], 443));
+        let key = (src, dst);
+
+        tokio::join!(
+            handle_udp(tunnel.inner(), b"ping-a", src, mk_metadata(src, dst)),
+            handle_udp(tunnel.inner(), b"ping-b", src, mk_metadata(src, dst)),
+        );
+
+        // Both calls raced past the NAT-miss check before either inserted, so
+        // both dialled — the claim must still leave exactly one session.
+        assert_eq!(
+            proxy.dials.load(Ordering::SeqCst),
+            2,
+            "test premise: both calls must overlap in the dial window"
+        );
+        assert_eq!(tunnel.inner().nat_table.len(), 1);
+        assert!(tunnel.inner().nat_table.get(&key).is_some());
+
+        let conns = proxy.conns.lock().unwrap();
+        let (open, lost): (Vec<_>, Vec<_>) = conns
+            .iter()
+            .partition(|(_, closed)| !closed.load(Ordering::SeqCst));
+        assert_eq!(open.len(), 1, "exactly one conn must survive");
+        assert_eq!(lost.len(), 1, "the losing conn must be closed");
+        assert_eq!(
+            open[0].0.load(Ordering::SeqCst),
+            2,
+            "both datagrams must be carried on the winning conn"
+        );
+        assert_eq!(
+            lost[0].0.load(Ordering::SeqCst),
+            0,
+            "the losing conn must never carry traffic"
+        );
+    }
+
+    /// Conn that, when written to, first installs `replacement` at `key` —
+    /// playing the part of a concurrent slow path that dialled a fresh
+    /// session while this write was in flight — and then fails the write.
+    struct SwapOnFailConn {
+        table: NatTable,
+        key: (SocketAddr, SocketAddr),
+        replacement: Arc<UdpSession>,
+    }
+
+    #[async_trait]
+    impl ProxyPacketConn for SwapOnFailConn {
+        async fn read_packet(&self, _buf: &mut [u8]) -> MeowResult<(usize, SocketAddr)> {
+            Ok((0, "0.0.0.0:0".parse().unwrap()))
+        }
+        async fn write_packet(&self, _buf: &[u8], _addr: &SocketAddr) -> MeowResult<usize> {
+            self.table.insert(self.key, Arc::clone(&self.replacement));
+            Err(MeowError::Other("upstream dead".into()))
+        }
+        fn local_addr(&self) -> MeowResult<SocketAddr> {
+            Ok("0.0.0.0:0".parse().unwrap())
+        }
+        fn close(&self) -> MeowResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Regression for issue #432 (fast path): a write failure on an existing
+    /// session must evict only the session that failed. If a concurrent slow
+    /// path has already replaced the entry with a fresh healthy session, the
+    /// old unconditional `remove(&key)` tore the replacement down and forced
+    /// the next packet to redial.
+    #[tokio::test]
+    async fn fast_path_failure_keeps_concurrent_replacement_session() {
+        let tunnel = mk_tunnel();
+
+        let src = SocketAddr::from(([127, 0, 0, 1], 7777));
+        let dst = SocketAddr::from(([198, 51, 100, 9], 443));
+        let key = (src, dst);
+
+        let replacement = mk_session();
+        tunnel.inner().nat_table.insert(
+            key,
+            Arc::new(UdpSession::new(
+                Box::new(SwapOnFailConn {
+                    table: Arc::clone(&tunnel.inner().nat_table),
+                    key,
+                    replacement: Arc::clone(&replacement),
+                }),
+                Arc::from("test"),
+            )),
+        );
+
+        handle_udp(tunnel.inner(), b"ping", src, mk_metadata(src, dst)).await;
+
+        let current = tunnel
+            .inner()
+            .nat_table
+            .get(&key)
+            .map(|s| Arc::clone(s.value()));
+        assert!(
+            current.is_some_and(|s| Arc::ptr_eq(&s, &replacement)),
+            "the fresh replacement session must survive the failed session's eviction"
         );
     }
 }


### PR DESCRIPTION
Fixes #432

## Root cause

`meow_tunnel::udp::handle_udp` created NAT sessions with an unsynchronized check-then-act sequence: look the key up, drop the DashMap guard, `.await` the outbound dial, then blindly `insert`. Nothing reserved the key during the dial, so two concurrent calls for the same brand-new `(src, dst)` both dialled an upstream and the second `insert` silently dropped — and thereby closed — the first session with the reply to its already-written datagram in flight. The same gap made the fast-path write-error eviction unconditional: `remove(&key)` could tear down a fresh healthy session installed by a concurrent slow path while the failed write was parked. This was a byproduct of 1454ef2, which correctly dropped the shard guard before await/remove but added no replacement claim.

## Fix

Both changes from the issue's suggested direction ((1)+(2)); neither holds a DashMap guard across an `.await`, so the deadlock fixed in 1454ef2 cannot return:

- **Slow path — atomic claim.** Build the session after the dial and claim the key with `entry().or_insert_with()` (shard-locked, no await inside; guard dropped before any write). The winner is deterministic; a loser closes its redundant conn and re-sends its datagram on the winner, so exactly one upstream flow ever carries traffic. The initial write moves after the claim so a losing conn is never written.
- **Fast path — compare-and-remove.** `remove_if(&key, |_, s| Arc::ptr_eq(s, &session))` so only the session that actually failed is evicted, never a newer replacement.

## Verification

Two new deterministic regression tests in `crates/meow-tunnel/src/udp.rs` (current-thread runtime + paused time, no timing flakiness):

- `concurrent_first_packets_fold_into_single_session` — `join!`s two `handle_udp` calls against a mock proxy whose `dial_udp` sleeps; asserts both dials overlapped (the racing premise), exactly one session survives, the losing conn is closed with zero writes, and both datagrams land on the winning conn.
- `fast_path_failure_keeps_concurrent_replacement_session` — a conn that installs a fresh replacement session at the key before failing its write; asserts the replacement survives the eviction (the old unconditional `remove` deleted it).

The pre-existing `fast_path_write_failure_evicts_without_deadlock` test still pins the no-guard-across-await invariant.

Gates (all green from the worktree root):
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` (default / `--no-default-features` / `--all-features`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` (13/13 suites, includes the new tests)

`UdpSession` layout untouched — `-Zprint-type-sizes` (aarch64-apple-darwin): 40 B / align 8 before and after (ADR-0011 M2 exit target 40 B).