### PR TITLE
fix(transport): flush stashed frames at shutdown + gun/reality polish (PR #439/#440 review follow-ups)

### DIFF
--- a/crates/meow-transport/src/grpc.rs
+++ b/crates/meow-transport/src/grpc.rs
@@ -288,7 +288,9 @@ struct GunStream {
     /// exactly once per logical write.  A retry after `Pending` must pass
     /// the same buffer (the `AsyncWrite` contract); `poll_write` enforces
     /// this via [`gun_frame_matches`] and rejects a changed buffer with
-    /// `InvalidInput` instead of silently sending the stale frame.
+    /// `InvalidInput` instead of silently sending the stale frame.  A frame
+    /// still stashed at `poll_shutdown` (i.e. the parked write was cancelled)
+    /// is flushed together with the closing EOS frame, never discarded.
     pending_write: Option<Bytes>,
 }
 
@@ -399,6 +401,14 @@ impl AsyncWrite for GunStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
+        // Mirror H2Stream: an empty write is a no-op reported as `Ok(0)`,
+        // checked *before* the changed-buffer guard so `write(&[])` while a
+        // frame is stashed does not trip `InvalidInput` (it is a distinct
+        // logical write, not a retry).  It also avoids sending a useless
+        // zero-payload gun frame.
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
         let this = self.get_mut();
 
         // Encode buf into a gun frame exactly once per logical write.
@@ -458,10 +468,18 @@ impl AsyncWrite for GunStream {
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = self.get_mut();
-        // Send empty DATA+EOS to signal end of the request stream.
-        this.send
-            .send_data(Bytes::new(), true)
-            .map_err(io::Error::other)?;
+        // Flush a frame stashed by a write that was cancelled at its Pending
+        // await before signalling end-of-stream: the caller handed those
+        // bytes to `write()` and they were encoded, so discarding them here
+        // would silently truncate the stream behind an empty DATA+EOS.  Only
+        // a cancelled write can leave `pending_write` set — the
+        // changed-buffer guard clears it before returning `InvalidInput`, so
+        // shutdown never resurrects a rejected frame.  `send_data` queues
+        // beyond the granted flow-control window inside h2, so this completes
+        // in a single poll (cancellation-safe) and is bounded to one frame.
+        let frame = this.pending_write.take().unwrap_or_default();
+        // DATA (possibly empty) + EOS signals end of the request stream.
+        this.send.send_data(frame, true).map_err(io::Error::other)?;
         Poll::Ready(Ok(()))
     }
 }

--- a/crates/meow-transport/src/h2_common.rs
+++ b/crates/meow-transport/src/h2_common.rs
@@ -126,7 +126,10 @@ pub struct H2Stream {
     /// `Ready(Ok(n))` the caller may legally submit a different buffer
     /// (issue #423).  Only granted capacity is ever handed to the
     /// connection, so a peer that stops reading applies real
-    /// backpressure instead of growing h2's internal buffer.
+    /// backpressure instead of growing h2's internal buffer.  A payload
+    /// still stashed at half-close (the parked write was cancelled) is
+    /// flushed together with the closing EOS frame by
+    /// [`Self::best_effort_eos`], never discarded.
     pending_write: Option<Bytes>,
     remote_no_error_is_eof: bool,
     eos_sent: bool,
@@ -152,7 +155,17 @@ impl H2Stream {
     fn best_effort_eos(&mut self) {
         if !self.eos_sent {
             self.eos_sent = true;
-            let _ = self.send.send_data(Bytes::new(), true);
+            // Flush any payload stashed by a write cancelled at its Pending
+            // await before half-closing — sending an empty EOS over it would
+            // silently truncate the stream (mirrors GunStream::poll_shutdown
+            // in grpc.rs).  Only a cancelled write leaves `pending_write`
+            // set: the changed-buffer guard clears it before returning
+            // `InvalidInput`, so this never resurrects rejected bytes.
+            // `send_data` queues beyond the granted flow-control window
+            // inside h2, so this stays a single non-blocking best-effort
+            // call, bounded to one stashed payload.
+            let data = self.pending_write.take().unwrap_or_default();
+            let _ = self.send.send_data(data, true);
         }
     }
 }
@@ -401,6 +414,183 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// Open one client stream against a server that accepts the request,
+    /// responds 200, and then *hoards* request-body flow-control capacity:
+    /// it consumes DATA frames without releasing the receive window until
+    /// the returned release sender fires, after which it drains the body to
+    /// end-of-stream and hands the collected bytes back through the returned
+    /// receiver.  Keeping the window shut parks `poll_write` in the
+    /// `Pending` + stashed-payload state.
+    async fn hoarding_h2_stream() -> (
+        H2Stream,
+        tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<Vec<u8>>,
+    ) {
+        let (client_io, server_io) = tokio::io::duplex(256 * 1024);
+        let (release_tx, mut release_rx) = tokio::sync::oneshot::channel::<()>();
+        let (body_tx, body_rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+
+        tokio::spawn(async move {
+            let Ok(mut conn) = h2::server::handshake(server_io).await else {
+                return;
+            };
+            let Some(Ok((request, mut respond))) = conn.accept().await else {
+                return;
+            };
+            // Drive connection-level frames in the background.
+            tokio::spawn(async move { while conn.accept().await.is_some() {} });
+            let _ = respond.send_response(http::Response::new(()), false);
+
+            let mut body = request.into_body();
+            let mut received = Vec::new();
+            // Hoard: consume DATA but never release capacity, so the
+            // client's send window (65535 initial) empties and stays empty.
+            loop {
+                tokio::select! {
+                    chunk = body.data() => match chunk {
+                        Some(Ok(chunk)) => received.extend_from_slice(&chunk),
+                        Some(Err(_)) => return, // reset — client went away
+                        None => {
+                            let _ = body_tx.send(received);
+                            return;
+                        }
+                    },
+                    _ = &mut release_rx => break,
+                }
+            }
+            // Reopen the window, then drain to end-of-stream.
+            let _ = body.flow_control().release_capacity(received.len());
+            loop {
+                match body.data().await {
+                    Some(Ok(chunk)) => {
+                        let _ = body.flow_control().release_capacity(chunk.len());
+                        received.extend_from_slice(&chunk);
+                    }
+                    Some(Err(_)) => return,
+                    None => {
+                        let _ = body_tx.send(received);
+                        return;
+                    }
+                }
+            }
+        });
+
+        let (send_request, connection) = h2::client::handshake(client_io)
+            .await
+            .expect("client handshake");
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://localhost")
+            .body(())
+            .expect("static request");
+        let mut send_request = send_request.ready().await.expect("send_request ready");
+        let (response, send_stream) = send_request
+            .send_request(request, false)
+            .expect("send_request");
+
+        (
+            H2Stream::new(send_stream, RecvState::new(response)),
+            release_tx,
+            body_rx,
+        )
+    }
+
+    /// Drive writes against `stream` until exactly `payload.len()` bytes have
+    /// been accepted (the h2 window may grant capacity piecemeal).
+    async fn write_all_yielding(stream: &mut H2Stream, payload: &[u8]) {
+        let mut sent = 0;
+        while sent < payload.len() {
+            match poll_write_once(stream, &payload[sent..]).await {
+                // Capacity not assigned yet — let the connection task run.
+                None => tokio::task::yield_now().await,
+                Some(Ok(n)) => sent += n,
+                Some(Err(error)) => panic!("window-filling write failed: {error}"),
+            }
+        }
+    }
+
+    /// `poll_shutdown` must flush a payload stashed by a cancelled write
+    /// together with the closing EOS frame instead of silently discarding it
+    /// behind an empty DATA+EOS (follow-up to the #440 review; mirrors
+    /// `grpc_shutdown_flushes_stashed_frame_before_eos` for GunStream).
+    #[tokio::test]
+    async fn shutdown_flushes_stashed_pending_write() {
+        let (mut stream, release_tx, body_rx) = hoarding_h2_stream().await;
+
+        // Exhaust the 65535-byte initial send window…
+        let fill = vec![b'a'; 65535];
+        write_all_yielding(&mut stream, &fill).await;
+
+        // …so this write parks on flow control with its payload stashed.
+        let tail = b"tail-after-cancelled-write";
+        assert!(
+            poll_write_once(&mut stream, tail).await.is_none(),
+            "tail write must park on flow control"
+        );
+        assert!(stream.pending_write.is_some(), "payload must be stashed");
+
+        // The parked write is never retried (cancellation); shutdown must
+        // flush the stashed payload, not drop it.
+        stream.shutdown().await.expect("shutdown");
+        assert!(
+            stream.pending_write.is_none(),
+            "shutdown must consume the stashed payload"
+        );
+
+        release_tx.send(()).expect("server task alive");
+        let received = tokio::time::timeout(Duration::from_secs(5), body_rx)
+            .await
+            .expect("server must observe end-of-stream")
+            .expect("server sent collected body");
+
+        let mut expected = fill;
+        expected.extend_from_slice(tail);
+        assert_eq!(
+            received, expected,
+            "stashed payload must be delivered before EOS"
+        );
+    }
+
+    /// Companion: a payload cleared by the changed-buffer `InvalidInput`
+    /// rejection must NOT be resurrected by a later shutdown — only a frame
+    /// stashed by a cancelled write gets flushed.
+    #[tokio::test]
+    async fn shutdown_after_rejected_buffer_does_not_resurrect_payload() {
+        let (mut stream, release_tx, body_rx) = hoarding_h2_stream().await;
+
+        let fill = vec![b'a'; 65535];
+        write_all_yielding(&mut stream, &fill).await;
+
+        assert!(
+            poll_write_once(&mut stream, b"stashed-then-rejected")
+                .await
+                .is_none(),
+            "write must park on flow control"
+        );
+
+        // Retrying with a different buffer trips the guard and clears the
+        // stash.
+        let error = match poll_write_once(&mut stream, b"different-buffer").await {
+            Some(Err(error)) => error,
+            other => panic!("changed buffer after Pending must be rejected, got {other:?}"),
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+
+        stream.shutdown().await.expect("shutdown");
+        release_tx.send(()).expect("server task alive");
+        let received = tokio::time::timeout(Duration::from_secs(5), body_rx)
+            .await
+            .expect("server must observe end-of-stream")
+            .expect("server sent collected body");
+        assert_eq!(
+            received, fill,
+            "a payload cleared by the changed-buffer rejection must not reappear at shutdown"
+        );
     }
 
     /// Dropping an `H2Stream` half-closes the request body with a clean

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -51,6 +51,15 @@ const GROUP_X25519: u16 = 0x001d;
 // few KB; `read_record` already caps a single record at 18 KiB, so a
 // legitimate flight cannot come close to either limit below. Mirrors
 // `MAX_GUN_FRAME_LEN` in `grpc.rs` and the size caps in `ws.rs`.
+//
+// Note these two constants are defense-in-depth, not the load-bearing
+// bound: that is `ServerFlightGuard`'s flight-ordering check, which admits
+// at most 3 messages (EncryptedExtensions / Certificate / CertificateVerify,
+// each exactly once, in order) of ~36 KiB each — a message must complete
+// within one 18 KiB record plus whatever partial tail the previous record
+// left buffered, or `pop_handshake_message` fails the loop. Changes to the
+// per-message size math must keep that guard intact; the caps below only
+// backstop it against future refactors.
 const MAX_PRE_AUTH_HS_MESSAGES: usize = 32;
 const MAX_PRE_AUTH_TRANSCRIPT_LEN: usize = 64 * 1024;
 

--- a/crates/meow-transport/src/reality_tls.rs
+++ b/crates/meow-transport/src/reality_tls.rs
@@ -52,14 +52,26 @@ const GROUP_X25519: u16 = 0x001d;
 // legitimate flight cannot come close to either limit below. Mirrors
 // `MAX_GUN_FRAME_LEN` in `grpc.rs` and the size caps in `ws.rs`.
 //
-// Note these two constants are defense-in-depth, not the load-bearing
-// bound: that is `ServerFlightGuard`'s flight-ordering check, which admits
-// at most 3 messages (EncryptedExtensions / Certificate / CertificateVerify,
-// each exactly once, in order) of ~36 KiB each — a message must complete
-// within one 18 KiB record plus whatever partial tail the previous record
-// left buffered, or `pop_handshake_message` fails the loop. Changes to the
-// per-message size math must keep that guard intact; the caps below only
-// backstop it against future refactors.
+// The two constants below are not equally load-bearing, and it matters
+// which is which when the size math changes.
+//
+// `ServerFlightGuard`'s flight-ordering check admits at most 3 messages
+// (EncryptedExtensions / Certificate / CertificateVerify, each exactly once,
+// in order), each at most ~36 KiB — a message must complete within one
+// 18 KiB record plus whatever partial tail the previous record left
+// buffered, or `pop_handshake_message` fails the loop.
+//
+// `MAX_PRE_AUTH_HS_MESSAGES` (32) is therefore pure defense-in-depth: the
+// ordering guard caps the count at 3, so 32 is unreachable while that guard
+// holds.
+//
+// `MAX_PRE_AUTH_TRANSCRIPT_LEN` (64 KiB) is *not* — it is the binding limit
+// on a large flight. At ~36 KiB per message, two messages already exceed
+// 64 KiB, so the transcript check in `ServerFlightGuard::admit` is what
+// actually rejects an oversized Certificate flight, before the message
+// count ever reaches 3. Treat it as a real bound: raising the per-message
+// size or the record cap without revisiting it changes what this code
+// accepts pre-authentication.
 const MAX_PRE_AUTH_HS_MESSAGES: usize = 32;
 const MAX_PRE_AUTH_TRANSCRIPT_LEN: usize = 64 * 1024;
 

--- a/crates/meow-transport/tests/grpc_test.rs
+++ b/crates/meow-transport/tests/grpc_test.rs
@@ -14,6 +14,9 @@
 //! | E  | `grpc_round_trip_with_deferred_response` — server withholds response HEADERS until the first client hunk (issue #377) |
 //! | F  | `grpc_poll_write_rejects_changed_buffer_after_pending` — changed-buffer guard (issue #433) |
 //! | G  | `grpc_poll_write_same_buffer_retry_succeeds_after_pending` — legitimate same-buffer retry still completes (issue #433) |
+//! | H  | `grpc_shutdown_flushes_stashed_frame_before_eos` — shutdown flushes a frame stashed by a cancelled write (PR #440 follow-up) |
+//! | I  | `grpc_shutdown_after_rejected_buffer_does_not_resurrect_frame` — shutdown never resends a frame cleared by the changed-buffer rejection (PR #440 follow-up) |
+//! | J  | `grpc_empty_write_is_noop_even_with_stashed_frame` — `write(&[])` returns `Ok(0)` without tripping the changed-buffer guard (PR #440 follow-up) |
 
 mod support;
 
@@ -327,10 +330,17 @@ async fn grpc_round_trip_with_deferred_response() {
 /// a message on `release_rx` (if ever), after which it drains and releases
 /// everything. Keeping the window shut forces the client's `poll_write` into
 /// the `Pending` + stashed-frame state that issue #433 is about.
+///
+/// The collected request-body bytes are sent through the returned receiver
+/// once the client half-closes with a clean end-of-stream. Reading the body
+/// to completion inside the task (instead of `std::mem::forget`-ing it) both
+/// keeps the h2 stream alive while the client has a write outstanding and
+/// lets tests H/I assert exactly which frames reached the wire.
 fn spawn_capacity_hoarding_server(
     server_io: tokio::io::DuplexStream,
     release_rx: tokio::sync::oneshot::Receiver<()>,
-) {
+) -> tokio::sync::oneshot::Receiver<Vec<u8>> {
+    let (body_tx, body_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         let Ok(mut conn) = h2::server::handshake(server_io).await else {
             return;
@@ -351,27 +361,47 @@ fn spawn_capacity_hoarding_server(
         // send window (65535 initial) empties and stays empty.
         let mut body = request.into_body();
         let mut release_rx = release_rx;
-        let mut held: usize = 0;
+        let mut received = Vec::new();
         loop {
             tokio::select! {
                 chunk = body.data() => match chunk {
-                    Some(Ok(chunk)) => held += chunk.len(),
-                    _ => return, // EOS or stream error — client went away
+                    Some(Ok(chunk)) => received.extend_from_slice(&chunk),
+                    Some(Err(_)) => return, // stream error — client went away
+                    None => {
+                        let _ = body_tx.send(received);
+                        return;
+                    }
                 },
                 _ = &mut release_rx => break,
             }
         }
         // Reopen the window: release everything held so far, then keep
-        // draining + releasing so the retried write completes.
-        let _ = body.flow_control().release_capacity(held);
-        while let Some(Ok(chunk)) = body.data().await {
-            let _ = body.flow_control().release_capacity(chunk.len());
+        // draining + releasing so the retried write completes; the body stays
+        // alive in this loop until end-of-stream or a reset.
+        let _ = body.flow_control().release_capacity(received.len());
+        loop {
+            match body.data().await {
+                Some(Ok(chunk)) => {
+                    let _ = body.flow_control().release_capacity(chunk.len());
+                    received.extend_from_slice(&chunk);
+                }
+                Some(Err(_)) => return,
+                None => {
+                    let _ = body_tx.send(received);
+                    return;
+                }
+            }
         }
-        // Keep the body alive so the stream is not reset while the client
-        // still has a write outstanding.
-        std::mem::forget(body);
     });
+    body_rx
 }
+
+/// Payload that fills the initial h2 send window: 65535 bytes of 0xAA encode
+/// to a 65544-byte gun frame — larger than the 65535-byte window — so after
+/// writing it the window is fully exhausted.  Tests H/I rebuild the expected
+/// wire bytes from these constants.
+const WINDOW_FILL_BYTE: u8 = 0xAA;
+const WINDOW_FILL_LEN: usize = 65535;
 
 /// Exhaust the client's h2 send window so the next write stashes its frame and
 /// returns `Pending`, then interrupt that write, leaving `pending_write` set.
@@ -386,10 +416,9 @@ async fn gun_stream_with_stashed_frame(
         .await
         .expect("grpc connect");
 
-    // One 65535-byte payload encodes to a 65544-byte gun frame — larger than
-    // the initial 65535-byte h2 send window — so after this write the window
-    // is fully exhausted (the server never releases capacity on its own).
-    let fill = vec![0xAA; 65535];
+    // Fully exhaust the send window (the server never releases capacity on
+    // its own).
+    let fill = vec![WINDOW_FILL_BYTE; WINDOW_FILL_LEN];
     tokio::time::timeout(Duration::from_secs(5), stream.write(&fill))
         .await
         .expect("window-filling write must complete")
@@ -420,7 +449,7 @@ async fn gun_stream_with_stashed_frame(
 async fn grpc_poll_write_rejects_changed_buffer_after_pending() {
     let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
     let (_release_tx, release_rx) = tokio::sync::oneshot::channel();
-    spawn_capacity_hoarding_server(server_io, release_rx);
+    let _body_rx = spawn_capacity_hoarding_server(server_io, release_rx);
 
     let pending = vec![0xBB; 100];
     let mut stream = gun_stream_with_stashed_frame(client_io, &pending).await;
@@ -450,7 +479,7 @@ async fn grpc_poll_write_rejects_changed_buffer_after_pending() {
 async fn grpc_poll_write_same_buffer_retry_succeeds_after_pending() {
     let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
     let (release_tx, release_rx) = tokio::sync::oneshot::channel();
-    spawn_capacity_hoarding_server(server_io, release_rx);
+    let _body_rx = spawn_capacity_hoarding_server(server_io, release_rx);
 
     let pending = vec![0xBB; 100];
     let mut stream = gun_stream_with_stashed_frame(client_io, &pending).await;
@@ -466,5 +495,135 @@ async fn grpc_poll_write_same_buffer_retry_succeeds_after_pending() {
         n,
         pending.len(),
         "retry must report the full payload length"
+    );
+}
+
+// ─── H/I: Shutdown with a stashed frame (PR #440 review follow-up) ────────────
+
+/// H: `grpc_shutdown_flushes_stashed_frame_before_eos`
+///
+/// Follow-up to the PR #440 review: `poll_shutdown` used to send an empty
+/// DATA+EOS while an encoded frame from a cancelled write still sat in
+/// `pending_write`, silently truncating the stream. Shutdown must flush the
+/// stashed frame together with the EOS instead of discarding it.
+#[tokio::test]
+async fn grpc_shutdown_flushes_stashed_frame_before_eos() {
+    let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let body_rx = spawn_capacity_hoarding_server(server_io, release_rx);
+
+    let pending = vec![0xBB; 100];
+    let mut stream = gun_stream_with_stashed_frame(client_io, &pending).await;
+
+    // Shutdown with the frame still stashed (the parked write was cancelled,
+    // never retried). h2 queues the flushed frame beyond the closed window,
+    // so this completes even before the server releases capacity.
+    tokio::time::timeout(Duration::from_secs(5), stream.shutdown())
+        .await
+        .expect("shutdown must not block on flow control")
+        .expect("shutdown");
+
+    // Reopen the window so the queued frames can reach the server.
+    release_tx.send(()).expect("server task alive");
+
+    let received = tokio::time::timeout(Duration::from_secs(5), body_rx)
+        .await
+        .expect("server must observe end-of-stream")
+        .expect("server sent collected body");
+
+    let mut expected = encode_gun_frame(&vec![WINDOW_FILL_BYTE; WINDOW_FILL_LEN]);
+    expected.extend_from_slice(&encode_gun_frame(&pending));
+    assert_eq!(
+        received, expected,
+        "the stashed frame must be delivered before EOS"
+    );
+}
+
+/// I: `grpc_shutdown_after_rejected_buffer_does_not_resurrect_frame`
+///
+/// Companion to H: only a frame stashed by a *cancelled* write gets flushed.
+/// A frame cleared by the changed-buffer `InvalidInput` rejection (test F)
+/// must not reappear on the wire when the stream is later shut down.
+#[tokio::test]
+async fn grpc_shutdown_after_rejected_buffer_does_not_resurrect_frame() {
+    let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let body_rx = spawn_capacity_hoarding_server(server_io, release_rx);
+
+    let pending = vec![0xBB; 100];
+    let mut stream = gun_stream_with_stashed_frame(client_io, &pending).await;
+
+    // Trip the changed-buffer guard: the stashed frame is cleared and the
+    // write fails with InvalidInput.
+    let different = vec![0xCC; 50];
+    let err = tokio::time::timeout(Duration::from_secs(5), stream.write(&different))
+        .await
+        .expect("changed-buffer write must fail fast")
+        .expect_err("changed buffer after Pending must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    tokio::time::timeout(Duration::from_secs(5), stream.shutdown())
+        .await
+        .expect("shutdown must not block on flow control")
+        .expect("shutdown");
+    release_tx.send(()).expect("server task alive");
+
+    let received = tokio::time::timeout(Duration::from_secs(5), body_rx)
+        .await
+        .expect("server must observe end-of-stream")
+        .expect("server sent collected body");
+    assert_eq!(
+        received,
+        encode_gun_frame(&vec![WINDOW_FILL_BYTE; WINDOW_FILL_LEN]),
+        "a frame cleared by the changed-buffer rejection must not be resurrected at shutdown"
+    );
+}
+
+/// J: `grpc_empty_write_is_noop_even_with_stashed_frame`
+///
+/// Follow-up to the PR #440 review: `poll_write` lacked `H2Stream`'s
+/// empty-buffer early return, so `write(&[])` while a frame was stashed was
+/// misread as a changed-buffer retry and failed with `InvalidInput` (and an
+/// empty write on an idle stream sent a useless zero-payload gun frame). An
+/// empty write must report `Ok(0)`, leave the stash intact, and send nothing.
+#[tokio::test]
+async fn grpc_empty_write_is_noop_even_with_stashed_frame() {
+    let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let body_rx = spawn_capacity_hoarding_server(server_io, release_rx);
+
+    let pending = vec![0xBB; 100];
+    let mut stream = gun_stream_with_stashed_frame(client_io, &pending).await;
+
+    // An empty write is a distinct logical write, not a retry: Ok(0).
+    let n = tokio::time::timeout(Duration::from_secs(5), stream.write(&[]))
+        .await
+        .expect("empty write must not block")
+        .expect("empty write must succeed");
+    assert_eq!(n, 0, "empty write must report Ok(0)");
+
+    // The stash must survive it: the contract-conforming same-buffer retry
+    // still completes once capacity is released, and exactly the fill frame
+    // plus the stashed frame reach the wire (no zero-payload frame).
+    release_tx.send(()).expect("server task alive");
+    let n = tokio::time::timeout(Duration::from_secs(5), stream.write(&pending))
+        .await
+        .expect("same-buffer retry must complete once capacity is released")
+        .expect("same-buffer retry must succeed");
+    assert_eq!(n, pending.len());
+
+    tokio::time::timeout(Duration::from_secs(5), stream.shutdown())
+        .await
+        .expect("shutdown must not block")
+        .expect("shutdown");
+    let received = tokio::time::timeout(Duration::from_secs(5), body_rx)
+        .await
+        .expect("server must observe end-of-stream")
+        .expect("server sent collected body");
+    let mut expected = encode_gun_frame(&vec![WINDOW_FILL_BYTE; WINDOW_FILL_LEN]);
+    expected.extend_from_slice(&encode_gun_frame(&pending));
+    assert_eq!(
+        received, expected,
+        "an empty write must put nothing on the wire"
     );
 }


### PR DESCRIPTION
Follow-up to the reviews of #440 (gRPC gun transport) and #439 (REALITY pre-auth flight bounds). These findings were classified minor/non-blocking at merge time; this PR fixes them properly. All four findings were re-verified against current `main` and still applied.

## Changes

### 1. `GunStream::poll_shutdown` flushes a stashed `pending_write` frame (follow-up to #440 review)
`poll_shutdown` sent an empty DATA+EOS while an encoded frame from a write cancelled at its `Pending` await still sat in `pending_write` — silently truncating the stream. It now takes the stashed frame and sends it together with the EOS flag.

Guard semantics preserved:
- **Cancellation-safe**: `send_data` queues beyond the granted flow-control window inside h2, so the flush completes in a single poll — no `Pending` state to lose.
- **Only a cancelled write is flushed**: the changed-buffer guard clears `pending_write` *before* returning `InvalidInput`, so shutdown after a rejection never resurrects the cleared frame (pinned by test I).

### 2. `H2Stream` had the same gap — fixed consistently
`H2Stream::pending_write` is owned `Bytes` (copied from the caller's buffer at stash time), so it can flush safely too. `best_effort_eos` (shared by `poll_shutdown` and `Drop`) now sends the stashed payload with the closing EOS frame. Pinned by new unit tests `shutdown_flushes_stashed_pending_write` and `shutdown_after_rejected_buffer_does_not_resurrect_payload`, which verify byte-exact delivery through a capacity-hoarding h2 server.

### 3. `GunStream::poll_write` empty-buffer early return (follow-up to #440 review)
Aligned with `H2Stream`'s `if buf.is_empty() { return Ok(0) }` ordering (checked before the changed-buffer guard). Previously `write(&[])` while a frame was stashed returned `InvalidInput`, and an empty write on an idle stream emitted a useless zero-payload gun frame. Pinned by test J, which also asserts the stash survives the empty write and nothing extra reaches the wire.

### 4. `grpc_test.rs` no longer leaks the h2 `RecvStream` (follow-up to #440 review)
`spawn_capacity_hoarding_server` used `std::mem::forget(body)` to keep the stream alive. It now drains the body to end-of-stream inside the task (holding it across the awaits) and reports the collected bytes over a oneshot — which tests H/I/J reuse to assert exactly which frames were sent.

### 5. `reality_tls.rs` bound-provenance comment (follow-up to #439 review)
Added a note on `MAX_PRE_AUTH_HS_MESSAGES` / `MAX_PRE_AUTH_TRANSCRIPT_LEN` (64 KiB) stating they are defense-in-depth: the load-bearing bound is `ServerFlightGuard`'s flight-ordering check, which admits at most 3 messages of ~36 KiB each (one 18 KiB record plus the previous record's buffered tail), so future changes to the per-message size math know what actually protects the loop.

## Tests
- New: gun tests H/I/J in `grpc_test.rs`; `H2Stream` tests `shutdown_flushes_stashed_pending_write` and `shutdown_after_rejected_buffer_does_not_resurrect_payload` in `h2_common.rs`.
- Adjusted (behavior unchanged): tests F/G bind the hoarding server's new byte-collection receiver.
- All existing tests green; no pinned behavior changed for uncancelled writes.

## Regression bar
Ran from the worktree root with `CARGO_TARGET_DIR` unset — all pass:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` (default / `--no-default-features` / `--all-features`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` (plus `cargo test -p meow-transport --features grpc,h2 --lib` and `--test grpc_test` explicitly)

No relay-path code or footprint-tracked types (`Metadata`, `ConnectionInfo`, `UdpSession`, DNS cache entries) touched.