### PR TITLE
fix(config): provider-path polish follow-ups from PR #444/#437 review

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -688,12 +688,17 @@ fn rebuild_from_raw_impl(
     // groups and provider-sourced proxies included (issue #377).
     let registry_lookup = |name: &str| proxies.get(name).cloned();
 
-    // Fail hard on any rule-provider path that would escape the provider
-    // cache directory — before any fetch or on-disk write happens, so a
-    // hostile `PUT /configs` is rejected without touching the filesystem
-    // (issue #429).
+    // Fail hard on any rule- or proxy-provider path that would escape the
+    // provider cache directory — before any fetch or on-disk write happens,
+    // so a hostile `PUT /configs` is rejected without touching the
+    // filesystem (issue #429). Proxy-providers get the same loud failure as
+    // rule-providers (PR #444 review follow-up) instead of being warn-skipped
+    // with every group referencing them silently degrading.
     if let Some(map) = raw.rule_providers.as_ref() {
         rule_provider::validate_paths(map, cache_dir)?;
+    }
+    if let Some(map) = raw.proxy_providers.as_ref() {
+        proxy_provider::validate_paths(map, cache_dir).map_err(|e| anyhow::anyhow!("{e}"))?;
     }
 
     // Fetch/read rule-provider payload bytes once — the parser-context build
@@ -2559,6 +2564,36 @@ rules:
             panic!("escaping rule-provider path must fail the rebuild");
         };
         assert!(err.to_string().contains("escapes"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn rebuild_rejects_proxy_provider_path_escaping_cache_dir() {
+        // PR #444 review follow-up: proxy-provider containment violations
+        // fail the rebuild loudly (rule-provider parity) instead of the
+        // provider being warn-skipped and its groups silently degrading.
+        let dir = tempfile::tempdir().unwrap();
+        let raw: raw::RawConfig = serde_yaml::from_str(
+            r#"
+proxy-providers:
+  evil:
+    type: http
+    url: "http://127.0.0.1:1/proxies.yaml"
+    path: "/etc/cron.d/pwned"
+proxy-groups:
+  - name: g
+    type: select
+    use: [evil]
+rules:
+  - "MATCH,DIRECT"
+"#,
+        )
+        .unwrap();
+        let Err(err) = rebuild_from_raw_with_cache_dir(&raw, Some(dir.path()), None) else {
+            panic!("escaping proxy-provider path must fail the rebuild");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("evil"), "must name the provider: {msg}");
+        assert!(msg.contains("escapes"), "unexpected: {msg}");
     }
 
     #[test]

--- a/crates/meow-config/src/proxy_provider.rs
+++ b/crates/meow-config/src/proxy_provider.rs
@@ -394,6 +394,41 @@ impl ProxyProvider {
     }
 }
 
+/// Validate every proxy-provider's on-disk path up front, so a path escaping
+/// the provider cache directory fails the whole (re)build loudly — matching
+/// `rule_provider::validate_paths` — instead of the provider being silently
+/// warn-skipped and every group referencing it degrading (PR #444 review
+/// follow-up).
+///
+/// Scope is containment only: paths that resolve outside `cache_dir`
+/// (explicit `path:` or the implicit name-derived cache location). Other
+/// per-provider problems (missing fields, unknown type, fetch failures) keep
+/// their historical warn-and-skip semantics in [`ProxyProvider::new`] /
+/// [`load_proxy_providers`]. Must stay in sync with the path resolution in
+/// [`ProxyProvider::new`].
+pub(crate) fn validate_paths(
+    raw_map: &HashMap<String, RawProxyProvider>,
+    cache_dir: Option<&Path>,
+) -> Result<(), String> {
+    // No containment root: no on-disk path is honoured at all, so there is
+    // nothing to contain (`ProxyProvider::new` errors/warns per provider).
+    let Some(dir) = cache_dir else {
+        return Ok(());
+    };
+    for (name, raw) in raw_map {
+        let requested = match (raw.provider_type.as_str(), raw.path.as_deref()) {
+            ("file" | "http", Some(p)) => PathBuf::from(p),
+            // The implicit http cache location is derived from the provider
+            // *name* (a YAML map key, also attacker-influenced).
+            ("http", None) => PathBuf::from(format!("provider_{name}.yaml")),
+            _ => continue,
+        };
+        crate::safe_path::resolve_contained(dir, &requested)
+            .map_err(|e| format!("proxy-provider '{name}': {e}"))?;
+    }
+    Ok(())
+}
+
 pub async fn load_proxy_providers(
     raw_map: &HashMap<String, RawProxyProvider>,
     cache_dir: Option<&Path>,
@@ -528,6 +563,46 @@ mod tests {
             panic!("escaping http cache path must be rejected");
         };
         assert!(err.contains("escapes"), "unexpected: {err}");
+    }
+
+    // PR #444 review follow-up: a proxy-provider path escaping the cache dir
+    // must fail the whole rebuild loudly (rule-provider parity), not just
+    // warn-skip the provider and silently degrade the groups using it.
+    #[test]
+    fn validate_paths_rejects_escaping_provider_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        for path in ["../../etc/pwned", "/etc/cron.d/pwned"] {
+            let mut map = HashMap::new();
+            map.insert("evil".to_string(), raw_file_provider(path));
+            let err = validate_paths(&map, Some(dir.path()))
+                .expect_err("escaping path must fail validation");
+            assert!(err.contains("evil"), "must name the provider: {err}");
+            assert!(err.contains("escapes"), "path {path}: unexpected: {err}");
+        }
+    }
+
+    #[test]
+    fn validate_paths_accepts_contained_and_pathless_providers() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut map = HashMap::new();
+        map.insert("f".to_string(), raw_file_provider("sub/proxies.yaml"));
+        map.insert(
+            "h".to_string(),
+            RawProxyProvider {
+                provider_type: "http".to_string(),
+                url: Some("http://127.0.0.1:1/proxies.yaml".to_string()),
+                path: None, // implicit cache location from the name
+                interval: None,
+                filter: None,
+                exclude_filter: None,
+                exclude_type: None,
+                health_check: None,
+                header: None,
+            },
+        );
+        validate_paths(&map, Some(dir.path())).expect("contained paths must validate");
+        // Rootless context: nothing on disk is honoured, nothing to contain.
+        validate_paths(&map, None).expect("no cache dir means nothing to validate");
     }
 
     #[test]

--- a/crates/meow-config/src/rule_provider.rs
+++ b/crates/meow-config/src/rule_provider.rs
@@ -206,7 +206,7 @@ fn read_payload_bytes(
 ) -> Result<Option<Vec<u8>>> {
     match cfg.provider_type.as_str() {
         "file" => {
-            let path = resolve_path(cfg, cache_dir, name)?
+            let path = resolve_path(cfg, cache_dir, name, false)?
                 .ok_or_else(|| anyhow!("file provider '{name}' requires a 'path'"))?;
             let bytes = std::fs::read(&path)
                 .with_context(|| format!("reading provider file {}", path.display()))?;
@@ -217,7 +217,7 @@ fn read_payload_bytes(
                 .url
                 .as_deref()
                 .ok_or_else(|| anyhow!("http provider '{name}' requires a 'url'"))?;
-            let cache_path = resolve_path(cfg, cache_dir, name)?;
+            let cache_path = resolve_path(cfg, cache_dir, name, false)?;
             let prefer_cache = cfg.interval.unwrap_or(0) > 0;
             let bytes = fetch_http_blocking_with_cache(
                 url,
@@ -378,7 +378,7 @@ fn load_file(
              (Class B per ADR-0002)"
         );
     }
-    let path = resolve_path(cfg, cache_dir, name)?
+    let path = resolve_path(cfg, cache_dir, name, false)?
         .ok_or_else(|| anyhow!("file provider '{name}' requires a 'path'"))?;
     let bytes = match prefetched {
         Some(b) => b.to_vec(),
@@ -412,7 +412,7 @@ fn load_http(
         .url
         .as_deref()
         .ok_or_else(|| anyhow!("http provider '{name}' requires a 'url'"))?;
-    let cache_path = resolve_path(cfg, cache_dir, name)?;
+    let cache_path = resolve_path(cfg, cache_dir, name, false)?;
     let explicit_format = parse_explicit_format(cfg)?;
     let interval = cfg.interval.unwrap_or(0);
     let bytes = match prefetched {
@@ -533,25 +533,47 @@ fn parse_text_payload(raw: &str) -> Vec<String> {
 /// `path:` is attacker-influenced whenever the config arrives over the REST
 /// API (`PUT /configs`), and for http providers it is a **write** target, so:
 ///
+/// - provider types that never read a path (`inline`) ignore a stray `path:`
+///   entirely — mihomo parity: a harmless leftover field must not fail a
+///   whole rebuild;
 /// - with a `cache_dir`, the resolved path (absolute or relative, `..` and
 ///   symlinks included) must stay inside it — anything else is a hard error;
 /// - without a `cache_dir` (runtime rebuilds such as `PUT /configs` or
 ///   `--config-string`) there is no containment root, so a `path:` is never
 ///   honoured: http providers fall back to fetching into memory, file
 ///   providers hard-error.
+///
+/// `emit_warnings` gates the ignoring-`path` warns. Every (re)build calls
+/// [`validate_paths`] exactly once before any fetch/load pass, so only that
+/// call passes `true` — otherwise the same warn would fire up to three times
+/// per provider per rebuild (validate, prefetch, and load all resolve).
 fn resolve_path(
     cfg: &RawRuleProvider,
     cache_dir: Option<&Path>,
     name: &str,
+    emit_warnings: bool,
 ) -> Result<Option<PathBuf>> {
+    // Only file (payload location) and http (on-disk cache) providers ever
+    // read the resolved path; other types must not fail on a stray `path:`.
+    if !matches!(cfg.provider_type.as_str(), "file" | "http") {
+        if cfg.path.is_some() && emit_warnings {
+            warn!(
+                "rule-provider '{}': ignoring 'path' — {} providers never read it",
+                name, cfg.provider_type
+            );
+        }
+        return Ok(None);
+    }
     if let Some(p) = cfg.path.as_deref() {
         let Some(dir) = cache_dir else {
             if cfg.provider_type == "http" {
-                warn!(
-                    "rule-provider '{}': ignoring 'path' (no provider cache directory in this \
-                     context); fetching to memory without an on-disk cache",
-                    name
-                );
+                if emit_warnings {
+                    warn!(
+                        "rule-provider '{}': ignoring 'path' (no provider cache directory in \
+                         this context); fetching to memory without an on-disk cache",
+                        name
+                    );
+                }
                 return Ok(None);
             }
             return Err(anyhow!(
@@ -577,12 +599,16 @@ fn resolve_path(
 /// fails hard before any fetch or write happens (issue #429). Called by
 /// `rebuild_from_raw_impl` for every path into a (re)build: startup,
 /// `PUT`/`PATCH /configs`, and subscription refresh.
+///
+/// This is the one pass that emits the ignoring-`path` warns, so they fire
+/// once per provider per rebuild (the prefetch and load passes resolve the
+/// same paths again, silently).
 pub(crate) fn validate_paths(
     raw_providers: &HashMap<String, RawRuleProvider>,
     cache_dir: Option<&Path>,
 ) -> Result<()> {
     for (name, cfg) in raw_providers {
-        resolve_path(cfg, cache_dir, name)?;
+        resolve_path(cfg, cache_dir, name, true)?;
     }
     Ok(())
 }
@@ -1077,7 +1103,7 @@ mod tests {
         for p in ["../../etc/pwned", "/etc/cron.d/pwned", "a/../../b"] {
             let mut cfg = http_cfg(None);
             cfg.path = Some(p.to_string());
-            let err = resolve_path(&cfg, Some(dir.path()), "x")
+            let err = resolve_path(&cfg, Some(dir.path()), "x", true)
                 .expect_err("escaping path must be rejected");
             assert!(err.to_string().contains("escapes"), "path {p}: {err}");
         }
@@ -1088,12 +1114,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut cfg = http_cfg(None);
         cfg.path = Some("sub/rules.yaml".to_string());
-        let got = resolve_path(&cfg, Some(dir.path()), "x").unwrap().unwrap();
+        let got = resolve_path(&cfg, Some(dir.path()), "x", true)
+            .unwrap()
+            .unwrap();
         assert!(got.starts_with(dir.path()), "unexpected: {}", got.display());
 
         // Absolute paths are fine as long as they stay inside the cache dir.
         cfg.path = Some(dir.path().join("rules.yaml").to_string_lossy().to_string());
-        assert!(resolve_path(&cfg, Some(dir.path()), "x").unwrap().is_some());
+        assert!(resolve_path(&cfg, Some(dir.path()), "x", true)
+            .unwrap()
+            .is_some());
     }
 
     #[test]
@@ -1102,7 +1132,8 @@ mod tests {
         cfg.provider_type = "file".to_string();
         cfg.url = None;
         cfg.path = Some("/etc/passwd".to_string());
-        let err = resolve_path(&cfg, None, "x").expect_err("file path without root must fail");
+        let err =
+            resolve_path(&cfg, None, "x", true).expect_err("file path without root must fail");
         assert!(
             err.to_string().contains("cache directory"),
             "unexpected: {err}"
@@ -1113,9 +1144,43 @@ mod tests {
     fn implicit_path_from_hostile_provider_name_is_rejected() {
         let dir = tempfile::tempdir().unwrap();
         let cfg = http_cfg(None); // no `path:` — implicit location from the name
-        let err = resolve_path(&cfg, Some(dir.path()), "../../evil")
+        let err = resolve_path(&cfg, Some(dir.path()), "../../evil", true)
             .expect_err("traversal via provider name must be rejected");
         assert!(err.to_string().contains("escapes"), "unexpected: {err}");
+    }
+
+    /// PR #444 review follow-up: a stray `path:` on an inline provider must
+    /// never fail a rebuild — inline providers never read it (mihomo ignores
+    /// it too), so it is warn-and-ignored in every context.
+    #[test]
+    fn stray_path_on_inline_provider_is_ignored() {
+        let inline_cfg = |path: &str| RawRuleProvider {
+            provider_type: "inline".to_string(),
+            behavior: "domain".to_string(),
+            format: None,
+            url: None,
+            path: Some(path.to_string()),
+            interval: None,
+            proxy: None,
+            payload: Some(vec!["example.com".to_string()]),
+        };
+
+        // No cache dir (the `PUT /configs` rebuild context): previously a
+        // hard error, now ignored.
+        let mut providers = HashMap::new();
+        providers.insert("i".to_string(), inline_cfg("leftover.yaml"));
+        validate_paths(&providers, None).expect("stray inline path must not fail validation");
+
+        // Even an escaping path is irrelevant on a provider type that never
+        // reads it.
+        let dir = tempfile::tempdir().unwrap();
+        providers.insert("i".to_string(), inline_cfg("../../etc/pwned"));
+        validate_paths(&providers, Some(dir.path()))
+            .expect("stray inline path must not be containment-checked");
+
+        // And the provider itself still loads normally.
+        let out = load_providers(&providers, Some(dir.path()), &ctx(), None);
+        assert_eq!(out.get("i").expect("inline must load").rule_count(), 1);
     }
 
     /// Regression test for issue #429: an http provider with a
@@ -1177,6 +1242,39 @@ mod tests {
         assert!(
             !victim.parent().unwrap().exists(),
             "parent of the attacker-controlled path was created"
+        );
+    }
+
+    /// PR #437 review follow-up: pin the body-size-cap *wiring* end to end —
+    /// `fetch_http_async` (the direct, no-proxy fetch every rule-provider
+    /// load/refresh goes through) must route its body read through
+    /// `internal_http::response_bytes_with_limit`. The unit tests on
+    /// `response_bytes_capped` cover the cap logic itself; here a local
+    /// server declares a `Content-Length` above `MAX_BODY_BYTES` (so nothing
+    /// close to 256 MiB is actually transferred) and the fetch must fail
+    /// with the cap error before buffering the body.
+    #[tokio::test]
+    async fn fetch_http_async_rejects_oversized_response_end_to_end() {
+        let oversized = internal_http::MAX_BODY_BYTES as u64 + 1;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf).await;
+            let head =
+                format!("HTTP/1.1 200 OK\r\ncontent-length: {oversized}\r\n\r\ntiny-partial-body");
+            let _ = stream.write_all(head.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        });
+
+        let err = fetch_http_async(&format!("http://{addr}/rules.yaml"), None)
+            .await
+            .expect_err("oversized response must be rejected");
+        assert!(
+            err.to_string().contains("exceeds max body size"),
+            "unexpected error: {err:#}"
         );
     }
 }

--- a/crates/meow-config/src/safe_path.rs
+++ b/crates/meow-config/src/safe_path.rs
@@ -6,6 +6,27 @@
 //! cache directory — mirroring mihomo's `C.Path.IsSafePath` guard.
 
 use std::path::{Component, Path, PathBuf};
+use tracing::warn;
+
+/// Name of the escape-hatch environment variable, mirroring mihomo.
+const SKIP_ENV: &str = "SKIP_SAFE_PATH_CHECK";
+
+/// Mirror of mihomo's `SKIP_SAFE_PATH_CHECK` escape hatch: when the env var
+/// holds a truthy value, containment failures are downgraded to a prominent
+/// `warn!` and the out-of-root path is allowed.
+///
+/// mihomo parses the variable with Go's `strconv.ParseBool`
+/// (`allowUnsafePath, _ := strconv.ParseBool(os.Getenv("SKIP_SAFE_PATH_CHECK"))`),
+/// so exactly `1`/`t`/`T`/`true`/`TRUE`/`True` enable it; anything else —
+/// including an unset or empty variable — keeps the check ON.
+fn skip_safe_path_check() -> bool {
+    std::env::var(SKIP_ENV).is_ok_and(|v| go_parse_bool_truthy(&v))
+}
+
+/// The truthy half of Go's `strconv.ParseBool` accepted values.
+fn go_parse_bool_truthy(value: &str) -> bool {
+    matches!(value, "1" | "t" | "T" | "true" | "TRUE" | "True")
+}
 
 /// Resolve `requested` against `base` and require the result to stay inside
 /// `base`.
@@ -15,9 +36,24 @@ use std::path::{Component, Path, PathBuf};
 /// `base`), and symlink tricks (the deepest existing ancestor of both sides
 /// is canonicalized and containment is re-checked on the resolved forms).
 ///
+/// Escape hatch (mihomo parity): setting `SKIP_SAFE_PATH_CHECK=1` in the
+/// environment downgrades a containment failure to a prominent `warn!` and
+/// lets the out-of-root path through — a migration path for configs that
+/// legitimately point providers outside the cache dir. It defaults OFF; with
+/// the variable unset the containment guarantee from issue #429 is fully
+/// intact.
+///
 /// Returns the normalized absolute path that callers must use for the actual
 /// I/O, so the checked path and the opened path cannot diverge lexically.
 pub(crate) fn resolve_contained(base: &Path, requested: &Path) -> Result<PathBuf, String> {
+    resolve_contained_impl(base, requested, skip_safe_path_check())
+}
+
+fn resolve_contained_impl(
+    base: &Path,
+    requested: &Path,
+    skip_check: bool,
+) -> Result<PathBuf, String> {
     let abs_base = normalize_absolute(base)?;
     let joined = if requested.is_absolute() {
         requested.to_path_buf()
@@ -26,6 +62,10 @@ pub(crate) fn resolve_contained(base: &Path, requested: &Path) -> Result<PathBuf
     };
     let abs_joined = normalize_absolute(&joined)?;
     if !abs_joined.starts_with(&abs_base) {
+        if skip_check {
+            warn_skip_active(requested, base, "");
+            return Ok(abs_joined);
+        }
         return Err(format!(
             "path '{}' escapes the provider directory '{}'",
             requested.display(),
@@ -37,6 +77,10 @@ pub(crate) fn resolve_contained(base: &Path, requested: &Path) -> Result<PathBuf
     let canon_base = canonicalize_existing_prefix(&abs_base);
     let canon_joined = canonicalize_existing_prefix(&abs_joined);
     if !canon_joined.starts_with(&canon_base) {
+        if skip_check {
+            warn_skip_active(requested, base, " via a symlink");
+            return Ok(abs_joined);
+        }
         return Err(format!(
             "path '{}' escapes the provider directory '{}' via a symlink",
             requested.display(),
@@ -44,6 +88,16 @@ pub(crate) fn resolve_contained(base: &Path, requested: &Path) -> Result<PathBuf
         ));
     }
     Ok(abs_joined)
+}
+
+fn warn_skip_active(requested: &Path, base: &Path, how: &str) {
+    warn!(
+        "{SKIP_ENV} is set: allowing provider path '{}' that escapes the provider \
+         directory '{}'{how} — the path-containment protection (issue #429) is DISABLED; \
+         unset {SKIP_ENV} to restore it",
+        requested.display(),
+        base.display(),
+    );
 }
 
 /// Make `path` absolute (against the current directory) and lexically fold
@@ -157,6 +211,57 @@ mod tests {
         std::os::unix::fs::symlink(outside.path(), base.path().join("link")).unwrap();
         let err = resolve_contained(base.path(), Path::new("link/pwned")).unwrap_err();
         assert!(err.contains("symlink"), "unexpected: {err}");
+    }
+
+    // -- SKIP_SAFE_PATH_CHECK escape hatch (mihomo parity) ------------------
+    //
+    // The skip flag is injected as a bool so these tests cannot race on the
+    // process-global environment; `skip_safe_path_check()` itself is covered
+    // by the `go_parse_bool_truthy` table below plus the pass-through in
+    // `resolve_contained`.
+
+    #[test]
+    fn escape_hatch_off_rejects_out_of_root_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        for p in ["../../etc/pwned", "/etc/cron.d/pwned"] {
+            let err = resolve_contained_impl(dir.path(), Path::new(p), false)
+                .expect_err("skip=false must keep the containment guarantee");
+            assert!(err.contains("escapes"), "path {p}: unexpected: {err}");
+        }
+    }
+
+    #[test]
+    fn escape_hatch_on_allows_out_of_root_paths_with_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let got = resolve_contained_impl(dir.path(), Path::new("/etc/cron.d/pwned"), true)
+            .expect("skip=true must allow the out-of-root path");
+        assert_eq!(got, PathBuf::from("/etc/cron.d/pwned"));
+        // Traversal is still lexically normalized before being handed back.
+        let got = resolve_contained_impl(dir.path(), Path::new("sub/../../outside"), true).unwrap();
+        assert!(!got.to_string_lossy().contains(".."));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn escape_hatch_on_allows_symlink_escape() {
+        let outside = tempfile::tempdir().unwrap();
+        let base = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), base.path().join("link")).unwrap();
+        resolve_contained_impl(base.path(), Path::new("link/pwned"), true)
+            .expect("skip=true must allow the symlink escape");
+        // …and skip=false still rejects the very same layout.
+        resolve_contained_impl(base.path(), Path::new("link/pwned"), false)
+            .expect_err("skip=false must reject the symlink escape");
+    }
+
+    #[test]
+    fn escape_hatch_env_parsing_matches_go_parse_bool() {
+        for truthy in ["1", "t", "T", "true", "TRUE", "True"] {
+            assert!(go_parse_bool_truthy(truthy), "{truthy} must enable");
+        }
+        for falsy in ["", "0", "false", "f", "yes", "on", "2", " true", "true "] {
+            assert!(!go_parse_bool_truthy(falsy), "{falsy:?} must NOT enable");
+        }
     }
 
     #[cfg(unix)]

--- a/crates/meow-config/src/safe_path.rs
+++ b/crates/meow-config/src/safe_path.rs
@@ -235,7 +235,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let got = resolve_contained_impl(dir.path(), Path::new("/etc/cron.d/pwned"), true)
             .expect("skip=true must allow the out-of-root path");
-        assert_eq!(got, PathBuf::from("/etc/cron.d/pwned"));
+        // `/etc/...` is root-relative rather than absolute on Windows (no
+        // drive prefix), so the impl anchors it on the base's drive and the
+        // result is `C:\etc\cron.d\pwned`. Assert on the properties that
+        // matter on every platform: the requested path came back intact, and
+        // it really does sit outside the base. Join the suffix so the
+        // comparison is component-wise with native separators.
+        assert!(
+            got.ends_with(Path::new("etc").join("cron.d").join("pwned")),
+            "unexpected: {}",
+            got.display()
+        );
+        assert!(
+            !got.starts_with(normalize_absolute(dir.path()).unwrap()),
+            "must have escaped the base: {}",
+            got.display()
+        );
         // Traversal is still lexically normalized before being handed back.
         let got = resolve_contained_impl(dir.path(), Path::new("sub/../../outside"), true).unwrap();
         assert!(!got.to_string_lossy().contains(".."));


### PR DESCRIPTION
Follow-up to #444 review and follow-up to #437 review: a group of minor findings classified non-blocking at merge time, now fixed properly. All four findings were re-verified against current `main` before fixing and still applied.

## Changes

### 1. Stray `path:` on inline rule-providers is ignored (#444 review)
`resolve_path`/`validate_paths` used to hard-error on a `path:` attached to an inline provider when no cache dir was available (and containment-check it when one was), even though inline providers never read the path. mihomo ignores a stray `path` on inline; we now warn-and-ignore it for any provider type that never reads it, so a harmless leftover field can't fail a whole rebuild. Test: `stray_path_on_inline_provider_is_ignored`.

### 2. `SKIP_SAFE_PATH_CHECK` escape hatch (#444 review)
The #429/#444 containment check shipped with no migration path for configs whose provider paths legitimately live outside the cache dir. Mirroring mihomo (`allowUnsafePath, _ := strconv.ParseBool(os.Getenv("SKIP_SAFE_PATH_CHECK"))`): when the env var holds a Go-ParseBool-truthy value (`1`/`t`/`T`/`true`/`TRUE`/`True`), a containment failure is downgraded to a prominent `warn!` (naming the path, the root, and how to restore the protection) and the out-of-root path is allowed.

**Security posture**: defaults OFF — requires the explicit env var; unset/empty/falsy values keep the containment guarantee fully intact. Both states are tested (`escape_hatch_off_rejects_out_of_root_paths`, `escape_hatch_on_allows_out_of_root_paths_with_warning`, `escape_hatch_on_allows_symlink_escape`, `escape_hatch_env_parsing_matches_go_parse_bool`) via bool injection so tests can't race on the process environment.

### 3. Proxy-provider out-of-root paths fail loudly (#444 review)
Previously an escaping proxy-provider path was warn-skipped in `load_proxy_providers`, silently degrading every group referencing the provider (each group only logged a generic "provider not found"). New `proxy_provider::validate_paths` runs in `rebuild_from_raw_impl` next to the rule-provider validation, so the rebuild fails hard with an error naming the provider — rule-provider parity. Scope is containment violations only; other per-provider problems (missing fields, unknown type, fetch failures) keep their historical warn-and-skip semantics. Tests: `validate_paths_rejects_escaping_provider_paths`, `validate_paths_accepts_contained_and_pathless_providers`, `rebuild_rejects_proxy_provider_path_escaping_cache_dir`.

**Behavioral note**: a config that previously *started degraded* (provider skipped, groups missing members) now fails the build/rebuild with a clear error. The new escape hatch (item 2) is the migration path for intentional out-of-root paths.

### 4. 'ignoring path' warn fires once per provider per rebuild (#444 review)
`validate_paths`, `prefetch_payloads`, and `load_http` all resolve the same path, so the "ignoring 'path' (no provider cache directory)" warn fired up to three times per http provider per rebuild. `resolve_path` now takes an `emit_warnings` flag; only `validate_paths` — which every (re)build runs exactly once, before any fetch/load pass — emits the warns.

### 5. End-to-end body-size-cap test (#437 review)
The existing cap tests exercised only the extracted `response_bytes_capped` helper. New `fetch_http_async_rejects_oversized_response_end_to_end` drives `fetch_http_async` against a local server declaring `Content-Length: MAX_BODY_BYTES + 1` (nothing near 256 MiB is transferred — the pre-check rejects on the header) to pin the actual wiring through `response_bytes_with_limit`.

## Tests
- No existing test was weakened; all pre-existing tests pass unchanged (only `resolve_path` test call sites gained the new `emit_warnings` argument).
- Full regression bar green locally: `cargo fmt --check`, three-way clippy (`-D warnings`), `cargo doc` (`-D warnings`), `cargo test --lib` (13/13 crates, 0 failures).

No hot-path, relay, or footprint-tracked types touched (ADR-0006/0007/0008/0011 not in scope).