### PR TITLE
fix(config): contain rule/proxy-provider paths inside the cache dir (#429)

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -1848,22 +1848,20 @@ async fn put_configs(
     )
     .await
     {
-            Ok(r) => r,
-            Err(e) => {
-                if force {
-                    tracing::error!("config reload forced despite validation error: {e}");
-                    (Default::default(), Vec::new())
-                } else {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(
-                            serde_json::json!({"message": format!("config validation error: {e}")}),
-                        ),
-                    )
-                        .into_response();
-                }
+        Ok(r) => r,
+        Err(e) => {
+            if force {
+                tracing::error!("config reload forced despite validation error: {e}");
+                (Default::default(), Vec::new())
+            } else {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"message": format!("config validation error: {e}")})),
+                )
+                    .into_response();
             }
-        };
+        }
+    };
 
     // Cold reload: close all connections with structured log (Class A divergence from upstream)
     let stats = state.tunnel.statistics();

--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -966,10 +966,20 @@ async fn apply_raw_to_tunnel(
         .iter()
         .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
         .collect();
-    let (proxies, rules) =
-        rebuild_from_raw_with_resolver_async(raw, Arc::clone(state.tunnel.resolver()), providers)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    // Same provider-cache directory the daemon loaded its startup config
+    // with — this is a trusted rebuild of the daemon's own running config,
+    // not an untrusted candidate, so relative rule-provider paths must keep
+    // resolving instead of hard-failing with `cache_dir: None` (issue #429
+    // follow-up).
+    let cache_dir = meow_config::resource_cache_dir_for_config_path(&state.config_path);
+    let (proxies, rules) = rebuild_from_raw_with_resolver_async(
+        raw,
+        Arc::clone(state.tunnel.resolver()),
+        providers,
+        cache_dir,
+    )
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     if let Some(missing) = expected_groups
         .iter()
         .find(|name| !proxies.contains_key(name.as_str()))
@@ -997,9 +1007,10 @@ async fn rebuild_from_raw_with_resolver_async(
     raw: RawConfig,
     resolver: Arc<meow_dns::Resolver>,
     providers: HashMap<String, Arc<ProxyProvider>>,
+    cache_dir: std::path::PathBuf,
 ) -> Result<meow_config::RebuildResult, String> {
     tokio::task::spawn_blocking(move || {
-        meow_config::rebuild_from_raw_runtime(&raw, Some(resolver), &providers)
+        meow_config::rebuild_from_raw_runtime(&raw, Some(resolver), &providers, Some(&cache_dir))
     })
     .await
     .map_err(|e| format!("config rebuild task failed: {e}"))?
@@ -1828,8 +1839,15 @@ async fn put_configs(
         .iter()
         .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
         .collect();
-    let (proxies, rules) =
-        match rebuild_from_raw_with_resolver_async(raw_config.clone(), resolver, providers).await {
+    let cache_dir = meow_config::resource_cache_dir_for_config_path(&state.config_path);
+    let (proxies, rules) = match rebuild_from_raw_with_resolver_async(
+        raw_config.clone(),
+        resolver,
+        providers,
+        cache_dir,
+    )
+    .await
+    {
             Ok(r) => r,
             Err(e) => {
                 if force {

--- a/crates/meow-app/src/geodata_fetch.rs
+++ b/crates/meow-app/src/geodata_fetch.rs
@@ -98,6 +98,7 @@ pub async fn run_on_startup(
     tunnel: Tunnel,
     raw_config: Arc<RwLock<RawConfig>>,
     resolver: Arc<Resolver>,
+    cache_dir: PathBuf,
 ) {
     let targets = compute_targets(&geo);
 
@@ -116,7 +117,14 @@ pub async fn run_on_startup(
     let raw = raw_config.read().clone();
     let rebuild = tokio::task::spawn_blocking({
         let resolver = Arc::clone(&resolver);
-        move || meow_config::rebuild_from_raw_with_resolver(&raw, Some(resolver))
+        let cache_dir = cache_dir.clone();
+        move || {
+            meow_config::rebuild_from_raw_with_resolver(
+                &raw,
+                Some(resolver),
+                Some(cache_dir.as_path()),
+            )
+        }
     })
     .await;
     match rebuild {
@@ -149,6 +157,7 @@ pub async fn auto_update_loop(
     tunnel: Tunnel,
     raw_config: Arc<RwLock<RawConfig>>,
     resolver: Arc<Resolver>,
+    cache_dir: PathBuf,
 ) {
     let interval = std::time::Duration::from_secs(geo.auto_update_interval as u64 * 3600);
     let mut ticker = tokio::time::interval(interval);
@@ -199,7 +208,14 @@ pub async fn auto_update_loop(
         let raw = raw_config.read().clone();
         let rebuild = tokio::task::spawn_blocking({
             let resolver = Arc::clone(&resolver);
-            move || meow_config::rebuild_from_raw_with_resolver(&raw, Some(resolver))
+            let cache_dir = cache_dir.clone();
+            move || {
+                meow_config::rebuild_from_raw_with_resolver(
+                    &raw,
+                    Some(resolver),
+                    Some(cache_dir.as_path()),
+                )
+            }
         })
         .await;
         match rebuild {

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -878,8 +878,12 @@ async fn run(
         let tunnel = tunnel.clone();
         let raw_config = Arc::clone(&raw_config);
         let resolver = Arc::clone(&resolver);
+        let cache_dir = meow_config::resource_cache_dir_for_config_path(&config_path);
         tokio::spawn(async move {
-            meow_app::geodata_fetch::run_on_startup(geodata, tunnel, raw_config, resolver).await;
+            meow_app::geodata_fetch::run_on_startup(
+                geodata, tunnel, raw_config, resolver, cache_dir,
+            )
+            .await;
         });
     }
 
@@ -889,8 +893,12 @@ async fn run(
         let tunnel = tunnel.clone();
         let raw_config = Arc::clone(&raw_config);
         let resolver = Arc::clone(&resolver);
+        let cache_dir = meow_config::resource_cache_dir_for_config_path(&config_path);
         tokio::spawn(async move {
-            meow_app::geodata_fetch::auto_update_loop(geodata, tunnel, raw_config, resolver).await;
+            meow_app::geodata_fetch::auto_update_loop(
+                geodata, tunnel, raw_config, resolver, cache_dir,
+            )
+            .await;
         });
     }
 

--- a/crates/meow-app/src/subscription_refresh.rs
+++ b/crates/meow-app/src/subscription_refresh.rs
@@ -15,6 +15,11 @@ use tracing::{error, info};
 /// remote config, replace proxies/groups/rules, rebuild the tunnel, and
 /// persist back to `config_path`. Runs forever; spawn as a background task.
 pub async fn run_loop(raw_config: Arc<RwLock<RawConfig>>, tunnel: Tunnel, config_path: String) {
+    // Same provider-cache directory `load_config` used at startup — trusted
+    // rebuilds of the daemon's own config must keep resolving relative
+    // rule-provider paths the same way, not hard-fail with `cache_dir: None`
+    // (issue #429 follow-up).
+    let cache_dir = meow_config::resource_cache_dir_for_config_path(&config_path);
     loop {
         let subs_to_refresh: Vec<(String, String)> = {
             let raw = raw_config.read();
@@ -68,8 +73,13 @@ pub async fn run_loop(raw_config: Arc<RwLock<RawConfig>>, tunnel: Tunnel, config
                     let resolver = Arc::clone(tunnel.resolver());
                     let rebuild = tokio::task::spawn_blocking({
                         let snapshot = snapshot.clone();
+                        let cache_dir = cache_dir.clone();
                         move || {
-                            meow_config::rebuild_from_raw_with_resolver(&snapshot, Some(resolver))
+                            meow_config::rebuild_from_raw_with_resolver(
+                                &snapshot,
+                                Some(resolver),
+                                Some(cache_dir.as_path()),
+                            )
                         }
                     })
                     .await;

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -2626,18 +2626,17 @@ rules:
 
         // `rebuild_from_raw_with_resolver` — used by subscription_refresh
         // and geodata_fetch.
-        let (_, rules) =
-            rebuild_from_raw_with_resolver(&raw, None, Some(dir.path())).expect(
-                "trusted rebuild with the real cache dir must not hard-fail on a file provider",
-            );
+        let (_, rules) = rebuild_from_raw_with_resolver(&raw, None, Some(dir.path())).expect(
+            "trusted rebuild with the real cache dir must not hard-fail on a file provider",
+        );
         assert_eq!(rules.len(), 2);
 
         // `rebuild_from_raw_runtime` — used by meow-api's `PUT /configs`
         // family via `rebuild_from_raw_with_resolver_async`.
-        let (_, rules) =
-            rebuild_from_raw_runtime(&raw, None, &HashMap::new(), Some(dir.path())).expect(
-                "trusted runtime rebuild with the real cache dir must not hard-fail on a file provider",
-            );
+        let (_, rules) = rebuild_from_raw_runtime(&raw, None, &HashMap::new(), Some(dir.path()))
+            .expect(
+            "trusted runtime rebuild with the real cache dir must not hard-fail on a file provider",
+        );
         assert_eq!(rules.len(), 2);
     }
 

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -416,22 +416,42 @@ pub fn rebuild_from_raw(raw: &raw::RawConfig) -> Result<RebuildResult, anyhow::E
 
 /// Rebuild proxies/rules and inject `resolver` into the built-in DIRECT
 /// adapter so it avoids the OS resolver when dialing hostnames.
+///
+/// `cache_dir` should be the same provider-cache directory the config was
+/// originally loaded with (see [`resource_cache_dir_for_config_path`]) —
+/// this is a *trusted* rebuild of the daemon's own running config, not an
+/// untrusted candidate, so relative rule-provider `path`s must keep
+/// resolving the same way they did at startup instead of hard-failing
+/// (issue #429 follow-up).
 pub fn rebuild_from_raw_with_resolver(
     raw: &raw::RawConfig,
     resolver: Option<Arc<Resolver>>,
+    cache_dir: Option<&Path>,
 ) -> Result<RebuildResult, anyhow::Error> {
-    rebuild_from_raw_impl(raw, None, resolver, &HashMap::new(), None, None, None)
+    rebuild_from_raw_impl(raw, cache_dir, resolver, &HashMap::new(), None, None, None)
 }
 
 /// Runtime rebuild variant that keeps live proxy-provider slots and the
 /// process-wide selection store wired into rebuilt groups.
+///
+/// See [`rebuild_from_raw_with_resolver`] for why `cache_dir` must be the
+/// startup provider-cache directory rather than `None`.
 pub fn rebuild_from_raw_runtime(
     raw: &raw::RawConfig,
     resolver: Option<Arc<Resolver>>,
     providers: &HashMap<String, Arc<ProxyProvider>>,
+    cache_dir: Option<&Path>,
 ) -> Result<RebuildResult, anyhow::Error> {
     let store = meow_proxy::SelectorStore::global();
-    rebuild_from_raw_impl(raw, None, resolver, providers, store.as_ref(), None, None)
+    rebuild_from_raw_impl(
+        raw,
+        cache_dir,
+        resolver,
+        providers,
+        store.as_ref(),
+        None,
+        None,
+    )
 }
 
 /// Same as [`rebuild_from_raw`] but accepts a `cache_dir` used to resolve
@@ -1393,7 +1413,16 @@ fn default_config_dir_without_home_override() -> PathBuf {
     base.join("meow")
 }
 
-fn resource_cache_dir_for_config_path(path: &str) -> PathBuf {
+/// Resolve the provider-cache directory for a config file path — the same
+/// directory [`load_config`] threads through as `cache_dir` at startup.
+///
+/// Trusted runtime rebuilds (subscription refresh, geodata rebuild, the
+/// config-mutating API endpoints) must recompute this from the daemon's own
+/// `config_path` and pass it back into [`rebuild_from_raw_with_resolver`] /
+/// [`rebuild_from_raw_runtime`] rather than passing `None`, or relative
+/// rule-provider `path`s that loaded fine at startup start hard-failing on
+/// every rebuild (issue #429 follow-up).
+pub fn resource_cache_dir_for_config_path(path: &str) -> PathBuf {
     resource_cache_dir_for_config_path_with_home(path, meow_common::meow_home_dir())
 }
 
@@ -2534,10 +2563,16 @@ rules:
 
     #[test]
     fn rebuild_rejects_file_provider_path_without_cache_dir() {
-        // `rebuild_from_raw` is the `cache_dir = None` path used by runtime
-        // rebuilds (`PUT /configs` goes through `rebuild_from_raw_runtime`,
-        // which shares the same impl): there is no containment root, so a
-        // caller-named file path is a hard error.
+        // `rebuild_from_raw` is the genuinely rootless `cache_dir = None`
+        // path (FFI callers with no on-disk config, plain unit tests, …).
+        // Trusted daemon rebuilds — subscription refresh, geodata rebuild,
+        // and `PUT /configs` via `rebuild_from_raw_runtime` — always thread
+        // the real startup provider-cache dir through instead (issue #429
+        // follow-up), so they hit the `Some(cache_dir)` path below, not
+        // this one.
+        //
+        // Here there is no containment root at all, so a caller-named file
+        // path is a hard error.
         let raw: raw::RawConfig = serde_yaml::from_str(
             r#"
 rule-providers:
@@ -2557,6 +2592,53 @@ rules:
             err.to_string().contains("cache directory"),
             "unexpected: {err}"
         );
+    }
+
+    #[test]
+    fn trusted_runtime_rebuilds_keep_working_with_a_file_rule_provider() {
+        // Regression for the PR #444 review finding: a config with a plain
+        // file rule-provider (the repo's own
+        // `test_file_rule_provider_end_to_end` shape) loads fine at startup
+        // and must keep rebuilding fine on every trusted runtime path —
+        // subscription refresh, geodata rebuild, and the `PUT /configs`
+        // family — once the real cache dir is threaded through instead of
+        // `None`.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ads.yaml"),
+            "payload:\n  - '+.ads.example'\n",
+        )
+        .unwrap();
+        let raw: raw::RawConfig = serde_yaml::from_str(
+            r#"
+rule-providers:
+  ads:
+    type: file
+    behavior: domain
+    format: yaml
+    path: ads.yaml
+rules:
+  - RULE-SET,ads,REJECT
+  - "MATCH,DIRECT"
+"#,
+        )
+        .unwrap();
+
+        // `rebuild_from_raw_with_resolver` — used by subscription_refresh
+        // and geodata_fetch.
+        let (_, rules) =
+            rebuild_from_raw_with_resolver(&raw, None, Some(dir.path())).expect(
+                "trusted rebuild with the real cache dir must not hard-fail on a file provider",
+            );
+        assert_eq!(rules.len(), 2);
+
+        // `rebuild_from_raw_runtime` — used by meow-api's `PUT /configs`
+        // family via `rebuild_from_raw_with_resolver_async`.
+        let (_, rules) =
+            rebuild_from_raw_runtime(&raw, None, &HashMap::new(), Some(dir.path())).expect(
+                "trusted runtime rebuild with the real cache dir must not hard-fail on a file provider",
+            );
+        assert_eq!(rules.len(), 2);
     }
 
     #[test]

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -15,6 +15,7 @@ pub mod proxy_provider;
 pub mod raw;
 pub mod rule_parser;
 pub mod rule_provider;
+mod safe_path;
 pub mod sub_rules_parser;
 pub mod subscription;
 
@@ -666,6 +667,14 @@ fn rebuild_from_raw_impl(
     // Per-provider `proxy:` overrides resolve against the full registry —
     // groups and provider-sourced proxies included (issue #377).
     let registry_lookup = |name: &str| proxies.get(name).cloned();
+
+    // Fail hard on any rule-provider path that would escape the provider
+    // cache directory — before any fetch or on-disk write happens, so a
+    // hostile `PUT /configs` is rejected without touching the filesystem
+    // (issue #429).
+    if let Some(map) = raw.rule_providers.as_ref() {
+        rule_provider::validate_paths(map, cache_dir)?;
+    }
 
     // Fetch/read rule-provider payload bytes once — the parser-context build
     // scans them for geo keys (issue #277) and the provider load below parses
@@ -2491,5 +2500,82 @@ mod async_guard_tests {
         use std::future::Future;
         use std::pin::Pin;
         let _fut: Pin<Box<dyn Future<Output = _>>> = Box::pin(super::load_config_from_str(""));
+    }
+}
+
+#[cfg(test)]
+mod provider_path_safety_tests {
+    //! Issue #429: rule-provider `path:` containment — a hostile config (e.g.
+    //! via `PUT /configs`) must fail validation before any fetch or write.
+    use super::*;
+
+    #[test]
+    fn rebuild_rejects_rule_provider_path_escaping_cache_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let raw: raw::RawConfig = serde_yaml::from_str(
+            r#"
+rule-providers:
+  x:
+    type: http
+    behavior: domain
+    format: yaml
+    url: "http://127.0.0.1:1/payload"
+    path: "/etc/cron.d/pwned"
+rules:
+  - "MATCH,DIRECT"
+"#,
+        )
+        .unwrap();
+        let Err(err) = rebuild_from_raw_with_cache_dir(&raw, Some(dir.path()), None) else {
+            panic!("escaping rule-provider path must fail the rebuild");
+        };
+        assert!(err.to_string().contains("escapes"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn rebuild_rejects_file_provider_path_without_cache_dir() {
+        // `rebuild_from_raw` is the `cache_dir = None` path used by runtime
+        // rebuilds (`PUT /configs` goes through `rebuild_from_raw_runtime`,
+        // which shares the same impl): there is no containment root, so a
+        // caller-named file path is a hard error.
+        let raw: raw::RawConfig = serde_yaml::from_str(
+            r#"
+rule-providers:
+  x:
+    type: file
+    behavior: domain
+    path: "/etc/passwd"
+rules:
+  - "MATCH,DIRECT"
+"#,
+        )
+        .unwrap();
+        let Err(err) = rebuild_from_raw(&raw) else {
+            panic!("file provider path without a cache dir must fail the rebuild");
+        };
+        assert!(
+            err.to_string().contains("cache directory"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn rebuild_rejects_traversal_in_rule_provider_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let raw: raw::RawConfig = serde_yaml::from_str(
+            r#"
+rule-providers:
+  x:
+    type: http
+    behavior: domain
+    url: "http://127.0.0.1:1/payload"
+    path: "../../outside.yaml"
+"#,
+        )
+        .unwrap();
+        let Err(err) = rebuild_from_raw_with_cache_dir(&raw, Some(dir.path()), None) else {
+            panic!("`..` traversal in rule-provider path must fail the rebuild");
+        };
+        assert!(err.to_string().contains("escapes"), "unexpected: {err}");
     }
 }

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -2905,7 +2905,9 @@ tls: true
             health_check: None,
             header: None,
         };
-        let provider = crate::proxy_provider::ProxyProvider::new("airport", &raw, None).unwrap();
+        let cache_dir = path.parent().expect("temp file has a parent dir");
+        let provider =
+            crate::proxy_provider::ProxyProvider::new("airport", &raw, Some(cache_dir)).unwrap();
         provider.refresh().await.unwrap();
         let mut providers = HashMap::new();
         providers.insert("airport".to_string(), Arc::new(provider));

--- a/crates/meow-config/src/proxy_provider.rs
+++ b/crates/meow-config/src/proxy_provider.rs
@@ -110,7 +110,12 @@ fn split_exclude_types(raw: Option<&[String]>) -> Vec<String> {
 
 enum Vehicle {
     File(PathBuf),
-    Http { url: String, cache_path: PathBuf },
+    Http {
+        url: String,
+        /// `None` = fetch to memory only (no containment root available for
+        /// an on-disk cache; issue #429).
+        cache_path: Option<PathBuf>,
+    },
 }
 
 impl ProxyProvider {
@@ -119,22 +124,25 @@ impl ProxyProvider {
         raw: &RawProxyProvider,
         cache_dir: Option<&Path>,
     ) -> Result<Self, String> {
+        // Any on-disk location (read or write) must stay inside `cache_dir`
+        // (issue #429): `path:` — and the provider *name* feeding the implicit
+        // cache location — are attacker-influenced when the config document
+        // does not come from a trusted on-disk file. Without a `cache_dir`
+        // there is no containment root, so no caller-named path is honoured.
         let (vehicle, vehicle_type) = match raw.provider_type.as_str() {
             "file" => {
                 let path_str = raw
                     .path
                     .as_deref()
                     .ok_or("file proxy-provider requires 'path'")?;
-                let path = if let Some(dir) = cache_dir {
-                    let p = Path::new(path_str);
-                    if p.is_absolute() {
-                        p.to_path_buf()
-                    } else {
-                        dir.join(p)
-                    }
-                } else {
-                    PathBuf::from(path_str)
+                let Some(dir) = cache_dir else {
+                    return Err(format!(
+                        "proxy-provider '{name}': 'path' cannot be used without a provider \
+                         cache directory"
+                    ));
                 };
+                let path = crate::safe_path::resolve_contained(dir, Path::new(path_str))
+                    .map_err(|e| format!("proxy-provider '{name}': {e}"))?;
                 (Vehicle::File(path), "File")
             }
             "http" => {
@@ -143,20 +151,27 @@ impl ProxyProvider {
                     .as_deref()
                     .ok_or("http proxy-provider requires 'url'")?
                     .to_string();
-                let cache_path = if let Some(p) = raw.path.as_deref() {
-                    if let Some(dir) = cache_dir {
-                        let pp = Path::new(p);
-                        if pp.is_absolute() {
-                            pp.to_path_buf()
-                        } else {
-                            dir.join(pp)
-                        }
-                    } else {
-                        PathBuf::from(p)
+                let cache_path = match (raw.path.as_deref(), cache_dir) {
+                    (Some(p), Some(dir)) => Some(
+                        crate::safe_path::resolve_contained(dir, Path::new(p))
+                            .map_err(|e| format!("proxy-provider '{name}': {e}"))?,
+                    ),
+                    (Some(_), None) => {
+                        warn!(
+                            provider = %name,
+                            "ignoring 'path' (no provider cache directory in this context); \
+                             fetching to memory without an on-disk cache"
+                        );
+                        None
                     }
-                } else {
-                    let dir = cache_dir.unwrap_or(Path::new("."));
-                    dir.join(format!("provider_{name}.yaml"))
+                    (None, Some(dir)) => Some(
+                        crate::safe_path::resolve_contained(
+                            dir,
+                            Path::new(&format!("provider_{name}.yaml")),
+                        )
+                        .map_err(|e| format!("proxy-provider '{name}': {e}"))?,
+                    ),
+                    (None, None) => None,
                 };
                 (Vehicle::Http { url, cache_path }, "HTTP")
             }
@@ -246,15 +261,17 @@ impl ProxyProvider {
                         match crate::internal_http::response_text_with_limit(resp).await {
                             Ok(text) => {
                                 // Cache to disk for offline fallback
-                                if let Some(parent) = cache_path.parent() {
-                                    let _ = tokio::fs::create_dir_all(parent).await;
+                                if let Some(cache_path) = cache_path {
+                                    if let Some(parent) = cache_path.parent() {
+                                        let _ = tokio::fs::create_dir_all(parent).await;
+                                    }
+                                    let _ = tokio::fs::write(cache_path, &text).await;
                                 }
-                                let _ = tokio::fs::write(cache_path, &text).await;
                                 Ok(text)
                             }
                             Err(e) => {
                                 warn!(provider = %self.name, error = %e, "HTTP body read failed, trying cache");
-                                read_cache(cache_path, &self.name).await
+                                read_cache(cache_path.as_deref(), &self.name).await
                             }
                         }
                     }
@@ -264,11 +281,11 @@ impl ProxyProvider {
                             status = %resp.status(),
                             "HTTP provider returned non-2xx, trying cache"
                         );
-                        read_cache(cache_path, &self.name).await
+                        read_cache(cache_path.as_deref(), &self.name).await
                     }
                     Err(e) => {
                         warn!(provider = %self.name, error = %e, "HTTP provider fetch failed, trying cache");
-                        read_cache(cache_path, &self.name).await
+                        read_cache(cache_path.as_deref(), &self.name).await
                     }
                 }
             }
@@ -415,7 +432,12 @@ fn compile_opt_regex(
     }
 }
 
-async fn read_cache(path: &Path, name: &str) -> Result<String, String> {
+async fn read_cache(path: Option<&Path>, name: &str) -> Result<String, String> {
+    let Some(path) = path else {
+        return Err(format!(
+            "proxy-provider '{name}': fetch failed and no on-disk cache is configured"
+        ));
+    };
     tokio::fs::read_to_string(path)
         .await
         .map_err(|e| format!("proxy-provider '{name}': no cache at {path:?}: {e}"))
@@ -459,11 +481,53 @@ mod tests {
 
     #[test]
     fn file_provider_new_succeeds() {
-        let raw = raw_file_provider("/tmp/proxies.yaml");
-        let p = ProxyProvider::new("test", &raw, None).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let raw = raw_file_provider("proxies.yaml");
+        let p = ProxyProvider::new("test", &raw, Some(dir.path())).unwrap();
         assert_eq!(p.name, "test");
         assert_eq!(p.vehicle_type, "File");
         assert!(p.header.is_empty());
+    }
+
+    #[test]
+    fn file_provider_requires_cache_dir_for_path() {
+        let raw = raw_file_provider("/tmp/proxies.yaml");
+        let Err(err) = ProxyProvider::new("test", &raw, None) else {
+            panic!("file path without a cache dir must fail");
+        };
+        assert!(err.contains("cache directory"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn file_provider_path_escaping_cache_dir_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        for path in ["../../etc/pwned", "/etc/pwned"] {
+            let raw = raw_file_provider(path);
+            let Err(err) = ProxyProvider::new("test", &raw, Some(dir.path())) else {
+                panic!("escaping path {path} must be rejected");
+            };
+            assert!(err.contains("escapes"), "path {path}: unexpected: {err}");
+        }
+    }
+
+    #[test]
+    fn http_provider_path_escaping_cache_dir_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let raw = RawProxyProvider {
+            provider_type: "http".to_string(),
+            url: Some("http://127.0.0.1:1/proxies.yaml".to_string()),
+            path: Some("/etc/cron.d/pwned".to_string()),
+            interval: None,
+            filter: None,
+            exclude_filter: None,
+            exclude_type: None,
+            health_check: None,
+            header: None,
+        };
+        let Err(err) = ProxyProvider::new("test", &raw, Some(dir.path())) else {
+            panic!("escaping http cache path must be rejected");
+        };
+        assert!(err.contains("escapes"), "unexpected: {err}");
     }
 
     #[test]
@@ -506,10 +570,11 @@ header:
 
     #[test]
     fn raw_proxy_provider_no_header_defaults_empty() {
-        let yaml = "type: file\npath: /tmp/proxies.yaml\n";
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = "type: file\npath: proxies.yaml\n";
         let raw: RawProxyProvider = serde_yaml::from_str(yaml).unwrap();
         assert!(raw.header.is_none());
-        let p = ProxyProvider::new("p", &raw, None).unwrap();
+        let p = ProxyProvider::new("p", &raw, Some(dir.path())).unwrap();
         assert!(p.header.is_empty());
     }
 
@@ -549,7 +614,8 @@ header:
 
     async fn file_provider(path: &std::path::Path) -> ProxyProvider {
         let raw = raw_file_provider(path.to_str().unwrap());
-        let p = ProxyProvider::new("airport", &raw, None).unwrap();
+        let cache_dir = path.parent().expect("temp file has a parent dir");
+        let p = ProxyProvider::new("airport", &raw, Some(cache_dir)).unwrap();
         p.refresh().await.unwrap();
         p
     }

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -206,7 +206,7 @@ fn read_payload_bytes(
 ) -> Result<Option<Vec<u8>>> {
     match cfg.provider_type.as_str() {
         "file" => {
-            let path = resolve_path(cfg, cache_dir, name)
+            let path = resolve_path(cfg, cache_dir, name)?
                 .ok_or_else(|| anyhow!("file provider '{name}' requires a 'path'"))?;
             let bytes = std::fs::read(&path)
                 .with_context(|| format!("reading provider file {}", path.display()))?;
@@ -217,7 +217,7 @@ fn read_payload_bytes(
                 .url
                 .as_deref()
                 .ok_or_else(|| anyhow!("http provider '{name}' requires a 'url'"))?;
-            let cache_path = resolve_path(cfg, cache_dir, name);
+            let cache_path = resolve_path(cfg, cache_dir, name)?;
             let prefer_cache = cfg.interval.unwrap_or(0) > 0;
             let bytes = fetch_http_blocking_with_cache(
                 url,
@@ -378,7 +378,7 @@ fn load_file(
              (Class B per ADR-0002)"
         );
     }
-    let path = resolve_path(cfg, cache_dir, name)
+    let path = resolve_path(cfg, cache_dir, name)?
         .ok_or_else(|| anyhow!("file provider '{name}' requires a 'path'"))?;
     let bytes = match prefetched {
         Some(b) => b.to_vec(),
@@ -412,7 +412,7 @@ fn load_http(
         .url
         .as_deref()
         .ok_or_else(|| anyhow!("http provider '{name}' requires a 'url'"))?;
-    let cache_path = resolve_path(cfg, cache_dir, name);
+    let cache_path = resolve_path(cfg, cache_dir, name)?;
     let explicit_format = parse_explicit_format(cfg)?;
     let interval = cfg.interval.unwrap_or(0);
     let bytes = match prefetched {
@@ -527,19 +527,64 @@ fn parse_text_payload(raw: &str) -> Vec<String> {
 // Path resolution
 // ---------------------------------------------------------------------------
 
-fn resolve_path(cfg: &RawRuleProvider, cache_dir: Option<&Path>, name: &str) -> Option<PathBuf> {
+/// Resolve the on-disk location of a provider's payload/cache, enforcing that
+/// it stays inside `cache_dir` (issue #429).
+///
+/// `path:` is attacker-influenced whenever the config arrives over the REST
+/// API (`PUT /configs`), and for http providers it is a **write** target, so:
+///
+/// - with a `cache_dir`, the resolved path (absolute or relative, `..` and
+///   symlinks included) must stay inside it — anything else is a hard error;
+/// - without a `cache_dir` (runtime rebuilds such as `PUT /configs` or
+///   `--config-string`) there is no containment root, so a `path:` is never
+///   honoured: http providers fall back to fetching into memory, file
+///   providers hard-error.
+fn resolve_path(
+    cfg: &RawRuleProvider,
+    cache_dir: Option<&Path>,
+    name: &str,
+) -> Result<Option<PathBuf>> {
     if let Some(p) = cfg.path.as_deref() {
-        let path = PathBuf::from(p);
-        if path.is_absolute() {
-            return Some(path);
-        }
-        return Some(match cache_dir {
-            Some(dir) => dir.join(path),
-            None => path,
-        });
+        let Some(dir) = cache_dir else {
+            if cfg.provider_type == "http" {
+                warn!(
+                    "rule-provider '{}': ignoring 'path' (no provider cache directory in this \
+                     context); fetching to memory without an on-disk cache",
+                    name
+                );
+                return Ok(None);
+            }
+            return Err(anyhow!(
+                "rule-provider '{name}': 'path' cannot be used without a provider cache directory"
+            ));
+        };
+        let path = crate::safe_path::resolve_contained(dir, Path::new(p))
+            .map_err(|e| anyhow!("rule-provider '{name}': {e}"))?;
+        return Ok(Some(path));
     }
-    let dir = cache_dir?;
-    Some(dir.join("rule-providers").join(format!("{name}.yaml")))
+    let Some(dir) = cache_dir else {
+        return Ok(None);
+    };
+    // The implicit location is derived from the provider *name* (a YAML map
+    // key, also attacker-influenced), so it gets the same containment check.
+    let implicit = Path::new("rule-providers").join(format!("{name}.yaml"));
+    let path = crate::safe_path::resolve_contained(dir, &implicit)
+        .map_err(|e| anyhow!("rule-provider '{name}': {e}"))?;
+    Ok(Some(path))
+}
+
+/// Validate every provider's payload/cache path up front, so a hostile config
+/// fails hard before any fetch or write happens (issue #429). Called by
+/// `rebuild_from_raw_impl` for every path into a (re)build: startup,
+/// `PUT`/`PATCH /configs`, and subscription refresh.
+pub(crate) fn validate_paths(
+    raw_providers: &HashMap<String, RawRuleProvider>,
+    cache_dir: Option<&Path>,
+) -> Result<()> {
+    for (name, cfg) in raw_providers {
+        resolve_path(cfg, cache_dir, name)?;
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -857,7 +902,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, None, &ctx(), None);
+        let out = load_providers(&providers, Some(dir.path()), &ctx(), None);
         let p = out.get("mrs-test").expect("provider should load");
         assert_eq!(p.rule_count(), 2);
     }
@@ -882,7 +927,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, None, &ctx(), None);
+        let out = load_providers(&providers, Some(dir.path()), &ctx(), None);
         assert_eq!(out.get("x").unwrap().rule_count(), 1);
     }
 
@@ -925,7 +970,7 @@ mod tests {
                 payload: None,
             },
         );
-        let out = load_providers(&providers, None, &ctx(), None);
+        let out = load_providers(&providers, Some(dir.path()), &ctx(), None);
         assert_eq!(out.len(), 1);
     }
 
@@ -1022,5 +1067,116 @@ mod tests {
         assert_eq!(ruleset_map.len(), 2);
         assert!(ruleset_map.contains_key("p1"));
         assert!(ruleset_map.contains_key("p2"));
+    }
+
+    // -- issue #429: provider paths must stay inside the cache dir ---------
+
+    #[test]
+    fn resolve_path_rejects_escaping_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        for p in ["../../etc/pwned", "/etc/cron.d/pwned", "a/../../b"] {
+            let mut cfg = http_cfg(None);
+            cfg.path = Some(p.to_string());
+            let err = resolve_path(&cfg, Some(dir.path()), "x")
+                .expect_err("escaping path must be rejected");
+            assert!(err.to_string().contains("escapes"), "path {p}: {err}");
+        }
+    }
+
+    #[test]
+    fn resolve_path_keeps_contained_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = http_cfg(None);
+        cfg.path = Some("sub/rules.yaml".to_string());
+        let got = resolve_path(&cfg, Some(dir.path()), "x").unwrap().unwrap();
+        assert!(got.starts_with(dir.path()), "unexpected: {}", got.display());
+
+        // Absolute paths are fine as long as they stay inside the cache dir.
+        cfg.path = Some(dir.path().join("rules.yaml").to_string_lossy().to_string());
+        assert!(resolve_path(&cfg, Some(dir.path()), "x").unwrap().is_some());
+    }
+
+    #[test]
+    fn file_provider_path_requires_cache_dir() {
+        let mut cfg = http_cfg(None);
+        cfg.provider_type = "file".to_string();
+        cfg.url = None;
+        cfg.path = Some("/etc/passwd".to_string());
+        let err = resolve_path(&cfg, None, "x").expect_err("file path without root must fail");
+        assert!(
+            err.to_string().contains("cache directory"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn implicit_path_from_hostile_provider_name_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = http_cfg(None); // no `path:` — implicit location from the name
+        let err = resolve_path(&cfg, Some(dir.path()), "../../evil")
+            .expect_err("traversal via provider name must be rejected");
+        assert!(err.to_string().contains("escapes"), "unexpected: {err}");
+    }
+
+    /// Regression test for issue #429: an http provider with a
+    /// caller-supplied `path:` and no cache directory (the `PUT /configs`
+    /// rebuild context) must fetch to memory and never write the path.
+    #[test]
+    fn http_provider_path_is_not_written_without_cache_dir() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return; // no fetch happened; the test still asserts no write
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(e) => panic!("HTTP test listener failed: {e}"),
+                }
+            };
+            stream.set_nonblocking(false).unwrap();
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf).unwrap();
+            let body = "payload:\n  - 'example.com'\n";
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        let victim_dir = tempfile::tempdir().unwrap();
+        let victim = victim_dir.path().join("outside").join("pwned");
+
+        let mut cfg = http_cfg(None);
+        cfg.url = Some(format!("http://{addr}/rules.yaml"));
+        cfg.path = Some(victim.to_string_lossy().to_string());
+        let mut providers = HashMap::new();
+        providers.insert("x".to_string(), cfg);
+
+        let out = load_providers(&providers, None, &ctx(), None);
+        server.join().unwrap();
+
+        // The provider still loads — payload fetched straight to memory…
+        let p = out.get("x").expect("provider must load to memory");
+        assert_eq!(p.rule_count(), 1);
+        // …but the caller-named path was never written, nor its parents created.
+        assert!(
+            !victim.exists(),
+            "attacker-controlled path was written: {}",
+            victim.display()
+        );
+        assert!(
+            !victim.parent().unwrap().exists(),
+            "parent of the attacker-controlled path was created"
+        );
     }
 }

--- a/crates/meow-config/src/safe_path.rs
+++ b/crates/meow-config/src/safe_path.rs
@@ -1,0 +1,173 @@
+//! Containment checks for config-supplied provider paths (issue #429).
+//!
+//! A `path:` on a rule- or proxy-provider is attacker-influenced whenever the
+//! config document arrives over the REST API (`PUT /configs`), so every path
+//! read or written on behalf of a provider must stay inside the provider
+//! cache directory — mirroring mihomo's `C.Path.IsSafePath` guard.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Resolve `requested` against `base` and require the result to stay inside
+/// `base`.
+///
+/// Robust to `..` traversal (paths are lexically normalized before the prefix
+/// check), absolute paths (allowed only when they already point inside
+/// `base`), and symlink tricks (the deepest existing ancestor of both sides
+/// is canonicalized and containment is re-checked on the resolved forms).
+///
+/// Returns the normalized absolute path that callers must use for the actual
+/// I/O, so the checked path and the opened path cannot diverge lexically.
+pub(crate) fn resolve_contained(base: &Path, requested: &Path) -> Result<PathBuf, String> {
+    let abs_base = normalize_absolute(base)?;
+    let joined = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        abs_base.join(requested)
+    };
+    let abs_joined = normalize_absolute(&joined)?;
+    if !abs_joined.starts_with(&abs_base) {
+        return Err(format!(
+            "path '{}' escapes the provider directory '{}'",
+            requested.display(),
+            base.display()
+        ));
+    }
+    // A symlink already present under `base` could still redirect the I/O
+    // outside of it; compare the symlink-resolved forms as well.
+    let canon_base = canonicalize_existing_prefix(&abs_base);
+    let canon_joined = canonicalize_existing_prefix(&abs_joined);
+    if !canon_joined.starts_with(&canon_base) {
+        return Err(format!(
+            "path '{}' escapes the provider directory '{}' via a symlink",
+            requested.display(),
+            base.display()
+        ));
+    }
+    Ok(abs_joined)
+}
+
+/// Make `path` absolute (against the current directory) and lexically fold
+/// `.` / `..` components. A `..` at the root is dropped (as the OS would),
+/// so an under-flowing traversal can never gain components.
+fn normalize_absolute(path: &Path) -> Result<PathBuf, String> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| format!("cannot resolve current directory: {e}"))?
+            .join(path)
+    };
+    let mut out = PathBuf::new();
+    for comp in abs.components() {
+        match comp {
+            Component::Prefix(_) | Component::RootDir => out.push(comp),
+            Component::CurDir => {}
+            // `pop()` refuses to remove the root/prefix, so this saturates
+            // at the filesystem root instead of underflowing.
+            Component::ParentDir => {
+                let _ = out.pop();
+            }
+            Component::Normal(c) => out.push(c),
+        }
+    }
+    Ok(out)
+}
+
+/// Canonicalize the deepest existing ancestor of `path` (resolving symlinks)
+/// and re-append the — already lexically normalized — non-existing remainder.
+fn canonicalize_existing_prefix(path: &Path) -> PathBuf {
+    let mut existing = path;
+    let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        match existing.canonicalize() {
+            Ok(canon) => {
+                let mut out = canon;
+                for c in suffix.iter().rev() {
+                    out.push(c);
+                }
+                return out;
+            }
+            Err(_) => match existing.parent() {
+                Some(parent) => {
+                    if let Some(name) = existing.file_name() {
+                        suffix.push(name.to_os_string());
+                    }
+                    existing = parent;
+                }
+                None => return path.to_path_buf(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_path_inside_base_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let got = resolve_contained(dir.path(), Path::new("sub/rules.yaml")).unwrap();
+        let base = normalize_absolute(dir.path()).unwrap();
+        assert_eq!(got, base.join("sub").join("rules.yaml"));
+    }
+
+    #[test]
+    fn absolute_path_inside_base_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let inside = dir.path().join("rules.yaml");
+        let got = resolve_contained(dir.path(), &inside).unwrap();
+        assert_eq!(got, inside);
+    }
+
+    #[test]
+    fn dotdot_traversal_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_contained(dir.path(), Path::new("../../etc/pwned")).unwrap_err();
+        assert!(err.contains("escapes"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn nested_dotdot_traversal_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_contained(dir.path(), Path::new("a/b/../../../evil")).unwrap_err();
+        assert!(err.contains("escapes"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn absolute_path_outside_base_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_contained(dir.path(), Path::new("/etc/cron.d/pwned")).unwrap_err();
+        assert!(err.contains("escapes"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn dotdot_stays_inside_base_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let got = resolve_contained(dir.path(), Path::new("sub/../rules.yaml")).unwrap();
+        assert!(got.ends_with("rules.yaml"));
+        assert!(!got.to_string_lossy().contains(".."));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_is_rejected() {
+        let outside = tempfile::tempdir().unwrap();
+        let base = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), base.path().join("link")).unwrap();
+        let err = resolve_contained(base.path(), Path::new("link/pwned")).unwrap_err();
+        assert!(err.contains("symlink"), "unexpected: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_base_still_contains_its_own_files() {
+        // e.g. macOS `/tmp` -> `/private/tmp`: base given via the symlink,
+        // target expressed through the same symlink must stay accepted.
+        let real = tempfile::tempdir().unwrap();
+        let holder = tempfile::tempdir().unwrap();
+        let alias = holder.path().join("alias");
+        std::os::unix::fs::symlink(real.path(), &alias).unwrap();
+        resolve_contained(&alias, Path::new("rules.yaml")).expect("contained path must resolve");
+    }
+}

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -942,7 +942,9 @@ async fn test_invalid_yaml() {
 
 #[tokio::test]
 async fn test_file_rule_provider_end_to_end() {
-    // Write a small domain list to a temp file.
+    // File rule-providers need a containment root for their `path:` (issue
+    // #429), so this goes through `load_config` with a real config file whose
+    // directory doubles as the provider root — the normal on-disk setup.
     let dir = tempfile::tempdir().unwrap();
     let list_path = dir.path().join("ads.yaml");
     std::fs::write(
@@ -951,23 +953,24 @@ async fn test_file_rule_provider_end_to_end() {
     )
     .unwrap();
 
-    let yaml = format!(
-        r#"
+    let yaml = r#"
 mixed-port: 7890
 rule-providers:
   ads:
     type: file
     behavior: domain
     format: yaml
-    path: {path}
+    path: ads.yaml
 rules:
   - RULE-SET,ads,REJECT
   - MATCH,DIRECT
-"#,
-        path = list_path.to_string_lossy()
-    );
+"#;
+    let config_path = dir.path().join("config.yaml");
+    std::fs::write(&config_path, yaml).unwrap();
 
-    let config = load_config_from_str(&yaml).await.unwrap();
+    let config = meow_config::load_config(config_path.to_str().unwrap())
+        .await
+        .unwrap();
     // RULE-SET rule + MATCH
     assert_eq!(config.rules.len(), 2);
     assert_eq!(config.rules[0].rule_type().to_string(), "RULE-SET");


### PR DESCRIPTION
Fixes #429.

## Root cause

`rule-providers[*].path` was used verbatim as a read/write target. `resolve_path` returned an absolute path as-is (cache dir ignored), joined a relative path onto the cache dir with no traversal check, and used a bare relative path when no cache dir was present. Because the runtime rebuild path (`rebuild_from_raw_runtime`, reached by `PUT /configs`) hardcodes `cache_dir = None` and is fed a fully caller-supplied YAML document, an API caller could make the daemon fetch an arbitrary URL and write the raw response bytes to any path the process can write — creating missing parent directories along the way, before the config was even validated. Upstream mihomo guards this with `C.Path.IsSafePath`; meow-rs had no equivalent. Proxy-providers (`proxy_provider.rs`) shared the same unchecked absolute/relative pattern.

## Fix

New `meow-config/src/safe_path.rs` mirrors mihomo`s `IsSafePath`: a requested path (explicit `path:`, or the implicit location derived from the provider name) is lexically normalized (`.`/`..` folded, `..` saturating at root so it can never gain components), joined onto the cache dir, and required to stay inside the canonicalized base. It is robust to `..` traversal, absolute paths, and symlinks planted inside the cache dir (the deepest existing ancestor of both sides is canonicalized and re-checked). It returns the normalized absolute path so the checked path and the opened path cannot diverge.

- Rule-provider paths are validated up front in `rebuild_from_raw_impl` via `rule_provider::validate_paths`, so a hostile config hard-fails **before any fetch or filesystem write** on every path into a (re)build: startup, `PUT`/`PATCH /configs`, and subscription refresh.
- When there is no cache dir (runtime rebuilds, `--config-string`) there is no containment root, so a caller-supplied `path:` is never honoured: http providers fetch to memory without an on-disk cache, file providers are a hard config error. The http proxy-provider cache path became `Option<PathBuf>` for the same reason (it previously defaulted to `./provider_<name>.yaml` in the CWD).

## Verification

- New regression tests: escaping / `..` / symlink paths rejected (unit tests in `safe_path`, `rule_provider`, `proxy_provider`); a hostile rebuild fails before touching the filesystem (`provider_path_safety_tests` in `lib.rs`); and `http_provider_path_is_not_written_without_cache_dir` proves an http provider with a caller-named `path:` and no cache dir loads to memory **without** creating the file or its parent dir (direct reproducer for the reported arbitrary-write).
- Full regression bar green: `cargo fmt --all -- --check`; three-way `cargo clippy --all-targets -D warnings` (default / no-default-features / all-features); `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`; `cargo test --lib`; plus the meow-config, meow-api, meow-app, and meow-tunnel (alloc-count / rule-ir-footprint) integration suites.