### PR TITLE
config: follow-up nits from PR #445/#446 review (docs wording, short-id warn)

### DIFF
--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1095,14 +1095,19 @@ fn parse_lb_strategy(strategy: Option<&str>) -> std::result::Result<LbStrategy, 
 /// - `uuid` invalid
 /// - `server` domain > 255 bytes
 /// - `vless-vision` feature absent + `flow: xtls-rprx-vision`
-/// - `flow: xtls-rprx-vision` + `smux`/`mux` protocol `smux`/`yamux`/`h2mux`
-///   — sing-box and Xray reject XTLS + sing-mux (`protocol: muxcool` is fine)
+/// - `flow: xtls-rprx-vision` + a `smux`/`mux` block using sing-mux
+///   (`protocol: smux`/`yamux`/`h2mux`) — sing-box and Xray reject XTLS +
+///   sing-mux (`protocol: muxcool` is fine)
 ///
 /// # Warn-once (Class B per ADR-0002)
 ///
 /// - `tls: false` with plain VLESS — plaintext, but correct destination
 /// - `mux: { enabled: true }` — sing-mux multiplexing (server must be sing-box/mihomo)
 /// - `flow: xtls-rprx-vision` + `udp: true` — Vision is TCP-only; UDP uses plain VLESS
+/// - `reality-opts.short-id` given as a bare YAML number (e.g. `0x1f`) —
+///   coerced to its decimal digits before hex-decoding (matching mihomo),
+///   which can silently reinterpret the value; quote it to preserve the
+///   literal digits
 #[cfg(feature = "vless")]
 fn parse_vless(
     name: &str,
@@ -1160,7 +1165,7 @@ fn parse_vless(
     let client_fingerprint = config.get("client-fingerprint").and_then(|v| v.as_str());
 
     // ── Reality opts ──────────────────────────────────────────────────────
-    let reality = parse_vless_reality_opts(config)?;
+    let reality = parse_vless_reality_opts(name, config)?;
     if reality.is_some() {
         if !tls {
             return Err("vless: reality-opts requires `tls: true`".into());
@@ -1761,6 +1766,7 @@ fn default_transport_alpn(network: &str, alpn: Vec<String>) -> Vec<String> {
 /// for future fingerprint-specific ClientHello work.
 #[cfg(feature = "vless")]
 fn parse_vless_reality_opts(
+    name: &str,
     config: &HashMap<String, serde_yaml::Value>,
 ) -> std::result::Result<Option<meow_transport::tls::RealityConfig>, String> {
     let Some(opts) = config.get("reality-opts") else {
@@ -1792,14 +1798,41 @@ fn parse_vless_reality_opts(
     // a subscription that yields a valid node on mihomo yields one here too
     // (#408). Note this only round-trips cleanly when the short-id happens to
     // be all decimal digits, e.g. `0x1f` parses as the number 31 and becomes
-    // `"31"`, not `"1f"` — the same lossy coercion mihomo performs.
+    // `"31"`, not `"1f"` — the same lossy coercion mihomo performs. (An
+    // all-decimal literal with a leading zero like `0012` is *not* affected:
+    // YAML's core-schema int resolver only matches decimal scalars without a
+    // leading zero, so `0012` parses as the plain string `"0012"` and never
+    // reaches this branch at all — verified by
+    // `parse_vless_reality_opts_leading_zero_short_id_preserved_no_warn`.)
+    // We warn on the Number coercion (see below) so operators who wrote a
+    // notation like `0x1f` expecting it to be read as literal hex digits
+    // know to quote the value instead.
     let short_id_str = match opts.get("short-id") {
         None | Some(serde_yaml::Value::Null) => String::new(),
-        Some(serde_yaml::Value::Number(n)) => n
-            .as_u64()
-            .map(|u| u.to_string())
-            .or_else(|| n.as_i64().map(|i| i.to_string()))
-            .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?,
+        Some(serde_yaml::Value::Number(n)) => {
+            let coerced = n
+                .as_u64()
+                .map(|u| u.to_string())
+                .or_else(|| n.as_i64().map(|i| i.to_string()))
+                .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?;
+            // A bare numeric short-id (e.g. `short-id: 0x1f`) is reinterpreted
+            // through YAML's own notation before we ever see it — `0x1f`
+            // arrives here as the decimal integer 31, which then hex-decodes
+            // to a different byte than the literal hex digits "1f" would.
+            // mihomo's decoder has the same lossy behavior, so we match it
+            // for the decoded value, but warn so operators who meant the
+            // literal digits know to quote the value instead of leaving it
+            // as a bare YAML number.
+            tracing::warn!(
+                proxy = %name,
+                "reality-opts.short-id was given as an unquoted YAML number \
+                 and coerced to its decimal digits \"{coerced}\" before hex-decoding; \
+                 if you wrote a different notation (e.g. `0x1f`) expecting it to be \
+                 read as literal hex digits, quote the value instead \
+                 (e.g. short-id: \"1f\")"
+            );
+            coerced
+        }
         Some(value) => value
             .as_str()
             .ok_or_else(|| "vless: reality-opts.short-id must be a hex string".to_string())?

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -461,6 +461,8 @@ proxies:
 /// YAML integer, not a string. mihomo's weakly-typed decoder coerces it back
 /// to its decimal digits before hex-decoding, so the identical subscription
 /// works there; without matching coercion the node is silently dropped (#408).
+/// The coercion also emits a warn telling the operator to quote the value
+/// if they meant the literal digits (leading zeros are otherwise lost).
 #[tokio::test]
 async fn parse_vless_reality_opts_numeric_short_id_coerced_to_string() {
     let yaml = r#"
@@ -476,19 +478,30 @@ proxies:
       public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
       short-id: 1234
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("REALITY VLESS config with unquoted numeric short-id must load");
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("REALITY VLESS config with unquoted numeric short-id must load");
     assert!(
         config.proxies.contains_key("v"),
         "REALITY VLESS proxy with unquoted numeric short-id must be registered, not dropped"
+    );
+    let warn_count = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.contains("short-id") && l.contains("quote"))
+        .count();
+    assert!(
+        warn_count >= 1,
+        "a WARN about the coerced numeric short-id (with a quoting hint) must be emitted; \
+         captured lines: {lines:?}"
     );
 }
 
 /// `short-id: 0x1f` parses as the YAML integer 31 (not the hex string "1f").
 /// Pin the exact (lossy) coercion mihomo's decoder performs: the integer is
 /// reformatted to its decimal string ("31") and hex-decoded from there, same
-/// as a literal `short-id: "31"` would be.
+/// as a literal `short-id: "31"` would be — a real footgun for anyone who
+/// wrote `0x1f` expecting it to be read as hex digits "1f". The coercion
+/// must warn so operators who meant the literal digits know to quote the
+/// value instead of leaving it as a bare YAML number.
 #[tokio::test]
 async fn parse_vless_reality_opts_hex_literal_short_id_decimal_coerced() {
     let yaml = r#"
@@ -504,12 +517,62 @@ proxies:
       public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
       short-id: 0x1f
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("REALITY VLESS config with `0x1f` short-id must load");
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("REALITY VLESS config with `0x1f` short-id must load");
     assert!(
         config.proxies.contains_key("v"),
         "REALITY VLESS proxy with `short-id: 0x1f` must be registered, not dropped"
+    );
+    let warn_count = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.contains("short-id") && l.contains("quote"))
+        .count();
+    assert!(
+        warn_count >= 1,
+        "a WARN about the coerced `0x1f` short-id (with a quoting hint) must be emitted; \
+         captured lines: {lines:?}"
+    );
+}
+
+/// A leading-zero all-decimal `short-id` (e.g. `short-id: 0012`, unquoted)
+/// is NOT reinterpreted as a YAML number by this parser: the core-schema
+/// int resolver only matches decimal scalars without a leading zero (plain
+/// `0` aside), so `0012` parses as the plain string `"0012"` and takes the
+/// pre-existing `as_str()` branch untouched — the leading zero, and thus the
+/// exact hex-decoded bytes (`0x00 0x12`), are preserved with no coercion and
+/// no warning. This pins that (verified) behavior so a future serde_yaml/
+/// resolver change that started collapsing such literals to numbers would
+/// be caught here rather than silently reintroducing the byte-loss bug the
+/// review finding described.
+#[tokio::test]
+async fn parse_vless_reality_opts_leading_zero_short_id_preserved_no_warn() {
+    let yaml = r#"
+proxies:
+  - name: v
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
+      short-id: 0012
+"#;
+    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
+    let config = result.expect("REALITY VLESS config with leading-zero string short-id must load");
+    assert!(
+        config.proxies.contains_key("v"),
+        "REALITY VLESS proxy with leading-zero short-id must be registered, not dropped"
+    );
+    let warn_count = lines
+        .iter()
+        .filter(|l| l.contains("WARN") && l.contains("short-id"))
+        .count();
+    assert_eq!(
+        warn_count, 0,
+        "`short-id: 0012` parses as a string already (leading zero preserved), so no \
+         numeric-coercion warning should fire; captured lines: {lines:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-ups from adversarial code review of #445 and #446, classified minor/non-blocking at merge time.

- **Follow-up to #445 review** — `crates/meow-config/src/proxy_parser.rs`: the `parse_vless` Errors-list doc bullet on Vision + sing-mux was grammatically garbled (`` `smux`/`mux` protocol `smux`/`yamux`/`h2mux` ``). Reworded to: Vision + a `smux`/`mux` block using sing-mux (`protocol: smux`/`yamux`/`h2mux`).
- **Follow-up to #446 review** — `crates/meow-config/src/proxy_parser.rs`: a bare numeric `reality-opts.short-id` (e.g. `short-id: 0x1f`, unquoted) is silently coerced through `Number::to_string()` before hex-decoding (matching mihomo's own lossy int-to-decimal-string coercion), with no indication to the operator that this happened. Now emits a `tracing::warn!` naming the coerced value and telling the operator to quote the field if a different literal was intended.

## Status: partial (one finding's premise didn't reproduce; fixed the underlying case)

The #446 finding as reported described the bug as "leading-zero all-decimal short-ids (e.g. `short-id: 0012`) silently lose the leading zero through the `Number::to_string()` coercion." I verified this specific scenario does **not** reproduce with this codebase's `serde_yaml`: its core-schema int resolver only matches decimal scalars *without* a leading zero (bare `0` itself aside), so `short-id: 0012` parses as the plain string `"0012"` and never reaches the `Number` branch at all — it takes the pre-existing `as_str()` arm untouched, preserving the leading zero and the exact hex-decoded bytes with zero coercion involved. I confirmed this with a standalone probe test before writing anything (`"0012" -> String("0012")`, `"1234" -> Number(1234)`, `"0x1f" -> Number(31)`, `"007" -> String("007")`).

The underlying general risk the finding was gesturing at is real, just for a different trigger: `short-id: 0x1f` (unquoted) *does* hit the `Number` branch — it parses as decimal `31`, gets coerced to `"31"`, and hex-decodes to a different byte than the literal hex digits `"1f"` the operator likely intended. I implemented the requested warning against that real, verified case (any bare-number short-id, which covers `0x1f`-style notation), rather than forcing a warning onto a code path (`0012`) that plain strings already handle correctly and that a Number-coercion warning would never actually fire for.

Documented the discrepancy in the code comments and added:
- `parse_vless_reality_opts_leading_zero_short_id_preserved_no_warn` — pins that `short-id: 0012` is unaffected (string path, no warn, bytes preserved).
- A warn-assertion added to the existing `parse_vless_reality_opts_hex_literal_short_id_decimal_coerced` (`0x1f`) test, and to `parse_vless_reality_opts_numeric_short_id_coerced_to_string` (`1234`).

No behavioral change to previously-pinned test expectations beyond adding warn assertions to tests that already exercised the `Number` coercion path; no existing test was weakened or removed.

## Regression bar (all green, from worktree root, `CARGO_TARGET_DIR` unset)

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` (workspace-wide)
- `cargo test -p meow-config` (all suites, including 45/45 `vless_config_test` cases)

No hot-path invariant type (`Metadata`/`ConnectionInfo`/`UdpSession`/DNS `CacheEntry`) was touched — no byte-count delta applicable.

## Test plan

- [x] `cargo test -p meow-config --test vless_config_test` — 45/45 passing, including new/updated short-id tests
- [x] Full regression bar above