### PR TITLE
fix(transport): exempt #[cfg(test)] items from the ADR-0001 src scan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,22 @@ cargo clippy --all-targets -- -D warnings
 cargo clippy --all-targets --no-default-features -- -D warnings
 cargo clippy --all-targets --all-features -- -D warnings
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
-cargo test --lib
+
+# Mirrors the "Unit + integration tests (default features)" CI step. `--lib`
+# alone is not enough: it skips every `--test` target, so a broken integration
+# test (e.g. the ADR-0001 guard in `crate_invariants_test`) passes locally and
+# lands `main` red.
+cargo test --lib --bin meow \
+  --test common_test --test dns_cache_test --test config_test \
+  --test statistics_test --test rules_test --test api_test \
+  --test config_persistence_test --test systemd_config_test \
+  --test trojan_integration --test vless_config_test --test vless_integration \
+  --test v2ray_plugin_integration --test pre_resolve_test \
+  --test tls_test --test ws_test --test crate_invariants_test
 ```
+
+Keep the target list in sync with `.github/workflows/test.yml`; a new `tests/`
+file that CI runs but this list omits is invisible to the local bar.
 
 The three-way clippy check (default / no-default-features / all-features) is enforced in CI via `.github/workflows/test.yml` (added in M1, per ADR-0010 §3).
 

--- a/crates/meow-transport/tests/crate_invariants_test.rs
+++ b/crates/meow-transport/tests/crate_invariants_test.rs
@@ -5,6 +5,7 @@
 //! is violated.
 
 use meow_transport::TransportError;
+use std::collections::HashSet;
 
 // ─── F1: no_proxy_dep ────────────────────────────────────────────────────────
 
@@ -46,7 +47,10 @@ fn no_proxy_dep() {
 /// `Acceptor`, `TcpListener`).
 ///
 /// `tests/` is intentionally excluded — `tests/support/loopback.rs` uses
-/// these legitimately.
+/// these legitimately.  `#[cfg(test)]` items inside `src/` are excluded for
+/// the same reason: they are stripped from the published library, and
+/// ADR-0001 §1 (implementation plan, M1.A-3) explicitly prescribes driving
+/// these client layers against "a loopback `h2` server in-process".
 #[test]
 fn no_server_side_symbols_in_src() {
     let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
@@ -70,10 +74,15 @@ fn no_server_side_symbols_in_src() {
     let mut violations: Vec<String> = Vec::new();
 
     walk_rs_files(&src_dir, &mut |path, content| {
+        let test_only = test_only_lines(path, content);
         for (line_no, line) in content.lines().enumerate() {
             // Skip comment lines — doc comments that *describe* the restriction
             // are not violations.  Only live code is checked.
             if line.trim().starts_with("//") {
+                continue;
+            }
+            // Skip `#[cfg(test)]` items — test scaffolding, not shipped code.
+            if test_only.contains(&line_no) {
                 continue;
             }
             for (re, pat) in regexes.iter().zip(forbidden_patterns.iter()) {
@@ -111,6 +120,254 @@ fn walk_rs_files(dir: &std::path::Path, f: &mut dyn FnMut(&std::path::Path, &str
             }
         }
     }
+}
+
+// ─── shared scan helpers ─────────────────────────────────────────────────────
+
+/// Line indices (0-based) covered by a `#[cfg(test)]` item.
+///
+/// `#[cfg(test)]` code is compiled out of the published library, so in-crate
+/// unit tests are scaffolding rather than shipped surface — the same reason
+/// `tests/` is excluded from both `src/` scans.  A mock server used to drive a
+/// *client* transport is therefore not an ADR-0001 §1 violation.
+///
+/// The span runs from the attribute line to the line that closes the item's
+/// block, tracked by brace depth.  An item with no block (`#[cfg(test)] use
+/// …;`) ends at its semicolon.  A span that never terminates is a panic, not a
+/// silent skip: failing loudly beats disabling the guard for the rest of the
+/// file.
+fn test_only_lines(path: &std::path::Path, content: &str) -> HashSet<usize> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut test_only = HashSet::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        if !is_cfg_test_attr(lines[i]) {
+            i += 1;
+            continue;
+        }
+
+        let start = i;
+        let mut depth: usize = 0;
+        let mut opened = false;
+        let mut terminated = false;
+
+        while i < lines.len() {
+            let code = strip_literals_and_comments(lines[i]);
+            for ch in code.chars() {
+                match ch {
+                    '{' => {
+                        depth += 1;
+                        opened = true;
+                    }
+                    '}' => depth = depth.saturating_sub(1),
+                    _ => {}
+                }
+            }
+            i += 1;
+
+            if opened {
+                if depth == 0 {
+                    terminated = true;
+                    break;
+                }
+            } else if code.trim_end().ends_with(';') {
+                // Block-less item: `#[cfg(test)] use …;`, `const …;`, etc.
+                terminated = true;
+                break;
+            }
+        }
+
+        assert!(
+            terminated,
+            "unterminated #[cfg(test)] item at {}:{} — the ADR-0001 scan cannot tell \
+             where test-only code ends, so it refuses to guess",
+            path.display(),
+            start + 1
+        );
+        test_only.extend(start..i);
+    }
+
+    test_only
+}
+
+/// Whether `line` opens a `#[cfg(test)]` (or `all(test, …)` / `any(test, …)`)
+/// attribute.  Deliberately narrow: a feature named `"test-utils"` must not
+/// match.
+fn is_cfg_test_attr(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("#[cfg(test)]")
+        || trimmed.starts_with("#[cfg(all(test")
+        || trimmed.starts_with("#[cfg(any(test")
+}
+
+/// Drop string/char literals and any trailing `//` comment from `line` so that
+/// braces inside them cannot skew the block-depth count.
+fn strip_literals_and_comments(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut code = String::with_capacity(line.len());
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        // Trailing line comment — nothing after it affects depth.
+        if c == '/' && chars.get(i + 1) == Some(&'/') {
+            break;
+        }
+
+        // Raw string: r"…", r#"…"#, r##"…"## … (also the tail of br"…").
+        if c == 'r' && matches!(chars.get(i + 1), Some('"') | Some('#')) {
+            if let Some(end) = raw_string_end(&chars, i) {
+                i = end;
+                continue;
+            }
+        }
+
+        // Ordinary string literal.
+        if c == '"' {
+            i = string_end(&chars, i);
+            continue;
+        }
+
+        // Char literal — but `'a` (lifetime) and `'outer:` (label) are code.
+        if c == '\'' {
+            if let Some(end) = char_literal_end(&chars, i) {
+                i = end;
+                continue;
+            }
+        }
+
+        code.push(c);
+        i += 1;
+    }
+
+    code
+}
+
+/// End index (exclusive) of the `"…"` literal opening at `start`.
+fn string_end(chars: &[char], start: usize) -> usize {
+    let mut i = start + 1;
+    while i < chars.len() {
+        match chars[i] {
+            '\\' => i += 2,
+            '"' => return i + 1,
+            _ => i += 1,
+        }
+    }
+    // Unterminated on this line (a multi-line string): the rest is literal.
+    chars.len()
+}
+
+/// End index (exclusive) of the raw string opening at `start`, or `None` when
+/// `start` is a raw *identifier* (`r#type`) rather than a raw string.
+fn raw_string_end(chars: &[char], start: usize) -> Option<usize> {
+    let mut i = start + 1;
+    let mut hashes = 0;
+    while chars.get(i) == Some(&'#') {
+        hashes += 1;
+        i += 1;
+    }
+    if chars.get(i) != Some(&'"') {
+        return None; // raw identifier, not a raw string
+    }
+    i += 1;
+    while i < chars.len() {
+        if chars[i] == '"'
+            && chars[i + 1..]
+                .iter()
+                .take(hashes)
+                .filter(|c| **c == '#')
+                .count()
+                == hashes
+        {
+            return Some(i + 1 + hashes);
+        }
+        i += 1;
+    }
+    Some(chars.len())
+}
+
+/// End index (exclusive) of the `'c'` literal opening at `start`, or `None`
+/// when the quote opens a lifetime or a loop label.
+fn char_literal_end(chars: &[char], start: usize) -> Option<usize> {
+    let mut i = start + 1;
+    if chars.get(i) == Some(&'\\') {
+        i += 1;
+        if chars.get(i) == Some(&'u') {
+            // '\u{7f}' — run to the closing quote.
+            while i < chars.len() && chars[i] != '\'' {
+                i += 1;
+            }
+            return (chars.get(i) == Some(&'\'')).then_some(i + 1);
+        }
+    }
+    (chars.get(i + 1) == Some(&'\'')).then_some(i + 2)
+}
+
+// ─── F2/F4 helper self-tests ─────────────────────────────────────────────────
+
+/// The scan exemption must cover exactly the `#[cfg(test)]` item — no more,
+/// no less.  A guard that over-reaches silently stops guarding.
+#[test]
+fn cfg_test_spans_cover_only_test_items() {
+    let src = "\
+fn client() {}
+#[cfg(test)]
+mod tests {
+    fn helper() {
+        let _ = \"} not a brace {\";
+    }
+}
+fn also_client() {}
+";
+    let span = test_only_lines(std::path::Path::new("<memory>"), src);
+    assert_eq!(span, (1..7).collect::<HashSet<usize>>());
+}
+
+#[test]
+fn cfg_test_span_ends_at_a_block_less_item() {
+    let src = "\
+#[cfg(test)]
+use std::net::TcpListener;
+fn client() {}
+";
+    let span = test_only_lines(std::path::Path::new("<memory>"), src);
+    assert_eq!(span, (0..2).collect::<HashSet<usize>>());
+}
+
+#[test]
+fn cfg_test_span_survives_braces_in_literals() {
+    let src = "\
+#[cfg(test)]
+mod tests {
+    fn f() {
+        let _ = '{';
+        let _ = r#\"raw } brace\"#;
+        let _ = format!(\"{}\", 1); // }
+    }
+}
+";
+    let span = test_only_lines(std::path::Path::new("<memory>"), src);
+    assert_eq!(span, (0..8).collect::<HashSet<usize>>());
+}
+
+#[test]
+fn non_test_cfg_attributes_are_not_exempt() {
+    let src = "\
+#[cfg(feature = \"test-utils\")]
+mod helpers {
+    fn f() {}
+}
+";
+    assert!(test_only_lines(std::path::Path::new("<memory>"), src).is_empty());
+}
+
+#[test]
+fn lifetimes_do_not_swallow_braces() {
+    let code = strip_literals_and_comments("fn f<'a>(x: &'a str) -> Foo { bar }");
+    assert_eq!(code.matches('{').count(), 1);
+    assert_eq!(code.matches('}').count(), 1);
 }
 
 // ─── F3: transport_error_is_non_exhaustive ───────────────────────────────────
@@ -160,10 +417,15 @@ fn no_anyhow_at_boundary() {
     let mut violations: Vec<String> = Vec::new();
 
     walk_rs_files(&src_dir, &mut |path, content| {
+        let test_only = test_only_lines(path, content);
         for (line_no, line) in content.lines().enumerate() {
             // Skip comment lines — doc comments explaining *why* anyhow is
             // banned are not themselves violations.
             if line.trim().starts_with("//") {
+                continue;
+            }
+            // `#[cfg(test)]` items never cross the crate boundary.
+            if test_only.contains(&line_no) {
                 continue;
             }
             if anyhow_re.is_match(line) {


### PR DESCRIPTION
## Problem

`main` is red at 5439f07. `crate_invariants_test::no_server_side_symbols_in_src` walks `meow-transport/src/**/*.rs` line by line with no notion of conditional compilation, so the in-src h2 mock server added with the write-cancellation contract tests (#428, #441) trips the `\baccept\b` pattern:

```
h2_common.rs:329: 'let _accepted = connection.accept().await;'
h2_common.rs:421: '.accept()'
h2_common.rs:424: '.expect("accept ok");'
h2_common.rs:446: 'while connection.accept().await.is_some() {}'
```

All four are inside `#[cfg(test)] mod tests`. The nightly `Coverage` job is red for the same reason.

## Why exempting is right, not a loosening

That code is compiled out of the published library, and ADR-0001 §1 (implementation plan, M1.A-3) explicitly prescribes exercising these client layers against *"a loopback `h2` server in-process"*. The guard was flagging the test strategy the ADR asks for. `tests/` is already exempt for exactly this reason — in-src test modules were simply never taught to the scanner.

## Change

- `test_only_lines()` returns the line span of every `#[cfg(test)]` item; both `src/` scans (F2 server symbols, F4 anyhow-at-boundary) skip those lines.
- Spans are tracked by brace depth over lines with string, raw-string and char literals stripped, so a `'{'` or an `r#"…}"#` cannot skew the count. Lifetimes (`'a`) and loop labels are not mistaken for char literals.
- Guard rails against the scanner silently switching itself off:
  - a block-less item (`#[cfg(test)] use …;`) terminates at its semicolon;
  - an unterminated span **panics** rather than swallowing the rest of the file;
  - `#[cfg(feature = "test-utils")]` does not match.
- Five self-tests pin that behaviour.

## Verification

The guard still bites — injecting `fn mutation_probe() -> Option<tokio::net::TcpListener>` into production code in `h2_common.rs` fails `no_server_side_symbols_in_src` exactly as before the change.

Full regression bar green locally: `fmt`, clippy ×3 (default / `--no-default-features` / `--all-features`), `RUSTDOCFLAGS="-D warnings" cargo doc`, and the full default-features test list (30 test binaries).

## Process fix

`CLAUDE.md`'s regression bar said `cargo test --lib`, which by construction runs **no** `--test` target and so could not have caught this before the push. It now mirrors the target list from the "Unit + integration tests (default features)" CI step, with a note to keep the two in sync.