### PR TITLE
fix(transport): follow-up h2 write-path cleanups from #428/#441 review

### DIFF
--- a/crates/meow-transport/src/h2_common.rs
+++ b/crates/meow-transport/src/h2_common.rs
@@ -115,18 +115,28 @@ impl RecvState {
     }
 }
 
+/// Per-poll cap on the bytes copied into `pending_write`.  Without a cap,
+/// a large write under backpressure re-copies the whole shrinking
+/// remainder on every `write_all` resubmission (a 1 MiB write through a
+/// 64 KiB window costs ~16 allocations / ~8 MiB of memcpy); capping the
+/// stash bounds every copy to one window's worth.  64 KiB is chosen to
+/// exceed h2's default 65535-byte initial window, so writes that fit the
+/// default window keep their single-poll behaviour.
+const WRITE_STASH_CAP: usize = 64 * 1024;
+
 /// Raw bidirectional bytes over one HTTP/2 request/response pair.
 pub struct H2Stream {
     send: h2::SendStream<Bytes>,
     recv: RecvState,
     read_buf: Bytes,
     /// Payload stashed while a `poll_write` waits for h2 send-window
-    /// capacity.  Only retained across a `Poll::Pending` return — every
-    /// `Ready` return (including a partial one) clears it, because after
-    /// `Ready(Ok(n))` the caller may legally submit a different buffer
-    /// (issue #423).  Only granted capacity is ever handed to the
-    /// connection, so a peer that stops reading applies real
-    /// backpressure instead of growing h2's internal buffer.
+    /// capacity — at most [`WRITE_STASH_CAP`] bytes, i.e. possibly only a
+    /// prefix of the caller's buffer.  Only retained across a
+    /// `Poll::Pending` return — every `Ready` return (including a partial
+    /// one) clears it, because after `Ready(Ok(n))` the caller may legally
+    /// submit a different buffer (issue #423).  Only granted capacity is
+    /// ever handed to the connection, so a peer that stops reading applies
+    /// real backpressure instead of growing h2's internal buffer.
     pending_write: Option<Bytes>,
     remote_no_error_is_eof: bool,
     eos_sent: bool,
@@ -226,12 +236,20 @@ impl AsyncWrite for H2Stream {
         // capacity has been reserved — do not copy or reserve again.
         // A Pending poll must be retried with the same buffer; reject a
         // changed buffer rather than silently sending stale bytes under
-        // its reported length.  This guard applies to the Pending path
+        // its reported length.  The stash may be a capped prefix of the
+        // caller's buffer, so compare it against the new buffer's prefix
+        // of the stash's length.  This guard applies to the Pending path
         // only: pending_write never survives a Ready return, so after a
         // partial `Ready(Ok(n))` the caller is free to submit anything
         // (issue #423).
         if let Some(data) = &this.pending_write {
-            if buf != data.as_ref() {
+            if buf.len() < data.len() || &buf[..data.len()] != data.as_ref() {
+                // Hand the stale stash's reservation back to the
+                // connection along with the stash itself: this error
+                // taints the stream, so nothing will ever send those
+                // bytes, and leaving the reservation requested would pin
+                // window capacity on the connection for good.
+                this.send.reserve_capacity(0);
                 this.pending_write = None;
                 return Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -240,7 +258,11 @@ impl AsyncWrite for H2Stream {
                 )));
             }
         } else {
-            let data = Bytes::copy_from_slice(buf);
+            // Stash (and therefore accept) at most WRITE_STASH_CAP bytes
+            // per poll so `write_all`-style resubmissions of a large
+            // buffer copy bounded chunks instead of the whole remainder.
+            let stash_len = buf.len().min(WRITE_STASH_CAP);
+            let data = Bytes::copy_from_slice(&buf[..stash_len]);
             this.send.reserve_capacity(data.len());
             this.pending_write = Some(data);
         }
@@ -304,50 +326,21 @@ impl AsyncWrite for H2Stream {
 
 impl Unpin for H2Stream {}
 
+/// Stalled-h2-server harness shared with the `h2_test` integration suite
+/// (single source in `tests/support/h2_stalled.rs`, see its module docs).
+#[cfg(test)]
+#[path = "../tests/support/h2_stalled.rs"]
+mod h2_stalled;
+
 #[cfg(test)]
 mod tests {
+    use super::h2_stalled::{stalled_h2_parts, STALLED_PAYLOAD_LEN};
     use super::*;
     use std::future::poll_fn;
     use tokio::io::AsyncWriteExt as _;
 
-    /// Payload larger than h2's default 65535-byte send window, so a write
-    /// against a stalled peer can never complete in one poll.
-    const STALLED_PAYLOAD_LEN: usize = 128 * 1024;
-
-    /// Open one client stream against a server that accepts the request and
-    /// then stops driving its connection: the request body is never read, so
-    /// the send window is never replenished and writes stall once the
-    /// initial window is spent.
     async fn stalled_h2_stream() -> (H2Stream, tokio::task::JoinHandle<()>) {
-        let (client_io, server_io) = tokio::io::duplex(256 * 1024);
-
-        let server = tokio::spawn(async move {
-            let mut connection = h2::server::Builder::new()
-                .handshake::<_, Bytes>(server_io)
-                .await
-                .expect("server handshake");
-            let _accepted = connection.accept().await;
-            // Never polled again: no WINDOW_UPDATE is ever sent back.
-            std::future::pending::<()>().await;
-        });
-
-        let (send_request, connection) = h2::client::handshake(client_io)
-            .await
-            .expect("client handshake");
-        tokio::spawn(async move {
-            let _ = connection.await;
-        });
-
-        let request = http::Request::builder()
-            .method(http::Method::POST)
-            .uri("https://localhost")
-            .body(())
-            .expect("static request");
-        let mut send_request = send_request.ready().await.expect("send_request ready");
-        let (response, send_stream) = send_request
-            .send_request(request, false)
-            .expect("send_request");
-
+        let (send_stream, response, server) = stalled_h2_parts().await;
         (H2Stream::new(send_stream, RecvState::new(response)), server)
     }
 
@@ -374,15 +367,20 @@ mod tests {
 
         // Drive the first logical write to its first Ready(Ok(n)).  The send
         // window (at most 64 KiB) cannot cover the payload, so the write is
-        // necessarily partial.
-        let sent = loop {
-            match poll_write_once(&mut stream, &payload).await {
-                // Capacity not assigned yet — let the connection task run.
-                None => tokio::task::yield_now().await,
-                Some(Ok(n)) => break n,
-                Some(Err(error)) => panic!("unexpected write error: {error}"),
+        // necessarily partial.  Deadline-bounded so a regression that never
+        // yields Ready fails with a diagnostic instead of hanging CI.
+        let sent = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match poll_write_once(&mut stream, &payload).await {
+                    // Capacity not assigned yet — let the connection task run.
+                    None => tokio::task::yield_now().await,
+                    Some(Ok(n)) => break n,
+                    Some(Err(error)) => panic!("unexpected write error: {error}"),
+                }
             }
-        };
+        })
+        .await
+        .expect("first write must reach Ready(Ok(n)) once capacity is assigned");
         assert!(sent < payload.len(), "expected a partial write");
 
         // Submit a buffer with different contents.  Before the fix this
@@ -401,6 +399,157 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// The stash is capped at [`WRITE_STASH_CAP`], so a parked large write
+    /// retried with the same *full* remainder (longer than the stash) must
+    /// keep parking: the changed-buffer guard compares the stash against
+    /// the retry buffer's prefix of the stash's length, not the whole
+    /// buffer.  Before the cap the two were always the same length, so an
+    /// exact comparison sufficed; with the cap an exact comparison would
+    /// falsely reject every `write_all` resubmission of a > 64 KiB buffer.
+    #[tokio::test]
+    async fn capped_stash_accepts_same_full_buffer_retry() {
+        let (mut stream, _server) = stalled_h2_stream().await;
+        let payload = vec![b'a'; STALLED_PAYLOAD_LEN];
+
+        // Exhaust the send window (at most 65535 bytes accepted), leaving a
+        // remainder strictly longer than WRITE_STASH_CAP parked in
+        // pending_write as a capped prefix.  A poll is treated as parked
+        // only after several consecutive Pendings with yields in between,
+        // so a capacity grant split across connection-task runs cannot
+        // race the assertions below.
+        let sent = tokio::time::timeout(Duration::from_secs(5), async {
+            let mut sent = 0usize;
+            let mut idle_polls = 0usize;
+            loop {
+                match poll_write_once(&mut stream, &payload[sent..]).await {
+                    None => {
+                        idle_polls += 1;
+                        if sent > 0 && idle_polls >= 3 {
+                            break sent;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                    Some(Ok(n)) => {
+                        sent += n;
+                        idle_polls = 0;
+                    }
+                    Some(Err(error)) => panic!("unexpected write error: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("the stalled window must park the write, not spin forever");
+        let remainder = &payload[sent..];
+        assert!(
+            remainder.len() > WRITE_STASH_CAP,
+            "setup: the parked remainder must exceed the stash cap"
+        );
+
+        // Contract-abiding retry with the same (uncapped) remainder: must
+        // stay Pending, never trip the changed-buffer guard.
+        for _ in 0..3 {
+            let polled = poll_write_once(&mut stream, remainder).await;
+            assert!(
+                polled.is_none(),
+                "same-buffer retry of a capped stash must stay Pending, got {polled:?}"
+            );
+        }
+    }
+
+    /// A large write against a peer with plenty of window is accepted in
+    /// at most [`WRITE_STASH_CAP`]-byte chunks per poll, so `write_all`
+    /// resubmissions copy bounded chunks instead of re-copying the whole
+    /// shrinking remainder each time.
+    #[tokio::test]
+    async fn large_write_accepts_at_most_stash_cap_per_poll() {
+        const PAYLOAD_LEN: usize = 1024 * 1024;
+
+        let (client_io, server_io) = tokio::io::duplex(256 * 1024);
+
+        // Server with windows large enough to cover the whole payload, so
+        // only the stash cap can bound a single accept.  It drains the
+        // request body while keeping the connection driven.
+        let server = tokio::spawn(async move {
+            let mut connection = h2::server::Builder::new()
+                .initial_window_size(2 * 1024 * 1024)
+                .initial_connection_window_size(2 * 1024 * 1024)
+                .handshake::<_, Bytes>(server_io)
+                .await
+                .expect("server handshake");
+            let (request, respond) = connection
+                .accept()
+                .await
+                .expect("one request")
+                .expect("accept ok");
+            let mut body = request.into_body();
+            let drain = async {
+                let mut total = 0usize;
+                while let Some(data) = body.data().await {
+                    let bytes = data.expect("body data");
+                    total += bytes.len();
+                    let _ = body.flow_control().release_capacity(bytes.len());
+                }
+                total
+            };
+            let drive = async {
+                while connection.accept().await.is_some() {}
+                std::future::pending::<()>().await;
+            };
+            let total = tokio::select! {
+                total = drain => total,
+                () = drive => unreachable!("drive never resolves"),
+            };
+            assert_eq!(total, PAYLOAD_LEN, "server must receive every byte");
+            drop(respond); // kept alive until here so the stream is not reset
+        });
+
+        let (send_request, connection) = h2::client::handshake(client_io)
+            .await
+            .expect("client handshake");
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://localhost")
+            .body(())
+            .expect("static request");
+        let mut send_request = send_request.ready().await.expect("send_request ready");
+        let (response, send_stream) = send_request
+            .send_request(request, false)
+            .expect("send_request");
+        let mut stream = H2Stream::new(send_stream, RecvState::new(response));
+
+        let payload = vec![b'z'; PAYLOAD_LEN];
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let mut sent = 0usize;
+            while sent < payload.len() {
+                match poll_write_once(&mut stream, &payload[sent..]).await {
+                    None => tokio::task::yield_now().await,
+                    Some(Ok(n)) => {
+                        assert!(
+                            n <= WRITE_STASH_CAP,
+                            "a single poll accepted {n} bytes, more than the stash cap"
+                        );
+                        sent += n;
+                    }
+                    Some(Err(error)) => panic!("unexpected write error: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("the whole payload must be accepted against an open window");
+
+        // Half-close so the server's body drain sees end-of-stream.
+        poll_fn(|cx| Pin::new(&mut stream).poll_shutdown(cx))
+            .await
+            .expect("shutdown");
+        tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("server must finish draining")
+            .expect("server task");
     }
 
     /// Dropping an `H2Stream` half-closes the request body with a clean

--- a/crates/meow-transport/tests/h2_test.rs
+++ b/crates/meow-transport/tests/h2_test.rs
@@ -26,6 +26,7 @@ use meow_transport::h2::{H2Config, H2Layer};
 use meow_transport::h2_common::{H2Stream, RecvState};
 use meow_transport::Transport;
 use meow_transport::TransportError;
+use support::h2_stalled::{stalled_h2_parts, STALLED_PAYLOAD_LEN};
 use support::loopback::{spawn_h2_server, spawn_h2_server_deferred_response};
 use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -284,45 +285,12 @@ async fn h2_round_trip_with_deferred_response() {
 
 // ─── D6/D7: write-cancellation contract on the shared H2 stream ──────────────
 
-/// Payload larger than h2's default 65535-byte send window, so the write
-/// cannot complete in one poll however the peer's SETTINGS race the first
-/// `poll_write`.
-const STALLED_PAYLOAD_LEN: usize = 128 * 1024;
-
-/// Open one client stream against a server that accepts the request and then
-/// stops driving its connection: the request body is never read, so the
-/// client's send window is never replenished and the write parks with the
-/// payload stashed in the stream's `pending_write`.
+/// Open one client stream against a stalled server (harness shared with the
+/// `h2_common` unit tests via `support::h2_stalled`): the request body is
+/// never read, so the client's send window is never replenished and the
+/// write parks with the payload stashed in the stream's `pending_write`.
 async fn stalled_h2_stream() -> (H2Stream, tokio::task::JoinHandle<()>) {
-    let (client_io, server_io) = tokio::io::duplex(256 * 1024);
-
-    let server = tokio::spawn(async move {
-        let mut connection = h2::server::Builder::new()
-            .handshake::<_, bytes::Bytes>(server_io)
-            .await
-            .expect("server handshake");
-        let _accepted = connection.accept().await;
-        // Never polled again: no WINDOW_UPDATE is ever sent back.
-        std::future::pending::<()>().await;
-    });
-
-    let (send_request, connection) = h2::client::handshake(client_io)
-        .await
-        .expect("client handshake");
-    tokio::spawn(async move {
-        let _ = connection.await;
-    });
-
-    let request = http::Request::builder()
-        .method(http::Method::POST)
-        .uri("https://localhost")
-        .body(())
-        .expect("static request");
-    let mut send_request = send_request.ready().await.expect("send_request ready");
-    let (response, send_stream) = send_request
-        .send_request(request, false)
-        .expect("send_request");
-
+    let (send_stream, response, server) = stalled_h2_parts().await;
     (H2Stream::new(send_stream, RecvState::new(response)), server)
 }
 
@@ -390,11 +358,18 @@ async fn h2_pending_write_retried_with_changed_buffer_is_rejected() {
     let sent = write_until_pending(&mut stream, &payload).await;
 
     // Same length as the stashed remainder: the guard must compare content,
-    // not just size.
+    // not just size.  One-shot poll (Pending surfaces as None) so a guard
+    // regression to accept-and-park fails the test instead of hanging it.
     let decoy = vec![b'b'; STALLED_PAYLOAD_LEN - sent];
-    let error = poll_fn(|cx| Pin::new(&mut stream).poll_write(cx, &decoy))
-        .await
-        .expect_err("a changed buffer must be rejected");
+    let error = poll_fn(|cx| {
+        Poll::Ready(match Pin::new(&mut stream).poll_write(cx, &decoy) {
+            Poll::Pending => None,
+            Poll::Ready(result) => Some(result),
+        })
+    })
+    .await
+    .expect("the changed-buffer guard must resolve in one poll, not park")
+    .expect_err("a changed buffer must be rejected");
     assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
     assert!(
         error.to_string().contains("write buffer changed"),

--- a/crates/meow-transport/tests/support/h2_stalled.rs
+++ b/crates/meow-transport/tests/support/h2_stalled.rs
@@ -1,0 +1,64 @@
+//! Stalled-h2-server harness shared between the `h2_common` unit tests and
+//! the `h2_test` integration suite (D6/D7).
+//!
+//! Single source of truth: the unit tests inside `src/h2_common.rs` include
+//! this file via `#[path]`, the integration tests via `support::h2_stalled` —
+//! keep it free of crate-relative paths (`crate::…` / `meow_transport::…`)
+//! so both contexts compile it unchanged.  That is also why
+//! [`stalled_h2_parts`] returns the raw h2 halves instead of an `H2Stream`:
+//! each suite wraps them in the stream type under its own path.
+// Included by two suites that use different subsets; dead-code warnings on
+// the unused half are expected and suppressed here (same policy as
+// loopback.rs).
+#![allow(dead_code)]
+
+use bytes::Bytes;
+
+/// Payload larger than h2's default 65535-byte send window, so a write
+/// against a stalled peer can never complete in one poll however the peer's
+/// SETTINGS race the first `poll_write`.
+pub const STALLED_PAYLOAD_LEN: usize = 128 * 1024;
+
+/// Open one client stream against a server that accepts the request and
+/// then stops driving its connection: the request body is never read, so
+/// the send window is never replenished and writes stall once the initial
+/// window is spent.
+///
+/// Returns the client send half and response future — callers wrap them in
+/// `H2Stream` — plus the server task handle.
+pub async fn stalled_h2_parts() -> (
+    h2::SendStream<Bytes>,
+    h2::client::ResponseFuture,
+    tokio::task::JoinHandle<()>,
+) {
+    let (client_io, server_io) = tokio::io::duplex(256 * 1024);
+
+    let server = tokio::spawn(async move {
+        let mut connection = h2::server::Builder::new()
+            .handshake::<_, Bytes>(server_io)
+            .await
+            .expect("server handshake");
+        let _accepted = connection.accept().await;
+        // Never polled again: no WINDOW_UPDATE is ever sent back.
+        std::future::pending::<()>().await;
+    });
+
+    let (send_request, connection) = h2::client::handshake(client_io)
+        .await
+        .expect("client handshake");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let request = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://localhost")
+        .body(())
+        .expect("static request");
+    let mut send_request = send_request.ready().await.expect("send_request ready");
+    let (response, send_stream) = send_request
+        .send_request(request, false)
+        .expect("send_request");
+
+    (send_stream, response, server)
+}

--- a/crates/meow-transport/tests/support/mod.rs
+++ b/crates/meow-transport/tests/support/mod.rs
@@ -4,5 +4,7 @@
 //! explicitly forbidden inside `src/` by acceptance criterion #8.
 //! Tests/support is whitelisted from the F2 grep-check.
 
+#[cfg(any(feature = "grpc", feature = "h2"))]
+pub mod h2_stalled;
 pub mod log_capture;
 pub mod loopback;


### PR DESCRIPTION
Follow-ups from the adversarial review of PR #441 and PR #428, classified minor/non-blocking at merge time and now fixed properly. All five findings were re-verified against current `main` before applying — all still applied.

## Follow-up to #441 review — `crates/meow-transport/src/h2_common.rs`

1. **Cap the per-poll `pending_write` stash at 64 KiB** (`WRITE_STASH_CAP`). Large writes under backpressure re-copied the whole shrinking remainder on every `write_all` resubmission (a 1 MiB write through a 64 KiB window: ~16 allocations / ~8 MiB memcpy). The stash — and therefore the bytes accepted per poll — is now bounded to one window's worth.
   - **Behavioral change**: `poll_write` on a buffer > 64 KiB now returns partial `Ready(Ok(n <= 65536))`. All in-tree callers audited: `H2Layer` consumers use generic `AsyncWrite` loops, h2mux `Stream` is driven by `write_all` and `PacketWriter`'s offset-tracking `write` loop — all partial-write-safe. gRPC's `GunStream` has its own separate guard and is untouched.
   - The cap (65536) deliberately exceeds h2's default 65535-byte initial window, so writes that fit the default window keep single-poll behavior and the existing "must park" test setups (128 KiB payloads vs 65535 window) still park — verified, not assumed: D6/D7, the h2mux changed-buffer test, and all #441 unit tests pass unchanged.
   - The changed-buffer Pending guard now compares the stash against the new buffer's **prefix of the stash's length** (the stash may be a capped prefix of the caller's buffer); a retry buffer shorter than the stash is rejected as changed.
2. **`reserve_capacity(0)` in the changed-buffer guard path** before the `InvalidInput` return, so the stale stash's h2 window reservation is handed back instead of staying requested on the error-tainted stream. (No direct assertion — h2 exposes granted, not requested, capacity; the path is exercised by D7 and the h2mux guard test.)
3. **Deadline on `partial_write_then_different_buffer_is_accepted`'s first poll/yield loop** — wrapped in `tokio::time::timeout(5s)` like the drop test, so a regression fails with a diagnostic instead of hanging CI.

## Follow-up to #428 review — h2 tests

4. **D7's final `poll_fn` no longer awaits the raw `poll_write`** — it uses the one-shot `Poll::Ready(match ...)` pattern D6 and `write_until_pending` already use, so a guard regression to accept-and-park fails the test instead of hanging it.
5. **Stalled-h2-server harness consolidated** into one shared source, `tests/support/h2_stalled.rs`: the `h2_common` unit tests include it via `#[cfg(test)] #[path]`, the integration suite via `support::h2_stalled` (gated `#[cfg(any(feature = "grpc", feature = "h2"))]` in `support/mod.rs`). The helper returns the raw h2 halves so both contexts wrap `H2Stream` under their own crate path; no assertion was weakened in either suite.

## New tests (pinning the cap)

- `capped_stash_accepts_same_full_buffer_retry` — a parked > 64 KiB remainder retried with the same full buffer must keep parking; an exact stash comparison would falsely reject every `write_all` resubmission of a large buffer.
- `large_write_accepts_at_most_stash_cap_per_poll` — a 1 MiB write against a draining server with 2 MiB windows is accepted in ≤ 64 KiB chunks per poll and completes end-to-end.

Existing tests updated only where the finding explicitly targeted them (finding 3: timeout wrapper; finding 4: one-shot poll; finding 5: harness relocation) — no pinned behavior was changed.

## Verification

Full regression bar green from a clean worktree (`CARGO_TARGET_DIR` unset):
`cargo fmt --all -- --check` ✓ · `cargo clippy --all-targets` (default / `--no-default-features` / `--all-features`) `-D warnings` ✓ · `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✓ · `cargo test --lib` (13 suites, 0 failures) ✓

Additionally: `cargo test -p meow-transport --features h2,grpc --test h2_test --test grpc_test --test grpc_unbounded_test` ✓ and `cargo test -p meow-proxy --features mux --lib mux::` (94 passed) ✓.

No ADR-0008 hot paths, key-type structs, or relay code touched.