### PR TITLE
fix(lwip): upgrade bindgen 0.69 → 0.72 to fix opaque struct generation on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,29 +357,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.10.5",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -388,6 +365,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -499,7 +478,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc39169cb8fa025002661c8d9148ed38a896908e4d308bb0cb55303f66e95d4"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cmake",
  "fs_extra",
  "fslock",
@@ -1650,15 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,12 +2113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,7 +2150,7 @@ version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "errno",
  "libc",
 ]
@@ -2196,12 +2160,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2552,7 +2510,7 @@ dependencies = [
 name = "meow-lwip"
 version = "0.21.0"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "bytes",
  "cc",
  "futures",
@@ -3660,19 +3618,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3680,7 +3625,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -4196,7 +4141,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -4972,18 +4917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/crates/meow-lwip/Cargo.toml
+++ b/crates/meow-lwip/Cargo.toml
@@ -63,5 +63,5 @@ tokio = { version = "1", features = [
 tokio-util = { version = "0.7", default-features = false }
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.72"
 cc = "1.0"


### PR DESCRIPTION
## Summary

Fixes #471 — `meow-lwip` fails to compile on Windows because bindgen 0.69 generates opaque bindings for structs whose fields are defined via C macros.

## Problem

bindgen 0.69 on Windows generates `pub struct tcp_pcb { pub _address: u8 }` for structs that use macro-defined fields (`IP_PCB;`, `TCP_PCB_COMMON(...)`, direct `netif` fields). All real fields (`local_ip`, `remote_ip`, `flags`, `snd_buf`, `mtu`, `input`, `output`, etc.) are lost, causing 12 compile errors in `core.rs`.

`clang -E` confirms the C headers expand correctly — the bug is in bindgen 0.69's libclang type traversal on Windows. bindgen 0.72 (which upgrades `clang-sys` from `clang_6_0` to `clang_11_0`) generates all fields correctly.

## Changes

- `crates/meow-lwip/Cargo.toml`: `bindgen = "0.69"` → `bindgen = "0.72"`
- `Cargo.lock`: updated accordingly

No changes to `build.rs` or any `rust/*.rs` file — all bindgen APIs used by `build.rs` are identical between 0.69 and 0.72.

## Verification (Windows)

- `meow-lwip` unit tests: 2/2 pass
- `meow-lwip` integration tests (NetStack init + SYN packet processing + teardown): 2/2 pass
- `meow-listener` TUN module tests (wintun, dns, route, udp): 71/71 pass
- `cargo clippy --release`: zero warnings
- Full `meow-app` build with `--no-default-features --features "boring-tls,full"`: success
