### PR TITLE
docs(tunnel): correct UdpSession.proxy_name Arc sharing claim

### DIFF
--- a/crates/meow-tunnel/src/udp.rs
+++ b/crates/meow-tunnel/src/udp.rs
@@ -18,9 +18,10 @@ pub const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
 
 /// NAT table entry for UDP sessions.
 // M2 layout change (ADR-0011 T3):
-//   proxy_name: String (24 B heap) → Arc<str> (16 B fat-ptr, −8 B)
-//   One allocation per distinct proxy name across all NAT entries; identical
-//   names share the same Arc instead of each holding an independent heap copy.
+//   proxy_name: String (24 B) → Arc<str> (16 B fat-ptr, −8 B per struct
+//   instance). Note this is *not* interning: the slow path in `handle_udp`
+//   builds a fresh `Arc::from(proxy.name())` per dial, so two sessions using
+//   the same proxy each hold their own heap allocation, not a shared one.
 pub struct UdpSession {
     pub conn: Box<dyn ProxyPacketConn>,
     pub proxy_name: Arc<str>,


### PR DESCRIPTION
## Summary

Follow-up to #438 review.

- `crates/meow-tunnel/src/udp.rs`: the M2 layout-change comment above `UdpSession` claimed that identical proxy names share one `Arc<str>` allocation across NAT table entries ("One allocation per distinct proxy name across all NAT entries; identical names share the same Arc instead of each holding an independent heap copy"). That's not what the code does — the slow path in `handle_udp` builds a fresh `Arc::from(proxy.name())` per dial (`udp.rs:224`), so two sessions using the same proxy each hold their own independent heap allocation, not a shared one. No interning table exists anywhere in this file.

This is a doc-only fix: the comment is corrected to describe the actual behavior. Per the review finding's own guidance, no interning was implemented — only the false claim was removed. The `String` → `Arc<str>` field-type change itself is still real and still shrinks the struct (24 B → 16 B fat pointer), consistent with the UdpSession M2 exit target of 40 B recorded in `CLAUDE.md`; this PR does not change that layout, size, or behavior in any way, so no byte-count delta applies.

## Findings addressed

1. `UdpSession` doc comment falsely claims Arc-sharing across NAT entries with identical proxy names — **fixed** (comment corrected; no nearby comment/type doc repeated the claim elsewhere in the file or workspace, verified by grep).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` (all crates, all green; no test changes — comment-only diff, no behavioral change to test)