### PR TITLE
fix(dns): harden fakeip store compare-and-delete symmetry

### DIFF
--- a/crates/meow-dns/src/fakeip.rs
+++ b/crates/meow-dns/src/fakeip.rs
@@ -123,13 +123,23 @@ impl Store for MemoryStore {
         // Evict the LRU pair from both directions so the two maps stay
         // consistent — bounded LRUs would evict each side independently.
         if inner.by_ip.len() > inner.cap {
-            if let Some((_, evicted_host)) = inner.by_ip.pop_lru() {
-                inner.by_host.pop(&evicted_host);
+            if let Some((evicted_ip, evicted_host)) = inner.by_ip.pop_lru() {
+                // Compare-and-delete: only drop the forward entry while it
+                // still points at the just-evicted ip. Same hazard as
+                // `del_by_ip` — if `evicted_host` was since remapped to a
+                // different address, the stale `by_ip` entry we're evicting
+                // here must not destroy that live forward mapping.
+                if inner.by_host.peek(&evicted_host) == Some(&evicted_ip) {
+                    inner.by_host.pop(&evicted_host);
+                }
             }
         }
         if inner.by_host.len() > inner.cap {
-            if let Some((_, evicted_ip)) = inner.by_host.pop_lru() {
-                inner.by_ip.pop(&evicted_ip);
+            if let Some((evicted_host, evicted_ip)) = inner.by_host.pop_lru() {
+                // Mirror image of the guard above, for the reverse direction.
+                if inner.by_ip.peek(&evicted_ip) == Some(&evicted_host) {
+                    inner.by_ip.pop(&evicted_ip);
+                }
             }
         }
     }
@@ -369,12 +379,21 @@ impl Store for FileStore {
         let host = self.reverse.lock().remove(&ip);
         if let Some(host) = host {
             let mut s = self.state.lock();
-            // Compare-and-delete — see `MemoryStore::del_by_ip`.
-            if s.entries.get(host.as_str()) == Some(&ip) {
+            // Compare-and-delete — see `MemoryStore::del_by_ip`. Only mark
+            // dirty when `entries` (the persisted map) actually changes —
+            // `reverse` is a non-persisted in-memory rebuild aid, so a stale
+            // hit there must not trigger a debounced rewrite of an
+            // unchanged snapshot.
+            let removed = if s.entries.get(host.as_str()) == Some(&ip) {
                 s.entries.remove(host.as_str());
-            }
+                true
+            } else {
+                false
+            };
             drop(s);
-            self.mark_dirty();
+            if removed {
+                self.mark_dirty();
+            }
         }
     }
     fn exists(&self, ip: IpAddr) -> bool {
@@ -861,6 +880,58 @@ mod tests {
         s.del_by_ip(ip2);
         assert!(s.get_by_host("h.example").is_none());
         assert!(s.get_by_ip(ip2).is_none());
+    }
+
+    #[test]
+    fn memory_store_cap_eviction_spares_remapped_host() {
+        // Same hazard as `memory_store_del_by_ip_spares_remapped_host`, but
+        // triggered via the cap-eviction path in `put` rather than an
+        // explicit `del_by_ip` call. cap=2: put "a"->ip1, "b"->ip2, then
+        // re-put "a"->ip3. by_ip now holds 3 entries (ip1, ip2, ip3) with
+        // ip1 the LRU (untouched since step 1), so the cap check evicts
+        // ip1 from by_ip. Without the compare-and-delete guard this would
+        // unconditionally pop by_host["a"] too — destroying the live
+        // "a" -> ip3 mapping just written.
+        let s = MemoryStore::new(2);
+        let ip1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let ip3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+        s.put("a", ip1);
+        s.put("b", ip2);
+        s.put("a", ip3); // ip1's reverse entry is now stale, cap exceeded on by_ip
+        assert!(s.get_by_ip(ip1).is_none(), "stale by_ip entry evicted");
+        assert_eq!(
+            s.get_by_host("a"),
+            Some(ip3),
+            "cap eviction of a stale by_ip entry must not delete the live forward mapping"
+        );
+        assert_eq!(s.get_by_ip(ip3).as_deref(), Some("a"));
+        assert_eq!(s.get_by_host("b"), Some(ip2));
+        assert_eq!(s.get_by_ip(ip2).as_deref(), Some("b"));
+    }
+
+    #[tokio::test]
+    async fn file_store_del_by_ip_stale_does_not_mark_dirty() {
+        // Companion to `file_store_del_by_ip_spares_remapped_host`: a
+        // compare-and-delete that finds the reverse entry stale (host since
+        // remapped) must leave the persisted `entries` map untouched, so it
+        // must not schedule a debounced rewrite of an identical snapshot.
+        let tmp = tempdir();
+        let path = tmp.join("fakeip-del-dirty.json");
+        let s = FileStore::open(&path).unwrap();
+        let ip1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        s.put("h.example", ip1);
+        s.put("h.example", ip2); // ip1's reverse entry is now stale
+                                 // Isolate the del_by_ip call from the dirty flag set by the puts above.
+        s.dirty.store(false, Ordering::Relaxed);
+        s.del_by_ip(ip1); // stale — compare-and-delete must no-op
+        assert!(
+            !s.dirty.load(Ordering::Relaxed),
+            "a no-op compare-and-delete must not mark the store dirty"
+        );
+        assert_eq!(s.get_by_host("h.example"), Some(ip2));
+        let _ = fs::remove_file(&path);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #436 review. Two minor/non-blocking findings from the adversarial review of that PR, fixed properly now:

1. **`MemoryStore::put`'s cap-eviction path lacked the compare-and-delete guard that `del_by_ip` has.** When the by_ip or by_host LRU exceeds `cap`, the evicted pair was popped from the *other* side unconditionally. If a host had been remapped to a new IP shortly before its old IP aged out of the LRU as the cap-eviction victim, that unconditional pop could destroy the host's live forward mapping. Applied the same "only pop the other side if it still points at the just-evicted value" guard in both eviction directions, symmetric with `del_by_ip`.

2. **`FileStore::del_by_ip` called `mark_dirty()` even when the compare-and-delete guard found the reverse entry stale** (persisted `entries` map left unchanged), scheduling a debounced rewrite of an identical snapshot. Moved `mark_dirty()` inside the branch that actually mutates `entries`.

Both findings were re-verified against current `main` before fixing — they still applied exactly as described in review.

## Changes

- `crates/meow-dns/src/fakeip.rs`:
  - `MemoryStore::put`: cap-eviction now compare-and-deletes on both sides (mirrors `del_by_ip`).
  - `FileStore::del_by_ip`: `mark_dirty()` only fires when `entries` is actually mutated.
  - New test `memory_store_cap_eviction_spares_remapped_host` — reproduces the cap-eviction hazard directly (cap=2, remap a host, force by_ip cap eviction of the stale IP, assert the live forward mapping survives).
  - New test `file_store_del_by_ip_stale_does_not_mark_dirty` — isolates a stale `del_by_ip` call and asserts the dirty flag stays clear.

No pinned behavior changed; all existing fakeip tests remain green as-is.

## Test plan
- [x] `cargo test -p meow-dns --lib` (22/22 fakeip tests pass, including the 2 new ones)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` (full workspace, all green)