### PR TITLE
vless: accept unquoted numeric reality-opts short-id

### DIFF
--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1782,13 +1782,30 @@ fn parse_vless_reality_opts(
 
     // Subscription generators (e.g. Clash Verge) emit `short-id: null` when
     // the server has no short-id; mihomo treats it as absent (#388).
+    //
+    // An all-decimal short-id (e.g. `short-id: 1234`, unquoted) parses as a
+    // YAML integer rather than a string, so it must be reformatted back to
+    // its decimal digits before hex-decoding — otherwise the `as_str()` arm
+    // below rejects it and the node is silently dropped. This mirrors
+    // mihomo's weakly-typed decoder, which does the same int-to-decimal-string
+    // coercion (`common/structure`'s `decodeString`) before hex-decoding, so
+    // a subscription that yields a valid node on mihomo yields one here too
+    // (#408). Note this only round-trips cleanly when the short-id happens to
+    // be all decimal digits, e.g. `0x1f` parses as the number 31 and becomes
+    // `"31"`, not `"1f"` — the same lossy coercion mihomo performs.
     let short_id_str = match opts.get("short-id") {
-        None | Some(serde_yaml::Value::Null) => "",
+        None | Some(serde_yaml::Value::Null) => String::new(),
+        Some(serde_yaml::Value::Number(n)) => n
+            .as_u64()
+            .map(|u| u.to_string())
+            .or_else(|| n.as_i64().map(|i| i.to_string()))
+            .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?,
         Some(value) => value
             .as_str()
-            .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?,
+            .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?
+            .to_string(),
     };
-    let short_id_vec = parse_reality_short_id(short_id_str)?;
+    let short_id_vec = parse_reality_short_id(&short_id_str)?;
     let mut short_id = [0u8; 8];
     short_id[..short_id_vec.len()].copy_from_slice(&short_id_vec);
 

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -457,6 +457,62 @@ proxies:
     );
 }
 
+/// An unquoted all-decimal `short-id` (e.g. `short-id: 1234`) parses as a
+/// YAML integer, not a string. mihomo's weakly-typed decoder coerces it back
+/// to its decimal digits before hex-decoding, so the identical subscription
+/// works there; without matching coercion the node is silently dropped (#408).
+#[tokio::test]
+async fn parse_vless_reality_opts_numeric_short_id_coerced_to_string() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+      short-id: 1234
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("REALITY VLESS config with unquoted numeric short-id must load");
+    assert!(
+        config.proxies.contains_key("v"),
+        "REALITY VLESS proxy with unquoted numeric short-id must be registered, not dropped"
+    );
+}
+
+/// `short-id: 0x1f` parses as the YAML integer 31 (not the hex string "1f").
+/// Pin the exact (lossy) coercion mihomo's decoder performs: the integer is
+/// reformatted to its decimal string ("31") and hex-decoded from there, same
+/// as a literal `short-id: "31"` would be.
+#[tokio::test]
+async fn parse_vless_reality_opts_hex_literal_short_id_decimal_coerced() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+      short-id: 0x1f
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("REALITY VLESS config with `0x1f` short-id must load");
+    assert!(
+        config.proxies.contains_key("v"),
+        "REALITY VLESS proxy with `short-id: 0x1f` must be registered, not dropped"
+    );
+}
+
 // ─── D10: tls: false + plain VLESS → warn once, loads ok ─────────────────────
 
 /// D10: `parse_vless_tls_false_plain_warns_once`


### PR DESCRIPTION
## Summary

Follow-up to #388 / c0f153c. An unquoted all-decimal `short-id` (e.g.
`short-id: 1234`) still dropped the VLESS node on main, while mihomo
accepts the same subscription.

## Root cause

`serde_yaml` parses an unquoted all-decimal scalar like `1234` as
`Value::Number`, not `Value::String`. In `parse_vless_reality_opts`
(`crates/meow-config/src/proxy_parser.rs`), the `short-id` match only
handled `None`/`Null` (absent) and fell through everything else to
`Value::as_str()`, which returns `None` for a `Number` — so the config
was rejected with `vless: reality-opts.short-id must be a hex string`
and the whole node was silently dropped.

mihomo's weakly-typed decoder (`WeaklyTypedInput` +
`common/structure`'s `decodeString`) coerces an int-kind value back to
its decimal string (`strconv.FormatInt`) before hex-decoding, so the
identical subscription parses fine there.

## Fix

`parse_vless_reality_opts` now matches `serde_yaml::Value::Number`
explicitly and formats it to its decimal digits (`u64` first, `i64`
fallback for the signed case) before handing it to
`parse_reality_short_id`, mirroring mihomo's coercion.

This intentionally reproduces mihomo's one lossy edge case too:
`short-id: 0x1f` parses as the YAML integer `31` and becomes the
string `"31"`, not `"1f"` — the original hex literal spelling isn't
recoverable once serde_yaml has folded it to a number. Pinned by a
dedicated test so the exact (lossy) behavior is deliberate.

## Tests

Added to `crates/meow-config/tests/vless_config_test.rs`:
- `parse_vless_reality_opts_numeric_short_id_coerced_to_string` — the
  issue's exact repro (`short-id: 1234`), asserts the node loads.
- `parse_vless_reality_opts_hex_literal_short_id_decimal_coerced` —
  pins the `0x1f` → `"31"` edge case.

Existing coverage (`..._invalid_short_id_skipped`,
`..._valid_loads_without_boring_tls`,
`..._null_short_id_treated_as_absent`) still passes unchanged.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo clippy --all-targets --no-default-features -- -D warnings
cargo clippy --all-targets --all-features -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
cargo test --lib
cargo test -p meow-config --test vless_config_test   # 42 passed
```

All green.

Fixes #408