### PR TITLE
feat(dns): support "rule-set:" patterns in nameserver-policy

### DIFF
--- a/crates/meow-config/src/dns_parser.rs
+++ b/crates/meow-config/src/dns_parser.rs
@@ -1,4 +1,5 @@
 use crate::raw::{HostsValue, RawConfig};
+use crate::rule_provider::RuleProvider;
 use crate::DnsConfig;
 use meow_common::DnsMode;
 use meow_dns::fakeip::{FileStore, MemoryStore, Pool, Skipper, SkipperMode, Store};
@@ -7,6 +8,7 @@ use meow_dns::resolver::{
 };
 use meow_dns::upstream::{NameServerEntry, NameServerUrl};
 use meow_dns::{DnsClient, HostOrIp, Resolver};
+use meow_rules::RuleSetBehavior;
 use meow_trie::DomainTrie;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -24,6 +26,7 @@ pub async fn parse_dns(
     cache_dir: Option<&std::path::Path>,
     proxy_registry: &HashMap<smol_str::SmolStr, Arc<dyn meow_common::Proxy>>,
     geosite: Option<Arc<meow_rules::geosite::GeositeDB>>,
+    rule_providers: &HashMap<String, Arc<RuleProvider>>,
 ) -> Result<DnsConfig, anyhow::Error> {
     let dns = match &raw.dns {
         Some(dns) if dns.enable.unwrap_or(false) => dns,
@@ -121,6 +124,7 @@ pub async fn parse_dns(
                     geosite.as_ref(),
                     &bootstrap_clients,
                     proxy_registry,
+                    rule_providers,
                 )
                 .await?,
             )
@@ -309,7 +313,10 @@ fn parse_nameserver_urls(servers: &[String]) -> Result<Vec<NameServerUrl>, anyho
 /// Build a `NameserverPolicy` from the raw YAML map.
 ///
 /// `geosite:` patterns are compiled into matchers when a geosite DB is loaded.
-/// Unsupported prefixes (currently `rule-set:`) warn once and skip.
+/// `rule-set:` patterns are compiled into matchers from the loaded
+/// rule-providers; the matcher snapshots the provider on each lookup so
+/// background refreshes take effect automatically.
+/// Other prefixed patterns (anything with `:`) warn once and skip.
 ///
 /// An entry with no valid nameservers after skipping → hard error.
 /// Class A per ADR-0002: DNS leakage risk for internal/corporate domains.
@@ -318,6 +325,7 @@ async fn build_nameserver_policy(
     geosite: Option<&Arc<meow_rules::geosite::GeositeDB>>,
     bootstrap_clients: &[Arc<DnsClient>],
     proxy_registry: &HashMap<smol_str::SmolStr, Arc<dyn meow_common::Proxy>>,
+    rule_providers: &HashMap<String, Arc<RuleProvider>>,
 ) -> Result<NameserverPolicy, anyhow::Error> {
     let mut policy = NameserverPolicy::new();
     let mut warned_unsupported_prefix = false;
@@ -350,10 +358,44 @@ async fn build_nameserver_policy(
                 continue;
             }
 
-            if key_lower.starts_with("rule-set:") || key_lower.contains(':') {
+            if key_lower.starts_with("rule-set:") {
+                // Provider names are case-sensitive — extract from the
+                // original-case `expanded_key`, not `key_lower`.
+                let name = expanded_key["rule-set:".len()..].trim();
+                if name.is_empty() {
+                    continue;
+                }
+                let provider = rule_providers.get(name).ok_or_else(|| {
+                    anyhow::anyhow!("nameserver-policy: not found rule-set: {name}")
+                })?;
+                match provider.behavior {
+                    RuleSetBehavior::IpCidr => {
+                        anyhow::bail!(
+                            "nameserver-policy: rule-set '{name}' behavior is IpCidr, \
+                             expected domain or classical"
+                        );
+                    }
+                    RuleSetBehavior::Classical => {
+                        // Warn once per entry; upstream only matches domain
+                        // rules inside a classical set.
+                        warn!(
+                            "nameserver-policy: rule-set '{name}' is classical; \
+                             only domain rules within it will be matched"
+                        );
+                    }
+                    RuleSetBehavior::Domain => {}
+                }
+                let provider = Arc::clone(provider);
+                patterns.push(PolicyPattern::Matcher(Arc::new(move |domain: &str| {
+                    provider.snapshot().matches_domain(domain)
+                })));
+                continue;
+            }
+
+            if key_lower.contains(':') {
                 if !warned_unsupported_prefix {
                     warn!(
-                        "nameserver-policy: unsupported prefixed patterns such as 'rule-set:' \
+                        "nameserver-policy: unsupported prefixed patterns containing ':' \
                         will be skipped"
                     );
                     warned_unsupported_prefix = true;
@@ -863,7 +905,7 @@ mod tests {
             "dns:\n  enable: true\n  nameserver:\n    - 1.1.1.1\n  proxy-server-nameserver:\n    - 223.5.5.5\n",
         )
         .unwrap();
-        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None)
+        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None, &HashMap::new())
             .await
             .unwrap();
         assert!(
@@ -876,7 +918,7 @@ mod tests {
     async fn no_proxy_server_nameserver_leaves_proxy_resolver_none() {
         let raw: RawConfig =
             serde_yaml::from_str("dns:\n  enable: true\n  nameserver:\n    - 1.1.1.1\n").unwrap();
-        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None)
+        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None, &HashMap::new())
             .await
             .unwrap();
         assert!(cfg.proxy_resolver.is_none());
@@ -890,7 +932,7 @@ mod tests {
             "dns:\n  enable: false\n  proxy-server-nameserver:\n    - 223.5.5.5\n",
         )
         .unwrap();
-        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None)
+        let cfg = parse_dns(&raw, None, None, &HashMap::new(), None, &HashMap::new())
             .await
             .unwrap();
         assert!(!cfg.enabled);
@@ -1041,7 +1083,8 @@ mod tests {
             "geosite:cn".to_string(),
             RawNspValue::One("rcode://success".to_string()),
         );
-        let result = build_nameserver_policy(&map, None, &[], &HashMap::new()).await;
+        let result =
+            build_nameserver_policy(&map, None, &[], &HashMap::new(), &HashMap::new()).await;
         assert!(result.is_ok(), "geosite: prefix must not hard-error");
         let pol = result.unwrap();
         assert!(
@@ -1063,7 +1106,7 @@ mod tests {
             "geosite:cn,private".to_string(),
             RawNspValue::One("rcode://success".to_string()),
         );
-        let pol = build_nameserver_policy(&map, Some(&db), &[], &HashMap::new())
+        let pol = build_nameserver_policy(&map, Some(&db), &[], &HashMap::new(), &HashMap::new())
             .await
             .unwrap();
         assert!(pol.lookup("example.cn").is_some());
@@ -1082,7 +1125,8 @@ mod tests {
             "corp.example".to_string(),
             RawNspValue::Many(vec!["quic://bad.example".to_string()]),
         );
-        let result = build_nameserver_policy(&map, None, &[], &HashMap::new()).await;
+        let result =
+            build_nameserver_policy(&map, None, &[], &HashMap::new(), &HashMap::new()).await;
         assert!(
             result.is_err(),
             "policy entry with no valid servers must be a hard error"
@@ -1098,12 +1142,150 @@ mod tests {
             "+.corp.internal".to_string(),
             RawNspValue::One("192.168.1.53".to_string()),
         );
-        let pol = build_nameserver_policy(&map, None, &[], &HashMap::new())
+        let pol = build_nameserver_policy(&map, None, &[], &HashMap::new(), &HashMap::new())
             .await
             .unwrap();
         assert!(pol.lookup("foo.corp.internal").is_some());
         assert!(pol.lookup("corp.internal").is_some());
         assert!(pol.lookup("other.example").is_none());
+    }
+
+    // Helper: build an inline rule-provider map from `(name, behavior, payload)`.
+    fn inline_rule_providers(
+        entries: &[(&str, &str, Vec<String>)],
+    ) -> HashMap<String, Arc<RuleProvider>> {
+        use crate::raw::RawRuleProvider;
+        let mut raw = HashMap::new();
+        for (name, behavior, payload) in entries {
+            raw.insert(
+                (*name).to_string(),
+                RawRuleProvider {
+                    provider_type: "inline".to_string(),
+                    behavior: (*behavior).to_string(),
+                    format: None,
+                    url: None,
+                    path: None,
+                    interval: None,
+                    proxy: None,
+                    payload: Some(payload.clone()),
+                },
+            );
+        }
+        let ctx = meow_rules::ParserContext::empty();
+        crate::rule_provider::load_providers(&raw, None, &ctx, None)
+    }
+
+    // rule-set: domain behavior compiles into a matcher that hits the
+    // provider's domains.
+    #[tokio::test]
+    async fn parse_nameserver_policy_rule_set_domain_matches_loaded_provider() {
+        use crate::raw::RawNspValue;
+        let providers = inline_rule_providers(&[(
+            "cn",
+            "domain",
+            vec!["example.cn".to_string(), "+.cn".to_string()],
+        )]);
+        let mut map = HashMap::new();
+        map.insert(
+            "rule-set:cn".to_string(),
+            RawNspValue::One("rcode://success".to_string()),
+        );
+        let pol = build_nameserver_policy(&map, None, &[], &HashMap::new(), &providers)
+            .await
+            .unwrap();
+        assert!(pol.lookup("example.cn").is_some());
+        assert!(pol.lookup("foo.cn").is_some());
+        assert!(pol.lookup("example.com").is_none());
+    }
+
+    // rule-set: referencing a missing provider is a hard error.
+    #[tokio::test]
+    async fn parse_nameserver_policy_rule_set_missing_provider_errors() {
+        use crate::raw::RawNspValue;
+        let providers = HashMap::new();
+        let mut map = HashMap::new();
+        map.insert(
+            "rule-set:missing".to_string(),
+            RawNspValue::One("rcode://success".to_string()),
+        );
+        let result = build_nameserver_policy(&map, None, &[], &HashMap::new(), &providers).await;
+        assert!(result.is_err());
+        let msg = result.err().unwrap().to_string();
+        assert!(msg.contains("not found rule-set"), "msg was: {msg}");
+    }
+
+    // rule-set: IpCidr behavior is rejected (expect domain/classical).
+    #[tokio::test]
+    async fn parse_nameserver_policy_rule_set_ipcidr_behavior_errors() {
+        use crate::raw::RawNspValue;
+        let providers = inline_rule_providers(&[("ips", "ipcidr", vec!["10.0.0.0/8".to_string()])]);
+        let mut map = HashMap::new();
+        map.insert(
+            "rule-set:ips".to_string(),
+            RawNspValue::One("rcode://success".to_string()),
+        );
+        let result = build_nameserver_policy(&map, None, &[], &HashMap::new(), &providers).await;
+        assert!(result.is_err());
+        let msg = result.err().unwrap().to_string();
+        assert!(msg.contains("IpCidr"), "msg was: {msg}");
+    }
+
+    // rule-set: classical behavior warns but still matches domain rules.
+    #[tokio::test]
+    async fn parse_nameserver_policy_rule_set_classical_warns_and_matches() {
+        use crate::raw::RawNspValue;
+        let providers = inline_rule_providers(&[(
+            "cls",
+            "classical",
+            vec!["DOMAIN-SUFFIX,google.com".to_string()],
+        )]);
+        let mut map = HashMap::new();
+        map.insert(
+            "rule-set:cls".to_string(),
+            RawNspValue::One("rcode://success".to_string()),
+        );
+        let pol = build_nameserver_policy(&map, None, &[], &HashMap::new(), &providers)
+            .await
+            .unwrap();
+        assert!(pol.lookup("mail.google.com").is_some());
+        assert!(pol.lookup("example.org").is_none());
+    }
+
+    // rule-set:a,b expands into two providers.
+    #[tokio::test]
+    async fn parse_nameserver_policy_rule_set_comma_expands() {
+        use crate::raw::RawNspValue;
+        let providers = inline_rule_providers(&[
+            ("a", "domain", vec!["a.example".to_string()]),
+            ("b", "domain", vec!["b.example".to_string()]),
+        ]);
+        let mut map = HashMap::new();
+        map.insert(
+            "rule-set:a,b".to_string(),
+            RawNspValue::One("rcode://success".to_string()),
+        );
+        let pol = build_nameserver_policy(&map, None, &[], &HashMap::new(), &providers)
+            .await
+            .unwrap();
+        assert!(pol.lookup("a.example").is_some());
+        assert!(pol.lookup("b.example").is_some());
+        assert!(pol.lookup("c.example").is_none());
+    }
+
+    // rule-set: provider names are case-sensitive.
+    #[tokio::test]
+    async fn parse_nameserver_policy_rule_set_case_sensitive_provider_name() {
+        use crate::raw::RawNspValue;
+        let providers = inline_rule_providers(&[("CN", "domain", vec!["example.cn".to_string()])]);
+        let mut map = HashMap::new();
+        map.insert(
+            "rule-set:CN".to_string(),
+            RawNspValue::One("rcode://success".to_string()),
+        );
+        let pol = build_nameserver_policy(&map, None, &[], &HashMap::new(), &providers)
+            .await
+            .unwrap();
+        assert!(pol.lookup("example.cn").is_some());
     }
 
     // Fallback-filter defaults when no raw config provided.

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -1712,6 +1712,26 @@ async fn build_config(
     )
     .await?;
 
+    // Load rule-providers before DNS so that `nameserver-policy` `rule-set:`
+    // entries can resolve against them. This uses the step-1 proxy registry;
+    // step-2 only differs in DIRECT's resolver field (see ADR-0012), which
+    // does not affect provider `proxy:` resolution or HTTP fetches.
+    let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
+    let rule_providers = match raw.rule_providers.as_ref() {
+        Some(map) if !map.is_empty() => {
+            load_rule_providers_async(
+                map.clone(),
+                cache_dir_buf.clone(),
+                ctx.clone(),
+                download_proxy,
+                proxies.clone(),
+                Arc::clone(&provider_payloads),
+            )
+            .await?
+        }
+        _ => HashMap::new(),
+    };
+
     // DNS — pass the explicit mmdb path so fallback-filter GeoIP uses the
     // same path as the rule engine, plus the proxy registry from step 1
     // so #PROXY-tagged nameservers can resolve their referenced adapter.
@@ -1721,6 +1741,7 @@ async fn build_config(
         cache_dir,
         &proxies,
         ctx.geosite.clone(),
+        &rule_providers,
     )
     .await?;
 
@@ -1734,22 +1755,6 @@ async fn build_config(
         Arc::clone(&provider_payloads),
     )
     .await?;
-
-    let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
-    let rule_providers = match raw.rule_providers.as_ref() {
-        Some(map) if !map.is_empty() => {
-            load_rule_providers_async(
-                map.clone(),
-                cache_dir_buf.clone(),
-                ctx.clone(),
-                download_proxy,
-                proxies.clone(),
-                provider_payloads,
-            )
-            .await?
-        }
-        _ => HashMap::new(),
-    };
 
     // Listener config
     let bind_addr = if general.allow_lan {

--- a/crates/meow-rules/src/rule_set.rs
+++ b/crates/meow-rules/src/rule_set.rs
@@ -82,6 +82,16 @@ pub trait RuleSet: Send + Sync {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Domain-only match for DNS `nameserver-policy` `rule-set:` entries.
+    ///
+    /// Unlike [`RuleSet::matches`], this takes a bare domain string instead of
+    /// a full [`Metadata`], because DNS policy dispatch only has the query
+    /// domain. IP-behavior sets return `false`; classical sets evaluate their
+    /// rules against a host-only `Metadata` (IP rules never match).
+    fn matches_domain(&self, _domain: &str) -> bool {
+        false
+    }
 }
 
 /// Build a rule-set of the given behavior from already-parsed entries.
@@ -297,6 +307,10 @@ impl RuleSet for DomainRuleSet {
     fn len(&self) -> usize {
         self.count
     }
+
+    fn matches_domain(&self, domain: &str) -> bool {
+        self.trie.search(domain).is_some()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -427,6 +441,20 @@ impl RuleSet for ClassicalRuleSet {
 
     fn should_find_process(&self) -> bool {
         self.rules.iter().any(|rule| rule.should_find_process())
+    }
+
+    fn matches_domain(&self, domain: &str) -> bool {
+        // Host-only metadata: IP/port/process/rules needing a resolver won't
+        // match, matching upstream's "only domain rules" semantics for
+        // classical sets. dst_port stays at the default 0 so DST-PORT rules
+        // never fire on a domain-only query.
+        let metadata = Metadata {
+            host: domain.into(),
+            ..Default::default()
+        };
+        self.rules
+            .iter()
+            .any(|r| r.match_metadata(&metadata, &RuleMatchHelper))
     }
 }
 
@@ -560,6 +588,43 @@ mod tests {
         let set = build_rule_set(RuleSetBehavior::Domain, &["example.com".to_string()], &ctx);
         assert_eq!(set.behavior(), RuleSetBehavior::Domain);
         assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn domain_rule_set_matches_domain_directly() {
+        let set = DomainRuleSet::from_entries(&["+.foo.com".to_string()]);
+        assert!(set.matches_domain("a.foo.com"));
+        assert!(set.matches_domain("foo.com"));
+        assert!(!set.matches_domain("bar.com"));
+        // case-insensitive, like the full Metadata path
+        assert!(set.matches_domain("A.Foo.COM"));
+    }
+
+    #[test]
+    fn classical_rule_set_matches_domain_only() {
+        let ctx = ParserContext::empty();
+        let set = ClassicalRuleSet::from_entries(
+            &[
+                "DOMAIN-SUFFIX,google.com".to_string(),
+                "IP-CIDR,10.0.0.0/8,no-resolve".to_string(),
+                // A DST-PORT rule must NOT fire on a domain-only query even
+                // though DNS runs on port 53 — guard against dst_port=53
+                // false positives in matches_domain.
+                "DST-PORT,53".to_string(),
+            ],
+            &ctx,
+        );
+        assert!(set.matches_domain("mail.google.com"));
+        // IP and port rules must not fire on a domain-only query.
+        assert!(!set.matches_domain("10.0.0.1"));
+        assert!(!set.matches_domain("example.org"));
+    }
+
+    #[test]
+    fn ipcidr_rule_set_matches_domain_is_false() {
+        let set = IpCidrRuleSet::from_entries(&["10.0.0.0/8".to_string()]);
+        assert!(!set.matches_domain("10.0.0.1"));
+        assert!(!set.matches_domain("foo.com"));
     }
 
     #[test]

--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -111,7 +111,8 @@ These fields parse without error but behave differently from Go mihomo:
 | `nameserver-policy` entry with all URLs stripped | Runtime panic | Hard parse error at load | A |
 | `fallback-filter` GeoIP/CIDR gates | Only on primary failure | Also on poisoned responses (non-CN IP, bogon) | A |
 | `fallback-filter.geoip: true` with no MMDB | Startup error | Warn-once, gate disabled | B |
-| `nameserver-policy` key with `geosite:` prefix | Resolved via geosite DB | Warn-once, entry skipped | B |
+| `nameserver-policy` key with `geosite:` prefix | Resolved via geosite DB | Same — resolved via geosite DB (needs geosite DB; warn-skip if absent) | — |
+| `nameserver-policy` key with `rule-set:` prefix | Resolved via rule-provider | Same — resolved via rule-provider (domain/classical); `ipcidr` behavior and missing provider are hard errors | — |
 | `IN-TYPE` with unknown value (e.g. `IN-TYPE,QUIC`) | Silently no-match | Hard parse error | A |
 | `PUT /configs` in-flight connections | Graceful handover | Cold reload, connections dropped + logged | A |
 | `PUT /configs` payload with raw YAML (not base64) | Accepted in some versions | 400 with helpful message | B |

--- a/docs/specs/dns-nameserver-policy-test-plan.md
+++ b/docs/specs/dns-nameserver-policy-test-plan.md
@@ -140,6 +140,12 @@ All new cases are `#[tokio::test]` to match the async DNS parser.
 | D10 | `parse_nameserver_policy_absent_is_valid` | No `nameserver-policy` key. Assert `Ok`, `policy: None` in resolver config. |
 | D11 | `parse_fallback_filter_invalid_cidr_errors` **[guard-rail]** | `ipcidr: ["not-a-cidr"]`. Assert `Err` at parse time, not at query time. Guards that CIDR parsing is eager. |
 | D12 | `parse_nameserver_policy_multiple_entries` | Three entries: one exact, two wildcard. Assert all three present in parsed policy. |
+| D13 | `parse_nameserver_policy_rule_set_domain_matches_loaded_provider` | `rule-set:cn` with an inline `domain` provider containing `example.cn`/`+.cn`. Assert `lookup("example.cn")` and `lookup("foo.cn")` hit; `lookup("example.com")` does not. |
+| D14 | `parse_nameserver_policy_rule_set_missing_provider_errors` | `rule-set:missing` with no provider. Assert `Err` containing `not found rule-set`. |
+| D15 | `parse_nameserver_policy_rule_set_ipcidr_behavior_errors` | `rule-set:ips` with an `ipcidr` provider. Assert `Err` mentioning `IpCidr`. |
+| D16 | `parse_nameserver_policy_rule_set_classical_warns_and_matches` | `rule-set:cls` with a `classical` provider containing `DOMAIN-SUFFIX,google.com`. Assert `lookup("mail.google.com")` hits; `lookup("example.org")` does not. |
+| D17 | `parse_nameserver_policy_rule_set_comma_expands` | `rule-set:a,b` with two providers. Assert both `a.example` and `b.example` hit. |
+| D18 | `parse_nameserver_policy_rule_set_case_sensitive_provider_name` | Provider named `CN` (uppercase). `rule-set:CN` hits; documents that provider names are case-sensitive. |
 
 ### E. Network-dependent integration tests (`crates/meow-dns/tests/nameserver_policy_integration.rs`)
 

--- a/docs/specs/dns-nameserver-policy.md
+++ b/docs/specs/dns-nameserver-policy.md
@@ -72,6 +72,8 @@ dns:
     "+.corp.internal": [192.168.1.53, 192.168.1.54]   # corporate resolver
     "+.google.com": https://dns.google/dns-query        # single-server policy (string OK)
     "example.com": [udp://9.9.9.9, tls://1.1.1.1:853]
+    "geosite:cn": [https://doh.pub/dns-query, 223.5.5.5]  # geosite category (needs geosite DB)
+    "rule-set:cn-domain": [https://doh.pub/dns-query]     # rule-provider (behavior: domain/classical)
   fallback-filter:
     geoip: true               # default: true
     geoip-code: CN            # default: CN
@@ -90,6 +92,8 @@ Field reference — `nameserver-policy`:
 |--------|---------|
 | `"exact.domain": [servers]` | Exact match on `exact.domain`. |
 | `"+.sub.domain": [servers]` | Matches `sub.domain` and all subdomains (`*.sub.domain`). |
+| `"geosite:<cat>[,<cat>]": [servers]` | Matches domains in the geosite DB category/ies. Requires a loaded geosite DB; skipped with a warning if absent. |
+| `"rule-set:<name>[,<name>]": [servers]` | Matches domains in the named rule-provider. Provider behavior must be `domain` (or `classical`, warned); `ipcidr` is a hard error; a missing provider is a hard error. |
 | Value is a string | Treated as a single-element list. |
 | Value is a list | Multiple nameservers for this policy; first responding wins. |
 
@@ -109,7 +113,7 @@ Field reference — `fallback-filter`:
 
 | # | Case | Class | Rationale |
 |---|------|:-----:|-----------|
-| 1 | `geosite:`/`rule-set:` patterns in nameserver-policy — upstream supports | B | Deferred to M1.x. Unknown-prefix patterns (not `+.` or bare domain) produce a warn-once at parse time and are skipped. NOT hard error — too many real configs use these. |
+| 1 | `geosite:`/`rule-set:` patterns in nameserver-policy — upstream supports | — | **Implemented.** `geosite:` compiles into a matcher from the loaded geosite DB (issue #299 / #237). `rule-set:` compiles into a matcher from the loaded rule-providers: `Domain` behavior matches directly, `Classical` warns once and matches only its domain rules, `IpCidr` is a hard error, and a missing provider is a hard error (`not found rule-set: <name>`). The matcher snapshots the provider on each lookup, so background refreshes take effect automatically. Other unknown `:`-prefixed patterns still warn-once and skip. |
 | 2 | `dhcp://` nameserver — upstream supports | B | Warn-once at parse time; entry skipped. |
 | 3 | `fallback-filter.geoip: true` with no MMDB — upstream errors at startup | B | We treat as `geoip: false` with `warn!`. Single-resolver configs are valid without a GeoIP DB. NOT a startup error. |
 | 4 | nameserver-policy entry with no valid nameservers (all skipped) → upstream panics | A | Hard parse error: "nameserver-policy entry 'KEY' has no valid nameservers after skipping unsupported prefixes." A policy entry with zero valid nameservers silently routes the configured domain to global nameservers — a potential DNS leakage for internal/corporate domains. Fail loudly. |

--- a/website/guide/dns.md
+++ b/website/guide/dns.md
@@ -67,16 +67,23 @@ DoH instead.
 
 ## Nameserver policy
 
-Route specific domains to specific upstreams. Keys are exact names, `+.`-wildcards, or
-`geosite:` category selectors; values are a single upstream or a list.
+Route specific domains to specific upstreams. Keys are exact names, `+.`-wildcards,
+`geosite:` category selectors, or `rule-set:` provider selectors; values are a single
+upstream or a list.
 
 ```yaml
 dns:
   nameserver-policy:
     "geosite:cn": [223.5.5.5, 119.29.29.29]
+    "rule-set:cn-domain": [223.5.5.5]   # behavior: domain (or classical)
     "+.local": 192.168.1.1
     "internal.corp": 10.0.0.1
 ```
+
+`rule-set:` references a rule-provider by name. The provider behavior must be `domain`
+(or `classical`, in which case only its domain rules are matched); an `ipcidr` provider or
+a missing provider is a config error. The matcher reads the provider live, so background
+refreshes apply automatically.
 
 ## Fallback filter
 


### PR DESCRIPTION
Closes #299

## What

Implements `rule-set:` pattern support in `dns.nameserver-policy`. This allows routing DNS queries for domains contained in a rule-provider (rule-set) to dedicated nameservers, matching upstream mihomo behavior.

## Why

Issue #299 requested both `geosite:` and `rule-set:` support in `nameserver-policy`. `geosite:` was already implemented; `rule-set:` was still skipped with a warn-once. This change completes the feature.

## Usage example

```yaml
dns:
  nameserver-policy:
    "rule-set:ShellClash-ChinaDomain": [223.5.5.5, 119.29.29.29]
    "rule-set:ShellClash-LocalAreaNetwork,ShellClash-GoogleCN": [127.0.0.1:53]
```

## How

- Added `RuleSet::matches_domain(&str) -> bool` in `crates/meow-rules`:
  - `DomainRuleSet`: direct trie search (hot path, no `Metadata` allocation).
  - `ClassicalRuleSet`: evaluates only domain rules against a host-only `Metadata` so IP/port/process rules cannot accidentally match.
  - `IpCidrRuleSet`: default `false`.
- Updated `crates/meow-config/src/dns_parser.rs::build_nameserver_policy` to:
  - Accept loaded rule-providers.
  - Compile `rule-set:` keys into `NameserverPolicyMatcher` closures that snapshot the provider on each lookup.
  - Validate provider behavior: `Domain` allowed, `Classical` allowed with a per-entry warning, `IpCidr` hard error, missing provider hard error.
  - Preserve original-case provider names (case-sensitive, like upstream).
- Reordered startup in `crates/meow-config/src/lib.rs` so rule-providers are loaded before DNS configuration is parsed.
- Updated tests, specs (`docs/specs/dns-nameserver-policy.md`), migration guide, and website guide.

## Breaking change

Configs that previously contained `rule-set:` keys in `nameserver-policy` were silently skipped with a warning. They now:

- hard-error if the referenced provider does not exist;
- hard-error if the provider behavior is `IpCidr`;
- warn per entry and match only domain rules if behavior is `Classical`.

This aligns with upstream mihomo and prevents silent DNS leakage.

## Changes

```
crates/meow-config/src/dns_parser.rs          | 202 ++++++++++++++++++++++++--
crates/meow-config/src/lib.rs                 |  37 +++--
crates/meow-rules/src/rule_set.rs             |  65 +++++++++
docs/migration-from-go-mihomo.md              |   3 +-
docs/specs/dns-nameserver-policy-test-plan.md |   6 +
docs/specs/dns-nameserver-policy.md           |   6 +-
website/guide/dns.md                          |  11 +-
```

## Testing

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` (default, no-default-features, all-features) ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✅
- `cargo test -p meow-rules -p meow-config --lib` ✅ 356 passed, 0 failed
- `cargo test --test rules_test` ✅ 102 passed
- `cargo test --test trojan_integration` ✅ 5 passed
- End-to-end smoke test with an [endfield](https://github.com/aimkiray/endfield) subscription (commit `2a25d57`) and a local sing-box VMess node:
  - `taobao.com` (ShellClash-ChinaDomain) → policy nameserver ✅
  - `alt1-mtalk.google.com` (ShellClash-GoogleCN) → policy nameserver ✅
  - `foo.internal` (ShellClash-LocalAreaNetwork) → policy nameserver ✅
  - `example.com` / `github.com` → global nameserver ✅
  - `curl --proxy socks5h://127.0.0.1:7893 https://www.gstatic.com/generate_204` → `204` via LocalVMess → sing-box ✅

## Notes for reviewers

- `geosite:` in `nameserver-policy` already worked on `main` and is not changed by this PR.
- The CI `test` job failure (`no_server_side_symbols_in_src`) is a **pre-existing breakage on `main`** (PR #441 introduced `h2::server::Connection::accept()` in `src/h2_common.rs` inline tests). PR #464 is fixing it. This PR does not touch any `meow-transport` files.
- The `meow-dns::client::tests::udp_client_times_out_on_unroutable` test is a pre-existing environment-dependent flaky test unrelated to this change.