### PR TITLE
docs(benchmarks): re-check mipsel binary-size blocker after #421 fix

### DIFF
--- a/docs/benchmarks/binary-size.md
+++ b/docs/benchmarks/binary-size.md
@@ -101,11 +101,50 @@ in the `full` bundle (`meow-app/Cargo.toml`), so it is part of every
 `default` build; it is excluded from `minimal` by design (ADR-0007 §1) and
 that profile is unaffected.
 
-**mipsel-unknown-linux-musl not measured**: blocked by #421 (`mux` uses
-`std::sync::atomic::AtomicU64` directly instead of
-`meow_common::atomic::AtomicU`, and mipsel has no 64-bit atomics — the
-`default` build does not compile for this target until #421 lands). Follow
-up once #421 merges.
+**mipsel-unknown-linux-musl still not measured, different reason now**:
+#421 (`mux` used `std::sync::atomic::AtomicU64` directly instead of
+`meow_common::atomic::AtomicU`) was fixed by #447, so the compile-time
+blocker is gone — `crates/meow-proxy/src/mux/` now uses
+`meow_common::atomic::AtomicU` exclusively (verified: no raw `AtomicU64`
+remains under `mux/`). But the target still cannot be measured with this
+repo's established method (`cargo zigbuild --release --target
+mipsel-unknown-linux-musl`, same as the other targets in this doc):
+`mipsel-unknown-linux-musl` is a **Tier 3** target
+([rustc platform support](https://doc.rust-lang.org/rustc/platform-support.html)) —
+rustup ships no prebuilt `std` for it on any host:
+
+```
+$ rustup target add mipsel-unknown-linux-musl
+error: toolchain 'stable-aarch64-apple-darwin' has no prebuilt artifacts
+available for target 'mipsel-unknown-linux-musl'
+note: this may happen to a low-tier target as per
+https://doc.rust-lang.org/nightly/rustc/platform-support.html
+note: you can find instructions on that page to build the target support
+from source
+```
+
+The only way to produce a `std`-linked binary for this target at all is
+`-Zbuild-std` on nightly (confirmed locally: `cargo +nightly zigbuild
+-Zbuild-std=std,panic_abort --release --target mipsel-unknown-linux-musl`
+does start compiling `core`/`alloc`/`std` from source). That is a
+materially different build — different toolchain (nightly vs. the
+workspace's pinned stable), different compiler flags, and a locally-built
+`std` rather than the distributed one — so a size measured that way
+would not be comparable to the zigbuild+stable numbers for the other
+targets in this table, and it is not this repo's established
+cross-compile method (see `docs/adr/0007-m2-footprint-budget.md` §"Single-
+target CI runners"). Per that ADR, mipsel is explicitly **soft-gated**
+for exactly this reason ("no mipsel cross-compile infra ... and no way to
+functionally validate a mipsel binary"), and CI's own `release.yml`
+release matrix does not build MIPS at all (excluded together with 32-bit
+musl and windows-gnu because they can't link `boring-sys`, which is part
+of the shipped `default` feature set). So this is not a regression from
+#412/mux or from this follow-up — mipsel `default`-profile size has never
+been measured end-to-end via the documented method, #421 only removed one
+blocker among several. Leaving this row `not measured` (status: toolchain
+gap, not a compile failure) rather than reporting a nightly-`build-std`
+number that would use a different build recipe than every other row in
+this document.
 
 ### `default` profile — absolute size vs. cap
 
@@ -113,11 +152,17 @@ up once #421 merges.
 |--------|------------------------|--------------------|----------|--------|
 | `aarch64-unknown-linux-musl` | 11,196,256 B (~10.68 MiB) | 18 MiB (18,874,368 B) | 7,678,112 B (~7.32 MiB), 59.3% used | ✓ under cap |
 | `x86_64-unknown-linux-musl` | 14,238,600 B (~13.58 MiB) | 20 MiB (20,971,520 B) | 6,732,920 B (~6.42 MiB), 67.9% used | ✓ under cap |
-| `mipsel-unknown-linux-musl` | not measured (blocked by #421) | 16 MiB (16,777,216 B) | — | — |
+| `mipsel-unknown-linux-musl` | not measured (Tier 3 toolchain gap, not #421 — see above) | 16 MiB (16,777,216 B) | — | — |
 
-No cap is breached or threatened; **no ADR-0007 amendment is required** for
-this change (ADR-0007 §6 only requires an amendment when a feature pushes a
-cap past its current value).
+No cap is breached or threatened on the two measured targets; **no
+ADR-0007 amendment is required** for this change (ADR-0007 §6 only
+requires an amendment when a feature pushes a cap past its current
+value). The mipsel cap remains unverified either way — it was unverified
+before this follow-up (blocked by #421) and remains unverified now
+(blocked by the Tier 3 toolchain gap above), so this follow-up cannot
+say whether the soft-gated mipsel cap holds; ADR-0007 already accounts
+for this ("no way to functionally validate a mipsel binary" at M2) and
+defers a hard gate to M3.
 
 ### Mux-attributable delta (mux on vs. mux off, same commit)
 


### PR DESCRIPTION
## Summary

Follow-up to #448 review (group: mipsel-size-measurement, from adversarial code review of PRs #414–#418 / #448).

- Finding: the post-mux ADR-0007 measurement (PR #448, issue #426) skipped `mipsel-unknown-linux-musl` because #421 (mux used raw `std::sync::atomic::AtomicU64` instead of `meow_common::atomic::AtomicU`, breaking the mipsel32 build) was unmerged at the time. #421 has since been fixed and merged (#447), so that specific blocker is gone — verified `crates/meow-proxy/src/mux/` now uses `meow_common::atomic::AtomicU` exclusively, no raw `AtomicU64` remains.
- However, re-attempting the measurement with the repo's established method (`cargo zigbuild --release --target mipsel-unknown-linux-musl` on stable, same profile/flags as the other targets in `docs/benchmarks/binary-size.md`) still fails — for a *different* reason than #421: `mipsel-unknown-linux-musl` is a Tier 3 target and rustup ships no prebuilt `std` for it on any host (`rustup target add mipsel-unknown-linux-musl` → "no prebuilt artifacts available ... low-tier target").
  - Confirmed the only way to produce a `std`-linked binary at all is `-Zbuild-std` on nightly (locally verified `cargo +nightly zigbuild -Zbuild-std=std,panic_abort --release --target mipsel-unknown-linux-musl` at least starts compiling `core`/`alloc`/`std` from source). That's a materially different toolchain/build recipe than every other row in the doc (nightly vs. the workspace's pinned stable, locally-built std vs. distributed), so a size measured that way wouldn't be comparable — and it's not this repo's established cross-compile method. Per group guidance, documenting this rather than forcing it.
  - This also isn't a regression from #412/mux: CI's own `release.yml` doesn't build MIPS at all (excluded together with 32-bit musl/windows-gnu because they can't link `boring-sys`, part of the shipped `default` feature set), and ADR-0007 already documents mipsel as soft-gated for exactly this class of reason ("no mipsel cross-compile infra... no way to functionally validate a mipsel binary").

**Status: partial.** #421's blocker is confirmed resolved and documented; the mipsel `default`-profile size remains genuinely unmeasurable with the toolchain available here (and in CI), so the row stays `not measured` with the concrete blocker spelled out instead of reporting a non-comparable nightly-build-std number. The soft-gated mipsel cap (ADR-0007 §2, 16 MiB) is therefore still unverified — this was true before this follow-up too (blocked by #421) and remains true now (blocked by the Tier 3 toolchain gap); ADR-0007 already defers a hard gate to M3 for this reason.

Doc-only change, no code touched, no behavior change, no ADR amendment needed (no cap breached on the two targets that *are* measured).

## Test plan

- [x] Read current code: confirmed no raw `AtomicU64` remains under `crates/meow-proxy/src/mux/` (only `meow_common::atomic::AtomicU`)
- [x] Confirmed #421 closed / #447 merged via `gh issue view` / `gh pr view`
- [x] Reproduced the Tier 3 toolchain gap locally (`rustup target add mipsel-unknown-linux-musl` fails; `-Zbuild-std` on nightly at least starts building std, confirming it's the only path and it's out of scope for this doc's methodology)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --lib` (all crates green)