### PR TITLE
fix(listener): align tproxy accept-error log level, add unbounded-cap test

### DIFF
--- a/crates/meow-listener/src/tproxy/mod.rs
+++ b/crates/meow-listener/src/tproxy/mod.rs
@@ -12,7 +12,7 @@ use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Semaphore;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Default cap on in-flight inbound connections per listener when the
 /// listener config doesn't set `max-connections` (mirrors
@@ -204,10 +204,12 @@ where
         // Log-and-continue on accept errors (matching mixed.rs) rather than
         // propagating: a transient EMFILE/ECONNABORTED must not tear down
         // `run_on`'s `_firewall` guard and take the redirect rules with it.
+        // Logged at error! (not debug!) so fd-exhaustion events are visible
+        // at default log levels, mirroring mixed.rs's accept-error handling.
         let (stream, src_addr) = match listener.accept().await {
             Ok(v) => v,
             Err(e) => {
-                debug!("TProxy listener '{}' accept error: {e}", name);
+                error!("TProxy listener '{}' accept error: {e}", name);
                 drop(permit);
                 continue;
             }
@@ -486,6 +488,94 @@ mod tests {
             max_observed.load(Ordering::SeqCst),
             CAP,
             "cap should have been reached but never exceeded"
+        );
+    }
+
+    /// Regression test for the `max_connections == 0` sentinel: it must
+    /// disable the cap entirely (no semaphore), letting far more handler
+    /// futures run concurrently than any small numeric cap would allow.
+    #[tokio::test]
+    async fn accept_loop_unbounded_when_max_connections_is_zero() {
+        // Deliberately larger than any small cap (e.g. the CAP=3 used by
+        // `accept_loop_never_exceeds_max_connections`) so saturating this
+        // many concurrent handlers proves `0` truly means unbounded rather
+        // than merely "a bigger-than-3 limit".
+        const CLIENTS: usize = 20;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_observed = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(Notify::new());
+        // Signalled once all CLIENTS handlers are simultaneously in flight,
+        // proving no cap ever throttled admission below that count.
+        let all_in_flight = Arc::new(Notify::new());
+
+        let in_flight_h = Arc::clone(&in_flight);
+        let max_observed_h = Arc::clone(&max_observed);
+        let release_h = Arc::clone(&release);
+        let all_in_flight_h = Arc::clone(&all_in_flight);
+
+        let loop_task = tokio::spawn(async move {
+            bounded_accept_loop(
+                listener,
+                0, // unlimited sentinel
+                "test-tproxy-unbounded".to_string(),
+                move |stream, _src| {
+                    let in_flight = Arc::clone(&in_flight_h);
+                    let max_observed = Arc::clone(&max_observed_h);
+                    let release = Arc::clone(&release_h);
+                    let all_in_flight = Arc::clone(&all_in_flight_h);
+                    async move {
+                        drop(stream);
+                        let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_observed.fetch_max(now, Ordering::SeqCst);
+                        if now == CLIENTS {
+                            all_in_flight.notify_one();
+                        }
+                        release.notified().await;
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                    }
+                },
+            )
+            .await
+        });
+
+        let (done_tx, mut done_rx) = mpsc::channel::<()>(CLIENTS);
+        for _ in 0..CLIENTS {
+            let done_tx = done_tx.clone();
+            tokio::spawn(async move {
+                let _ = TcpStream::connect(addr).await;
+                let _ = done_tx.send(()).await;
+            });
+        }
+        drop(done_tx);
+
+        // With no cap, all CLIENTS handlers must be able to run at once —
+        // none should be blocked waiting for a permit.
+        tokio::time::timeout(Duration::from_secs(5), all_in_flight.notified())
+            .await
+            .expect("all handlers should have been admitted concurrently with max_connections=0");
+        assert_eq!(
+            in_flight.load(Ordering::SeqCst),
+            CLIENTS,
+            "unbounded accept loop should admit every connection without queuing"
+        );
+
+        release.notify_waiters();
+        let _ = tokio::time::timeout(Duration::from_secs(5), async {
+            for _ in 0..CLIENTS {
+                done_rx.recv().await;
+            }
+        })
+        .await;
+
+        loop_task.abort();
+        assert_eq!(
+            max_observed.load(Ordering::SeqCst),
+            CLIENTS,
+            "max_connections=0 must allow more concurrent handlers than any small cap"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #443 review. Both findings verified against current `main` and still applicable:

- **Log level mismatch**: `bounded_accept_loop`'s accept-error branch in `crates/meow-listener/src/tproxy/mod.rs` logged at `debug!`, while `mixed.rs`'s equivalent accept-error branch (which it explicitly mirrors, per its own doc comment) logs at `error!`. At default log levels this made fd-exhaustion events (EMFILE) on the tproxy listener invisible. Changed to `error!` to match `mixed.rs`.
- **Missing test coverage for the unbounded sentinel**: no unit test exercised `max_connections == 0` (the "disable the cap" sentinel) through `bounded_accept_loop`. Added `accept_loop_unbounded_when_max_connections_is_zero`, which admits 20 concurrent handlers at once with `max_connections = 0` — more than any small numeric cap (e.g. the existing `CAP = 3` bounded test) would ever allow — proving `0` truly means unbounded rather than "some larger limit."

## Behavioral change

Log level only (`debug!` → `error!` on tproxy accept errors); no change to control flow, the accept-error branch still logs-and-continues rather than propagating.

## Checks

Full regression bar run from a clean worktree with `CARGO_TARGET_DIR` unset:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --lib` (all crates, including the new and existing `tproxy::tests` — 18/18 in `meow-listener`)

All green. No `Metadata`/`ConnectionInfo`/`UdpSession`/DNS `CacheEntry` byte-size changes; relay-buffer stack-allocation invariant untouched (not in the diff).

## Test plan

- [x] `cargo test -p meow-listener --lib tproxy:: --features listener-tproxy` — 18 passed
- [x] `cargo test --lib` (workspace) — all green
- [x] Three-way clippy (default / no-default-features / all-features) — clean
- [x] `cargo doc --workspace --no-deps` with `-D warnings` — clean