### PR TITLE
chore(release): 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "base64",
  "futures",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "meow-lwip"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "bindgen 0.69.5",
  "bytes",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.20.2"
+version = "0.21.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -128,7 +128,7 @@ tun-rs = { version = "2.8", features = ["async_tokio"] }
 # poll_next UAF / poll_flush deadlock / FIN_WAIT_2 leak / livelock fixes that
 # upstream `lwip` lacks. Registry version, not a `git =` pin — crates.io
 # forbids git deps in a published manifest (see docs/RELEASING.md).
-lwip = { package = "meow-lwip", path = "crates/meow-lwip", version = "0.20.2" }
+lwip = { package = "meow-lwip", path = "crates/meow-lwip", version = "0.21.0" }
 route_manager = "0.2"
 
 # Crypto
@@ -237,16 +237,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.20.2" }
-meow-trie = { path = "crates/meow-trie", version = "0.20.2" }
+meow-common = { path = "crates/meow-common", version = "0.21.0" }
+meow-trie = { path = "crates/meow-trie", version = "0.21.0" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.20.2" }
-meow-dns = { path = "crates/meow-dns", version = "0.20.2", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.20.2" }
-meow-transport = { path = "crates/meow-transport", version = "0.20.2" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.20.2", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.20.2" }
-meow-listener = { path = "crates/meow-listener", version = "0.20.2", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.20.2" }
-meow-config = { path = "crates/meow-config", version = "0.20.2", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.21.0" }
+meow-dns = { path = "crates/meow-dns", version = "0.21.0", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.21.0" }
+meow-transport = { path = "crates/meow-transport", version = "0.21.0" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.21.0", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.21.0" }
+meow-listener = { path = "crates/meow-listener", version = "0.21.0", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.21.0" }
+meow-config = { path = "crates/meow-config", version = "0.21.0", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,7 +12,7 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.20.2"
+version = "0.21.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
@@ -26,7 +26,7 @@ name = "anytls_rs"
 path = "src/lib.rs"
 
 [dependencies]
-meow-common = { path = "../meow-common", version = "0.20.2" }
+meow-common = { path = "../meow-common", version = "0.21.0" }
 tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",


### PR DESCRIPTION
Bump the workspace version and in-tree pins from 0.20.2 to 0.21.0 so GitHub Release and crates.io can publish a new version.

- `[workspace.package]` + `[workspace.dependencies]` (including `lwip`/`meow-lwip`)
- `crates/meow-anytls` (does not inherit workspace version)
- `Cargo.lock` refreshed via `cargo update -w`

This is the first workspace-versioned publish of `meow-lwip` (crates.io currently only has `0.3.15`). No live `git =` dependencies remain in published manifests.

After merge, tag `v0.21.0` on the merge commit to trigger `Release` and `Publish to crates.io`.