### PR TITLE
test: consolidate redundant tests into table-driven cases (-150 tests)

### DIFF
--- a/crates/meow-api/tests/api_logs_ws_test.rs
+++ b/crates/meow-api/tests/api_logs_ws_test.rs
@@ -136,44 +136,67 @@ fn log_level_ordering() {
 // ── B. Frame delivery (real TCP server + WS client) ───────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn logs_ws_emits_info_events() {
-    let (state, log_tx) = make_state();
-    let (addr, _handle) = spawn_server(state).await;
-    let mut ws = ws_connect(&format!("ws://127.0.0.1:{}/logs?level=info", addr.port())).await;
+async fn logs_ws_emits_level_table() {
+    // (case label, injected level, payload, expected `type` key in the frame).
+    // Every case uses a `?level=info` client, so the warning/error rows also
+    // cover the `>=` filter passing higher-severity events to an info client.
+    let cases: &[(&str, LogLevel, &str, &str)] = &[
+        ("B1 info event", LogLevel::Info, "hello", "info"),
+        // "warning", NOT "warn" — the structured (`?format=structured`) branch
+        // renames it, the plain mihomo frame must not.
+        ("B2 warning event", LogLevel::Warning, "warn", "warning"),
+        ("B3 error event", LogLevel::Error, "err", "error"),
+        (
+            "C: warning passes filter for info client",
+            LogLevel::Warning,
+            "warn-msg",
+            "warning",
+        ),
+    ];
 
-    log_tx.send(log_msg(LogLevel::Info, "hello")).unwrap();
+    let mut failures: Vec<String> = Vec::new();
+    for (label, level, payload, expected_type) in cases {
+        let (state, log_tx) = make_state();
+        let (addr, _handle) = spawn_server(state).await;
+        let mut ws = ws_connect(&format!("ws://127.0.0.1:{}/logs?level=info", addr.port())).await;
 
-    let text = recv_text(&mut ws).await;
-    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert_eq!(v["type"], "info");
-    assert_eq!(v["payload"], "hello");
-}
+        log_tx.send(log_msg(*level, payload)).unwrap();
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn logs_ws_emits_warning_events() {
-    let (state, log_tx) = make_state();
-    let (addr, _handle) = spawn_server(state).await;
-    let mut ws = ws_connect(&format!("ws://127.0.0.1:{}/logs?level=info", addr.port())).await;
+        let text = match tokio::time::timeout(Duration::from_millis(500), ws.next()).await {
+            Ok(Some(Ok(msg))) => msg.into_text().unwrap().to_string(),
+            other => {
+                failures.push(format!(
+                    "[{label}] no WS text frame within 500ms: {other:?}"
+                ));
+                continue;
+            }
+        };
+        let v: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(v) => v,
+            Err(e) => {
+                failures.push(format!("[{label}] frame is not JSON ({e}): {text}"));
+                continue;
+            }
+        };
+        if v["type"] != *expected_type {
+            failures.push(format!(
+                "[{label}] expected type {expected_type:?}, got {}",
+                v["type"]
+            ));
+        }
+        if v["payload"] != *payload {
+            failures.push(format!(
+                "[{label}] expected payload {payload:?}, got {}",
+                v["payload"]
+            ));
+        }
+    }
 
-    log_tx.send(log_msg(LogLevel::Warning, "warn")).unwrap();
-
-    let text = recv_text(&mut ws).await;
-    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert_eq!(v["type"], "warning");
-    assert_eq!(v["payload"], "warn");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn logs_ws_emits_error_events() {
-    let (state, log_tx) = make_state();
-    let (addr, _handle) = spawn_server(state).await;
-    let mut ws = ws_connect(&format!("ws://127.0.0.1:{}/logs?level=info", addr.port())).await;
-
-    log_tx.send(log_msg(LogLevel::Error, "err")).unwrap();
-
-    let text = recv_text(&mut ws).await;
-    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert_eq!(v["type"], "error");
+    assert!(
+        failures.is_empty(),
+        "log frame table failures:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -226,20 +249,6 @@ async fn logs_ws_level_filter_suppresses_debug() {
         result.is_err(),
         "debug message must be suppressed for level=info client"
     );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn logs_ws_level_filter_passes_warning_for_info_client() {
-    let (state, log_tx) = make_state();
-    let (addr, _handle) = spawn_server(state).await;
-    let mut ws = ws_connect(&format!("ws://127.0.0.1:{}/logs?level=info", addr.port())).await;
-
-    log_tx.send(log_msg(LogLevel::Warning, "warn-msg")).unwrap();
-
-    let text = recv_text(&mut ws).await;
-    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert_eq!(v["type"], "warning");
-    assert_eq!(v["payload"], "warn-msg");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -952,31 +952,6 @@ async fn delete_proxy_group_not_found() {
 }
 
 #[tokio::test]
-async fn select_proxy_in_selector_group() {
-    let mut raw = test_raw_config();
-    raw.proxy_groups = Some(vec![RawProxyGroup {
-        name: "Sel".into(),
-        group_type: "select".into(),
-        proxies: Some(vec!["DIRECT".into(), "REJECT".into()]),
-        ..Default::default()
-    }]);
-    let state = test_state(raw);
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/api/proxy-groups/Sel/select")
-                .header("content-type", "application/json")
-                .body(axum::body::Body::from(r#"{"name":"REJECT"}"#))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-}
-
-#[tokio::test]
 async fn select_proxy_invalid_target() {
     let mut raw = test_raw_config();
     raw.proxy_groups = Some(vec![RawProxyGroup {
@@ -1417,196 +1392,186 @@ async fn select_proxy_roundtrip() {
 // ── Bearer auth middleware ───────────────────────────────────────
 
 #[tokio::test]
-async fn auth_unset_secret_allows_api_request() {
-    let state = test_state_default();
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-}
-
-#[tokio::test]
-async fn auth_empty_secret_allows_api_request() {
-    let state = test_state_with_secret("");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-}
-
-#[tokio::test]
-async fn auth_missing_header_rejects_with_401() {
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn auth_wrong_token_rejects_with_401() {
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .header("authorization", "Bearer wrongtoken")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn auth_correct_token_allows_request() {
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .header("authorization", "Bearer hunter2")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-}
-
-#[tokio::test]
-async fn auth_lowercase_bearer_prefix_rejected() {
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/version")
-                .header("authorization", "bearer hunter2")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn auth_non_bearer_scheme_rejected() {
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .header("authorization", "Basic hunter2")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn auth_ui_routes_remain_unauthenticated() {
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(Request::get("/ui").body(axum::body::Body::empty()).unwrap())
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-}
-
-#[tokio::test]
-async fn auth_gated_write_endpoint_rejects_unauthenticated_post() {
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::post("/rules")
-                .header("content-type", "application/json")
-                .body(axum::body::Body::from(r#"{"rules":[]}"#))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-// Edge cases: malformed Authorization header values
-#[tokio::test]
-async fn auth_bearer_empty_value_rejects_with_401() {
-    // "Bearer " with nothing after the space: strip_prefix yields "", != secret.
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .header("authorization", "Bearer ")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn auth_no_space_after_bearer_rejects_with_401() {
-    // "Bearertoken" — neither "Bearer " nor "bearer " prefix present; strip_prefix
-    // returns None so middleware cannot extract a token.
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .header("authorization", "Bearerhunter2")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn auth_multibyte_utf8_header_value_rejects_with_401() {
-    // "Bearer café" — é is 0xC3 0xA9 (two UTF-8 bytes, not valid ASCII).
-    // HeaderValue::to_str() returns Err for non-ASCII bytes, so the middleware
-    // sees None for the provided token and returns 401.
+async fn auth_middleware_table() {
     use axum::http::header::HeaderValue;
-    let state = test_state_with_secret("hunter2");
-    let app = create_router(state);
-    let hv = HeaderValue::from_bytes(b"Bearer caf\xc3\xa9").unwrap();
-    let resp = app
-        .oneshot(
-            Request::get("/proxies")
-                .header("authorization", hv)
-                .body(axum::body::Body::empty())
+
+    /// `Authorization` header a case sends.
+    enum AuthHeader {
+        /// No `Authorization` header at all.
+        Absent,
+        /// Header value that is valid ASCII.
+        Str(&'static str),
+        /// Raw bytes, so non-ASCII values can be exercised.
+        Raw(&'static [u8]),
+    }
+
+    struct Case {
+        label: &'static str,
+        /// `None` → `AppState.secret` is `None`; `Some(s)` → `Some(s.to_string())`.
+        secret: Option<&'static str>,
+        method: &'static str,
+        path: &'static str,
+        auth: AuthHeader,
+        /// JSON request body; sets `content-type: application/json` when present.
+        body: Option<&'static str>,
+        expected: StatusCode,
+    }
+
+    let cases = [
+        Case {
+            label: "unset secret: auth disabled, API request allowed",
+            secret: None,
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Absent,
+            body: None,
+            expected: StatusCode::OK,
+        },
+        Case {
+            label: "empty secret: auth disabled, API request allowed",
+            secret: Some(""),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Absent,
+            body: None,
+            expected: StatusCode::OK,
+        },
+        Case {
+            label: "missing Authorization header rejected",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Absent,
+            body: None,
+            expected: StatusCode::UNAUTHORIZED,
+        },
+        Case {
+            label: "wrong token rejected",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Str("Bearer wrongtoken"),
+            body: None,
+            expected: StatusCode::UNAUTHORIZED,
+        },
+        Case {
+            label: "correct token allows request",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Str("Bearer hunter2"),
+            body: None,
+            expected: StatusCode::OK,
+        },
+        Case {
+            // /version is deliberately probed here: it proves the gate covers it too.
+            label: "lowercase `bearer ` prefix rejected (only `Bearer ` is stripped)",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/version",
+            auth: AuthHeader::Str("bearer hunter2"),
+            body: None,
+            expected: StatusCode::UNAUTHORIZED,
+        },
+        Case {
+            label: "non-Bearer scheme rejected",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Str("Basic hunter2"),
+            body: None,
+            expected: StatusCode::UNAUTHORIZED,
+        },
+        Case {
+            label: "UI routes remain unauthenticated",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/ui",
+            auth: AuthHeader::Absent,
+            body: None,
+            expected: StatusCode::OK,
+        },
+        Case {
+            label: "gated write endpoint rejects unauthenticated POST",
+            secret: Some("hunter2"),
+            method: "POST",
+            path: "/rules",
+            auth: AuthHeader::Absent,
+            body: Some(r#"{"rules":[]}"#),
+            expected: StatusCode::UNAUTHORIZED,
+        },
+        Case {
+            // "Bearer " with nothing after the space: strip_prefix yields "", != secret.
+            label: "`Bearer ` with empty value rejected",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Str("Bearer "),
+            body: None,
+            expected: StatusCode::UNAUTHORIZED,
+        },
+        Case {
+            // "Bearerhunter2" — no "Bearer " prefix, so strip_prefix returns None
+            // and the middleware cannot extract a token.
+            label: "no space after `Bearer` rejected",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Str("Bearerhunter2"),
+            body: None,
+            expected: StatusCode::UNAUTHORIZED,
+        },
+        Case {
+            // "Bearer café" — é is 0xC3 0xA9 (two UTF-8 bytes, not valid ASCII).
+            // HeaderValue::to_str() returns Err for non-ASCII bytes, so the
+            // middleware sees None for the provided token and returns 401.
+            label: "multibyte UTF-8 header value rejected",
+            secret: Some("hunter2"),
+            method: "GET",
+            path: "/proxies",
+            auth: AuthHeader::Raw(b"Bearer caf\xc3\xa9"),
+            body: None,
+            expected: StatusCode::UNAUTHORIZED,
+        },
+    ];
+
+    let mut failures = Vec::new();
+    for case in &cases {
+        let state = match case.secret {
+            None => test_state_default(),
+            Some(secret) => test_state_with_secret(secret),
+        };
+        let app = create_router(state);
+
+        let mut builder = Request::builder().method(case.method).uri(case.path);
+        match case.auth {
+            AuthHeader::Absent => {}
+            AuthHeader::Str(value) => builder = builder.header("authorization", value),
+            AuthHeader::Raw(bytes) => {
+                builder = builder.header("authorization", HeaderValue::from_bytes(bytes).unwrap());
+            }
+        }
+        let req = match case.body {
+            Some(body) => builder
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
                 .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+            None => builder.body(axum::body::Body::empty()).unwrap(),
+        };
+
+        let status = app.oneshot(req).await.unwrap().status();
+        if status != case.expected {
+            failures.push(format!(
+                "[{}] {} {} → expected {}, got {status}",
+                case.label, case.method, case.path, case.expected
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "auth middleware cases failed:\n{}",
+        failures.join("\n")
+    );
 }
 
 // ── Delay endpoints (M1.G-2) ─────────────────────────────────────────
@@ -1962,85 +1927,88 @@ async fn a1_get_proxy_delay_ok_records_delay() {
 
 // ── B: single-proxy error surface ────────────────────────────────────
 
+/// Error-surface table for the single-proxy delay endpoint: every case shares
+/// the same `TestAdapter`/state setup and differs only in the request path and
+/// the expected status/body. Cases are labelled and all of them run even when
+/// an earlier one fails.
 #[tokio::test]
-async fn b1_missing_url_is_400_body_invalid() {
-    let adapter = TestAdapter::new(
-        "T",
-        DialBehavior::SleepThenOk(std::time::Duration::from_millis(5)),
-    )
-    .into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(app, "/proxies/T/delay?timeout=1000".to_string()).await;
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(&bytes[..], br#"{"message":"Body invalid"}"#);
-}
+async fn b_series_delay_error_table() {
+    struct Case {
+        label: &'static str,
+        path: String,
+        expected_status: StatusCode,
+        expected_body: Option<&'static [u8]>,
+    }
 
-#[tokio::test]
-async fn b2_missing_timeout_is_400_body_invalid() {
-    let adapter = TestAdapter::new(
-        "T",
-        DialBehavior::SleepThenOk(std::time::Duration::from_millis(5)),
-    )
-    .into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(app, format!("/proxies/T/delay?url={}", url_q())).await;
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(&bytes[..], br#"{"message":"Body invalid"}"#);
-}
+    let cases = vec![
+        Case {
+            label: "b1 missing url is 400 Body invalid",
+            path: "/proxies/T/delay?timeout=1000".to_string(),
+            expected_status: StatusCode::BAD_REQUEST,
+            expected_body: Some(br#"{"message":"Body invalid"}"#),
+        },
+        Case {
+            label: "b2 missing timeout is 400 Body invalid",
+            path: format!("/proxies/T/delay?url={}", url_q()),
+            expected_status: StatusCode::BAD_REQUEST,
+            expected_body: Some(br#"{"message":"Body invalid"}"#),
+        },
+        Case {
+            label: "b3 timeout too large is 400 Body invalid",
+            path: format!("/proxies/T/delay?url={}&timeout=100000", url_q()),
+            expected_status: StatusCode::BAD_REQUEST,
+            expected_body: Some(br#"{"message":"Body invalid"}"#),
+        },
+        Case {
+            label: "b4 timeout zero is 400",
+            path: format!("/proxies/T/delay?url={}&timeout=0", url_q()),
+            expected_status: StatusCode::BAD_REQUEST,
+            expected_body: None,
+        },
+        Case {
+            label: "b5 unknown proxy is 404 resource not found",
+            path: format!("/proxies/NOPE/delay?url={}&timeout=1000", url_q()),
+            expected_status: StatusCode::NOT_FOUND,
+            expected_body: Some(br#"{"message":"resource not found"}"#),
+        },
+    ];
 
-#[tokio::test]
-async fn b3_timeout_too_large_is_400() {
-    let adapter = TestAdapter::new(
-        "T",
-        DialBehavior::SleepThenOk(std::time::Duration::from_millis(5)),
-    )
-    .into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(
-        app,
-        format!("/proxies/T/delay?url={}&timeout=100000", url_q()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(&bytes[..], br#"{"message":"Body invalid"}"#);
-}
+    let mut failures: Vec<String> = Vec::new();
+    for case in cases {
+        let adapter = TestAdapter::new(
+            "T",
+            DialBehavior::SleepThenOk(std::time::Duration::from_millis(5)),
+        )
+        .into_proxy();
+        let state = state_with_proxies(vec![("T", adapter)]);
+        let app = create_router(state);
+        let resp = delay_req(app, case.path.clone()).await;
+        let status = resp.status();
+        if status != case.expected_status {
+            failures.push(format!(
+                "[{}] GET {}: expected status {}, got {status}",
+                case.label, case.path, case.expected_status
+            ));
+        }
+        if let Some(expected_body) = case.expected_body {
+            let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+            if &bytes[..] != expected_body {
+                failures.push(format!(
+                    "[{}] GET {}: expected body {}, got {}",
+                    case.label,
+                    case.path,
+                    String::from_utf8_lossy(expected_body),
+                    String::from_utf8_lossy(&bytes)
+                ));
+            }
+        }
+    }
 
-#[tokio::test]
-async fn b4_timeout_zero_is_400() {
-    let adapter = TestAdapter::new(
-        "T",
-        DialBehavior::SleepThenOk(std::time::Duration::from_millis(5)),
-    )
-    .into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(app, format!("/proxies/T/delay?url={}&timeout=0", url_q())).await;
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-}
-
-#[tokio::test]
-async fn b5_unknown_proxy_is_404_resource_not_found() {
-    let adapter = TestAdapter::new(
-        "T",
-        DialBehavior::SleepThenOk(std::time::Duration::from_millis(5)),
-    )
-    .into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(
-        app,
-        format!("/proxies/NOPE/delay?url={}&timeout=1000", url_q()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(&bytes[..], br#"{"message":"resource not found"}"#);
+    assert!(
+        failures.is_empty(),
+        "delay error-surface cases failed:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[tokio::test]
@@ -2114,28 +2082,41 @@ async fn d1_group_delay_ok_all_members_reported() {
 }
 
 #[tokio::test]
-async fn d2_group_delay_non_group_is_404() {
-    // upstream: findProxyByName rejects non-groups with 404 for the group route.
-    let a = TestAdapter::new("A", DialBehavior::InstantOk).into_proxy();
-    let state = state_with_proxies(vec![("A", a)]);
-    let app = create_router(state);
-    let resp = delay_req(app, format!("/group/A/delay?url={}&timeout=1000", url_q())).await;
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(&bytes[..], br#"{"message":"resource not found"}"#);
-}
+async fn d2_d3_group_delay_404_table() {
+    // (case_label, target_name, expect_body_check)
+    //
+    // `non_group` (was d2): upstream findProxyByName rejects a *known*
+    // non-group name with 404 for the group route — `group.members()` is
+    // None. Body message is asserted exactly, as the original d2 did.
+    // `unknown_group` (was d3): the name is absent from the proxies map
+    // entirely. These are two distinct 404 branches in `get_group_delay`;
+    // both must stay covered.
+    let cases: [(&str, &str, bool); 2] =
+        [("non_group", "A", true), ("unknown_group", "NOPE", false)];
 
-#[tokio::test]
-async fn d3_group_delay_unknown_group_is_404() {
-    let a = TestAdapter::new("A", DialBehavior::InstantOk).into_proxy();
-    let state = state_with_proxies(vec![("A", a)]);
-    let app = create_router(state);
-    let resp = delay_req(
-        app,
-        format!("/group/NOPE/delay?url={}&timeout=1000", url_q()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    for (case_label, target_name, expect_body_check) in cases {
+        let a = TestAdapter::new("A", DialBehavior::InstantOk).into_proxy();
+        let state = state_with_proxies(vec![("A", a)]);
+        let app = create_router(state);
+        let resp = delay_req(
+            app,
+            format!("/group/{target_name}/delay?url={}&timeout=1000", url_q()),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "case {case_label}: expected 404"
+        );
+        if expect_body_check {
+            let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(
+                &bytes[..],
+                br#"{"message":"resource not found"}"#,
+                "case {case_label}: unexpected error body"
+            );
+        }
+    }
 }
 
 #[tokio::test]
@@ -2488,70 +2469,106 @@ async fn g3_get_proxy_delay_url_encoded_name() {
 // `httpHealthCheck` helper in `component/proxydialer/http.go`.
 
 #[tokio::test]
-async fn h1_default_expected_accepts_2xx() {
-    // No `expected` query param; response is 204 → success.
-    let adapter =
-        TestAdapter::new("T", DialBehavior::InstantStatus(204, "No Content")).into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(
-        app,
-        format!("/proxies/T/delay?url={}&timeout=1000", url_q()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::OK);
-}
+async fn h_series_expected_status_table() {
+    // Merge of h1..h4: identical setup (one `TestAdapter` whose canned HTTP
+    // response carries a configurable status line, probed via
+    // `/proxies/T/delay`), varying only the canned status, the `expected`
+    // query param, and the resulting HTTP status / body. Every case is
+    // labelled and every case runs even if an earlier one fails, so a single
+    // run reports all mismatches.
+    struct Case {
+        label: &'static str,
+        canned_status: u16,
+        canned_reason: &'static str,
+        expected_param: Option<&'static str>,
+        want_http: StatusCode,
+        want_body: Option<&'static [u8]>,
+    }
 
-#[tokio::test]
-async fn h2_default_expected_rejects_non_2xx() {
-    // 500 → default expected (2xx) misses → transport error → 503.
-    let adapter =
-        TestAdapter::new("T", DialBehavior::InstantStatus(500, "Server Error")).into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(
-        app,
-        format!("/proxies/T/delay?url={}&timeout=1000", url_q()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(
-        &bytes[..],
-        br#"{"message":"An error occurred in the delay test"}"#
+    const ERR_BODY: &[u8] = br#"{"message":"An error occurred in the delay test"}"#;
+
+    let cases = [
+        Case {
+            // h1: no `expected` query param; response is 204 -> success.
+            label: "h1_default_expected_accepts_2xx",
+            canned_status: 204,
+            canned_reason: "No Content",
+            expected_param: None,
+            want_http: StatusCode::OK,
+            want_body: None,
+        },
+        Case {
+            // h2: 500 -> default expected (2xx) misses -> transport error -> 503.
+            label: "h2_default_expected_rejects_non_2xx",
+            canned_status: 500,
+            canned_reason: "Server Error",
+            expected_param: None,
+            want_http: StatusCode::SERVICE_UNAVAILABLE,
+            want_body: Some(ERR_BODY),
+        },
+        Case {
+            // h3: 301 is outside 2xx but within the explicit range the caller
+            // asked for.
+            label: "h3_expected_range_accepts_member",
+            canned_status: 301,
+            canned_reason: "Moved",
+            expected_param: Some("200,301-399"),
+            want_http: StatusCode::OK,
+            want_body: None,
+        },
+        Case {
+            // h4: 204 is inside 2xx but the caller restricted to 200 exactly.
+            label: "h4_expected_range_rejects_out_of_range",
+            canned_status: 204,
+            canned_reason: "No Content",
+            expected_param: Some("200"),
+            want_http: StatusCode::SERVICE_UNAVAILABLE,
+            want_body: None,
+        },
+    ];
+
+    let mut failures: Vec<String> = Vec::new();
+    for case in &cases {
+        let adapter = TestAdapter::new(
+            "T",
+            DialBehavior::InstantStatus(case.canned_status, case.canned_reason),
+        )
+        .into_proxy();
+        let state = state_with_proxies(vec![("T", adapter)]);
+        let app = create_router(state);
+        let path = match case.expected_param {
+            Some(expected) => format!(
+                "/proxies/T/delay?url={}&timeout=1000&expected={expected}",
+                url_q()
+            ),
+            None => format!("/proxies/T/delay?url={}&timeout=1000", url_q()),
+        };
+        let resp = delay_req(app, path).await;
+        let got_http = resp.status();
+        if got_http != case.want_http {
+            failures.push(format!(
+                "[{}] status: want {}, got {got_http}",
+                case.label, case.want_http
+            ));
+        }
+        if let Some(want_body) = case.want_body {
+            let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+            if &bytes[..] != want_body {
+                failures.push(format!(
+                    "[{}] body: want {:?}, got {:?}",
+                    case.label,
+                    String::from_utf8_lossy(want_body),
+                    String::from_utf8_lossy(&bytes)
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "delay `expected` cases failed:\n{}",
+        failures.join("\n")
     );
-}
-
-#[tokio::test]
-async fn h3_expected_range_accepts_member() {
-    // 301 is outside 2xx but within the explicit range the caller asked for.
-    let adapter = TestAdapter::new("T", DialBehavior::InstantStatus(301, "Moved")).into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(
-        app,
-        format!(
-            "/proxies/T/delay?url={}&timeout=1000&expected=200,301-399",
-            url_q()
-        ),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::OK);
-}
-
-#[tokio::test]
-async fn h4_expected_range_rejects_out_of_range() {
-    // 204 is inside 2xx but the caller restricted to 200 exactly.
-    let adapter =
-        TestAdapter::new("T", DialBehavior::InstantStatus(204, "No Content")).into_proxy();
-    let state = state_with_proxies(vec![("T", adapter)]);
-    let app = create_router(state);
-    let resp = delay_req(
-        app,
-        format!("/proxies/T/delay?url={}&timeout=1000&expected=200", url_q()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
 
 #[tokio::test]

--- a/crates/meow-app/tests/systemd_config_test.rs
+++ b/crates/meow-app/tests/systemd_config_test.rs
@@ -19,56 +19,76 @@ fn minimal_raw_config() -> RawConfig {
 // ── systemd unit generation tests ───────────────────────────────────
 
 #[test]
-fn unit_contains_read_write_paths_for_config_dir() {
-    let unit = meow_app::generate_systemd_unit("/usr/bin/meow", "/etc/meow/config.yaml");
+fn systemd_unit_generation_table() {
+    // Table of (case_label, bin_path, config_path, expected_substrings).
+    // Rows correspond 1:1 to the former standalone tests:
+    //   read-write paths for config dir        <- unit_contains_read_write_paths_for_config_dir
+    //   exec start uses absolute config path   <- unit_exec_start_uses_absolute_config_path
+    //   hardening: protect system strict       <- unit_has_protect_system_strict
+    //   working directory matches config parent<- unit_working_directory_matches_config_parent
+    //   nested config path consistency         <- unit_paths_consistent_for_nested_config
+    //   edge case: config at filesystem root   <- unit_root_config_path_defaults_to_slash
+    let cases: &[(&str, &str, &str, &[&str])] = &[
+        (
+            "read-write paths for config dir",
+            "/usr/bin/meow",
+            "/etc/meow/config.yaml",
+            &["ReadWritePaths=/etc/meow"],
+        ),
+        (
+            "exec start uses absolute config path",
+            "/usr/bin/meow",
+            "/etc/meow/config.yaml",
+            &["ExecStart=/usr/bin/meow -f /etc/meow/config.yaml"],
+        ),
+        (
+            "hardening: protect system strict",
+            "/usr/bin/meow",
+            "/etc/meow/config.yaml",
+            &["ProtectSystem=strict"],
+        ),
+        (
+            "working directory matches config parent",
+            "/usr/bin/meow",
+            "/opt/meow/config.yaml",
+            &["WorkingDirectory=/opt/meow", "ReadWritePaths=/opt/meow"],
+        ),
+        (
+            "nested config path consistency",
+            "/usr/bin/meow",
+            "/var/lib/meow/configs/config.yaml",
+            &[
+                "WorkingDirectory=/var/lib/meow/configs",
+                "ReadWritePaths=/var/lib/meow/configs",
+            ],
+        ),
+        (
+            "edge case: config at filesystem root",
+            "/usr/bin/meow",
+            "/config.yaml",
+            &["WorkingDirectory=/", "ReadWritePaths=/"],
+        ),
+    ];
+
+    // Every case runs even if an earlier one fails, so a single run reports
+    // all mismatches instead of stopping at the first.
+    let mut failures: Vec<String> = Vec::new();
+    for &(label, bin, config_path, expected) in cases {
+        let unit = meow_app::generate_systemd_unit(bin, config_path);
+        for needle in expected {
+            if !unit.contains(needle) {
+                failures.push(format!(
+                    "[{label}] generate_systemd_unit({bin:?}, {config_path:?}) is missing {needle:?}\ngenerated unit:\n{unit}"
+                ));
+            }
+        }
+    }
 
     assert!(
-        unit.contains("ReadWritePaths=/etc/meow"),
-        "Unit must grant ReadWritePaths to config directory:\n{unit}",
+        failures.is_empty(),
+        "systemd unit generation mismatches:\n{}",
+        failures.join("\n---\n")
     );
-}
-
-#[test]
-fn unit_working_directory_matches_config_parent() {
-    let unit = meow_app::generate_systemd_unit("/usr/bin/meow", "/opt/meow/config.yaml");
-
-    assert!(unit.contains("WorkingDirectory=/opt/meow"));
-    assert!(unit.contains("ReadWritePaths=/opt/meow"));
-}
-
-#[test]
-fn unit_exec_start_uses_absolute_config_path() {
-    let unit = meow_app::generate_systemd_unit("/usr/bin/meow", "/etc/meow/config.yaml");
-
-    assert!(
-        unit.contains("ExecStart=/usr/bin/meow -f /etc/meow/config.yaml"),
-        "ExecStart should use the absolute config path:\n{unit}",
-    );
-}
-
-#[test]
-fn unit_has_protect_system_strict() {
-    let unit = meow_app::generate_systemd_unit("/usr/bin/meow", "/etc/meow/config.yaml");
-
-    assert!(unit.contains("ProtectSystem=strict"));
-}
-
-#[test]
-fn unit_paths_consistent_for_nested_config() {
-    let unit =
-        meow_app::generate_systemd_unit("/usr/bin/meow", "/var/lib/meow/configs/config.yaml");
-
-    assert!(unit.contains("WorkingDirectory=/var/lib/meow/configs"));
-    assert!(unit.contains("ReadWritePaths=/var/lib/meow/configs"));
-}
-
-#[test]
-fn unit_root_config_path_defaults_to_slash() {
-    // Edge case: config at filesystem root
-    let unit = meow_app::generate_systemd_unit("/usr/bin/meow", "/config.yaml");
-
-    assert!(unit.contains("WorkingDirectory=/"));
-    assert!(unit.contains("ReadWritePaths=/"));
 }
 
 // ── config save under restricted permissions (simulates ProtectSystem=strict) ──

--- a/crates/meow-common/src/sniffer/tls.rs
+++ b/crates/meow-common/src/sniffer/tls.rs
@@ -147,24 +147,22 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_sni_basic() {
-        let data = build_client_hello("example.com");
-        assert_eq!(sniff_tls(&data).as_deref(), Some("example.com"));
-    }
-
-    #[test]
-    fn test_extract_sni_subdomain() {
-        let data = build_client_hello("www.google.com");
-        assert_eq!(sniff_tls(&data).as_deref(), Some("www.google.com"));
-    }
-
-    #[test]
-    fn test_extract_sni_long_hostname() {
-        let data = build_client_hello("very.long.subdomain.example.co.uk");
-        assert_eq!(
-            sniff_tls(&data).as_deref(),
-            Some("very.long.subdomain.example.co.uk")
-        );
+    fn sniff_tls_sni_extraction_cases() {
+        // `very.long.subdomain.example.co.uk` is longer than the 23-byte SmolStr
+        // inline limit, so it also covers the heap-allocated return path; the two
+        // shorter names stay inlined. Keep all three literals.
+        for host in [
+            "example.com",
+            "www.google.com",
+            "very.long.subdomain.example.co.uk",
+        ] {
+            let data = build_client_hello(host);
+            assert_eq!(
+                sniff_tls(&data).as_deref(),
+                Some(host),
+                "SNI extraction failed for hostname {host:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/meow-common/tests/common_test.rs
+++ b/crates/meow-common/tests/common_test.rs
@@ -95,17 +95,23 @@ fn test_tunnel_mode_default() {
 }
 
 #[test]
-fn test_tunnel_mode_from_str() {
-    assert_eq!("global".parse::<TunnelMode>().unwrap(), TunnelMode::Global);
-    assert_eq!("rule".parse::<TunnelMode>().unwrap(), TunnelMode::Rule);
-    assert_eq!("direct".parse::<TunnelMode>().unwrap(), TunnelMode::Direct);
-}
-
-#[test]
-fn test_tunnel_mode_from_str_case_insensitive() {
-    assert_eq!("GLOBAL".parse::<TunnelMode>().unwrap(), TunnelMode::Global);
-    assert_eq!("Rule".parse::<TunnelMode>().unwrap(), TunnelMode::Rule);
-    assert_eq!("DIRECT".parse::<TunnelMode>().unwrap(), TunnelMode::Direct);
+fn tunnel_mode_from_str_cases() {
+    // Lowercase canonical spellings plus mixed/upper case: parsing is case-insensitive.
+    let cases = vec![
+        ("global", TunnelMode::Global),
+        ("rule", TunnelMode::Rule),
+        ("direct", TunnelMode::Direct),
+        ("GLOBAL", TunnelMode::Global),
+        ("Rule", TunnelMode::Rule),
+        ("DIRECT", TunnelMode::Direct),
+    ];
+    for (input, expected) in cases {
+        assert_eq!(
+            input.parse::<TunnelMode>().unwrap(),
+            expected,
+            "TunnelMode::from_str({input:?})"
+        );
+    }
 }
 
 #[test]
@@ -166,92 +172,91 @@ fn test_metadata_default() {
 }
 
 #[test]
-fn test_metadata_remote_address_with_host() {
-    let m = Metadata {
-        host: "example.com".into(),
-        dst_port: 443,
-        ..Default::default()
-    };
-    assert_eq!(m.remote_address(), "example.com:443");
+fn metadata_remote_address_cases() {
+    // host wins over dst_ip; otherwise dst_ip is formatted as a SocketAddr
+    // (IPv6 bracketed); with neither, only the port is rendered.
+    let cases: Vec<(&str, &str, Option<IpAddr>, u16, &str)> = vec![
+        ("with host", "example.com", None, 443, "example.com:443"),
+        (
+            "with ipv4",
+            "",
+            Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+            80,
+            "1.2.3.4:80",
+        ),
+        (
+            "with ipv6",
+            "",
+            Some(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+            8080,
+            "[::1]:8080",
+        ),
+        ("no host no ip", "", None, 443, ":443"),
+        (
+            "host takes priority over dst_ip",
+            "example.com",
+            Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+            443,
+            "example.com:443",
+        ),
+    ];
+    for (label, host, dst_ip, dst_port, expected) in cases {
+        let m = Metadata {
+            host: host.into(),
+            dst_ip,
+            dst_port,
+            ..Default::default()
+        };
+        assert_eq!(m.remote_address(), expected, "{label}");
+    }
 }
 
 #[test]
-fn test_metadata_remote_address_with_ipv4() {
-    let m = Metadata {
-        dst_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
-        dst_port: 80,
-        ..Default::default()
-    };
-    assert_eq!(m.remote_address(), "1.2.3.4:80");
+fn test_metadata_source_address_cases() {
+    let cases = vec![
+        (
+            "with src_ip",
+            Some(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100))),
+            12345u16,
+            "192.168.1.100:12345",
+        ),
+        ("no src_ip", None, 12345u16, ":12345"),
+    ];
+    for (label, src_ip, src_port, expected) in cases {
+        let m = Metadata {
+            src_ip,
+            src_port,
+            ..Default::default()
+        };
+        assert_eq!(m.source_address(), expected, "case: {label}");
+    }
 }
 
 #[test]
-fn test_metadata_remote_address_with_ipv6() {
-    let m = Metadata {
-        dst_ip: Some(IpAddr::V6(Ipv6Addr::LOCALHOST)),
-        dst_port: 8080,
-        ..Default::default()
-    };
-    assert_eq!(m.remote_address(), "[::1]:8080");
-}
-
-#[test]
-fn test_metadata_remote_address_no_host_no_ip() {
-    let m = Metadata {
-        dst_port: 443,
-        ..Default::default()
-    };
-    assert_eq!(m.remote_address(), ":443");
-}
-
-#[test]
-fn test_metadata_remote_address_host_takes_priority() {
-    let m = Metadata {
-        host: "example.com".into(),
-        dst_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
-        dst_port: 443,
-        ..Default::default()
-    };
-    // host should take priority over dst_ip
-    assert_eq!(m.remote_address(), "example.com:443");
-}
-
-#[test]
-fn test_metadata_source_address_with_ip() {
-    let m = Metadata {
-        src_ip: Some(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100))),
-        src_port: 12345,
-        ..Default::default()
-    };
-    assert_eq!(m.source_address(), "192.168.1.100:12345");
-}
-
-#[test]
-fn test_metadata_source_address_no_ip() {
-    let m = Metadata {
-        src_port: 12345,
-        ..Default::default()
-    };
-    assert_eq!(m.source_address(), ":12345");
-}
-
-#[test]
-fn test_metadata_rule_host_sniff_priority() {
-    let m = Metadata {
-        host: "original.com".into(),
-        sniff_host: "sniffed.com".into(),
-        ..Default::default()
-    };
-    assert_eq!(m.rule_host(), "sniffed.com");
-}
-
-#[test]
-fn test_metadata_rule_host_fallback_to_host() {
-    let m = Metadata {
-        host: "original.com".into(),
-        ..Default::default()
-    };
-    assert_eq!(m.rule_host(), "original.com");
+fn test_metadata_rule_host_cases() {
+    // (label, host, sniff_host, expected rule_host())
+    let cases = [
+        (
+            "sniff takes priority over host",
+            "original.com",
+            "sniffed.com",
+            "sniffed.com",
+        ),
+        (
+            "empty sniff falls back to host",
+            "original.com",
+            "",
+            "original.com",
+        ),
+    ];
+    for (label, host, sniff_host, expected) in cases {
+        let m = Metadata {
+            host: host.into(),
+            sniff_host: sniff_host.into(),
+            ..Default::default()
+        };
+        assert_eq!(m.rule_host(), expected, "case: {label}");
+    }
 }
 
 #[test]
@@ -313,30 +318,46 @@ fn test_metadata_pure_clears_extra_fields() {
 }
 
 #[test]
-fn test_metadata_display_with_host() {
-    let m = Metadata {
-        src_ip: Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
-        src_port: 1234,
-        host: "example.com".into(),
-        dst_port: 443,
-        ..Default::default()
-    };
-    let s = m.to_string();
-    assert!(s.contains("example.com"));
-    assert!(s.contains("443"));
-    assert!(s.contains("tcp"));
-}
+fn test_metadata_display_cases() {
+    struct Case {
+        name: &'static str,
+        metadata: Metadata,
+        expected_substrings: &'static [&'static str],
+    }
 
-#[test]
-fn test_metadata_display_with_ip() {
-    let m = Metadata {
-        dst_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
-        dst_port: 80,
-        ..Default::default()
-    };
-    let s = m.to_string();
-    assert!(s.contains("1.2.3.4"));
-    assert!(s.contains("80"));
+    let cases = [
+        Case {
+            name: "with_host",
+            metadata: Metadata {
+                src_ip: Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+                src_port: 1234,
+                host: "example.com".into(),
+                dst_port: 443,
+                ..Default::default()
+            },
+            expected_substrings: &["example.com", "443", "tcp"],
+        },
+        Case {
+            name: "with_ip",
+            metadata: Metadata {
+                dst_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+                dst_port: 80,
+                ..Default::default()
+            },
+            expected_substrings: &["1.2.3.4", "80"],
+        },
+    ];
+
+    for case in &cases {
+        let s = case.metadata.to_string();
+        for expected in case.expected_substrings {
+            assert!(
+                s.contains(expected),
+                "case `{}`: display output `{s}` is missing `{expected}`",
+                case.name
+            );
+        }
+    }
 }
 
 // ============================================================

--- a/crates/meow-config/src/auth.rs
+++ b/crates/meow-config/src/auth.rs
@@ -84,21 +84,21 @@ mod tests {
     }
 
     #[test]
-    fn credentials_verify_correct() {
+    fn credentials_verify_table() {
         let cfg = make_auth(&["alice:hunter2"]);
-        assert!(cfg.credentials.verify("alice", "hunter2"));
-    }
-
-    #[test]
-    fn credentials_verify_wrong_password() {
-        let cfg = make_auth(&["alice:hunter2"]);
-        assert!(!cfg.credentials.verify("alice", "wrong"));
-    }
-
-    #[test]
-    fn credentials_verify_unknown_user() {
-        let cfg = make_auth(&["alice:hunter2"]);
-        assert!(!cfg.credentials.verify("bob", "hunter2"));
+        // (case label, username, password, expected)
+        let cases: &[(&str, &str, &str, bool)] = &[
+            ("correct credentials", "alice", "hunter2", true),
+            ("wrong password", "alice", "wrong", false),
+            ("unknown user", "bob", "hunter2", false),
+        ];
+        for (label, username, password, expected) in cases {
+            assert_eq!(
+                cfg.credentials.verify(username, password),
+                *expected,
+                "case {label}: verify({username:?}, {password:?}) should be {expected}"
+            );
+        }
     }
 
     #[test]

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -2367,16 +2367,24 @@ tls: true
 
     #[cfg(feature = "ss")]
     #[test]
-    fn test_serialize_plugin_opts_empty_map() {
-        let yaml = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        assert!(serialize_plugin_opts(&yaml).is_none());
-    }
-
-    #[cfg(feature = "ss")]
-    #[test]
-    fn test_serialize_plugin_opts_null() {
-        let yaml = serde_yaml::Value::Null;
-        assert!(serialize_plugin_opts(&yaml).is_none());
+    fn test_serialize_plugin_opts_none_cases() {
+        // Every empty-ish YAML value must serialize to None. `empty mapping`
+        // exercises the `parts.is_empty()` branch; `null` exercises the
+        // catch-all arm of serialize_plugin_opts.
+        let cases: [(&str, serde_yaml::Value); 2] = [
+            (
+                "empty mapping",
+                serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            ),
+            ("null", serde_yaml::Value::Null),
+        ];
+        for (label, yaml) in cases {
+            assert!(
+                serialize_plugin_opts(&yaml).is_none(),
+                "{label}: expected None, got {:?}",
+                serialize_plugin_opts(&yaml)
+            );
+        }
     }
 
     #[cfg(feature = "ss")]
@@ -2548,24 +2556,82 @@ tls: true
 
     #[cfg(feature = "hysteria2")]
     #[test]
-    fn parse_hysteria2_rejects_missing_password() {
-        let cfg = hy2_config("name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 443\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("missing password"), "msg: {err}");
-    }
+    fn parse_hysteria2_rejects_invalid_configs() {
+        // (label, yaml, expected error substring)
+        let cases: &[(&str, &str, &str)] = &[
+            (
+                "missing password",
+                "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 443\n",
+                "missing password",
+            ),
+            (
+                "zero port without ports",
+                "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 0\npassword: secret\n",
+                "port must be non-zero",
+            ),
+            (
+                "missing both port and ports",
+                "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\npassword: secret\n",
+                "missing port",
+            ),
+            (
+                "wildcard ports without port",
+                "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nports: '*'\npassword: secret\n",
+                "missing port",
+            ),
+            (
+                "empty password",
+                "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 443\npassword: ''\n",
+                "password must not be empty",
+            ),
+            (
+                "gecko obfs (mihomo divergence: unsupported)",
+                "name: jp-hy2\n\
+                 type: hysteria2\n\
+                 server: 1.2.3.4\n\
+                 port: 443\n\
+                 password: secret\n\
+                 obfs: gecko\n\
+                 obfs-password: secret\n",
+                "gecko",
+            ),
+            (
+                "obfs without obfs-password",
+                "name: jp-hy2\n\
+                 type: hysteria2\n\
+                 server: 1.2.3.4\n\
+                 port: 443\n\
+                 password: secret\n\
+                 obfs: salamander\n",
+                "missing obfs-password",
+            ),
+            (
+                "mTLS client certificate (mihomo divergence: unsupported)",
+                "name: jp-hy2\n\
+                 type: hysteria2\n\
+                 server: 1.2.3.4\n\
+                 port: 443\n\
+                 password: secret\n\
+                 certificate: ./client.crt\n",
+                "certificate",
+            ),
+        ];
 
-    #[cfg(feature = "hysteria2")]
-    #[test]
-    fn parse_hysteria2_rejects_zero_port() {
-        let cfg = hy2_config(
-            "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 0\npassword: secret\n",
-        );
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("port must be non-zero"), "msg: {err}");
+        // Collect every failure instead of asserting inline so one bad row does
+        // not mask the rest of the table.
+        let mut failures: Vec<String> = Vec::new();
+        for &(label, yaml, expected) in cases {
+            match parse_proxy(&hy2_config(yaml)) {
+                Ok(_) => failures.push(format!("[{label}] must hard-error (Class A), got Ok")),
+                Err(err) if !err.contains(expected) => {
+                    failures.push(format!(
+                        "[{label}] error must contain {expected:?}, got: {err}"
+                    ));
+                }
+                Err(_) => {}
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
     }
 
     #[cfg(feature = "hysteria2")]
@@ -2586,39 +2652,6 @@ tls: true
             "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 0\nports: '443,8443'\npassword: secret\n",
         );
         assert!(parse_proxy(&cfg).is_ok());
-    }
-
-    #[cfg(feature = "hysteria2")]
-    #[test]
-    fn parse_hysteria2_rejects_missing_port_and_ports() {
-        let cfg = hy2_config("name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\npassword: secret\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("missing port"), "msg: {err}");
-    }
-
-    #[cfg(feature = "hysteria2")]
-    #[test]
-    fn parse_hysteria2_rejects_wildcard_ports_without_port() {
-        let cfg = hy2_config(
-            "name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nports: '*'\npassword: secret\n",
-        );
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("missing port"), "msg: {err}");
-    }
-
-    #[cfg(feature = "hysteria2")]
-    #[test]
-    fn parse_hysteria2_rejects_empty_password() {
-        let cfg =
-            hy2_config("name: jp-hy2\ntype: hysteria2\nserver: 1.2.3.4\nport: 443\npassword: ''\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("password must not be empty"), "msg: {err}");
     }
 
     #[cfg(feature = "hysteria2")]
@@ -2653,58 +2686,6 @@ tls: true
         assert_eq!(parse_hy2_bandwidth("8 MBps").unwrap(), 8_000_000);
         assert_eq!(parse_hy2_bandwidth("10").unwrap(), 1_250_000);
         assert_eq!(parse_hy2_bandwidth("").unwrap(), 0);
-    }
-
-    #[cfg(feature = "hysteria2")]
-    #[test]
-    fn parse_hysteria2_rejects_gecko_obfs() {
-        let cfg = hy2_config(
-            "name: jp-hy2\n\
-             type: hysteria2\n\
-             server: 1.2.3.4\n\
-             port: 443\n\
-             password: secret\n\
-             obfs: gecko\n\
-             obfs-password: secret\n",
-        );
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("gecko"), "msg: {err}");
-    }
-
-    #[cfg(feature = "hysteria2")]
-    #[test]
-    fn parse_hysteria2_rejects_obfs_without_password() {
-        let cfg = hy2_config(
-            "name: jp-hy2\n\
-             type: hysteria2\n\
-             server: 1.2.3.4\n\
-             port: 443\n\
-             password: secret\n\
-             obfs: salamander\n",
-        );
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("missing obfs-password"), "msg: {err}");
-    }
-
-    #[cfg(feature = "hysteria2")]
-    #[test]
-    fn parse_hysteria2_rejects_unsupported_mtls() {
-        let cfg = hy2_config(
-            "name: jp-hy2\n\
-             type: hysteria2\n\
-             server: 1.2.3.4\n\
-             port: 443\n\
-             password: secret\n\
-             certificate: ./client.crt\n",
-        );
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("must hard-error");
-        };
-        assert!(err.contains("certificate"), "msg: {err}");
     }
 
     #[cfg(feature = "hysteria2")]
@@ -3001,52 +2982,53 @@ tls: true
 
     #[cfg(feature = "snell")]
     #[test]
-    fn parse_snell_missing_psk() {
-        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("missing psk must hard-error (Class A)");
-        };
-        assert!(err.contains("missing psk"), "msg: {err}");
-    }
+    fn parse_snell_rejects_invalid_fields() {
+        // (label, yaml, expected error substring). Every row is a Class A hard
+        // error: a required field is missing or invalid, and parsing must fail
+        // with a message naming that field.
+        let cases: &[(&str, &str, &str)] = &[
+            (
+                "missing psk",
+                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\n",
+                "missing psk",
+            ),
+            (
+                "missing server",
+                "name: sn\ntype: snell\nport: 8388\npsk: secret\n",
+                "missing server",
+            ),
+            (
+                "missing port",
+                "name: sn\ntype: snell\nserver: 1.2.3.4\npsk: secret\n",
+                "missing port",
+            ),
+            (
+                "port zero",
+                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 0\npsk: secret\n",
+                "port must be non-zero",
+            ),
+            (
+                "empty psk (caught by SnellAdapter::new)",
+                "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: ''\n",
+                "psk must not be empty",
+            ),
+        ];
 
-    #[cfg(feature = "snell")]
-    #[test]
-    fn parse_snell_missing_server() {
-        let cfg = snell_config("name: sn\ntype: snell\nport: 8388\npsk: secret\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("missing server must hard-error (Class A)");
-        };
-        assert!(err.contains("missing server"), "msg: {err}");
-    }
-
-    #[cfg(feature = "snell")]
-    #[test]
-    fn parse_snell_missing_port() {
-        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\npsk: secret\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("missing port must hard-error (Class A)");
-        };
-        assert!(err.contains("missing port"), "msg: {err}");
-    }
-
-    #[cfg(feature = "snell")]
-    #[test]
-    fn parse_snell_rejects_port_zero() {
-        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\nport: 0\npsk: secret\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("port 0 must hard-error (Class A)");
-        };
-        assert!(err.contains("port must be non-zero"), "msg: {err}");
-    }
-
-    #[cfg(feature = "snell")]
-    #[test]
-    fn parse_snell_rejects_empty_psk() {
-        let cfg = snell_config("name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: ''\n");
-        let Err(err) = parse_proxy(&cfg) else {
-            panic!("empty psk must hard-error (Class A)");
-        };
-        assert!(err.contains("psk must not be empty"), "msg: {err}");
+        // Collect every failure instead of asserting inline so one bad row does
+        // not mask the rest of the table.
+        let mut failures: Vec<String> = Vec::new();
+        for &(label, yaml, expected) in cases {
+            match parse_proxy(&snell_config(yaml)) {
+                Ok(_) => failures.push(format!("[{label}] must hard-error (Class A), got Ok")),
+                Err(err) if !err.contains(expected) => {
+                    failures.push(format!(
+                        "[{label}] error must contain {expected:?}, got: {err}"
+                    ));
+                }
+                Err(_) => {}
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
     }
 
     #[cfg(feature = "snell")]

--- a/crates/meow-config/src/sub_rules_parser.rs
+++ b/crates/meow-config/src/sub_rules_parser.rs
@@ -248,36 +248,72 @@ mod tests {
         assert!(idx("C") < idx("A"));
     }
 
-    #[test]
-    fn cycle_detected_two_block() {
-        let raw_map = raw(&[("A", &["SUB-RULE,B"]), ("B", &["SUB-RULE,A"])]);
-        let graph = build_reference_graph(&raw_map).unwrap();
-        let err = topo_order_with_cycle_check(&raw_map, &graph).unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("cycle"), "unexpected: {msg}");
-        // Path must include both A and B.
-        assert!(msg.contains("A") && msg.contains("B"), "unexpected: {msg}");
+    /// One cycle topology plus the substrings its error message must contain.
+    struct CycleCase {
+        label: &'static str,
+        blocks: &'static [(&'static str, &'static [&'static str])],
+        expected: &'static [&'static str],
     }
 
     #[test]
-    fn cycle_detected_self_reference() {
-        let raw_map = raw(&[("A", &["SUB-RULE,A"])]);
-        let graph = build_reference_graph(&raw_map).unwrap();
-        let err = topo_order_with_cycle_check(&raw_map, &graph).unwrap_err();
-        assert!(format!("{err}").contains("cycle"));
-    }
+    fn cycle_detected_table() {
+        let cases: &[CycleCase] = &[
+            CycleCase {
+                label: "two-block cycle A -> B -> A",
+                blocks: &[("A", &["SUB-RULE,B"]), ("B", &["SUB-RULE,A"])],
+                // Path must include both A and B.
+                expected: &["cycle", "A", "B"],
+            },
+            CycleCase {
+                label: "self reference A -> A",
+                blocks: &[("A", &["SUB-RULE,A"])],
+                expected: &["cycle"],
+            },
+            CycleCase {
+                label: "three-node cycle A -> B -> C -> A",
+                blocks: &[
+                    ("A", &["SUB-RULE,B"]),
+                    ("B", &["SUB-RULE,C"]),
+                    ("C", &["SUB-RULE,A"]),
+                ],
+                expected: &["cycle"],
+            },
+        ];
 
-    #[test]
-    fn cycle_detected_three_node() {
-        let raw_map = raw(&[
-            ("A", &["SUB-RULE,B"]),
-            ("B", &["SUB-RULE,C"]),
-            ("C", &["SUB-RULE,A"]),
-        ]);
-        let graph = build_reference_graph(&raw_map).unwrap();
-        let err = topo_order_with_cycle_check(&raw_map, &graph).unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("cycle"), "unexpected: {msg}");
+        // Every case runs; failures are collected so one bad topology does not
+        // hide the others.
+        let mut failures: Vec<String> = Vec::new();
+        for case in cases {
+            let label = case.label;
+            let raw_map = raw(case.blocks);
+            let graph = match build_reference_graph(&raw_map) {
+                Ok(graph) => graph,
+                Err(err) => {
+                    failures.push(format!("{label}: building reference graph failed: {err}"));
+                    continue;
+                }
+            };
+            match topo_order_with_cycle_check(&raw_map, &graph) {
+                Ok(order) => {
+                    failures.push(format!(
+                        "{label}: expected a cycle error, got order {order:?}"
+                    ));
+                }
+                Err(err) => {
+                    let msg = format!("{err}");
+                    for needle in case.expected {
+                        if !msg.contains(needle) {
+                            failures
+                                .push(format!("{label}: error message missing {needle:?}: {msg}"));
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "cycle detection failures: {failures:#?}"
+        );
     }
 
     #[test]

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -21,31 +21,86 @@ mixed-port: 7890
 }
 
 #[tokio::test]
-async fn test_general_config_defaults() {
-    let yaml = "";
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert_eq!(config.general.mode.to_string(), "rule");
-    assert_eq!(config.general.log_level, "info");
-    assert!(!config.general.ipv6);
-    assert!(!config.general.allow_lan);
-    assert_eq!(config.general.bind_address, "127.0.0.1");
-}
+async fn test_general_config_table() {
+    struct Case {
+        label: &'static str,
+        yaml: &'static str,
+        mode: &'static str,
+        log_level: &'static str,
+        ipv6: bool,
+        allow_lan: bool,
+        bind_address: &'static str,
+    }
 
-#[tokio::test]
-async fn test_general_config_custom() {
-    let yaml = r#"
+    let cases = [
+        Case {
+            label: "defaults (empty config)",
+            yaml: "",
+            mode: "rule",
+            log_level: "info",
+            ipv6: false,
+            allow_lan: false,
+            bind_address: "127.0.0.1",
+        },
+        Case {
+            label: "custom general section",
+            yaml: r#"
 mode: global
 log-level: debug
 ipv6: true
 allow-lan: true
 bind-address: "0.0.0.0"
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert_eq!(config.general.mode.to_string(), "global");
-    assert_eq!(config.general.log_level, "debug");
-    assert!(config.general.ipv6);
-    assert!(config.general.allow_lan);
-    assert_eq!(config.general.bind_address, "0.0.0.0");
+"#,
+            mode: "global",
+            log_level: "debug",
+            ipv6: true,
+            allow_lan: true,
+            bind_address: "0.0.0.0",
+        },
+    ];
+
+    // Collect every mismatch instead of panicking on the first one, so both
+    // the defaults path and the override path always run and a failure names
+    // the case and the field.
+    let mut failures: Vec<String> = Vec::new();
+    for case in &cases {
+        let config = load_config_from_str(case.yaml).await.unwrap();
+        let general = &config.general;
+
+        let mode = general.mode.to_string();
+        if mode != case.mode {
+            failures.push(format!(
+                "[{}] mode: expected {:?}, got {:?}",
+                case.label, case.mode, mode
+            ));
+        }
+        if general.log_level != case.log_level {
+            failures.push(format!(
+                "[{}] log_level: expected {:?}, got {:?}",
+                case.label, case.log_level, general.log_level
+            ));
+        }
+        if general.ipv6 != case.ipv6 {
+            failures.push(format!(
+                "[{}] ipv6: expected {}, got {}",
+                case.label, case.ipv6, general.ipv6
+            ));
+        }
+        if general.allow_lan != case.allow_lan {
+            failures.push(format!(
+                "[{}] allow_lan: expected {}, got {}",
+                case.label, case.allow_lan, general.allow_lan
+            ));
+        }
+        if general.bind_address != case.bind_address {
+            failures.push(format!(
+                "[{}] bind_address: expected {:?}, got {:?}",
+                case.label, case.bind_address, general.bind_address
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
 #[tokio::test]
@@ -739,199 +794,115 @@ proxies:
 }
 
 #[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_http() {
-    // `plugin: obfs` with mode=http is handled by the built-in simple-obfs
-    // implementation — no external binary is required, so the proxy must
-    // register successfully.
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-http"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts:
-      mode: http
-      host: bing.com
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(config.proxies.contains_key("ss-obfs-http"));
-}
+async fn test_proxy_parsing_ss_with_builtin_obfs_table() {
+    // Built-in simple-obfs (`plugin: obfs` / `plugin: simple-obfs`) needs no
+    // external binary, so a well-formed node must register; a node whose obfs
+    // config cannot be resolved to a valid mode must be skipped (never
+    // silently falling back to the "external plugin" path).
+    //
+    // Each case supplies the `plugin:`/`plugin-opts:` tail (and, where it
+    // matters, the `server:` value) plus the expected registration outcome.
+    struct Case {
+        label: &'static str,
+        name: &'static str,
+        server: &'static str,
+        plugin_block: &'static str,
+        expect_present: bool,
+    }
 
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_tls() {
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-tls"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts:
-      mode: tls
-      host: gateway.icloud.com
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(config.proxies.contains_key("ss-obfs-tls"));
-}
+    let cases = [
+        Case {
+            label: "yaml map, mode=http",
+            name: "ss-obfs-http",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: http\n      host: bing.com\n",
+            expect_present: true,
+        },
+        Case {
+            label: "yaml map, mode=tls",
+            name: "ss-obfs-tls",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: tls\n      host: gateway.icloud.com\n",
+            expect_present: true,
+        },
+        Case {
+            label: "SIP003 string form `obfs=tls;obfs-host=...`",
+            name: "ss-obfs-str",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n    plugin-opts: \"obfs=tls;obfs-host=cloudflare.com\"\n",
+            expect_present: true,
+        },
+        Case {
+            label: "legacy `plugin: simple-obfs` alias",
+            name: "ss-simple-obfs",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: simple-obfs\n    plugin-opts:\n      mode: http\n      host: bing.com\n",
+            expect_present: true,
+        },
+        Case {
+            label: "yaml map with SIP003-native keys `obfs`/`obfs-host`",
+            name: "ss-obfs-sip003-map",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n    plugin-opts:\n      obfs: tls\n      obfs-host: gateway.icloud.com\n",
+            expect_present: true,
+        },
+        Case {
+            label: "mode parsed case-insensitively (TLS)",
+            name: "ss-obfs-upper",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: TLS\n      host: cloudflare.com\n",
+            expect_present: true,
+        },
+        Case {
+            label: "host omitted falls back to the ss server name",
+            name: "ss-obfs-default-host",
+            server: "ss.example.org",
+            plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: http\n",
+            expect_present: true,
+        },
+        Case {
+            label: "missing `mode` is invalid -> skipped",
+            name: "ss-obfs-bad",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n    plugin-opts:\n      host: example.com\n",
+            expect_present: false,
+        },
+        Case {
+            label: "no plugin-opts at all -> skipped, no external fallback",
+            name: "ss-obfs-no-opts",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n",
+            expect_present: false,
+        },
+        Case {
+            label: "unknown mode `quic` -> skipped",
+            name: "ss-obfs-bad-mode",
+            server: "1.2.3.4",
+            plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: quic\n      host: foo\n",
+            expect_present: false,
+        },
+    ];
 
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_string_opts() {
-    // SIP003 string form (`obfs=http;obfs-host=...`) must also be accepted.
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-str"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts: "obfs=tls;obfs-host=cloudflare.com"
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(config.proxies.contains_key("ss-obfs-str"));
-}
-
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_missing_mode() {
-    // Without `mode`, the built-in obfs config is invalid and the proxy is skipped.
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-bad"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts:
-      host: example.com
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(!config.proxies.contains_key("ss-obfs-bad"));
-}
-
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_simple_obfs_alias() {
-    // The legacy `plugin: simple-obfs` (the SIP003 binary's name) must also
-    // route through the built-in implementation.
-    let yaml = r#"
-proxies:
-  - name: "ss-simple-obfs"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: simple-obfs
-    plugin-opts:
-      mode: http
-      host: bing.com
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(config.proxies.contains_key("ss-simple-obfs"));
-}
-
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_sip003_keys_yaml_map() {
-    // YAML map using SIP003-native key names `obfs` / `obfs-host`.
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-sip003-map"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts:
-      obfs: tls
-      obfs-host: gateway.icloud.com
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(config.proxies.contains_key("ss-obfs-sip003-map"));
-}
-
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_uppercase_mode() {
-    // Mode value should be parsed case-insensitively.
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-upper"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts:
-      mode: TLS
-      host: cloudflare.com
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(config.proxies.contains_key("ss-obfs-upper"));
-}
-
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_no_plugin_opts() {
-    // Built-in obfs requires `mode`; with no plugin-opts at all, the proxy
-    // must be skipped instead of accidentally falling back to "external".
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-no-opts"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(!config.proxies.contains_key("ss-obfs-no-opts"));
-}
-
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_host_falls_back_to_server() {
-    // If `host` is omitted, the built-in obfs uses the SS server name as
-    // the fake Host: / SNI.
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-default-host"
-    type: ss
-    server: "ss.example.org"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts:
-      mode: http
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(config.proxies.contains_key("ss-obfs-default-host"));
-}
-
-#[tokio::test]
-async fn test_proxy_parsing_ss_with_builtin_obfs_invalid_mode_skipped() {
-    let yaml = r#"
-proxies:
-  - name: "ss-obfs-bad-mode"
-    type: ss
-    server: "1.2.3.4"
-    port: 8388
-    cipher: "aes-256-gcm"
-    password: "password123"
-    plugin: obfs
-    plugin-opts:
-      mode: quic
-      host: foo
-"#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(!config.proxies.contains_key("ss-obfs-bad-mode"));
+    let mut failures = Vec::new();
+    for case in &cases {
+        let yaml = format!(
+            "proxies:\n  - name: \"{}\"\n    type: ss\n    server: \"{}\"\n    port: 8388\n    cipher: \"aes-256-gcm\"\n    password: \"password123\"\n{}",
+            case.name, case.server, case.plugin_block
+        );
+        let config = load_config_from_str(&yaml).await.unwrap();
+        let present = config.proxies.contains_key(case.name);
+        if present != case.expect_present {
+            failures.push(format!(
+                "[{}] proxy `{}`: expected present={}, got present={}",
+                case.label, case.name, case.expect_present, present
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "built-in obfs parsing mismatches:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[tokio::test]

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -1045,88 +1045,64 @@ proxies:
     );
 }
 
-/// D16j: sing-mux on VMess → accepted (default h2mux).
+/// D16j / D16j2 / D16k: VMess mux blocks that must load with no mux warn.
+///
+/// * D16j  — sing-mux via the legacy `mux:` alias (default protocol h2mux).
+/// * D16j2 — the canonical mihomo `smux:` key (same block as the legacy alias).
+/// * D16k  — `protocol: muxcool`: CommandMux 0x03 is the VMess request
+///   header's native mux signaling; sing-vmess routes it to
+///   `HandleMuxConnection`.
+///
+/// Every case runs even if an earlier one fails; failures are reported
+/// together with their label.
 #[cfg(all(feature = "mux", feature = "vmess"))]
 #[tokio::test]
-async fn parse_vmess_mux_singmux_accepted() {
-    let yaml = r#"
-proxies:
-  - name: m
-    type: vmess
-    server: example.com
-    port: 443
-    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
-    cipher: auto
-    mux:
-      enabled: true
-"#;
-    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    let config = result.expect("vmess mux must load");
-    assert!(config.proxies.contains_key("m"), "vmess proxy must be kept");
-    let mux_warns = lines
-        .iter()
-        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
-        .count();
-    assert_eq!(
-        mux_warns, 0,
-        "vmess sing-mux is implemented: no warn expected"
-    );
-}
+async fn parse_vmess_mux_protocol_table() {
+    const CASES: &[(&str, &str)] = &[
+        (
+            "D16j: sing-mux via the legacy `mux:` alias (default h2mux)",
+            "    mux:\n      enabled: true\n",
+        ),
+        (
+            "D16j2: the canonical mihomo `smux:` key",
+            "    smux:\n      enabled: true\n",
+        ),
+        (
+            "D16k: `protocol: muxcool` (VMess CommandMux 0x03)",
+            "    mux:\n      enabled: true\n      protocol: muxcool\n",
+        ),
+    ];
 
-/// D16j2: the canonical mihomo `smux:` key on VMess → accepted
-/// (same block as the legacy `mux:` alias, which stays covered above).
-#[cfg(all(feature = "mux", feature = "vmess"))]
-#[tokio::test]
-async fn parse_vmess_smux_key_accepted() {
-    let yaml = r#"
-proxies:
-  - name: m
-    type: vmess
-    server: example.com
-    port: 443
-    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
-    cipher: auto
-    smux:
-      enabled: true
-"#;
-    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    let config = result.expect("vmess smux: must load");
-    assert!(config.proxies.contains_key("m"), "vmess proxy must be kept");
-    let mux_warns = lines
-        .iter()
-        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
-        .count();
-    assert_eq!(mux_warns, 0, "smux: key is canonical: no warn expected");
-}
-
-/// D16k: `protocol: muxcool` on VMess → accepted (CommandMux 0x03 is the
-/// VMess request header's native mux signaling; sing-vmess routes it to
-/// HandleMuxConnection).
-#[cfg(all(feature = "mux", feature = "vmess"))]
-#[tokio::test]
-async fn parse_vmess_mux_muxcool_accepted() {
-    let yaml = r#"
-proxies:
-  - name: m
-    type: vmess
-    server: example.com
-    port: 443
-    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
-    cipher: auto
-    mux:
-      enabled: true
-      protocol: muxcool
-"#;
-    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    let config = result.expect("vmess muxcool must load");
-    assert!(config.proxies.contains_key("m"), "vmess proxy must be kept");
-    let mux_warns = lines
-        .iter()
-        .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
-        .count();
-    assert_eq!(
-        mux_warns, 0,
-        "vmess muxcool is implemented: no warn expected"
+    let mut failures: Vec<String> = Vec::new();
+    for (label, mux_block) in CASES {
+        let yaml = format!(
+            "proxies:\n  - name: m\n    type: vmess\n    server: example.com\n    \
+             port: 443\n    uuid: b831381d-6324-4d53-ad4f-8cda48b30811\n    \
+             cipher: auto\n{mux_block}"
+        );
+        let (result, lines) = with_warn_capture_async(load_config_from_str(&yaml)).await;
+        match result {
+            Err(e) => failures.push(format!("{label}: config must load, got error: {e}")),
+            Ok(config) => {
+                if !config.proxies.contains_key("m") {
+                    failures.push(format!("{label}: vmess proxy must be kept; {lines:?}"));
+                }
+                let mux_warns = lines
+                    .iter()
+                    .filter(|l| l.contains("WARN") && l.to_lowercase().contains("mux"))
+                    .count();
+                if mux_warns != 0 {
+                    failures.push(format!(
+                        "{label}: implemented, no mux warn expected, got {mux_warns}; {lines:?}"
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "vmess mux cases failed:\n{}",
+        failures.join("\n")
     );
 }
 

--- a/crates/meow-dns/src/fakeip.rs
+++ b/crates/meow-dns/src/fakeip.rs
@@ -931,36 +931,117 @@ mod tests {
         );
     }
 
+    /// Table-driven merge of the former `skipper_blacklist_skips_matched`,
+    /// `skipper_whitelist_skips_unmatched`, `skipper_plain_entry_is_suffix`
+    /// and `skipper_empty_filter_never_skips` cases. Every row is evaluated
+    /// even if an earlier one fails; all failures are reported together with
+    /// their case label.
     #[test]
-    fn skipper_blacklist_skips_matched() {
-        let s = Skipper::new(&["+.local".to_string()], SkipperMode::BlackList);
-        assert!(s.should_skip("foo.local"));
-        assert!(s.should_skip("local"));
-        assert!(!s.should_skip("example.com"));
-    }
+    fn skipper_table_driven_cases() {
+        struct Case {
+            label: &'static str,
+            patterns: &'static [&'static str],
+            mode: SkipperMode,
+            host: &'static str,
+            expect_skip: bool,
+        }
 
-    #[test]
-    fn skipper_whitelist_skips_unmatched() {
-        let s = Skipper::new(&["+.example.com".to_string()], SkipperMode::WhiteList);
-        assert!(!s.should_skip("foo.example.com"));
-        assert!(s.should_skip("other.test"));
-    }
+        let cases = [
+            // BlackList: a `+.` pattern matches sub-domains AND the bare root.
+            Case {
+                label: "blacklist/+.local/sub",
+                patterns: &["+.local"],
+                mode: SkipperMode::BlackList,
+                host: "foo.local",
+                expect_skip: true,
+            },
+            Case {
+                label: "blacklist/+.local/root",
+                patterns: &["+.local"],
+                mode: SkipperMode::BlackList,
+                host: "local",
+                expect_skip: true,
+            },
+            Case {
+                label: "blacklist/+.local/unrelated",
+                patterns: &["+.local"],
+                mode: SkipperMode::BlackList,
+                host: "example.com",
+                expect_skip: false,
+            },
+            // WhiteList inverts: matched hosts keep fake-ip, others bypass.
+            Case {
+                label: "whitelist/+.example.com/matched",
+                patterns: &["+.example.com"],
+                mode: SkipperMode::WhiteList,
+                host: "foo.example.com",
+                expect_skip: false,
+            },
+            Case {
+                label: "whitelist/+.example.com/unmatched",
+                patterns: &["+.example.com"],
+                mode: SkipperMode::WhiteList,
+                host: "other.test",
+                expect_skip: true,
+            },
+            // A plain entry is a suffix match that also covers the root, and
+            // must respect label boundaries (not a raw substring match).
+            Case {
+                label: "blacklist/plain/sub",
+                patterns: &["example.com"],
+                mode: SkipperMode::BlackList,
+                host: "foo.example.com",
+                expect_skip: true,
+            },
+            Case {
+                label: "blacklist/plain/root",
+                patterns: &["example.com"],
+                mode: SkipperMode::BlackList,
+                host: "example.com",
+                expect_skip: true,
+            },
+            Case {
+                label: "blacklist/plain/label-boundary",
+                patterns: &["example.com"],
+                mode: SkipperMode::BlackList,
+                host: "notexample.com",
+                expect_skip: false,
+            },
+            // Empty filter never skips — including WhiteList, where the naive
+            // reading would bypass every host (defensive foot-gun guard).
+            Case {
+                label: "empty/blacklist",
+                patterns: &[],
+                mode: SkipperMode::BlackList,
+                host: "foo.test",
+                expect_skip: false,
+            },
+            Case {
+                label: "empty/whitelist-defensive",
+                patterns: &[],
+                mode: SkipperMode::WhiteList,
+                host: "foo.test",
+                expect_skip: false,
+            },
+        ];
 
-    #[test]
-    fn skipper_plain_entry_is_suffix() {
-        let s = Skipper::new(&["example.com".to_string()], SkipperMode::BlackList);
-        assert!(s.should_skip("foo.example.com"));
-        assert!(s.should_skip("example.com"));
-        assert!(!s.should_skip("notexample.com"));
-    }
-
-    #[test]
-    fn skipper_empty_filter_never_skips() {
-        let s = Skipper::new(&[], SkipperMode::BlackList);
-        assert!(!s.should_skip("foo.test"));
-        // Whitelist + empty = treated as "skip nothing" (defensive).
-        let s = Skipper::new(&[], SkipperMode::WhiteList);
-        assert!(!s.should_skip("foo.test"));
+        let mut failures = Vec::new();
+        for c in &cases {
+            let patterns: Vec<String> = c.patterns.iter().copied().map(String::from).collect();
+            let skipper = Skipper::new(&patterns, c.mode);
+            let got = skipper.should_skip(c.host);
+            if got != c.expect_skip {
+                failures.push(format!(
+                    "[{}] Skipper::new({:?}, {:?}).should_skip({:?}) = {got}, want {}",
+                    c.label, c.patterns, c.mode, c.host, c.expect_skip
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "skipper cases failed:\n{}",
+            failures.join("\n")
+        );
     }
 
     #[tokio::test]

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -1629,28 +1629,42 @@ mod tests {
     }
 
     #[test]
-    fn clamp_ttl_zero_returns_min() {
-        assert_eq!(clamp_ttl(Duration::ZERO), Duration::from_secs(10));
-    }
+    fn clamp_ttl_table_driven() {
+        // (label, raw TTL, expected clamped TTL) — MIN_TTL 10s, MAX_TTL 3600s.
+        let cases: [(&str, Duration, Duration); 4] = [
+            ("zero returns min", Duration::ZERO, Duration::from_secs(10)),
+            (
+                "below min returns min",
+                Duration::from_secs(3),
+                Duration::from_secs(10),
+            ),
+            (
+                "in range returns raw",
+                Duration::from_secs(120),
+                Duration::from_secs(120),
+            ),
+            (
+                "above max returns max",
+                Duration::from_secs(99_999),
+                Duration::from_secs(3600),
+            ),
+        ];
 
-    #[test]
-    fn clamp_ttl_below_min_returns_min() {
-        assert_eq!(clamp_ttl(Duration::from_secs(3)), Duration::from_secs(10));
-    }
-
-    #[test]
-    fn clamp_ttl_in_range_returns_raw() {
-        assert_eq!(
-            clamp_ttl(Duration::from_secs(120)),
-            Duration::from_secs(120)
-        );
-    }
-
-    #[test]
-    fn clamp_ttl_above_max_returns_max() {
-        assert_eq!(
-            clamp_ttl(Duration::from_secs(99_999)),
-            Duration::from_secs(3600)
+        // Collect instead of asserting inline so every case runs and all
+        // mismatches are reported in one failure.
+        let mut failures: Vec<String> = Vec::new();
+        for (label, raw, expected) in cases {
+            let got = clamp_ttl(raw);
+            if got != expected {
+                failures.push(format!(
+                    "{label}: clamp_ttl({raw:?}) = {got:?}, expected {expected:?}"
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "clamp_ttl cases failed:\n{}",
+            failures.join("\n")
         );
     }
 

--- a/crates/meow-dns/src/server.rs
+++ b/crates/meow-dns/src/server.rs
@@ -844,19 +844,27 @@ mod tests {
     }
 
     #[test]
-    fn parse_question_rejects_truncated_label() {
-        // Label length byte 5 but only 2 bytes follow → label-truncated error.
-        let bad = [5u8, b'a', b'b'];
-        let err = DnsServer::parse_question_for_test(&bad);
-        assert!(err.is_err(), "must reject truncated label");
-    }
+    fn parse_question_rejects_malformed_input_table() {
+        // Each row exercises a distinct rejection branch in `parse_question`.
+        let cases: &[(&str, &[u8])] = &[
+            // Label length byte 5 but only 2 bytes follow -> label-truncated error.
+            ("truncated label", &[5u8, b'a', b'b']),
+            // Just a name terminator, no type/class.
+            ("missing qtype/qclass", &[3u8, b'a', b'b', b'c', 0x00]),
+        ];
 
-    #[test]
-    fn parse_question_rejects_missing_type_class() {
-        // Just a name terminator, no type/class.
-        let bad = [3u8, b'a', b'b', b'c', 0x00];
-        let err = DnsServer::parse_question_for_test(&bad);
-        assert!(err.is_err(), "must reject missing qtype/qclass");
+        // Collect instead of asserting per row so every case still runs and a
+        // failure names every row that wrongly parsed.
+        let accepted: Vec<&str> = cases
+            .iter()
+            .filter(|(_, bytes)| DnsServer::parse_question_for_test(bytes).is_ok())
+            .map(|(label, _)| *label)
+            .collect();
+
+        assert!(
+            accepted.is_empty(),
+            "malformed questions must be rejected, but these parsed: {accepted:?}"
+        );
     }
 
     #[test]
@@ -932,22 +940,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_query_rejects_packet_shorter_than_header() {
-        let resolver = empty_resolver();
-        let err = DnsServer::handle_query(&[0u8; 5], &resolver).await;
-        assert!(err.is_err(), "must reject too-short packets");
-    }
+    async fn handle_query_rejects_malformed_packets_table() {
+        // Malformed inputs must be rejected outright — no response is emitted.
+        let short = vec![0u8; 5];
+        let zero_questions = {
+            // Valid 12-byte header but QDCOUNT (bytes [4..6]) left at zero.
+            let mut q = vec![0u8; 12];
+            q[0] = 0x12;
+            q[1] = 0x34;
+            q
+        };
+        let cases: [(&str, &[u8]); 2] = [
+            ("packet shorter than the 12-byte header", &short),
+            ("valid header with qdcount=0", &zero_questions),
+        ];
 
-    #[tokio::test]
-    async fn handle_query_rejects_zero_questions() {
-        // Valid header but qdcount=0.
-        let mut q = [0u8; 12];
-        q[0] = 0x12;
-        q[1] = 0x34;
-        // qdcount bytes [4..6] left at zero
         let resolver = empty_resolver();
-        let err = DnsServer::handle_query(&q, &resolver).await;
-        assert!(err.is_err(), "must reject queries with no question");
+        // Collect rather than assert per-case, so a failure in one case does
+        // not stop the loop and hide the other case's result.
+        let mut failures = Vec::new();
+        for (label, packet) in cases {
+            if DnsServer::handle_query(packet, &resolver).await.is_ok() {
+                failures.push(label);
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "handle_query must reject these malformed packets: {failures:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/meow-listener/src/sniffer.rs
+++ b/crates/meow-listener/src/sniffer.rs
@@ -387,60 +387,99 @@ mod tests {
     }
 
     #[test]
-    fn maybe_apply_sniff_disabled_is_noop() {
-        let cfg = SnifferConfig {
-            enable: false,
-            override_destination: true,
-            ..Default::default()
-        };
-        let rt = make_runtime(cfg);
-        let mut meta = make_metadata("1.2.3.4", 443);
-        rt.maybe_apply_sniff("example.com", &mut meta);
-        assert_eq!(meta.sniff_host, "");
-        assert_eq!(meta.host, "1.2.3.4");
-    }
+    fn maybe_apply_sniff_cases() {
+        struct Case {
+            name: &'static str,
+            enable: bool,
+            override_destination: bool,
+            skip_domain: &'static [&'static str],
+            meta_host: &'static str,
+            meta_port: u16,
+            sniffed: &'static str,
+            expected_sniff_host: &'static str,
+            expected_host: &'static str,
+        }
 
-    #[test]
-    fn maybe_apply_sniff_skip_domain_drops_host() {
-        let cfg = SnifferConfig {
-            enable: true,
-            override_destination: true,
-            skip_domain: vec!["+.ads.example.com".into()],
-            ..Default::default()
-        };
-        let rt = make_runtime(cfg);
-        let mut meta = make_metadata("1.2.3.4", 80);
-        rt.maybe_apply_sniff("tracker.ads.example.com", &mut meta);
-        assert_eq!(meta.sniff_host, "");
-        assert_eq!(meta.host, "1.2.3.4");
-    }
+        let cases = [
+            // Sniffer disabled → no-op even with override-destination on.
+            Case {
+                name: "disabled_is_noop",
+                enable: false,
+                override_destination: true,
+                skip_domain: &[],
+                meta_host: "1.2.3.4",
+                meta_port: 443,
+                sniffed: "example.com",
+                expected_sniff_host: "",
+                expected_host: "1.2.3.4",
+            },
+            // skip-domain match → the sniffed host is discarded entirely.
+            Case {
+                name: "skip_domain_drops_host",
+                enable: true,
+                override_destination: true,
+                skip_domain: &["+.ads.example.com"],
+                meta_host: "1.2.3.4",
+                meta_port: 80,
+                sniffed: "tracker.ads.example.com",
+                expected_sniff_host: "",
+                expected_host: "1.2.3.4",
+            },
+            // override-destination on → both sniff_host and host are rewritten.
+            Case {
+                name: "override_destination_mutates_host",
+                enable: true,
+                override_destination: true,
+                skip_domain: &[],
+                meta_host: "1.2.3.4",
+                meta_port: 80,
+                sniffed: "example.com",
+                expected_sniff_host: "example.com",
+                expected_host: "example.com",
+            },
+            // override-destination off → only sniff_host is recorded.
+            Case {
+                name: "override_false_keeps_host",
+                enable: true,
+                override_destination: false,
+                skip_domain: &[],
+                meta_host: "1.2.3.4",
+                meta_port: 80,
+                sniffed: "example.com",
+                expected_sniff_host: "example.com",
+                expected_host: "1.2.3.4",
+            },
+        ];
 
-    #[test]
-    fn maybe_apply_sniff_override_destination_mutates_host() {
-        let cfg = SnifferConfig {
-            enable: true,
-            override_destination: true,
-            ..Default::default()
-        };
-        let rt = make_runtime(cfg);
-        let mut meta = make_metadata("1.2.3.4", 80);
-        rt.maybe_apply_sniff("example.com", &mut meta);
-        assert_eq!(meta.sniff_host, "example.com");
-        assert_eq!(meta.host, "example.com");
-    }
-
-    #[test]
-    fn maybe_apply_sniff_override_false_keeps_host() {
-        let cfg = SnifferConfig {
-            enable: true,
-            override_destination: false,
-            ..Default::default()
-        };
-        let rt = make_runtime(cfg);
-        let mut meta = make_metadata("1.2.3.4", 80);
-        rt.maybe_apply_sniff("example.com", &mut meta);
-        assert_eq!(meta.sniff_host, "example.com");
-        assert_eq!(meta.host, "1.2.3.4");
+        let mut failures = Vec::new();
+        for case in cases {
+            let cfg = SnifferConfig {
+                enable: case.enable,
+                override_destination: case.override_destination,
+                skip_domain: case.skip_domain.iter().copied().map(Into::into).collect(),
+                ..Default::default()
+            };
+            let rt = make_runtime(cfg);
+            let mut meta = make_metadata(case.meta_host, case.meta_port);
+            rt.maybe_apply_sniff(case.sniffed, &mut meta);
+            if meta.sniff_host != case.expected_sniff_host {
+                failures.push(format!(
+                    "[{}] sniff_host: expected {:?}, got {:?}",
+                    case.name, case.expected_sniff_host, meta.sniff_host
+                ));
+            }
+            if meta.host != case.expected_host {
+                failures.push(format!(
+                    "[{}] host: expected {:?}, got {:?}",
+                    case.name, case.expected_host, meta.host
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "maybe_apply_sniff cases failed:\n{}",
+            failures.join("\n")
+        );
     }
 
     #[tokio::test]

--- a/crates/meow-listener/src/socks5_udp.rs
+++ b/crates/meow-listener/src/socks5_udp.rs
@@ -365,26 +365,46 @@ fn encode_udp_header(out: &mut SmallVec<[u8; 1500]>, addr: &SocketAddr) {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parse_udp_request_ipv4() {
-        // RSV FRAG ATYP=1 1.2.3.4 :443 "hi"
-        let dg = [0, 0, 0, ATYP_IPV4, 1, 2, 3, 4, 0x01, 0xBB, b'h', b'i'];
-        let (ip, host, port, off) = parse_udp_request(&dg).unwrap();
-        assert_eq!(ip, Some(IpAddr::from([1, 2, 3, 4])));
-        assert!(host.is_empty());
-        assert_eq!(port, 443);
-        assert_eq!(&dg[off..], b"hi");
-    }
+    /// (label, datagram, expected ip, expected host, expected port, expected payload)
+    type ParseUdpRequestCase = (
+        &'static str,
+        &'static [u8],
+        Option<IpAddr>,
+        &'static str,
+        u16,
+        &'static [u8],
+    );
 
     #[test]
-    fn parse_udp_request_domain() {
-        let mut dg = vec![0, 0, 0, ATYP_DOMAIN, 3, b'a', b'.', b'b', 0x00, 0x35];
-        dg.extend_from_slice(b"q");
-        let (ip, host, port, off) = parse_udp_request(&dg).unwrap();
-        assert_eq!(ip, None);
-        assert_eq!(host, "a.b");
-        assert_eq!(port, 53);
-        assert_eq!(&dg[off..], b"q");
+    fn parse_udp_request_cases() {
+        let cases: &[ParseUdpRequestCase] = &[
+            (
+                "ipv4",
+                // RSV FRAG ATYP=1 1.2.3.4 :443 "hi"
+                &[0, 0, 0, ATYP_IPV4, 1, 2, 3, 4, 0x01, 0xBB, b'h', b'i'],
+                Some(IpAddr::from([1, 2, 3, 4])),
+                "",
+                443,
+                b"hi",
+            ),
+            (
+                "domain",
+                // RSV FRAG ATYP=3 len=3 "a.b" :53 "q"
+                &[0, 0, 0, ATYP_DOMAIN, 3, b'a', b'.', b'b', 0x00, 0x35, b'q'],
+                None,
+                "a.b",
+                53,
+                b"q",
+            ),
+        ];
+        for (label, dg, want_ip, want_host, want_port, want_payload) in cases {
+            let (ip, host, port, off) =
+                parse_udp_request(dg).unwrap_or_else(|e| panic!("{label}: parse failed: {e}"));
+            assert_eq!(ip, *want_ip, "{label}: ip");
+            assert_eq!(host, *want_host, "{label}: host");
+            assert_eq!(port, *want_port, "{label}: port");
+            assert_eq!(&dg[off..], *want_payload, "{label}: payload");
+        }
     }
 
     #[test]

--- a/crates/meow-listener/src/tun/wintun.rs
+++ b/crates/meow-listener/src/tun/wintun.rs
@@ -198,26 +198,48 @@ mod tests {
     }
 
     #[test]
-    fn prefers_dll_next_to_the_executable() {
+    fn resolve_from_search_order() {
         // Forward slashes so Path::parent works on Unix CI hosts too.
-        let exe = PathBuf::from("/opt/meow/meow.exe");
-        let cwd = PathBuf::from("/home/me");
-        let found = resolve_from(Some(&exe), Some(&cwd), |p| {
-            p == Path::new("/opt/meow").join(WINTUN_DLL)
-        })
-        .expect("exe-adjacent dll");
-        assert_eq!(found, PathBuf::from("/opt/meow").join(WINTUN_DLL));
-    }
+        struct Case {
+            name: &'static str,
+            exe: &'static str,
+            cwd: &'static str,
+            /// The only directory whose `wintun.dll` the predicate accepts.
+            present_dir: &'static str,
+        }
 
-    #[test]
-    fn falls_back_to_working_directory() {
-        let exe = PathBuf::from("/missing/meow.exe");
-        let cwd = PathBuf::from("/work/meow-rs");
-        let found = resolve_from(Some(&exe), Some(&cwd), |p| {
-            p == Path::new("/work/meow-rs").join(WINTUN_DLL)
-        })
-        .expect("cwd dll");
-        assert_eq!(found, PathBuf::from("/work/meow-rs").join(WINTUN_DLL));
+        let cases = [
+            Case {
+                name: "prefers the dll next to the executable",
+                exe: "/opt/meow/meow.exe",
+                cwd: "/home/me",
+                present_dir: "/opt/meow",
+            },
+            Case {
+                name: "falls back to the working directory",
+                exe: "/missing/meow.exe",
+                cwd: "/work/meow-rs",
+                present_dir: "/work/meow-rs",
+            },
+        ];
+
+        let mut failures = Vec::new();
+        for case in &cases {
+            let expected = Path::new(case.present_dir).join(WINTUN_DLL);
+            let exe = PathBuf::from(case.exe);
+            let cwd = PathBuf::from(case.cwd);
+            match resolve_from(Some(&exe), Some(&cwd), |p| p == expected) {
+                Ok(found) if found == expected => {}
+                Ok(found) => failures.push(format!(
+                    "{}: expected {}, got {}",
+                    case.name,
+                    expected.display(),
+                    found.display()
+                )),
+                Err(e) => failures.push(format!("{}: resolve_from failed: {e}", case.name)),
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("; "));
     }
 
     #[test]

--- a/crates/meow-proxy/src/ech_tls_tunnel.rs
+++ b/crates/meow-proxy/src/ech_tls_tunnel.rs
@@ -270,30 +270,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_fingerprint_chrome() {
-        let cfg = parse_opts(&format!(
-            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64};fingerprint=chrome"
-        ))
-        .expect("ok");
-        assert_eq!(cfg.fingerprint.as_deref(), Some("chrome"));
-    }
+    fn parse_fingerprint_cases() {
+        // (label, opts suffix appended to the minimal client opts, expected cfg.fingerprint)
+        let cases: &[(&str, &str, Option<&str>)] = &[
+            ("explicit chrome", ";fingerprint=chrome", Some("chrome")),
+            ("absent defaults to chrome", "", Some("chrome")),
+            ("none opts out", ";fingerprint=none", None),
+        ];
 
-    #[test]
-    fn parse_fingerprint_defaults_to_chrome() {
-        let cfg = parse_opts(&format!(
-            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64}"
-        ))
-        .expect("ok");
-        assert_eq!(cfg.fingerprint.as_deref(), Some("chrome"));
-    }
-
-    #[test]
-    fn parse_fingerprint_none_opts_out() {
-        let cfg = parse_opts(&format!(
-            "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64};fingerprint=none"
-        ))
-        .expect("ok");
-        assert!(cfg.fingerprint.is_none());
+        for (label, suffix, expected) in cases {
+            let cfg = parse_opts(&format!(
+                "mode=client;sni=t.example;path=/ws;ech_config={FAKE_ECH_B64}{suffix}"
+            ))
+            .unwrap_or_else(|e| panic!("case {label}: parse_opts failed: {e}"));
+            assert_eq!(cfg.fingerprint.as_deref(), *expected, "case: {label}");
+        }
     }
 
     #[test]

--- a/crates/meow-proxy/src/group/load_balance.rs
+++ b/crates/meow-proxy/src/group/load_balance.rs
@@ -352,23 +352,32 @@ mod tests {
     // ─── D. FNV-1a 32-bit implementation ─────────────────────────────────────
 
     #[test]
-    fn fnv1a_empty_input() {
-        // FNV-1a starts from the offset basis; empty input returns it unchanged.
-        assert_eq!(fnv1a(&[]), 0x811c9dc5);
-    }
-
-    #[test]
-    fn fnv1a_single_byte() {
-        // Known FNV-1a 32-bit vector for single null byte.
+    fn fnv1a_known_vectors() {
+        // Known-answer vectors for the inline FNV-1a 32-bit implementation.
         // Reference: https://fnvhash.github.io/fnv-calculator-online/
-        assert_eq!(fnv1a(&[0x00]), 0x050c5d1f);
-    }
+        // Case labels map to docs/specs/group-load-balance-test-plan.md D1-D3.
+        // D3 ([1,1,1,1] = 0x154df079 / 357429369) guards consistent hashing,
+        // which derives its proxy index from this hash.
+        let cases: &[(&str, &[u8], u32)] = &[
+            ("D1 empty input (offset basis)", &[], 0x811c_9dc5),
+            ("D2 single null byte", &[0x00], 0x050c_5d1f),
+            ("D3 ipv4 bytes 1.1.1.1", &[1, 1, 1, 1], 0x154d_f079),
+        ];
 
-    #[test]
-    fn fnv1a_ipv4_bytes() {
-        // FNV-1a 32-bit of [1,1,1,1] = 0x154df079
-        // verified: fnv1a([1,1,1,1]) = 0x154df079 (357429369)
-        assert_eq!(fnv1a(&[1, 1, 1, 1]), 0x154d_f079);
+        let mut failures = Vec::new();
+        for (label, input, expected) in cases {
+            let got = fnv1a(input);
+            if got != *expected {
+                failures.push(format!(
+                    "{label}: fnv1a({input:?}) = {got:#010x}, expected {expected:#010x}"
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "FNV-1a vector mismatches:\n{}",
+            failures.join("\n")
+        );
     }
 
     // D4 is a build-time check: no `fnv` or `fnv1` crate dependency in Cargo.toml.
@@ -623,22 +632,37 @@ mod tests {
     // ─── E. UDP support ───────────────────────────────────────────────────────
 
     #[test]
-    fn support_udp_true_if_any_proxy_supports_udp() {
-        let a = MockProxy::new_udp("A");
-        let b = MockProxy::new("B");
-        let c = MockProxy::new("C");
-        let proxies: Vec<Arc<dyn Proxy>> = vec![a, b, c];
-        let group = make_rr(proxies);
-        assert!(group.support_udp());
-    }
+    fn support_udp_reflects_membership() {
+        // support_udp() is `any()` over members: true when at least one member
+        // supports UDP, false when none do.
+        type Case = (&'static str, Vec<Arc<dyn Proxy>>, bool);
+        let cases: Vec<Case> = vec![
+            (
+                "one of three members supports UDP",
+                vec![
+                    MockProxy::new_udp("A"),
+                    MockProxy::new("B"),
+                    MockProxy::new("C"),
+                ],
+                true,
+            ),
+            (
+                "no member supports UDP",
+                vec![MockProxy::new("A"), MockProxy::new("B")],
+                false,
+            ),
+        ];
 
-    #[test]
-    fn support_udp_false_if_none_support_udp() {
-        let a = MockProxy::new("A");
-        let b = MockProxy::new("B");
-        let proxies: Vec<Arc<dyn Proxy>> = vec![a, b];
-        let group = make_rr(proxies);
-        assert!(!group.support_udp());
+        let mut failures = Vec::new();
+        for (label, proxies, expected) in cases {
+            let got = make_rr(proxies).support_udp();
+            if got != expected {
+                failures.push(format!(
+                    "{label}: expected support_udp() == {expected}, got {got}"
+                ));
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("; "));
     }
 
     #[tokio::test]
@@ -701,16 +725,6 @@ mod tests {
     fn adapter_type_serialises_to_load_balance() {
         let json = serde_json::to_string(&AdapterType::LoadBalance).unwrap();
         assert_eq!(json, r#""LoadBalance""#);
-    }
-
-    #[test]
-    fn adapter_type_enum_variant_exists() {
-        // Guards that the variant is in the enum (not caught by _ arm).
-        let ty = AdapterType::LoadBalance;
-        match ty {
-            AdapterType::LoadBalance => {}
-            _ => panic!("LoadBalance variant not matched"),
-        }
     }
 
     #[test]

--- a/crates/meow-proxy/src/health.rs
+++ b/crates/meow-proxy/src/health.rs
@@ -426,61 +426,110 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_http_url() {
-        let p = ParsedUrl::parse("http://www.gstatic.com/generate_204").unwrap();
-        assert!(!p.https);
-        assert_eq!(p.host, "www.gstatic.com");
-        assert_eq!(p.port, 80);
-        assert_eq!(p.path, "/generate_204");
+    fn parsed_url_cases() {
+        // (input, https, host, port, path)
+        let accepted: &[(&str, bool, &str, u16, &str)] = &[
+            (
+                "http://www.gstatic.com/generate_204",
+                false,
+                "www.gstatic.com",
+                80,
+                "/generate_204",
+            ),
+            (
+                "https://cp.cloudflare.com/generate_204",
+                true,
+                "cp.cloudflare.com",
+                443,
+                "/generate_204",
+            ),
+            ("http://example.com:8080", false, "example.com", 8080, "/"),
+            ("http://[::1]:8080/x", false, "::1", 8080, "/x"),
+        ];
+        let rejected: &[&str] = &["ftp://x", "example.com"];
+
+        // Collect instead of asserting inline so one bad input does not hide
+        // the remaining cases.
+        let mut failures = Vec::new();
+        for (input, https, host, port, path) in accepted {
+            match ParsedUrl::parse(input) {
+                Some(p) => {
+                    let got = (p.https, p.host.as_str(), p.port, p.path.as_str());
+                    if got != (*https, *host, *port, *path) {
+                        failures.push(format!(
+                            "{input:?}: expected (https={https}, host={host:?}, port={port}, path={path:?}), got {got:?}"
+                        ));
+                    }
+                }
+                None => failures.push(format!("{input:?}: expected a parse, got None")),
+            }
+        }
+        for input in rejected {
+            if let Some(p) = ParsedUrl::parse(input) {
+                failures.push(format!("{input:?}: expected None, got {p:?}"));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "ParsedUrl::parse mismatches:\n{}",
+            failures.join("\n")
+        );
     }
 
     #[test]
-    fn parses_https_default_port() {
-        let p = ParsedUrl::parse("https://cp.cloudflare.com/generate_204").unwrap();
-        assert!(p.https);
-        assert_eq!(p.port, 443);
-    }
+    fn parse_expected_cases() {
+        // (label, input, expected): expected is Some(ranges) when the input
+        // must parse to exactly those ranges, None when it must be rejected.
+        type Case = (
+            &'static str,
+            Option<&'static str>,
+            Option<&'static [(u16, u16)]>,
+        );
+        let cases: &[Case] = &[
+            ("default: None is 2xx", None, Some(&[(200, 299)])),
+            (
+                "default: empty string is 2xx",
+                Some(""),
+                Some(&[(200, 299)]),
+            ),
+            (
+                "mixed list of codes and ranges",
+                Some("200,204-206,301"),
+                Some(&[(200, 200), (204, 206), (301, 301)]),
+            ),
+            ("inverted range is rejected", Some("300-200"), None),
+            ("garbage is rejected", Some("abc"), None),
+        ];
 
-    #[test]
-    fn parses_explicit_port_and_empty_path() {
-        let p = ParsedUrl::parse("http://example.com:8080").unwrap();
-        assert_eq!(p.port, 8080);
-        assert_eq!(p.path, "/");
-    }
-
-    #[test]
-    fn parses_ipv6_literal() {
-        let p = ParsedUrl::parse("http://[::1]:8080/x").unwrap();
-        assert_eq!(p.host, "::1");
-        assert_eq!(p.port, 8080);
-        assert_eq!(p.path, "/x");
-    }
-
-    #[test]
-    fn rejects_unknown_scheme() {
-        assert!(ParsedUrl::parse("ftp://x").is_none());
-        assert!(ParsedUrl::parse("example.com").is_none());
-    }
-
-    #[test]
-    fn expected_default_is_2xx() {
-        assert_eq!(parse_expected(None).unwrap(), vec![(200, 299)]);
-        assert_eq!(parse_expected(Some("")).unwrap(), vec![(200, 299)]);
-    }
-
-    #[test]
-    fn expected_parses_mixed_list() {
-        let r = parse_expected(Some("200,204-206,301")).unwrap();
-        assert_eq!(r, vec![(200, 200), (204, 206), (301, 301)]);
-    }
-
-    #[test]
-    fn expected_rejects_inverted_range() {
-        assert!(parse_expected(Some("300-200")).is_err());
-    }
-
-    #[test]
-    fn expected_rejects_garbage() {
-        assert!(parse_expected(Some("abc")).is_err());
+        // Every case runs even if an earlier one fails, so one bad input does
+        // not hide the rest.
+        let mut failures = Vec::new();
+        for (label, input, expected) in cases {
+            match (parse_expected(*input), expected) {
+                (Ok(got), Some(want)) => {
+                    if got.as_slice() != *want {
+                        failures.push(format!(
+                            "{label} ({input:?}): expected {want:?}, got {got:?}"
+                        ));
+                    }
+                }
+                (Err(_), None) => {}
+                (Ok(got), None) => {
+                    failures.push(format!(
+                        "{label} ({input:?}): expected an error, got {got:?}"
+                    ));
+                }
+                (Err(e), Some(want)) => {
+                    failures.push(format!(
+                        "{label} ({input:?}): expected {want:?}, got error {e:?}"
+                    ));
+                }
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "parse_expected mismatches:\n{}",
+            failures.join("\n")
+        );
     }
 }

--- a/crates/meow-proxy/src/http_adapter.rs
+++ b/crates/meow-proxy/src/http_adapter.rs
@@ -753,20 +753,29 @@ mod tests {
     // ─── parse_http_status ────────────────────────────────────────────────────
 
     #[test]
-    fn parse_status_200() {
-        assert_eq!(parse_http_status("HTTP/1.1 200 OK").unwrap(), 200);
-    }
+    fn parse_http_status_cases() {
+        // (label, response line, expected): `Some(code)` => `Ok(code)`, `None` => `Err`.
+        let cases: &[(&str, &str, Option<u16>)] = &[
+            ("200 ok", "HTTP/1.1 200 OK", Some(200)),
+            (
+                "407 proxy auth required",
+                "HTTP/1.0 407 Proxy Auth Required",
+                Some(407),
+            ),
+            ("bad line", "GARBAGE", None),
+        ];
 
-    #[test]
-    fn parse_status_407() {
-        assert_eq!(
-            parse_http_status("HTTP/1.0 407 Proxy Auth Required").unwrap(),
-            407
-        );
-    }
-
-    #[test]
-    fn parse_status_bad_line() {
-        assert!(parse_http_status("GARBAGE").is_err());
+        // Collect instead of asserting inline so every case runs even if one fails.
+        let mut failures = Vec::new();
+        for &(label, line, expected) in cases {
+            match (parse_http_status(line), expected) {
+                (Ok(code), Some(want)) if code == want => {}
+                (Err(_), None) => {}
+                (got, want) => failures.push(format!(
+                    "case {label:?}: parse_http_status({line:?}) expected {want:?}, got {got:?}"
+                )),
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
     }
 }

--- a/crates/meow-proxy/src/v2ray_plugin.rs
+++ b/crates/meow-proxy/src/v2ray_plugin.rs
@@ -196,59 +196,131 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_websocket_mux() {
-        let cfg = parse_opts("mode=websocket;mux=1;host=example.com;path=/ws").expect("parse ok");
-        assert_eq!(cfg.mode, Mode::Websocket);
-        assert!(!cfg.tls);
-        assert!(cfg.mux);
-        assert_eq!(cfg.host, "example.com");
-        assert_eq!(cfg.path, "/ws");
-        assert!(!cfg.skip_cert_verify);
-    }
+    fn parse_opts_cases() {
+        struct Case {
+            name: &'static str,
+            input: &'static str,
+            /// `None` means `parse_opts` must return `Err`.
+            expect: Option<V2rayPluginConfig>,
+        }
 
-    #[test]
-    fn parse_tls_websocket_mux_skip_verify() {
-        let cfg =
-            parse_opts("mode=websocket;tls;mux=1;host=example.com;path=/ws;skip-cert-verify=true")
-                .expect("parse ok");
-        assert!(cfg.tls);
-        assert!(cfg.mux);
-        assert!(cfg.skip_cert_verify);
-        assert_eq!(cfg.host, "example.com");
-        assert_eq!(cfg.path, "/ws");
-    }
+        let cases = [
+            Case {
+                name: "websocket_mux",
+                input: "mode=websocket;mux=1;host=example.com;path=/ws",
+                expect: Some(V2rayPluginConfig {
+                    mode: Mode::Websocket,
+                    tls: false,
+                    host: "example.com".to_string(),
+                    path: "/ws".to_string(),
+                    headers: Default::default(),
+                    skip_cert_verify: false,
+                    mux: true,
+                }),
+            },
+            Case {
+                name: "tls_websocket_mux_skip_verify",
+                input: "mode=websocket;tls;mux=1;host=example.com;path=/ws;skip-cert-verify=true",
+                expect: Some(V2rayPluginConfig {
+                    mode: Mode::Websocket,
+                    tls: true,
+                    host: "example.com".to_string(),
+                    path: "/ws".to_string(),
+                    headers: Default::default(),
+                    skip_cert_verify: true,
+                    mux: true,
+                }),
+            },
+            Case {
+                name: "defaults_on_empty",
+                input: "",
+                expect: Some(V2rayPluginConfig {
+                    mode: Mode::Websocket,
+                    tls: false,
+                    host: String::new(),
+                    path: "/".to_string(),
+                    headers: Default::default(),
+                    skip_cert_verify: false,
+                    mux: false,
+                }),
+            },
+            Case {
+                name: "bare_tls_and_mux",
+                input: "tls;mux",
+                expect: Some(V2rayPluginConfig {
+                    mode: Mode::Websocket,
+                    tls: true,
+                    host: String::new(),
+                    path: "/".to_string(),
+                    headers: Default::default(),
+                    skip_cert_verify: false,
+                    mux: true,
+                }),
+            },
+            Case {
+                name: "unknown_key_ignored",
+                input: "mode=websocket;foo=bar;path=/ws",
+                expect: Some(V2rayPluginConfig {
+                    mode: Mode::Websocket,
+                    tls: false,
+                    host: String::new(),
+                    path: "/ws".to_string(),
+                    headers: Default::default(),
+                    skip_cert_verify: false,
+                    mux: false,
+                }),
+            },
+            Case {
+                name: "header_opt",
+                input: "mode=websocket;header=X-Foo:bar;host=example.com",
+                expect: Some(V2rayPluginConfig {
+                    mode: Mode::Websocket,
+                    tls: false,
+                    host: "example.com".to_string(),
+                    path: "/".to_string(),
+                    headers: [("X-Foo".to_string(), "bar".to_string())]
+                        .into_iter()
+                        .collect(),
+                    skip_cert_verify: false,
+                    mux: false,
+                }),
+            },
+            Case {
+                name: "bad_mode_errors",
+                input: "mode=quic",
+                expect: None,
+            },
+        ];
 
-    #[test]
-    fn parse_defaults_on_empty() {
-        let cfg = parse_opts("").expect("parse ok");
-        assert_eq!(cfg.mode, Mode::Websocket);
-        assert!(!cfg.tls);
-        assert_eq!(cfg.path, "/");
-        assert!(!cfg.mux);
-        assert!(cfg.host.is_empty());
-    }
+        let mut failures = Vec::new();
+        for case in &cases {
+            match (parse_opts(case.input), case.expect.as_ref()) {
+                (Ok(cfg), Some(want)) => {
+                    if cfg.mode != want.mode
+                        || cfg.tls != want.tls
+                        || cfg.host != want.host
+                        || cfg.path != want.path
+                        || cfg.headers != want.headers
+                        || cfg.skip_cert_verify != want.skip_cert_verify
+                        || cfg.mux != want.mux
+                    {
+                        failures.push(format!("{}: got {cfg:?}, want {want:?}", case.name));
+                    }
+                }
+                (Ok(cfg), None) => {
+                    failures.push(format!("{}: expected Err, got Ok({cfg:?})", case.name));
+                }
+                (Err(e), Some(_)) => {
+                    failures.push(format!("{}: expected Ok, got Err({e})", case.name));
+                }
+                (Err(_), None) => {}
+            }
+        }
 
-    #[test]
-    fn parse_bare_tls_and_mux() {
-        let cfg = parse_opts("tls;mux").expect("parse ok");
-        assert!(cfg.tls);
-        assert!(cfg.mux);
-    }
-
-    #[test]
-    fn parse_unknown_key_ignored() {
-        let cfg = parse_opts("mode=websocket;foo=bar;path=/ws").expect("parse ok");
-        assert_eq!(cfg.path, "/ws");
-    }
-
-    #[test]
-    fn parse_bad_mode_errors() {
-        assert!(parse_opts("mode=quic").is_err());
-    }
-
-    #[test]
-    fn parse_header_opt() {
-        let cfg = parse_opts("mode=websocket;header=X-Foo:bar;host=example.com").expect("parse ok");
-        assert_eq!(cfg.headers.get("X-Foo").map(String::as_str), Some("bar"));
+        assert!(
+            failures.is_empty(),
+            "parse_opts case failures:\n{}",
+            failures.join("\n")
+        );
     }
 }

--- a/crates/meow-rules/src/dscp.rs
+++ b/crates/meow-rules/src/dscp.rs
@@ -75,15 +75,28 @@ mod tests {
     }
 
     #[test]
-    fn dscp_match() {
-        let r = DscpRule::new("46", "PROXY").unwrap();
-        assert!(r.match_metadata(&meta_with_dscp(Some(46)), &helper()));
-    }
+    fn dscp_match_cases() {
+        // (label, rule payload, metadata dscp, expected match)
+        let cases: &[(&str, &str, Option<u8>, bool)] = &[
+            ("EF (46) matches dscp 46", "46", Some(46), true),
+            ("rule 46 must not match dscp 0", "46", Some(0), false),
+        ];
 
-    #[test]
-    fn dscp_no_match_different_value() {
-        let r = DscpRule::new("46", "PROXY").unwrap();
-        assert!(!r.match_metadata(&meta_with_dscp(Some(0)), &helper()));
+        let mut failures = Vec::new();
+        for &(label, payload, dscp, expected) in cases {
+            let r = DscpRule::new(payload, "PROXY").unwrap();
+            let got = r.match_metadata(&meta_with_dscp(dscp), &helper());
+            if got != expected {
+                failures.push(format!(
+                    "{label}: DSCP,{payload} vs metadata dscp={dscp:?} — expected {expected}, got {got}"
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "DSCP match mismatches:\n{}",
+            failures.join("\n")
+        );
     }
 
     /// `None` (HTTP/SOCKS5/Mixed) must never match any DSCP rule, including 0.
@@ -104,18 +117,25 @@ mod tests {
     }
 
     #[test]
-    fn dscp_out_of_range_errors() {
-        assert!(DscpRule::new("64", "DIRECT").is_err());
-        assert!(DscpRule::new("255", "DIRECT").is_err());
-    }
-
-    #[test]
-    fn dscp_invalid_payload_errors() {
-        assert!(DscpRule::new("abc", "DIRECT").is_err());
-    }
-
-    #[test]
-    fn dscp_boundary_63_valid() {
-        assert!(DscpRule::new("63", "DIRECT").is_ok());
+    fn dscp_validity_cases() {
+        // (payload, expect_ok)
+        let cases: &[(&str, bool)] = &[
+            ("64", false),  // out of range (> 63)
+            ("255", false), // out of range (> 63)
+            ("abc", false), // not an integer
+            ("63", true),   // boundary: max valid 6-bit value
+        ];
+        let mut failures = Vec::new();
+        for (payload, expect_ok) in cases {
+            let got = DscpRule::new(payload, "DIRECT");
+            if got.is_ok() != *expect_ok {
+                failures.push(format!(
+                    "DSCP payload {payload:?}: expected {}, got {:?}",
+                    if *expect_ok { "Ok" } else { "Err" },
+                    got.as_ref().map(|_| "Ok").map_err(String::as_str),
+                ));
+            }
+        }
+        assert!(failures.is_empty(), "DSCP validity failures: {failures:#?}");
     }
 }

--- a/crates/meow-rules/src/in_port.rs
+++ b/crates/meow-rules/src/in_port.rs
@@ -110,34 +110,73 @@ mod tests {
     }
 
     #[test]
-    fn in_port_exact_match() {
-        let r = InPortRule::new("8080", "DIRECT").unwrap();
-        assert!(r.match_metadata(&meta_with_port(8080), &helper()));
-    }
+    fn in_port_match_cases() {
+        // (payload, adapter, metadata.in_port, expected match, label)
+        let cases = [
+            ("8080", "DIRECT", 8080u16, true, "exact match"),
+            ("8080", "DIRECT", 8081, false, "exact no match"),
+            ("1000-2000", "PROXY", 1000, true, "range lower bound"),
+            ("1000-2000", "PROXY", 2000, true, "range upper bound"),
+            (
+                "1000-2000",
+                "PROXY",
+                999,
+                false,
+                "range rejects below lower bound",
+            ),
+            (
+                "1000-2000",
+                "PROXY",
+                2001,
+                false,
+                "range rejects above upper bound",
+            ),
+            // in_port == 0 means the listener did not populate the field
+            // ("unknown"), not port 0 — it must never match.
+            (
+                "8080",
+                "DIRECT",
+                0,
+                false,
+                "zero in_port never matches nonzero rule",
+            ),
+            (
+                "80/8080/443/8443",
+                "PROXY",
+                8080,
+                true,
+                "slash list matches interior entry",
+            ),
+            (
+                "80/8080/443/8443",
+                "PROXY",
+                8443,
+                true,
+                "slash list matches last entry",
+            ),
+            (
+                "80/8080/443/8443",
+                "PROXY",
+                53,
+                false,
+                "slash list rejects unlisted port",
+            ),
+        ];
 
-    #[test]
-    fn in_port_exact_no_match() {
-        let r = InPortRule::new("8080", "DIRECT").unwrap();
-        assert!(!r.match_metadata(&meta_with_port(8081), &helper()));
-    }
-
-    #[test]
-    fn in_port_range_matches_lower_bound() {
-        let r = InPortRule::new("1000-2000", "PROXY").unwrap();
-        assert!(r.match_metadata(&meta_with_port(1000), &helper()));
-    }
-
-    #[test]
-    fn in_port_range_matches_upper_bound() {
-        let r = InPortRule::new("1000-2000", "PROXY").unwrap();
-        assert!(r.match_metadata(&meta_with_port(2000), &helper()));
-    }
-
-    #[test]
-    fn in_port_range_rejects_outside() {
-        let r = InPortRule::new("1000-2000", "PROXY").unwrap();
-        assert!(!r.match_metadata(&meta_with_port(999), &helper()));
-        assert!(!r.match_metadata(&meta_with_port(2001), &helper()));
+        let mut failures = Vec::new();
+        for (spec, adapter, port, expected, label) in cases {
+            let rule = InPortRule::new(spec, adapter).unwrap();
+            let got = rule.match_metadata(&meta_with_port(port), &helper());
+            if got != expected {
+                failures.push(format!(
+                    "{label}: IN-PORT '{spec}' vs in_port {port} => {got}, expected {expected}"
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "IN-PORT match mismatches: {failures:#?}"
+        );
     }
 
     #[test]
@@ -148,21 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn in_port_zero_in_metadata_never_matches_nonzero_rule() {
-        let r = InPortRule::new("8080", "DIRECT").unwrap();
-        assert!(!r.match_metadata(&meta_with_port(0), &helper()));
-    }
-
-    #[test]
     fn in_port_inverted_range_errors() {
         assert!(InPortRule::new("2000-1000", "DIRECT").is_err());
-    }
-
-    #[test]
-    fn in_port_slash_list_matches() {
-        let r = InPortRule::new("80/8080/443/8443", "PROXY").unwrap();
-        assert!(r.match_metadata(&meta_with_port(8080), &helper()));
-        assert!(r.match_metadata(&meta_with_port(8443), &helper()));
-        assert!(!r.match_metadata(&meta_with_port(53), &helper()));
     }
 }

--- a/crates/meow-rules/src/ip_suffix.rs
+++ b/crates/meow-rules/src/ip_suffix.rs
@@ -171,7 +171,6 @@ impl Rule for IpSuffixRule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{Ipv4Addr, Ipv6Addr};
     use std::str::FromStr;
 
     fn helper() -> RuleMatchHelper {
@@ -185,55 +184,52 @@ mod tests {
         }
     }
 
-    // Upstream: rules/common/ipcidr.go — IP-SUFFIX applies mask to low bits.
+    /// Upstream: `rules/common/ipcidr.go` — IP-SUFFIX applies the mask to the
+    /// **low** bits. Cross-family comparisons must not panic; they return false.
     #[test]
-    fn ip_suffix_ipv4_32_exact_match() {
-        let r = IpSuffixRule::new("8.8.8.8/32", "PROXY", false, true).unwrap();
-        assert!(r.matches_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
-        assert!(!r.matches_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 9))));
-    }
+    fn ip_suffix_matches_ip_cases() {
+        // (label, payload, candidate ip, expected)
+        let cases: &[(&str, &str, &str, bool)] = &[
+            // /32 — exact IPv4 match.
+            ("ipv4 /32 exact hit", "8.8.8.8/32", "8.8.8.8", true),
+            ("ipv4 /32 exact miss", "8.8.8.8/32", "8.8.8.9", false),
+            // /8 — low byte must equal 0x01 → matches any a.b.c.1.
+            ("ipv4 /8 low byte hit a", "0.0.0.1/8", "10.20.30.1", true),
+            ("ipv4 /8 low byte hit b", "0.0.0.1/8", "192.168.0.1", true),
+            ("ipv4 /8 low byte miss", "0.0.0.1/8", "10.20.30.2", false),
+            // /24 — low 24 bits must equal 0x010203 (0.1.2.3) → matches x.1.2.3.
+            ("ipv4 /24 hit a", "0.1.2.3/24", "10.1.2.3", true),
+            ("ipv4 /24 hit b", "0.1.2.3/24", "200.1.2.3", true),
+            ("ipv4 /24 miss", "0.1.2.3/24", "10.1.2.4", false),
+            // /64 — low 64 bits must equal ::1.
+            ("ipv6 /64 low half hit a", "::1/64", "2001:db8::1", true),
+            ("ipv6 /64 low half hit b", "::1/64", "fd00::1", true),
+            ("ipv6 /64 low half miss", "::1/64", "2001:db8::2", false),
+            // /128 — exact IPv6 match.
+            ("ipv6 /128 hit", "2001:db8::1/128", "2001:db8::1", true),
+            ("ipv6 /128 miss", "2001:db8::1/128", "2001:db8::2", false),
+            // Cross-family: never matches, never panics.
+            ("ipv4 rule vs ipv6 addr", "0.0.0.1/8", "::1", false),
+            ("ipv6 rule vs ipv4 addr", "::1/8", "1.2.3.4", false),
+        ];
 
-    #[test]
-    fn ip_suffix_ipv4_8_low_byte() {
-        // Low 8 bits must equal 0x01 → matches any a.b.c.1
-        let r = IpSuffixRule::new("0.0.0.1/8", "PROXY", false, true).unwrap();
-        assert!(r.matches_ip(IpAddr::V4(Ipv4Addr::new(10, 20, 30, 1))));
-        assert!(r.matches_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))));
-        assert!(!r.matches_ip(IpAddr::V4(Ipv4Addr::new(10, 20, 30, 2))));
-    }
-
-    #[test]
-    fn ip_suffix_ipv4_24_low_three_bytes() {
-        // Low 24 bits must equal 0x010203 (0.1.2.3) — matches x.1.2.3
-        let r = IpSuffixRule::new("0.1.2.3/24", "PROXY", false, true).unwrap();
-        assert!(r.matches_ip(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))));
-        assert!(r.matches_ip(IpAddr::V4(Ipv4Addr::new(200, 1, 2, 3))));
-        assert!(!r.matches_ip(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 4))));
-    }
-
-    #[test]
-    fn ip_suffix_ipv6_64_low_half() {
-        // Low 64 bits must equal ::1 → matches any prefix with low half = 1
-        let r = IpSuffixRule::new("::1/64", "PROXY", false, true).unwrap();
-        assert!(r.matches_ip(IpAddr::V6(Ipv6Addr::from_str("2001:db8::1").unwrap())));
-        assert!(r.matches_ip(IpAddr::V6(Ipv6Addr::from_str("fd00::1").unwrap())));
-        assert!(!r.matches_ip(IpAddr::V6(Ipv6Addr::from_str("2001:db8::2").unwrap())));
-    }
-
-    #[test]
-    fn ip_suffix_ipv6_128_exact_match() {
-        let r = IpSuffixRule::new("2001:db8::1/128", "PROXY", false, true).unwrap();
-        assert!(r.matches_ip(IpAddr::V6(Ipv6Addr::from_str("2001:db8::1").unwrap())));
-        assert!(!r.matches_ip(IpAddr::V6(Ipv6Addr::from_str("2001:db8::2").unwrap())));
-    }
-
-    /// Cross-family comparison must not panic; returns false.
-    #[test]
-    fn ip_suffix_ipv4_vs_ipv6_family_no_match() {
-        let r4 = IpSuffixRule::new("0.0.0.1/8", "PROXY", false, true).unwrap();
-        assert!(!r4.matches_ip(IpAddr::V6(Ipv6Addr::from_str("::1").unwrap())));
-        let r6 = IpSuffixRule::new("::1/8", "PROXY", false, true).unwrap();
-        assert!(!r6.matches_ip(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))));
+        // Every case runs; failures are collected so one bad row does not hide
+        // the rest.
+        let mut failures = Vec::new();
+        for (label, payload, ip, expected) in cases {
+            let rule = IpSuffixRule::new(payload, "PROXY", false, true).unwrap();
+            let got = rule.matches_ip(IpAddr::from_str(ip).unwrap());
+            if got != *expected {
+                failures.push(format!(
+                    "{label}: IP-SUFFIX {payload} vs {ip} = {got}, expected {expected}"
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "IP-SUFFIX match mismatches:\n{}",
+            failures.join("\n")
+        );
     }
 
     #[test]
@@ -249,17 +245,6 @@ mod tests {
         // ipnet rejects /33 on IPv4 itself, but make sure the error path returns Err.
         assert!(IpSuffixRule::new("1.2.3.4/33", "PROXY", false, true).is_err());
         assert!(IpSuffixRule::new("::1/129", "PROXY", false, true).is_err());
-    }
-
-    #[test]
-    fn ip_suffix_error_message_distinct_from_ipcidr() {
-        match IpSuffixRule::new("garbage", "PROXY", false, true) {
-            Ok(_) => panic!("expected parse error"),
-            Err(err) => assert!(
-                err.contains("IP-SUFFIX"),
-                "IP-SUFFIX error should self-identify, got: {err}"
-            ),
-        }
     }
 
     #[test]

--- a/crates/meow-rules/tests/rules_test.rs
+++ b/crates/meow-rules/tests/rules_test.rs
@@ -44,28 +44,47 @@ fn meta_ip(ip: &str, dst_port: u16) -> Metadata {
 // ─── DOMAIN ─────────────────────────────────────────────────────────
 
 #[test]
-fn domain_exact_match() {
-    let r = DomainRule::new("google.com", "Proxy");
-    assert!(r.match_metadata(&meta("google.com", 443), &helper()));
-}
+fn domain_match_cases() {
+    // (case label, DOMAIN pattern, request host, expected match)
+    let cases: &[(&str, &str, &str, bool)] = &[
+        ("exact match", "google.com", "google.com", true),
+        (
+            "case-insensitive: mixed-case pattern vs lowercase host",
+            "Google.COM",
+            "google.com",
+            true,
+        ),
+        (
+            "case-insensitive: mixed-case pattern vs uppercase host",
+            "Google.COM",
+            "GOOGLE.COM",
+            true,
+        ),
+        // DOMAIN is exact-only: a subdomain must NOT match (that is DOMAIN-SUFFIX).
+        ("no match: subdomain", "google.com", "www.google.com", false),
+        (
+            "no match: different domain",
+            "google.com",
+            "example.com",
+            false,
+        ),
+    ];
 
-#[test]
-fn domain_case_insensitive() {
-    let r = DomainRule::new("Google.COM", "Proxy");
-    assert!(r.match_metadata(&meta("google.com", 443), &helper()));
-    assert!(r.match_metadata(&meta("GOOGLE.COM", 443), &helper()));
-}
-
-#[test]
-fn domain_no_match_subdomain() {
-    let r = DomainRule::new("google.com", "Proxy");
-    assert!(!r.match_metadata(&meta("www.google.com", 443), &helper()));
-}
-
-#[test]
-fn domain_no_match_different() {
-    let r = DomainRule::new("google.com", "Proxy");
-    assert!(!r.match_metadata(&meta("example.com", 443), &helper()));
+    let mut failures = Vec::new();
+    for (label, pattern, host, expected) in cases {
+        let r = DomainRule::new(pattern, "Proxy");
+        let got = r.match_metadata(&meta(host, 443), &helper());
+        if got != *expected {
+            failures.push(format!(
+                "{label}: DOMAIN,{pattern} vs host {host} => {got}, expected {expected}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "domain match failures:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[test]
@@ -87,87 +106,198 @@ fn domain_type_and_payload() {
 // ─── DOMAIN-SUFFIX ──────────────────────────────────────────────────
 
 #[test]
-fn domain_suffix_exact() {
-    let r = DomainSuffixRule::new("google.com", "Proxy");
-    assert!(r.match_metadata(&meta("google.com", 443), &helper()));
-}
+fn domain_suffix_match_cases() {
+    // (case label, DOMAIN-SUFFIX pattern, request host, expected match)
+    let cases: &[(&str, &str, &str, bool)] = &[
+        (
+            "exact match: host equals suffix",
+            "google.com",
+            "google.com",
+            true,
+        ),
+        ("subdomain: one label", "google.com", "www.google.com", true),
+        (
+            "subdomain: one label (mail)",
+            "google.com",
+            "mail.google.com",
+            true,
+        ),
+        (
+            "subdomain: multiple labels",
+            "google.com",
+            "a.b.c.google.com",
+            true,
+        ),
+        // "notgoogle.com" must NOT match suffix "google.com": the suffix has to
+        // start at a label boundary, not mid-label.
+        (
+            "no match: partial label",
+            "google.com",
+            "notgoogle.com",
+            false,
+        ),
+        (
+            "case-insensitive: mixed-case pattern and host",
+            "Google.COM",
+            "WWW.google.com",
+            true,
+        ),
+        (
+            "no match: different domain",
+            "google.com",
+            "example.com",
+            false,
+        ),
+    ];
 
-#[test]
-fn domain_suffix_subdomain() {
-    let r = DomainSuffixRule::new("google.com", "Proxy");
-    assert!(r.match_metadata(&meta("www.google.com", 443), &helper()));
-    assert!(r.match_metadata(&meta("mail.google.com", 443), &helper()));
-    assert!(r.match_metadata(&meta("a.b.c.google.com", 443), &helper()));
-}
-
-#[test]
-fn domain_suffix_no_partial() {
-    // "notgoogle.com" should NOT match suffix "google.com"
-    let r = DomainSuffixRule::new("google.com", "Proxy");
-    assert!(!r.match_metadata(&meta("notgoogle.com", 443), &helper()));
-}
-
-#[test]
-fn domain_suffix_case_insensitive() {
-    let r = DomainSuffixRule::new("Google.COM", "Proxy");
-    assert!(r.match_metadata(&meta("WWW.google.com", 443), &helper()));
-}
-
-#[test]
-fn domain_suffix_no_match() {
-    let r = DomainSuffixRule::new("google.com", "Proxy");
-    assert!(!r.match_metadata(&meta("example.com", 443), &helper()));
+    let mut failures = Vec::new();
+    for (label, pattern, host, expected) in cases {
+        let r = DomainSuffixRule::new(pattern, "Proxy");
+        let got = r.match_metadata(&meta(host, 443), &helper());
+        if got != *expected {
+            failures.push(format!(
+                "{label}: DOMAIN-SUFFIX,{pattern} vs host {host} => {got}, expected {expected}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "domain-suffix match failures:\n{}",
+        failures.join("\n")
+    );
 }
 
 // ─── DOMAIN-KEYWORD ─────────────────────────────────────────────────
 
 #[test]
-fn domain_keyword_match() {
-    let r = DomainKeywordRule::new("google", "Proxy");
-    assert!(r.match_metadata(&meta("www.google.com", 443), &helper()));
-    assert!(r.match_metadata(&meta("google.co.jp", 443), &helper()));
-}
+fn domain_keyword_match_cases() {
+    // (case label, DOMAIN-KEYWORD pattern, request host, expected match)
+    let cases: &[(&str, &str, &str, bool)] = &[
+        (
+            "match: keyword as interior label",
+            "google",
+            "www.google.com",
+            true,
+        ),
+        (
+            "match: keyword as leading label",
+            "google",
+            "google.co.jp",
+            true,
+        ),
+        (
+            "case-insensitive: uppercase pattern vs lowercase host",
+            "GOOGLE",
+            "www.google.com",
+            true,
+        ),
+        (
+            "no match: keyword absent from host",
+            "google",
+            "example.com",
+            false,
+        ),
+        (
+            "partial: keyword matches a mid-label substring, not only whole labels",
+            "oog",
+            "google.com",
+            true,
+        ),
+    ];
 
-#[test]
-fn domain_keyword_case_insensitive() {
-    let r = DomainKeywordRule::new("GOOGLE", "Proxy");
-    assert!(r.match_metadata(&meta("www.google.com", 443), &helper()));
-}
-
-#[test]
-fn domain_keyword_no_match() {
-    let r = DomainKeywordRule::new("google", "Proxy");
-    assert!(!r.match_metadata(&meta("example.com", 443), &helper()));
-}
-
-#[test]
-fn domain_keyword_partial() {
-    let r = DomainKeywordRule::new("oog", "Proxy");
-    assert!(r.match_metadata(&meta("google.com", 443), &helper()));
+    let mut failures = Vec::new();
+    for (label, pattern, host, expected) in cases {
+        let r = DomainKeywordRule::new(pattern, "Proxy");
+        let got = r.match_metadata(&meta(host, 443), &helper());
+        if got != *expected {
+            failures.push(format!(
+                "{label}: DOMAIN-KEYWORD,{pattern} vs host {host} => {got}, expected {expected}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "domain-keyword match failures:\n{}",
+        failures.join("\n")
+    );
 }
 
 // ─── DOMAIN-REGEX ───────────────────────────────────────────────────
 
 #[test]
-fn domain_regex_match() {
-    let r = DomainRegexRule::new(r"^(.*\.)?google\.com$", "Proxy").unwrap();
-    assert!(r.match_metadata(&meta("google.com", 443), &helper()));
-    assert!(r.match_metadata(&meta("www.google.com", 443), &helper()));
-}
+fn domain_regex_match_cases() {
+    // (case label, DOMAIN-REGEX pattern, request host, dst port, expected match)
+    let cases: &[(&str, &str, &str, u16, bool)] = &[
+        // from `domain_regex_match`
+        (
+            "anchored: apex domain",
+            r"^(.*\.)?google\.com$",
+            "google.com",
+            443,
+            true,
+        ),
+        (
+            "anchored: subdomain",
+            r"^(.*\.)?google\.com$",
+            "www.google.com",
+            443,
+            true,
+        ),
+        // from `domain_regex_no_match`
+        (
+            "anchored: unrelated domain",
+            r"^(.*\.)?google\.com$",
+            "example.com",
+            443,
+            false,
+        ),
+        // `$` anchor must reject a lookalike that only *contains* the domain.
+        (
+            "anchored: suffix-lookalike must not match",
+            r"^(.*\.)?google\.com$",
+            "google.com.evil.net",
+            443,
+            false,
+        ),
+        // from `domain_regex_complex`
+        (
+            "complex: ads. label",
+            r"^ad[sv]?\d*\.",
+            "ads.example.com",
+            80,
+            true,
+        ),
+        (
+            "complex: adv123. label",
+            r"^ad[sv]?\d*\.",
+            "adv123.tracker.io",
+            80,
+            true,
+        ),
+        (
+            "complex: admin. must not match",
+            r"^ad[sv]?\d*\.",
+            "admin.example.com",
+            80,
+            false,
+        ),
+    ];
 
-#[test]
-fn domain_regex_no_match() {
-    let r = DomainRegexRule::new(r"^(.*\.)?google\.com$", "Proxy").unwrap();
-    assert!(!r.match_metadata(&meta("example.com", 443), &helper()));
-    assert!(!r.match_metadata(&meta("google.com.evil.net", 443), &helper()));
-}
-
-#[test]
-fn domain_regex_complex() {
-    let r = DomainRegexRule::new(r"^ad[sv]?\d*\.", "Proxy").unwrap();
-    assert!(r.match_metadata(&meta("ads.example.com", 80), &helper()));
-    assert!(r.match_metadata(&meta("adv123.tracker.io", 80), &helper()));
-    assert!(!r.match_metadata(&meta("admin.example.com", 80), &helper()));
+    let mut failures = Vec::new();
+    for &(label, pattern, host, dst_port, expected) in cases {
+        let r = DomainRegexRule::new(pattern, "Proxy").unwrap();
+        let got = r.match_metadata(&meta(host, dst_port), &helper());
+        if got != expected {
+            failures.push(format!(
+                "{label}: DOMAIN-REGEX,{pattern} vs host {host}:{dst_port} => {got}, expected {expected}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "domain-regex match failures:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[test]
@@ -184,36 +314,59 @@ fn domain_regex_type() {
 // ─── IP-CIDR ────────────────────────────────────────────────────────
 
 #[test]
-fn ipcidr_v4_match() {
-    let r = IpCidrRule::new("192.168.1.0/24", "DIRECT", false, true).unwrap();
-    assert!(r.match_metadata(&meta_ip("192.168.1.1", 80), &helper()));
-    assert!(r.match_metadata(&meta_ip("192.168.1.254", 80), &helper()));
-}
+fn ipcidr_match_cases() {
+    // (label, cidr, dst ip, expected match)
+    let cases: [(&str, &str, &str, bool); 8] = [
+        (
+            "v4 /24 low host in range",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            true,
+        ),
+        (
+            "v4 /24 high host in range",
+            "192.168.1.0/24",
+            "192.168.1.254",
+            true,
+        ),
+        (
+            "v4 /24 adjacent prefix",
+            "192.168.1.0/24",
+            "192.168.2.1",
+            false,
+        ),
+        (
+            "v4 /24 unrelated private block",
+            "192.168.1.0/24",
+            "10.0.0.1",
+            false,
+        ),
+        ("v4 /32 single host exact", "10.0.0.1/32", "10.0.0.1", true),
+        (
+            "v4 /32 single host neighbour",
+            "10.0.0.1/32",
+            "10.0.0.2",
+            false,
+        ),
+        ("v6 /8 inside ULA prefix", "fd00::/8", "fd12::1", true),
+        ("v6 /8 outside ULA prefix", "fd00::/8", "2001:db8::1", false),
+    ];
 
-#[test]
-fn ipcidr_v4_no_match() {
-    let r = IpCidrRule::new("192.168.1.0/24", "DIRECT", false, true).unwrap();
-    assert!(!r.match_metadata(&meta_ip("192.168.2.1", 80), &helper()));
-    assert!(!r.match_metadata(&meta_ip("10.0.0.1", 80), &helper()));
-}
-
-#[test]
-fn ipcidr_v4_single_host() {
-    let r = IpCidrRule::new("10.0.0.1/32", "DIRECT", false, true).unwrap();
-    assert!(r.match_metadata(&meta_ip("10.0.0.1", 80), &helper()));
-    assert!(!r.match_metadata(&meta_ip("10.0.0.2", 80), &helper()));
-}
-
-#[test]
-fn ipcidr_v6_match() {
-    let r = IpCidrRule::new("fd00::/8", "DIRECT", false, true).unwrap();
-    assert!(r.match_metadata(&meta_ip("fd12::1", 80), &helper()));
-}
-
-#[test]
-fn ipcidr_v6_no_match() {
-    let r = IpCidrRule::new("fd00::/8", "DIRECT", false, true).unwrap();
-    assert!(!r.match_metadata(&meta_ip("2001:db8::1", 80), &helper()));
+    let mut failures = Vec::new();
+    for (label, cidr, ip, expected) in cases {
+        let r = IpCidrRule::new(cidr, "DIRECT", false, true).unwrap();
+        let got = r.match_metadata(&meta_ip(ip, 80), &helper());
+        if got != expected {
+            failures.push(format!(
+                "{label}: IP-CIDR,{cidr} vs {ip} -> expected {expected}, got {got}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "ipcidr match mismatches:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[test]
@@ -224,20 +377,19 @@ fn ipcidr_no_ip_no_match() {
 }
 
 #[test]
-fn ipcidr_src() {
+fn ipcidr_src_match_cases() {
     let r = IpCidrRule::new("10.0.0.0/8", "DIRECT", true, true).unwrap();
     assert_eq!(r.rule_type(), RuleType::SrcIpCidr);
-    let mut m = meta("", 80);
-    m.src_ip = Some("10.1.2.3".parse().unwrap());
-    assert!(r.match_metadata(&m, &helper()));
-}
 
-#[test]
-fn ipcidr_src_no_match() {
-    let r = IpCidrRule::new("10.0.0.0/8", "DIRECT", true, true).unwrap();
-    let mut m = meta("", 80);
-    m.src_ip = Some("192.168.1.1".parse().unwrap());
-    assert!(!r.match_metadata(&m, &helper()));
+    for (src_ip, expected) in [("10.1.2.3", true), ("192.168.1.1", false)] {
+        let mut m = meta("", 80);
+        m.src_ip = Some(src_ip.parse().unwrap());
+        assert_eq!(
+            r.match_metadata(&m, &helper()),
+            expected,
+            "src_ip {src_ip} vs 10.0.0.0/8: expected match={expected}"
+        );
+    }
 }
 
 #[test]
@@ -256,47 +408,47 @@ fn ipcidr_invalid() {
 // ─── PORT ───────────────────────────────────────────────────────────
 
 #[test]
-fn port_single_match() {
-    let r = PortRule::new("80", "DIRECT", false).unwrap();
-    assert!(r.match_metadata(&meta("example.com", 80), &helper()));
-    assert!(!r.match_metadata(&meta("example.com", 443), &helper()));
-}
+fn port_match_cases() {
+    // (spec, adapter, host, dst_port, expected_match)
+    let cases: &[(&str, &str, &str, u16, bool)] = &[
+        // port_single_match
+        ("80", "DIRECT", "example.com", 80, true),
+        ("80", "DIRECT", "example.com", 443, false),
+        // port_range_match
+        ("8000-9000", "Proxy", "", 8000, true),
+        ("8000-9000", "Proxy", "", 8500, true),
+        ("8000-9000", "Proxy", "", 9000, true),
+        ("8000-9000", "Proxy", "", 7999, false),
+        ("8000-9000", "Proxy", "", 9001, false),
+        // port_multiple
+        ("80,443,8080", "Proxy", "", 80, true),
+        ("80,443,8080", "Proxy", "", 443, true),
+        ("80,443,8080", "Proxy", "", 8080, true),
+        ("80,443,8080", "Proxy", "", 8081, false),
+        // port_slash_multiple
+        ("80/8080/443/8443", "Proxy", "", 80, true),
+        ("80/8080/443/8443", "Proxy", "", 8080, true),
+        ("80/8080/443/8443", "Proxy", "", 443, true),
+        ("80/8080/443/8443", "Proxy", "", 8443, true),
+        ("80/8080/443/8443", "Proxy", "", 22, false),
+        // port_mixed_single_and_range
+        ("22,80,8000-9000", "Proxy", "", 22, true),
+        ("22,80,8000-9000", "Proxy", "", 8500, true),
+        ("22,80,8000-9000", "Proxy", "", 23, false),
+    ];
 
-#[test]
-fn port_range_match() {
-    let r = PortRule::new("8000-9000", "Proxy", false).unwrap();
-    assert!(r.match_metadata(&meta("", 8000), &helper()));
-    assert!(r.match_metadata(&meta("", 8500), &helper()));
-    assert!(r.match_metadata(&meta("", 9000), &helper()));
-    assert!(!r.match_metadata(&meta("", 7999), &helper()));
-    assert!(!r.match_metadata(&meta("", 9001), &helper()));
-}
-
-#[test]
-fn port_multiple() {
-    let r = PortRule::new("80,443,8080", "Proxy", false).unwrap();
-    assert!(r.match_metadata(&meta("", 80), &helper()));
-    assert!(r.match_metadata(&meta("", 443), &helper()));
-    assert!(r.match_metadata(&meta("", 8080), &helper()));
-    assert!(!r.match_metadata(&meta("", 8081), &helper()));
-}
-
-#[test]
-fn port_slash_multiple() {
-    let r = PortRule::new("80/8080/443/8443", "Proxy", false).unwrap();
-    assert!(r.match_metadata(&meta("", 80), &helper()));
-    assert!(r.match_metadata(&meta("", 8080), &helper()));
-    assert!(r.match_metadata(&meta("", 443), &helper()));
-    assert!(r.match_metadata(&meta("", 8443), &helper()));
-    assert!(!r.match_metadata(&meta("", 22), &helper()));
-}
-
-#[test]
-fn port_mixed_single_and_range() {
-    let r = PortRule::new("22,80,8000-9000", "Proxy", false).unwrap();
-    assert!(r.match_metadata(&meta("", 22), &helper()));
-    assert!(r.match_metadata(&meta("", 8500), &helper()));
-    assert!(!r.match_metadata(&meta("", 23), &helper()));
+    let mut failures = Vec::new();
+    for (spec, adapter, host, port, expected) in cases {
+        let r = PortRule::new(spec, adapter, false)
+            .unwrap_or_else(|e| panic!("PortRule::new({spec:?}) failed: {e}"));
+        let got = r.match_metadata(&meta(host, *port), &helper());
+        if got != *expected {
+            failures.push(format!(
+                "spec {spec:?} port {port}: expected match={expected}, got {got}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "port match mismatches: {failures:#?}");
 }
 
 #[test]
@@ -325,60 +477,88 @@ fn port_invalid() {
 // ─── NETWORK ────────────────────────────────────────────────────────
 
 #[test]
-fn network_tcp() {
-    let r = NetworkRule::new("tcp", "Proxy").unwrap();
-    let mut m = meta("", 80);
-    m.network = Network::Tcp;
-    assert!(r.match_metadata(&m, &helper()));
-    m.network = Network::Udp;
-    assert!(!r.match_metadata(&m, &helper()));
+fn network_match_cases() {
+    // (case label, NETWORK payload, metadata network, expected match)
+    let cases: &[(&str, &str, Network, bool)] = &[
+        ("tcp rule vs tcp traffic", "tcp", Network::Tcp, true),
+        ("tcp rule vs udp traffic", "tcp", Network::Udp, false),
+        ("udp rule vs udp traffic", "udp", Network::Udp, true),
+        ("udp rule vs tcp traffic", "udp", Network::Tcp, false),
+    ];
+
+    let mut failures = Vec::new();
+    for (label, payload, network, expected) in cases {
+        let r = NetworkRule::new(payload, "Proxy").unwrap();
+        let mut m = meta("", 80);
+        m.network = *network;
+        let got = r.match_metadata(&m, &helper());
+        if got != *expected {
+            failures.push(format!(
+                "{label}: NETWORK,{payload} vs metadata network {network:?} => {got}, expected {expected}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "network match failures:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[test]
-fn network_udp() {
-    let r = NetworkRule::new("udp", "Proxy").unwrap();
-    let mut m = meta("", 80);
-    m.network = Network::Udp;
-    assert!(r.match_metadata(&m, &helper()));
-    m.network = Network::Tcp;
-    assert!(!r.match_metadata(&m, &helper()));
-}
-
-#[test]
-fn network_case_insensitive() {
-    assert!(NetworkRule::new("TCP", "Proxy").is_ok());
-    assert!(NetworkRule::new("Udp", "Proxy").is_ok());
-}
-
-#[test]
-fn network_invalid() {
-    assert!(NetworkRule::new("icmp", "Proxy").is_err());
+fn network_parse_validity_cases() {
+    // (literal, should_parse)
+    let cases: &[(&str, bool)] = &[
+        ("TCP", true),   // case-insensitive accept
+        ("Udp", true),   // case-insensitive accept
+        ("icmp", false), // unknown network rejected
+    ];
+    let mut failures = Vec::new();
+    for (literal, should_parse) in cases {
+        let ok = NetworkRule::new(literal, "Proxy").is_ok();
+        if ok != *should_parse {
+            failures.push(format!(
+                "NetworkRule::new({literal:?}): expected is_ok()={should_parse}, got {ok}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "network parse validity mismatches: {failures:?}"
+    );
 }
 
 // ─── PROCESS-NAME ───────────────────────────────────────────────────
 
 #[test]
-fn process_match() {
-    let r = ProcessRule::new("chrome", "Proxy");
-    let mut m = meta("", 443);
-    m.process = "chrome".into();
-    assert!(r.match_metadata(&m, &helper()));
-}
-
-#[test]
-fn process_case_insensitive() {
-    let r = ProcessRule::new("Chrome", "Proxy");
-    let mut m = meta("", 443);
-    m.process = "chrome".into();
-    assert!(r.match_metadata(&m, &helper()));
-}
-
-#[test]
-fn process_no_match() {
-    let r = ProcessRule::new("chrome", "Proxy");
-    let mut m = meta("", 443);
-    m.process = "firefox".into();
-    assert!(!r.match_metadata(&m, &helper()));
+fn process_match_cases() {
+    // (label, rule pattern, metadata process name, expected match)
+    let cases: &[(&str, &str, &str, bool)] = &[
+        ("exact name matches", "chrome", "chrome", true),
+        ("pattern case is ignored", "Chrome", "chrome", true),
+        (
+            "different process does not match",
+            "chrome",
+            "firefox",
+            false,
+        ),
+    ];
+    let mut failures = Vec::new();
+    for &(label, pattern, process, expected) in cases {
+        let r = ProcessRule::new(pattern, "Proxy");
+        let mut m = meta("", 443);
+        m.process = process.into();
+        let got = r.match_metadata(&m, &helper());
+        if got != expected {
+            failures.push(format!(
+                "{label}: PROCESS-NAME,{pattern} vs process {process:?} expected {expected}, got {got}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "process-name match mismatches: {failures:?}"
+    );
 }
 
 #[test]
@@ -408,26 +588,44 @@ fn final_type_and_payload() {
 // ─── LOGIC: AND ─────────────────────────────────────────────────────
 
 #[test]
-fn and_all_match() {
-    let rules: Vec<Box<dyn Rule>> = vec![
-        Box::new(DomainSuffixRule::new("google.com", "")),
-        Box::new(PortRule::new("443", "", false).unwrap()),
+fn and_rule_match_cases() {
+    // AndRule([DOMAIN-SUFFIX,google.com] AND [DST-PORT,443]) matches only when
+    // every child rule matches.
+    let cases: &[(&str, &str, u16, bool)] = &[
+        ("all children match", "www.google.com", 443, true),
+        (
+            "domain matches but port does not",
+            "www.google.com",
+            80,
+            false,
+        ),
+        (
+            "port matches but domain does not",
+            "example.com",
+            443,
+            false,
+        ),
     ];
-    let r = AndRule::new(rules, "Proxy");
-    assert!(r.match_metadata(&meta("www.google.com", 443), &helper()));
-}
 
-#[test]
-fn and_partial_no_match() {
-    let rules: Vec<Box<dyn Rule>> = vec![
-        Box::new(DomainSuffixRule::new("google.com", "")),
-        Box::new(PortRule::new("443", "", false).unwrap()),
-    ];
-    let r = AndRule::new(rules, "Proxy");
-    // Domain matches but port doesn't
-    assert!(!r.match_metadata(&meta("www.google.com", 80), &helper()));
-    // Port matches but domain doesn't
-    assert!(!r.match_metadata(&meta("example.com", 443), &helper()));
+    let mut failures = Vec::new();
+    for &(label, host, port, expected) in cases {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainSuffixRule::new("google.com", "")),
+            Box::new(PortRule::new("443", "", false).unwrap()),
+        ];
+        let r = AndRule::new(rules, "Proxy");
+        let actual = r.match_metadata(&meta(host, port), &helper());
+        if actual != expected {
+            failures.push(format!(
+                "case `{label}` (host={host}, port={port}): expected {expected}, got {actual}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "AndRule match mismatches:\n{}",
+        failures.join("\n")
+    );
 }
 
 #[test]
@@ -440,33 +638,31 @@ fn and_type() {
 // ─── LOGIC: OR ──────────────────────────────────────────────────────
 
 #[test]
-fn or_first_matches() {
-    let rules: Vec<Box<dyn Rule>> = vec![
-        Box::new(DomainRule::new("google.com", "")),
-        Box::new(DomainRule::new("example.com", "")),
+fn or_rule_match_cases() {
+    // OR([DOMAIN google.com, DOMAIN example.com]) — (host, expected):
+    // first sub-rule matches, second sub-rule matches, neither matches.
+    let cases: &[(&str, bool)] = &[
+        ("google.com", true),
+        ("example.com", true),
+        ("other.com", false),
     ];
-    let r = OrRule::new(rules, "Proxy");
-    assert!(r.match_metadata(&meta("google.com", 80), &helper()));
-}
 
-#[test]
-fn or_second_matches() {
-    let rules: Vec<Box<dyn Rule>> = vec![
-        Box::new(DomainRule::new("google.com", "")),
-        Box::new(DomainRule::new("example.com", "")),
-    ];
-    let r = OrRule::new(rules, "Proxy");
-    assert!(r.match_metadata(&meta("example.com", 80), &helper()));
-}
+    let mut failures = Vec::new();
+    for &(host, expected) in cases {
+        let rules: Vec<Box<dyn Rule>> = vec![
+            Box::new(DomainRule::new("google.com", "")),
+            Box::new(DomainRule::new("example.com", "")),
+        ];
+        let r = OrRule::new(rules, "Proxy");
+        let got = r.match_metadata(&meta(host, 80), &helper());
+        if got != expected {
+            failures.push(format!(
+                "OR([DOMAIN google.com, DOMAIN example.com]) vs host {host}: expected {expected}, got {got}"
+            ));
+        }
+    }
 
-#[test]
-fn or_none_match() {
-    let rules: Vec<Box<dyn Rule>> = vec![
-        Box::new(DomainRule::new("google.com", "")),
-        Box::new(DomainRule::new("example.com", "")),
-    ];
-    let r = OrRule::new(rules, "Proxy");
-    assert!(!r.match_metadata(&meta("other.com", 80), &helper()));
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
 #[test]
@@ -641,24 +837,27 @@ fn parse_match() {
 }
 
 #[test]
-fn parse_unknown_type_error() {
-    assert!(parse_rule("UNKNOWN-RULE,payload,Proxy").is_err());
-}
+fn parse_rule_malformed_input_errors() {
+    // Syntactically malformed rule lines the parser must reject. Each case is
+    // labelled and every case is evaluated, so a regression names the exact
+    // offending input(s) instead of stopping at the first failure.
+    let cases = [
+        ("too few parts: type only", "DOMAIN"),
+        ("too few parts: no target", "DOMAIN,google.com"),
+        ("invalid regex payload", "DOMAIN-REGEX,[bad,Proxy"),
+        ("invalid CIDR payload", "IP-CIDR,not-a-cidr,DIRECT"),
+    ];
 
-#[test]
-fn parse_too_few_parts_error() {
-    assert!(parse_rule("DOMAIN").is_err());
-    assert!(parse_rule("DOMAIN,google.com").is_err());
-}
+    let accepted: Vec<&str> = cases
+        .iter()
+        .filter(|(_, line)| parse_rule(line).is_ok())
+        .map(|(label, _)| *label)
+        .collect();
 
-#[test]
-fn parse_invalid_regex_error() {
-    assert!(parse_rule("DOMAIN-REGEX,[bad,Proxy").is_err());
-}
-
-#[test]
-fn parse_invalid_cidr_error() {
-    assert!(parse_rule("IP-CIDR,not-a-cidr,DIRECT").is_err());
+    assert!(
+        accepted.is_empty(),
+        "parse_rule accepted malformed lines: {accepted:?}"
+    );
 }
 
 #[test]

--- a/crates/meow-transport/tests/h2_test.rs
+++ b/crates/meow-transport/tests/h2_test.rs
@@ -29,20 +29,20 @@ use meow_transport::TransportError;
 use support::loopback::{spawn_h2_server, spawn_h2_server_deferred_response};
 use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-async fn assert_h2_config_error(config: H2Config, expected: &str) {
+async fn assert_h2_config_error(case: &str, config: H2Config, expected: &str) {
     let (client, _server) = tokio::io::duplex(64);
     let layer = H2Layer::new(config);
     let Err(err) = layer.connect(Box::new(client)).await else {
-        panic!("invalid h2 config unexpectedly connected");
+        panic!("[{case}] invalid h2 config unexpectedly connected");
     };
     match err {
         TransportError::Config(msg) => {
             assert!(
                 msg.contains(expected),
-                "expected config error containing {expected:?}, got: {msg}"
+                "[{case}] expected config error containing {expected:?}, got: {msg}"
             );
         }
-        other => panic!("expected TransportError::Config, got: {other:?}"),
+        other => panic!("[{case}] expected TransportError::Config, got: {other:?}"),
     }
 }
 
@@ -210,37 +210,40 @@ async fn h2_path_forwarded() {
     );
 }
 
+/// Config validation rejects bad `H2Config` before any handshake bytes are
+/// written: empty host list, CRLF injection in `path`, and an invalid host.
 #[tokio::test]
-async fn h2_rejects_empty_hosts_before_handshake() {
-    assert_h2_config_error(
-        H2Config {
-            path: "/".into(),
-            hosts: vec![],
-        },
-        "hosts",
-    )
-    .await;
-}
+async fn h2_rejects_invalid_config_table() {
+    let cases: [(&str, H2Config, &str); 3] = [
+        (
+            "empty hosts",
+            H2Config {
+                path: "/".into(),
+                hosts: vec![],
+            },
+            "hosts",
+        ),
+        (
+            "crlf injection in path",
+            H2Config {
+                path: "/ok\r\nx: y".into(),
+                hosts: vec!["example.com".into()],
+            },
+            "invalid request config",
+        ),
+        (
+            "invalid host with space",
+            H2Config {
+                path: "/".into(),
+                hosts: vec!["bad host".into()],
+            },
+            "invalid request config",
+        ),
+    ];
 
-#[tokio::test]
-async fn h2_rejects_invalid_request_config_before_handshake() {
-    assert_h2_config_error(
-        H2Config {
-            path: "/ok\r\nx: y".into(),
-            hosts: vec!["example.com".into()],
-        },
-        "invalid request config",
-    )
-    .await;
-
-    assert_h2_config_error(
-        H2Config {
-            path: "/".into(),
-            hosts: vec!["bad host".into()],
-        },
-        "invalid request config",
-    )
-    .await;
+    for (case, config, expected) in cases {
+        assert_h2_config_error(case, config, expected).await;
+    }
 }
 
 // ─── D5: Response HEADERS withheld until the first client DATA frame ──────────

--- a/crates/meow-tunnel/tests/statistics_test.rs
+++ b/crates/meow-tunnel/tests/statistics_test.rs
@@ -4,48 +4,42 @@ use smallvec::smallvec;
 use std::sync::Arc;
 
 #[test]
-fn test_statistics_new() {
-    let stats = Statistics::new();
-    let (up, down) = stats.snapshot();
-    assert_eq!(up, 0);
-    assert_eq!(down, 0);
-    assert!(stats.active_connections().is_empty());
+fn test_statistics_new_and_default_start_zeroed() {
+    let from_new = Statistics::new();
+    let (up, down) = from_new.snapshot();
+    assert_eq!(up, 0, "Statistics::new() upload_total must start at 0");
+    assert_eq!(down, 0, "Statistics::new() download_total must start at 0");
+    assert!(
+        from_new.active_connections().is_empty(),
+        "Statistics::new() must start with no active connections"
+    );
+
+    let from_default = Statistics::default();
+    let (up, down) = from_default.snapshot();
+    assert_eq!(up, 0, "Statistics::default() upload_total must start at 0");
+    assert_eq!(
+        down, 0,
+        "Statistics::default() download_total must start at 0"
+    );
+    assert!(
+        from_default.active_connections().is_empty(),
+        "Statistics::default() must start with no active connections"
+    );
 }
 
 #[test]
-fn test_statistics_default() {
-    let stats = Statistics::default();
-    let (up, down) = stats.snapshot();
-    assert_eq!(up, 0);
-    assert_eq!(down, 0);
-}
-
-#[test]
-fn test_add_upload() {
+fn test_add_upload_and_download_accumulate_independently() {
     let stats = Statistics::new();
+
     stats.add_upload(100);
-    stats.add_upload(200);
-    let (up, _) = stats.snapshot();
-    assert_eq!(up, 300);
-}
-
-#[test]
-fn test_add_download() {
-    let stats = Statistics::new();
     stats.add_download(500);
-    stats.add_download(1500);
-    let (_, down) = stats.snapshot();
-    assert_eq!(down, 2000);
-}
+    // One add per direction: each counter sees only its own bytes.
+    assert_eq!(stats.snapshot(), (100, 500));
 
-#[test]
-fn test_upload_and_download_independent() {
-    let stats = Statistics::new();
-    stats.add_upload(100);
-    stats.add_download(200);
-    let (up, down) = stats.snapshot();
-    assert_eq!(up, 100);
-    assert_eq!(down, 200);
+    stats.add_upload(200);
+    stats.add_download(1500);
+    // Repeated adds accumulate per direction, still without cross-contamination.
+    assert_eq!(stats.snapshot(), (300, 2000));
 }
 
 #[test]


### PR DESCRIPTION
Minimizes test count while preserving behavioral coverage. Near-identical tests that differed only in input data are folded into table-driven tests over a labelled const case array; a handful asserting only derive'd or fully-subsumed behavior are removed outright.

**1912 → 1762 `#[test]`/`#[tokio::test]` (−150, −7.8%)** — 200 test fns removed, 53 merged table tests added.

| Crate group | Before | After | Δ |
|---|---:|---:|---:|
| meow-proxy | 452 | 431 | −21 |
| meow-config | 388 | 360 | −28 |
| meow-rules + meow-common | 329 | 273 | −56 |
| meow-api + transport + app | 262 | 233 | −29 |
| meow-listener + meow-tunnel | 220 | 212 | −8 |
| meow-dns + meow-trie | 206 | 198 | −8 |

## What was kept

Each proposal got an independent adversarial review before being applied. **54 of 112 proposals (48%) were rejected as coverage-losing and are not in this PR.** Rejections clustered on four themes worth recording:

- **ADR-0002 Class A divergence anchors** — named tests an ADR audit greps for by name; merging dissolves the name.
- **Named spec identities** — e.g. C2/C3/C4 in `docs/specs/group-relay-test-plan.md`.
- **Per-case failure isolation** — merging N independent signals into one means a break in `adapter_type()` fails the whole table instead of one accessor.
- **Fail-fast masking** — a table that panics on case 1 never executes cases 2..N. Protocol matrices (mode × key-type, `xor_mode` 0-RTT paths) stay separate for this reason.

Untouched by construction: the leak/alloc/footprint/invariant tests gating ADR-0006/0007/0008/0011, and every issue/CVE-tagged regression test. No integration test *file* was removed, so the CI target list in `.github/workflows/test.yml` and `CLAUDE.md` remains valid.

## Coverage preservation

Every case in a merged table keeps its input and its assertions, with the case label in the assert message so failures stay diagnosable. Setup differences are preserved structurally rather than flattened — e.g. the `api_test` auth table carries an `AuthHeader` enum so absent / ASCII / raw-bytes header cases stay genuinely distinct rather than collapsing to strings.

## Note on diff size

`+2487 / −1900`, i.e. net **+587 lines** despite −150 tests. Table-driven cases with labelled `Case` structs are more verbose per case than the one-liner tests they replace. The win here is test-count and duplication, not LOC.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (default / `--no-default-features` / `--all-features`) ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✅
- Full CI test target list ✅ — all targets pass, 0 failures

No production code changed.