### PR TITLE
vless: narrow XTLS Vision + mux gate to sing-mux, allow Mux.Cool

### DIFF
--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1095,6 +1095,8 @@ fn parse_lb_strategy(strategy: Option<&str>) -> std::result::Result<LbStrategy, 
 /// - `uuid` invalid
 /// - `server` domain > 255 bytes
 /// - `vless-vision` feature absent + `flow: xtls-rprx-vision`
+/// - `flow: xtls-rprx-vision` + `smux`/`mux` protocol `smux`/`yamux`/`h2mux`
+///   — sing-box and Xray reject XTLS + sing-mux (`protocol: muxcool` is fine)
 ///
 /// # Warn-once (Class B per ADR-0002)
 ///
@@ -1451,15 +1453,24 @@ fn parse_vless(
 
     #[cfg(feature = "mux")]
     if let Some(mux_options) = parse_mux_options(name, config)? {
-        // XTLS Vision + mux is rejected by both sing-box and Xray servers.
-        // Building a Vision-wrapped mux session gets the user a connection
-        // the server tears down with no diagnostic — hard error at config
-        // time rather than a silent dial failure.
+        // Vision + sing-mux (smux/yamux/h2mux) is rejected by both sing-box
+        // and Xray servers: the mux session dials the reserved mux
+        // destination and the server tears the Vision-wrapped connection
+        // down with no diagnostic — hard error at config time rather than a
+        // silent dial failure. Vision + Mux.Cool (`protocol: muxcool`) is
+        // the opposite case: Xray's own Mux.Cool signaling rides inside the
+        // VLESS request that Vision splices, and this has been live-tested
+        // against a real Xray node (see docs/specs/proxy-mux.md "Test Plan"
+        // items 2-3, issue #424) — so only the sing-mux protocols are gated
+        // here.
         #[cfg(feature = "vless-vision")]
-        if flow == Some(VlessFlow::XtlsRprxVision) {
+        if flow == Some(VlessFlow::XtlsRprxVision)
+            && mux_options.protocol != meow_proxy::mux::Protocol::MuxCool
+        {
             return Err(
-                "vless: flow xtls-rprx-vision is incompatible with multiplexing \
-                 (sing-box and Xray reject XTLS + mux)"
+                "vless: flow xtls-rprx-vision is incompatible with sing-mux \
+                 (smux/yamux/h2mux); sing-box and Xray reject XTLS + sing-mux. \
+                 Use `protocol: muxcool` for Vision + multiplexing instead."
                     .into(),
             );
         }

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -808,6 +808,76 @@ proxies:
     assert_eq!(mux_warns, 0, "muxcool is implemented: no warn expected");
 }
 
+/// D16f2 (issue #424): `flow: xtls-rprx-vision` + `protocol: muxcool` on
+/// VLESS → accepted. Xray's own Mux.Cool signaling rides inside the VLESS
+/// request that Vision splices, and this combination is live-tested against
+/// a real Xray node (docs/specs/proxy-mux.md "Test Plan" items 2-3); only
+/// the sing-mux protocols (smux/yamux/h2mux) are incompatible with Vision.
+#[cfg(all(feature = "mux", feature = "vless-vision"))]
+#[tokio::test]
+async fn parse_vless_vision_muxcool_accepted() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    flow: "xtls-rprx-vision"
+    mux:
+      enabled: true
+      protocol: muxcool
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("vision + muxcool must load (issue #424)");
+    assert!(
+        config.proxies.contains_key("v"),
+        "vision + muxcool proxy must be kept"
+    );
+    let mux_warns = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+        .count();
+    assert_eq!(
+        mux_warns, 0,
+        "vision + muxcool is implemented: no warn expected; captured lines: {lines:?}"
+    );
+}
+
+/// D16f3 (issue #424): `flow: xtls-rprx-vision` + a sing-mux protocol
+/// (default h2mux) on VLESS → hard error. sing-box and Xray both reject
+/// XTLS + sing-mux; this remains gated even though `protocol: muxcool` is
+/// now accepted above.
+#[cfg(all(feature = "mux", feature = "vless-vision"))]
+#[tokio::test]
+async fn parse_vless_vision_singmux_rejected() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    flow: "xtls-rprx-vision"
+    mux:
+      enabled: true
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("invalid proxy must not fail the whole config");
+    assert!(
+        !config.proxies.contains_key("v"),
+        "vision + sing-mux (h2mux default) node must be skipped"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("incompatible with sing-mux")),
+        "expected a sing-mux incompatibility warn; {lines:?}"
+    );
+}
+
 /// D16g: `protocol: muxcool` on Trojan → rejected (VLESS/VMess-only protocol;
 /// trojan's CommandMux is smux, not Mux.Cool frames).
 #[cfg(all(feature = "mux", feature = "trojan"))]


### PR DESCRIPTION
Fixes #424

## Root cause

`parse_vless` in `crates/meow-config/src/proxy_parser.rs` rejected `flow:
xtls-rprx-vision` combined with **any** mux protocol, with the comment
"XTLS Vision + mux is rejected by both sing-box and Xray servers." That
rationale is only true for sing-mux (smux/yamux/h2mux).
`docs/specs/proxy-mux.md`'s Test Plan documents Vision + `protocol:
muxcool` as live-tested and working — including against a real Xray node
(`meow-real-muxcool.yml`) — and explicitly notes that *sing-mux* against
that same node fails, confirming the two mux families are not
interchangeable and the blanket gate was wrong for Mux.Cool.

The unconditional gate also made the Vision + Mux.Cool dial path already
implemented in `vless_adapter.rs::with_mux` (the `Protocol::MuxCool`
branch that wraps a `VlessConn::new_mux_deferred` connection in
`VisionConn`, added in #418) unreachable from any config — the docs
advertised a configuration the binary refused to load.

## Fix

Narrow the hard-error gate so it only fires when the mux protocol is
`smux`/`yamux`/`h2mux`; `protocol: muxcool` is now accepted with `flow:
xtls-rprx-vision`. Updated the doc comments on `parse_vless` and the
`with_mux` gate to explain why the two mux families are treated
differently, and reworded the error message to say "sing-mux" instead of
"mux" and point users at `protocol: muxcool` as the alternative.

## Verification

- New config tests in `crates/meow-config/tests/vless_config_test.rs`:
  - `parse_vless_vision_muxcool_accepted` — Vision + `protocol: muxcool`
    loads with no warn (pins the fix).
  - `parse_vless_vision_singmux_rejected` — Vision + sing-mux (default
    h2mux) still hard-errors, now with the narrowed
    "incompatible with sing-mux" message.
  - Confirmed neither test existed before (the old unconditional
    rejection had no test pinning it).
- Full regression bar, run from a clean worktree with
  `unset CARGO_TARGET_DIR`:
  - `cargo fmt --all -- --check` — clean
  - `cargo clippy --all-targets -- -D warnings` — clean
  - `cargo clippy --all-targets --no-default-features -- -D warnings` — clean
  - `cargo clippy --all-targets --all-features -- -D warnings` — clean
  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
  - `cargo test --lib` — all crates pass, no failures
  - `cargo test -p meow-config` (unit + all integration test files,
    including the new tests) — all pass