### PR TITLE
feat: pluggable TcpDialer for dialer-proxy chaining (Phase 1)

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -536,6 +536,7 @@ pub fn rebuild_from_raw_with_cache_dir(
 fn apply_dialer_proxies(
     proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
     raw_proxies: &[HashMap<String, serde_yaml::Value>],
+    ipv6: bool,
 ) {
     // Collect proxy -> dialer edges from the raw config.
     let mut pending: Vec<(SmolStr, SmolStr)> = Vec::new();
@@ -598,7 +599,7 @@ fn apply_dialer_proxies(
                 let proxy_dialer: Arc<dyn meow_proxy::dialer::TcpDialer> = Arc::new(
                     meow_proxy::dialer::ProxyDialer::new(Arc::clone(&dialer_proxy)),
                 );
-                match proxy_parser::parse_proxy_with_dialer(raw, &proxy_dialer) {
+                match proxy_parser::parse_proxy_with_dialer(raw, &proxy_dialer, ipv6) {
                     Ok(rebuilt) => {
                         proxies.insert(name.clone(), rebuilt);
                     }
@@ -784,7 +785,7 @@ fn rebuild_from_raw_impl(
 
     // Apply per-outbound `dialer-proxy` wrappers (issue #210). Runs after both
     // leaf proxies and groups are built so a dialer may reference either.
-    apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]));
+    apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]), ipv6);
 
     let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     // Per-provider `proxy:` overrides resolve against the full registry —
@@ -1999,7 +2000,7 @@ mod dialer_proxy_tests {
     fn wraps_proxy_with_dialer() {
         let mut proxies = registry(&["A", "fast"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("fast"))]);
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("fast"))], true);
         assert!(was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "fast"));
     }
@@ -2008,7 +2009,7 @@ mod dialer_proxy_tests {
     fn self_reference_is_skipped() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("A"))]);
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("A"))], true);
         assert!(!was_wrapped(&before, &proxies, "A"));
     }
 
@@ -2016,7 +2017,7 @@ mod dialer_proxy_tests {
     fn missing_dialer_is_skipped() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("ghost"))]);
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("ghost"))], true);
         assert!(!was_wrapped(&before, &proxies, "A"));
     }
 
@@ -2027,6 +2028,7 @@ mod dialer_proxy_tests {
         apply_dialer_proxies(
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("A"))],
+            true,
         );
         assert!(!was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "B"));
@@ -2040,6 +2042,7 @@ mod dialer_proxy_tests {
         apply_dialer_proxies(
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("C"))],
+            true,
         );
         assert!(was_wrapped(&before, &proxies, "A"));
         assert!(was_wrapped(&before, &proxies, "B"));
@@ -2092,11 +2095,11 @@ mod dialer_proxy_tests {
         // below is what actually distinguishes the two paths.
         let mut proxies = registry(&["A", "front"]);
         let parsed_a =
-            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true)).expect("parse socks5");
+            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true), true).expect("parse socks5");
         proxies.insert(SmolStr::from("A"), parsed_a);
         let before = proxies.clone();
 
-        apply_dialer_proxies(&mut proxies, &[raw_socks5_proxy("A", Some("front"), true)]);
+        apply_dialer_proxies(&mut proxies, &[raw_socks5_proxy("A", Some("front"), true)], true);
 
         assert!(was_wrapped(&before, &proxies, "A"), "A should be re-parsed");
         assert!(
@@ -2136,7 +2139,7 @@ mod dialer_proxy_tests {
             let mut proxies = registry(&["A", "front"]);
             let before = proxies.clone();
 
-            apply_dialer_proxies(&mut proxies, &[raw_typed_proxy("A", ty, Some("front"))]);
+            apply_dialer_proxies(&mut proxies, &[raw_typed_proxy("A", ty, Some("front"))], true);
 
             let after = proxies.get("A").expect("entry survives");
             assert!(
@@ -2174,7 +2177,7 @@ mod dialer_proxy_tests {
 
         // Must not panic and must not spawn: the parse is rejected before
         // `ShadowsocksAdapter::new` runs, so the fallback wrapper is used.
-        apply_dialer_proxies(&mut proxies, &[raw]);
+        apply_dialer_proxies(&mut proxies, &[raw], true);
 
         assert!(
             proxies.contains_key("A"),
@@ -2200,7 +2203,7 @@ mod dialer_proxy_tests {
             serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
         );
 
-        apply_dialer_proxies(&mut proxies, &[first, last]);
+        apply_dialer_proxies(&mut proxies, &[first, last], true);
 
         let rebuilt = proxies.get("A").expect("present after");
         assert_eq!(
@@ -2219,12 +2222,12 @@ mod dialer_proxy_tests {
         let mut proxies = registry(&["A", "front"]);
         // Give "A" a real socks5 adapter so the fallback has something to wrap.
         let parsed_a =
-            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true)).expect("parse socks5");
+            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true), true).expect("parse socks5");
         proxies.insert(SmolStr::from("A"), parsed_a);
         let before = proxies.clone();
 
         // raw_proxy has no `type` → parse_proxy_with_dialer fails → fallback.
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("front"))]);
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("front"))], true);
 
         assert!(
             was_wrapped(&before, &proxies, "A"),
@@ -2350,14 +2353,14 @@ mod dialer_proxy_tests {
         let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
         proxies.insert(
             SmolStr::from("front"),
-            proxy_parser::parse_proxy(&raw_front).expect("parse front"),
+            proxy_parser::parse_proxy(&raw_front, true).expect("parse front"),
         );
         proxies.insert(
             SmolStr::from("inner"),
-            proxy_parser::parse_proxy(&raw_inner).expect("parse inner"),
+            proxy_parser::parse_proxy(&raw_inner, true).expect("parse inner"),
         );
 
-        apply_dialer_proxies(&mut proxies, &[raw_front, raw_inner]);
+        apply_dialer_proxies(&mut proxies, &[raw_front, raw_inner], true);
 
         // Dial a final target through `inner`; `inner` must reach its own
         // server (127.0.0.1:inner_port) *via* `front`.

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -509,9 +509,20 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// For every proxy that declares `dialer-proxy: <name>`, its registry entry is
 /// re-parsed from the raw config with a [`meow_proxy::dialer::ProxyDialer`]
 /// injected, so the adapter dials its server through `<name>` transparently
-/// (mihomo `proxyDialer` model). If re-parsing fails (e.g. incomplete test
-/// configs or unsupported protocol types), it falls back to wrapping the
-/// existing entry with a [`meow_proxy::DialerProxyAdapter`] (relay chain).
+/// (mihomo `proxyDialer` model).
+///
+/// Adapter types that do not establish their underlying connection through the
+/// pluggable dialer — `anytls`, `hysteria2` (QUIC), and `ss` with an external
+/// SIP003 plugin — reject the injected dialer at parse time. Those fall back to
+/// wrapping the existing entry with a [`meow_proxy::DialerProxyAdapter`] (relay
+/// chain), which works where `connect_over` is implemented (HTTP/SOCKS5/Snell)
+/// and fails loudly at dial time otherwise. The fallback never degrades to a
+/// direct dial, so a configured chain cannot be silently bypassed.
+///
+/// UDP: paths that use a raw datagram socket bypass the TCP dialer entirely
+/// (Shadowsocks plain relay, SOCKS5 UDP ASSOCIATE). Those refuse the
+/// association rather than leaking the real source path; mux-based UDP rides
+/// the dialer over TCP and is unaffected.
 ///
 /// Nested dialer-proxies are resolved deepest-first so each layer sees its
 /// dialer's final (already-rebuilt) form, and dialer-proxy cycles are detected
@@ -571,12 +582,17 @@ fn apply_dialer_proxies(
                 resolved.insert(name);
                 continue;
             };
-            // The inner outbound may have failed to parse earlier; skip if so.
-            // Re-parse with ProxyDialer injected (mihomo model).
-            // Falls back to DialerProxyAdapter wrapper if re-parsing fails
-            // (e.g. incomplete test configs or unsupported protocol types).
+            // Re-parse the raw block with a `ProxyDialer` injected (mihomo
+            // model), so the adapter's own dial + handshake runs on the
+            // tunneled stream.
+            //
+            // `rev()` matters: the registry-building loop above uses `insert`,
+            // so for a config with duplicate `name:` entries the *last* block
+            // wins. A forward `find` here would resurrect the *first* block and
+            // silently swap the running definition out from under the user.
             let raw_proxy = raw_proxies
                 .iter()
+                .rev()
                 .find(|rp| rp.get("name").and_then(|v| v.as_str()) == Some(&*name));
             if let Some(raw) = raw_proxy {
                 let proxy_dialer: Arc<dyn meow_proxy::dialer::TcpDialer> = Arc::new(
@@ -586,15 +602,39 @@ fn apply_dialer_proxies(
                     Ok(rebuilt) => {
                         proxies.insert(name.clone(), rebuilt);
                     }
-                    Err(_) => {
-                        // Fallback: wrap with DialerProxyAdapter (relay_tcp path).
+                    Err(e) => {
+                        // The adapter type cannot carry an injected dialer
+                        // (anytls, hysteria2, SS-with-external-SIP003-plugin) or
+                        // the block is otherwise unparseable. Fall back to the
+                        // relay-based `DialerProxyAdapter`, which preserves the
+                        // pre-dialer behaviour: it works for the protocols that
+                        // implement `connect_over` (HTTP/SOCKS5/Snell) and fails
+                        // loudly at dial time for the rest — never silently
+                        // dialing direct and leaking past the chain.
+                        //
+                        // The inner outbound may itself have failed to parse
+                        // earlier, in which case there is nothing to wrap.
                         if let Some(inner) = proxies.get(&name).cloned() {
+                            warn!(
+                                "proxy '{name}': cannot inject dialer-proxy '{dialer}' \
+                                 ({e}); falling back to the relay-based wrapper"
+                            );
                             let wrapped: Arc<dyn Proxy> =
                                 Arc::new(meow_proxy::DialerProxyAdapter::new(inner, dialer_proxy));
                             proxies.insert(name.clone(), wrapped);
+                        } else {
+                            warn!(
+                                "proxy '{name}': dialer-proxy '{dialer}' not applied \
+                                 ({e}); the outbound itself failed to parse"
+                            );
                         }
                     }
                 }
+            } else {
+                warn!(
+                    "proxy '{name}': dialer-proxy '{dialer}' not applied; no raw \
+                     config block found for this name"
+                );
             }
             resolved.insert(name);
         }
@@ -2044,18 +2084,13 @@ mod dialer_proxy_tests {
     }
 
     #[test]
-    fn re_parse_injects_proxy_dialer_for_real_protocol() {
-        // A socks5 proxy with `dialer-proxy: front` should be re-parsed with
-        // a ProxyDialer injected (the primary mihomo-model path), not wrapped
-        // with the DialerProxyAdapter fallback.
-        //
-        // Distinguishing the two paths: Socks5Adapter::support_udp() returns
-        // true for `udp: true`, while DialerProxyAdapter::support_udp() always
-        // returns false. If the re-parse path is taken, support_udp is true;
-        // if the fallback is taken, it is false.
+    fn re_parse_replaces_entry_and_keeps_adapter_type() {
+        // A socks5 proxy with `dialer-proxy: front` is re-parsed with a
+        // ProxyDialer injected (the mihomo-model path). The entry is replaced
+        // and still presents as Socks5 — a DialerProxyAdapter wrapper would
+        // also report the inner type, so `chain_reaches_target_through_front`
+        // below is what actually distinguishes the two paths.
         let mut proxies = registry(&["A", "front"]);
-        // Parse a real socks5 adapter so the initial registry entry has the
-        // correct adapter type (the re-parse replaces it).
         let parsed_a =
             proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true)).expect("parse socks5");
         proxies.insert(SmolStr::from("A"), parsed_a);
@@ -2068,17 +2103,110 @@ mod dialer_proxy_tests {
             !was_wrapped(&before, &proxies, "front"),
             "front is the dialer, not re-parsed"
         );
-
-        let rebuilt = proxies.get("A").expect("present after");
         assert_eq!(
-            rebuilt.adapter_type(),
+            proxies.get("A").expect("present after").adapter_type(),
             meow_common::AdapterType::Socks5,
             "rebuilt proxy should still be Socks5"
         );
+    }
+
+    /// A raw `type: <ty>` block with a `server`/`port` and optional
+    /// `dialer-proxy` — for the types that cannot carry an injected dialer.
+    fn raw_typed_proxy(
+        name: &str,
+        ty: &str,
+        dialer: Option<&str>,
+    ) -> HashMap<String, serde_yaml::Value> {
+        let mut m = raw_socks5_proxy(name, dialer, false);
+        m.insert(
+            "type".to_string(),
+            serde_yaml::Value::String(ty.to_string()),
+        );
+        m
+    }
+
+    /// `anytls` / `hysteria2` establish their own transport and never call the
+    /// pluggable dialer. Accepting the injected dialer there would silently
+    /// drop the user's `dialer-proxy` and egress from the real source path, so
+    /// the parser rejects it and the relay-based wrapper takes over — which
+    /// fails loudly at dial time rather than dialing direct.
+    #[test]
+    fn types_that_cannot_carry_a_dialer_fall_back_to_the_wrapper() {
+        for ty in ["anytls", "hysteria2"] {
+            let mut proxies = registry(&["A", "front"]);
+            let before = proxies.clone();
+
+            apply_dialer_proxies(&mut proxies, &[raw_typed_proxy("A", ty, Some("front"))]);
+
+            let after = proxies.get("A").expect("entry survives");
+            assert!(
+                was_wrapped(&before, &proxies, "A"),
+                "{ty}: entry must be replaced by the relay wrapper, not left \
+                 dialing direct"
+            );
+            assert!(
+                !after.support_udp(),
+                "{ty}: the wrapper must not advertise UDP over the chain"
+            );
+        }
+    }
+
+    /// `ss` with an *external* SIP003 plugin must not be re-parsed: the
+    /// constructor spawns the plugin subprocess, so a second parse would leave
+    /// two copies running whenever a group still holds the original Arc.
+    #[test]
+    fn external_sip003_plugin_is_not_re_parsed() {
+        let mut proxies = registry(&["A", "front"]);
+        let mut raw = raw_typed_proxy("A", "ss", Some("front"));
+        raw.insert(
+            "cipher".to_string(),
+            serde_yaml::Value::String("aes-256-gcm".to_string()),
+        );
+        raw.insert(
+            "password".to_string(),
+            serde_yaml::Value::String("pw".to_string()),
+        );
+        // A plugin name that is not one of the built-ins → external subprocess.
+        raw.insert(
+            "plugin".to_string(),
+            serde_yaml::Value::String("obfs-local-does-not-exist".to_string()),
+        );
+
+        // Must not panic and must not spawn: the parse is rejected before
+        // `ShadowsocksAdapter::new` runs, so the fallback wrapper is used.
+        apply_dialer_proxies(&mut proxies, &[raw]);
+
         assert!(
-            rebuilt.support_udp(),
-            "re-parse path should preserve udp: true (ProxyDialer injected, \
-             not DialerProxyAdapter fallback which always returns false)"
+            proxies.contains_key("A"),
+            "the entry must survive the rejected re-parse"
+        );
+    }
+
+    /// Duplicate `name:` blocks: the registry-building loop uses `insert`, so
+    /// the *last* block wins. The re-parse lookup must agree, or it resurrects
+    /// the first definition and swaps the running proxy out from under the user.
+    #[test]
+    fn duplicate_names_re_parse_the_last_block() {
+        let mut proxies = registry(&["A", "front"]);
+
+        let mut first = raw_socks5_proxy("A", Some("front"), false);
+        first.insert(
+            "port".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(1111)),
+        );
+        let mut last = raw_socks5_proxy("A", Some("front"), false);
+        last.insert(
+            "port".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
+        );
+
+        apply_dialer_proxies(&mut proxies, &[first, last]);
+
+        let rebuilt = proxies.get("A").expect("present after");
+        assert_eq!(
+            rebuilt.addr(),
+            "127.0.0.1:2222",
+            "the last duplicate block must win, matching registry insert order"
         );
     }
 
@@ -2106,6 +2234,154 @@ mod dialer_proxy_tests {
         assert!(
             !rebuilt.support_udp(),
             "DialerProxyAdapter fallback should disable UDP even if inner supports it"
+        );
+    }
+
+    /// End-to-end proof that the injected dialer is actually used: stand up two
+    /// mock SOCKS5 servers, chain `inner` behind `front` via `dialer-proxy`,
+    /// and assert `front` was asked to CONNECT to *inner's server address*
+    /// (not to the final target).  This is the assertion that distinguishes the
+    /// re-parse path from the relay wrapper, and it catches a silently dropped
+    /// dialer that a type-only check would miss.
+    #[tokio::test]
+    async fn chain_dials_inner_server_through_front_proxy() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        /// Minimal SOCKS5 server: no-auth handshake, records the requested
+        /// target, replies success, then echoes.  Returns the CONNECT target
+        /// as `host:port`.
+        async fn mock_socks5(
+            listener: tokio::net::TcpListener,
+        ) -> tokio::sync::oneshot::Receiver<String> {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            tokio::spawn(async move {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                // Greeting: VER NMETHODS METHODS…
+                let mut head = [0u8; 2];
+                if sock.read_exact(&mut head).await.is_err() {
+                    return;
+                }
+                let mut methods = vec![0u8; head[1] as usize];
+                if sock.read_exact(&mut methods).await.is_err() {
+                    return;
+                }
+                // Select no-auth.
+                if sock.write_all(&[0x05, 0x00]).await.is_err() {
+                    return;
+                }
+                // Request: VER CMD RSV ATYP …
+                let mut req = [0u8; 4];
+                if sock.read_exact(&mut req).await.is_err() {
+                    return;
+                }
+                let target = match req[3] {
+                    0x01 => {
+                        let mut ip = [0u8; 4];
+                        let mut port = [0u8; 2];
+                        if sock.read_exact(&mut ip).await.is_err()
+                            || sock.read_exact(&mut port).await.is_err()
+                        {
+                            return;
+                        }
+                        format!(
+                            "{}.{}.{}.{}:{}",
+                            ip[0],
+                            ip[1],
+                            ip[2],
+                            ip[3],
+                            u16::from_be_bytes(port)
+                        )
+                    }
+                    0x03 => {
+                        let mut len = [0u8; 1];
+                        if sock.read_exact(&mut len).await.is_err() {
+                            return;
+                        }
+                        let mut host = vec![0u8; len[0] as usize];
+                        let mut port = [0u8; 2];
+                        if sock.read_exact(&mut host).await.is_err()
+                            || sock.read_exact(&mut port).await.is_err()
+                        {
+                            return;
+                        }
+                        format!(
+                            "{}:{}",
+                            String::from_utf8_lossy(&host),
+                            u16::from_be_bytes(port)
+                        )
+                    }
+                    other => format!("unsupported-atyp-{other}"),
+                };
+                let _ = tx.send(target);
+                // Success reply with a dummy BND.ADDR.
+                let _ = sock
+                    .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+                    .await;
+                // Keep the conn alive long enough for the inner handshake.
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+            });
+            rx
+        }
+
+        let front_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind front");
+        let front_port = front_listener.local_addr().expect("addr").port();
+        let front_target = mock_socks5(front_listener).await;
+
+        // `inner`'s server address is never bound — the point is that the dial
+        // is routed to `front` instead, so nothing should ever connect to it.
+        let inner_port = 59_999;
+
+        let mut raw_front = raw_socks5_proxy("front", None, false);
+        raw_front.insert(
+            "port".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(front_port)),
+        );
+        let mut raw_inner = raw_socks5_proxy("inner", Some("front"), false);
+        raw_inner.insert(
+            "port".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(inner_port)),
+        );
+
+        let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
+        proxies.insert(
+            SmolStr::from("front"),
+            proxy_parser::parse_proxy(&raw_front).expect("parse front"),
+        );
+        proxies.insert(
+            SmolStr::from("inner"),
+            proxy_parser::parse_proxy(&raw_inner).expect("parse inner"),
+        );
+
+        apply_dialer_proxies(&mut proxies, &[raw_front, raw_inner]);
+
+        // Dial a final target through `inner`; `inner` must reach its own
+        // server (127.0.0.1:inner_port) *via* `front`.
+        let meta = meow_common::Metadata {
+            host: "example.com".into(),
+            dst_port: 443,
+            ..Default::default()
+        };
+        let _ = proxies
+            .get("inner")
+            .expect("inner present")
+            .dial_tcp(&meta)
+            .await;
+
+        let observed = tokio::time::timeout(std::time::Duration::from_secs(5), front_target)
+            .await
+            .expect("front proxy should have received a CONNECT")
+            .expect("front proxy task should report the target");
+
+        assert_eq!(
+            observed,
+            format!("127.0.0.1:{inner_port}"),
+            "front must be asked to reach inner's *server*, not the final \
+             target — otherwise the injected dialer was dropped"
         );
     }
 }

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -504,14 +504,18 @@ pub fn rebuild_from_raw_with_cache_dir(
     rebuild_from_raw_impl(raw, cache_dir, resolver, &HashMap::new(), None, None, None)
 }
 
-/// Apply per-outbound `dialer-proxy` wrappers in place (issue #210).
+/// Apply per-outbound `dialer-proxy` in place (issue #210).
 ///
 /// For every proxy that declares `dialer-proxy: <name>`, its registry entry is
-/// replaced by a [`meow_proxy::DialerProxyAdapter`] that dials the inner
-/// outbound through `<name>`. Nested dialer-proxies are wrapped deepest-first so
-/// each layer sees its dialer's final (already-wrapped) form, and dialer-proxy
-/// cycles are detected and skipped with a warning (the outbound then dials
-/// directly).
+/// re-parsed from the raw config with a [`meow_proxy::dialer::ProxyDialer`]
+/// injected, so the adapter dials its server through `<name>` transparently
+/// (mihomo `proxyDialer` model). If re-parsing fails (e.g. incomplete test
+/// configs or unsupported protocol types), it falls back to wrapping the
+/// existing entry with a [`meow_proxy::DialerProxyAdapter`] (relay chain).
+///
+/// Nested dialer-proxies are resolved deepest-first so each layer sees its
+/// dialer's final (already-rebuilt) form, and dialer-proxy cycles are detected
+/// and skipped with a warning (the outbound then dials directly).
 ///
 /// Note: this rewrites the registry entry, so direct rule references
 /// (`…,<proxy>`) and dialers that are groups both work. A proxy that is also a
@@ -568,10 +572,29 @@ fn apply_dialer_proxies(
                 continue;
             };
             // The inner outbound may have failed to parse earlier; skip if so.
-            if let Some(inner) = proxies.get(&name).cloned() {
-                let wrapped: Arc<dyn Proxy> =
-                    Arc::new(meow_proxy::DialerProxyAdapter::new(inner, dialer_proxy));
-                proxies.insert(name.clone(), wrapped);
+            // Re-parse with ProxyDialer injected (mihomo model).
+            // Falls back to DialerProxyAdapter wrapper if re-parsing fails
+            // (e.g. incomplete test configs or unsupported protocol types).
+            let raw_proxy = raw_proxies
+                .iter()
+                .find(|rp| rp.get("name").and_then(|v| v.as_str()) == Some(&*name));
+            if let Some(raw) = raw_proxy {
+                let proxy_dialer: Arc<dyn meow_proxy::dialer::TcpDialer> = Arc::new(
+                    meow_proxy::dialer::ProxyDialer::new(Arc::clone(&dialer_proxy)),
+                );
+                match proxy_parser::parse_proxy_with_dialer(raw, &proxy_dialer) {
+                    Ok(rebuilt) => {
+                        proxies.insert(name.clone(), rebuilt);
+                    }
+                    Err(_) => {
+                        // Fallback: wrap with DialerProxyAdapter (relay_tcp path).
+                        if let Some(inner) = proxies.get(&name).cloned() {
+                            let wrapped: Arc<dyn Proxy> =
+                                Arc::new(meow_proxy::DialerProxyAdapter::new(inner, dialer_proxy));
+                            proxies.insert(name.clone(), wrapped);
+                        }
+                    }
+                }
             }
             resolved.insert(name);
         }
@@ -1981,6 +2004,109 @@ mod dialer_proxy_tests {
         assert!(was_wrapped(&before, &proxies, "A"));
         assert!(was_wrapped(&before, &proxies, "B"));
         assert!(!was_wrapped(&before, &proxies, "C"));
+    }
+
+    /// Raw config for a `type: socks5` proxy with optional `dialer-proxy` and
+    /// `udp` fields — exercises the re-parse path (vs. the fallback
+    /// `DialerProxyAdapter` wrapper used by the bare `raw_proxy` helper).
+    fn raw_socks5_proxy(
+        name: &str,
+        dialer: Option<&str>,
+        udp: bool,
+    ) -> HashMap<String, serde_yaml::Value> {
+        let mut m = HashMap::new();
+        m.insert(
+            "name".to_string(),
+            serde_yaml::Value::String(name.to_string()),
+        );
+        m.insert(
+            "type".to_string(),
+            serde_yaml::Value::String("socks5".to_string()),
+        );
+        m.insert(
+            "server".to_string(),
+            serde_yaml::Value::String("127.0.0.1".to_string()),
+        );
+        m.insert(
+            "port".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(1080)),
+        );
+        if udp {
+            m.insert("udp".to_string(), serde_yaml::Value::Bool(true));
+        }
+        if let Some(d) = dialer {
+            m.insert(
+                "dialer-proxy".to_string(),
+                serde_yaml::Value::String(d.to_string()),
+            );
+        }
+        m
+    }
+
+    #[test]
+    fn re_parse_injects_proxy_dialer_for_real_protocol() {
+        // A socks5 proxy with `dialer-proxy: front` should be re-parsed with
+        // a ProxyDialer injected (the primary mihomo-model path), not wrapped
+        // with the DialerProxyAdapter fallback.
+        //
+        // Distinguishing the two paths: Socks5Adapter::support_udp() returns
+        // true for `udp: true`, while DialerProxyAdapter::support_udp() always
+        // returns false. If the re-parse path is taken, support_udp is true;
+        // if the fallback is taken, it is false.
+        let mut proxies = registry(&["A", "front"]);
+        // Parse a real socks5 adapter so the initial registry entry has the
+        // correct adapter type (the re-parse replaces it).
+        let parsed_a =
+            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true)).expect("parse socks5");
+        proxies.insert(SmolStr::from("A"), parsed_a);
+        let before = proxies.clone();
+
+        apply_dialer_proxies(&mut proxies, &[raw_socks5_proxy("A", Some("front"), true)]);
+
+        assert!(was_wrapped(&before, &proxies, "A"), "A should be re-parsed");
+        assert!(
+            !was_wrapped(&before, &proxies, "front"),
+            "front is the dialer, not re-parsed"
+        );
+
+        let rebuilt = proxies.get("A").expect("present after");
+        assert_eq!(
+            rebuilt.adapter_type(),
+            meow_common::AdapterType::Socks5,
+            "rebuilt proxy should still be Socks5"
+        );
+        assert!(
+            rebuilt.support_udp(),
+            "re-parse path should preserve udp: true (ProxyDialer injected, \
+             not DialerProxyAdapter fallback which always returns false)"
+        );
+    }
+
+    #[test]
+    fn fallback_wraps_when_re_parse_fails() {
+        // A raw proxy with no `type` field cannot be re-parsed — the fallback
+        // DialerProxyAdapter wrapper should be used instead. We verify this
+        // by checking that support_udp is false (DialerProxyAdapter always
+        // returns false, even if the inner proxy supported UDP).
+        let mut proxies = registry(&["A", "front"]);
+        // Give "A" a real socks5 adapter so the fallback has something to wrap.
+        let parsed_a =
+            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true)).expect("parse socks5");
+        proxies.insert(SmolStr::from("A"), parsed_a);
+        let before = proxies.clone();
+
+        // raw_proxy has no `type` → parse_proxy_with_dialer fails → fallback.
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("front"))]);
+
+        assert!(
+            was_wrapped(&before, &proxies, "A"),
+            "A should be wrapped via fallback"
+        );
+        let rebuilt = proxies.get("A").expect("present after");
+        assert!(
+            !rebuilt.support_udp(),
+            "DialerProxyAdapter fallback should disable UDP even if inner supports it"
+        );
     }
 }
 

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -2094,12 +2094,16 @@ mod dialer_proxy_tests {
         // also report the inner type, so `chain_reaches_target_through_front`
         // below is what actually distinguishes the two paths.
         let mut proxies = registry(&["A", "front"]);
-        let parsed_a =
-            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true), true).expect("parse socks5");
+        let parsed_a = proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true), true)
+            .expect("parse socks5");
         proxies.insert(SmolStr::from("A"), parsed_a);
         let before = proxies.clone();
 
-        apply_dialer_proxies(&mut proxies, &[raw_socks5_proxy("A", Some("front"), true)], true);
+        apply_dialer_proxies(
+            &mut proxies,
+            &[raw_socks5_proxy("A", Some("front"), true)],
+            true,
+        );
 
         assert!(was_wrapped(&before, &proxies, "A"), "A should be re-parsed");
         assert!(
@@ -2139,7 +2143,11 @@ mod dialer_proxy_tests {
             let mut proxies = registry(&["A", "front"]);
             let before = proxies.clone();
 
-            apply_dialer_proxies(&mut proxies, &[raw_typed_proxy("A", ty, Some("front"))], true);
+            apply_dialer_proxies(
+                &mut proxies,
+                &[raw_typed_proxy("A", ty, Some("front"))],
+                true,
+            );
 
             let after = proxies.get("A").expect("entry survives");
             assert!(
@@ -2221,8 +2229,8 @@ mod dialer_proxy_tests {
         // returns false, even if the inner proxy supported UDP).
         let mut proxies = registry(&["A", "front"]);
         // Give "A" a real socks5 adapter so the fallback has something to wrap.
-        let parsed_a =
-            proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true), true).expect("parse socks5");
+        let parsed_a = proxy_parser::parse_proxy(&raw_socks5_proxy("A", None, true), true)
+            .expect("parse socks5");
         proxies.insert(SmolStr::from("A"), parsed_a);
         let before = proxies.clone();
 

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -140,6 +140,7 @@ pub fn parse_proxy(
                 udp,
                 plugin,
                 plugin_opts_str.as_deref(),
+                std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
             )
             .map_err(|e| format!("ss: {e}"))?;
             #[cfg(feature = "mux")]
@@ -182,7 +183,7 @@ pub fn parse_proxy(
 
             #[cfg_attr(not(feature = "mux"), allow(unused_mut))]
             let mut adapter =
-                TrojanAdapter::new(name, server, port, password, sni, skip_verify, udp);
+                TrojanAdapter::new(name, server, port, password, sni, skip_verify, udp, std::sync::Arc::new(meow_proxy::dialer::DirectDialer));
             #[cfg(feature = "mux")]
             if let Some(mux_options) = parse_mux_options(name, config)? {
                 // muxcool rides VLESS CommandMux; trojan has no equivalent
@@ -389,7 +390,7 @@ fn parse_snell(
         SnellObfs::None
     };
 
-    SnellAdapter::new(name, server, port, psk, obfs, version, udp, reuse)
+    SnellAdapter::new(name, server, port, psk, obfs, version, udp, reuse, std::sync::Arc::new(meow_proxy::dialer::DirectDialer))
         .map_err(|e| format!("snell[{name}]: {e}"))
 }
 
@@ -452,6 +453,7 @@ fn parse_http(
         tls,
         skip_cert_verify,
         extra_headers,
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
     ))
 }
 
@@ -500,7 +502,7 @@ fn parse_socks5(
         .and_then(serde_yaml::Value::as_bool)
         .unwrap_or(false);
 
-    Ok(Socks5Adapter::new(name, server, port, auth, tls, skip_cert_verify).with_udp(udp))
+    Ok(Socks5Adapter::new(name, server, port, auth, tls, skip_cert_verify, std::sync::Arc::new(meow_proxy::dialer::DirectDialer)).with_udp(udp))
 }
 
 /// Parse a `type: direct` proxy block into a [`DirectAdapter`].
@@ -1455,7 +1457,7 @@ fn parse_vless(
     }
 
     #[cfg_attr(not(feature = "vless-encryption"), allow(unused_mut))]
-    let mut adapter = VlessAdapter::new(name, server, port, uuid_bytes, flow, udp, chain);
+    let mut adapter = VlessAdapter::new(name, server, port, uuid_bytes, flow, udp, chain, std::sync::Arc::new(meow_proxy::dialer::DirectDialer));
     #[cfg(feature = "vless-encryption")]
     adapter.set_encryption(vless_encryption);
 
@@ -2075,8 +2077,16 @@ fn parse_vmess(
     }
 
     #[cfg_attr(not(feature = "mux"), allow(unused_mut))]
-    let mut adapter =
-        meow_proxy::VmessAdapter::new(name, server, port, uuid_bytes, security, udp, chain);
+    let mut adapter = meow_proxy::VmessAdapter::new(
+        name,
+        server,
+        port,
+        uuid_bytes,
+        security,
+        udp,
+        chain,
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
+    );
     #[cfg(feature = "mux")]
     if let Some(mux_options) = parse_mux_options(name, config)? {
         adapter = adapter.with_mux(mux_options);

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -98,6 +98,19 @@ pub fn parse_proxy(
     config: &HashMap<String, serde_yaml::Value>,
     ipv6: bool,
 ) -> std::result::Result<Arc<dyn Proxy>, String> {
+    let dialer: std::sync::Arc<dyn meow_proxy::dialer::TcpDialer> =
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer);
+    parse_proxy_with_dialer(config, &dialer)
+}
+
+/// Like [parse_proxy] but injects a custom [meow_proxy::dialer::TcpDialer]
+/// into every adapter. Used by apply_dialer_proxies to inject a
+/// [meow_proxy::dialer::ProxyDialer] so that dialer-proxy chaining works
+/// for all protocols without requiring connect_over.
+pub fn parse_proxy_with_dialer(
+    config: &HashMap<String, serde_yaml::Value>,
+    dialer: &std::sync::Arc<dyn meow_proxy::dialer::TcpDialer>,
+) -> std::result::Result<Arc<dyn Proxy>, String> {
     let name = config
         .get("name")
         .and_then(|v| v.as_str())
@@ -140,7 +153,7 @@ pub fn parse_proxy(
                 udp,
                 plugin,
                 plugin_opts_str.as_deref(),
-                std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
+                Arc::clone(dialer),
             )
             .map_err(|e| format!("ss: {e}"))?;
             #[cfg(feature = "mux")]
@@ -182,8 +195,16 @@ pub fn parse_proxy(
                 .unwrap_or(false);
 
             #[cfg_attr(not(feature = "mux"), allow(unused_mut))]
-            let mut adapter =
-                TrojanAdapter::new(name, server, port, password, sni, skip_verify, udp, std::sync::Arc::new(meow_proxy::dialer::DirectDialer));
+            let mut adapter = TrojanAdapter::new(
+                name,
+                server,
+                port,
+                password,
+                sni,
+                skip_verify,
+                udp,
+                Arc::clone(dialer),
+            );
             #[cfg(feature = "mux")]
             if let Some(mux_options) = parse_mux_options(name, config)? {
                 // muxcool rides VLESS CommandMux; trojan has no equivalent
@@ -203,15 +224,15 @@ pub fn parse_proxy(
         }
         #[cfg(feature = "vless")]
         "vless" => {
-            let adapter = parse_vless(name, config)?;
+            let adapter = parse_vless(name, config, dialer)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         "http" => {
-            let adapter = parse_http(name, config)?;
+            let adapter = parse_http(name, config, dialer)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         "socks5" => {
-            let adapter = parse_socks5(name, config)?;
+            let adapter = parse_socks5(name, config, dialer)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         "direct" => {
@@ -230,12 +251,12 @@ pub fn parse_proxy(
         }
         #[cfg(feature = "vmess")]
         "vmess" => {
-            let adapter = parse_vmess(name, config)?;
+            let adapter = parse_vmess(name, config, dialer)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         #[cfg(feature = "snell")]
         "snell" => {
-            let adapter = parse_snell(name, config)?;
+            let adapter = parse_snell(name, config, dialer)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         #[cfg(not(feature = "ss"))]
@@ -309,6 +330,7 @@ fn feature_gated_proxy_type(proxy_type: &str) -> String {
 fn parse_snell(
     name: &str,
     config: &HashMap<String, serde_yaml::Value>,
+    dialer: &Arc<dyn meow_proxy::dialer::TcpDialer>,
 ) -> std::result::Result<meow_proxy::SnellAdapter, String> {
     use meow_proxy::{SnellAdapter, SnellObfs, SnellVersion};
 
@@ -390,8 +412,18 @@ fn parse_snell(
         SnellObfs::None
     };
 
-    SnellAdapter::new(name, server, port, psk, obfs, version, udp, reuse, std::sync::Arc::new(meow_proxy::dialer::DirectDialer))
-        .map_err(|e| format!("snell[{name}]: {e}"))
+    SnellAdapter::new(
+        name,
+        server,
+        port,
+        psk,
+        obfs,
+        version,
+        udp,
+        reuse,
+        Arc::clone(dialer),
+    )
+    .map_err(|e| format!("snell[{name}]: {e}"))
 }
 
 /// Parse a `type: http` proxy config block into an `HttpAdapter`.
@@ -408,6 +440,7 @@ fn parse_snell(
 fn parse_http(
     name: &str,
     config: &HashMap<String, serde_yaml::Value>,
+    dialer: &Arc<dyn meow_proxy::dialer::TcpDialer>,
 ) -> std::result::Result<HttpAdapter, String> {
     let server = config
         .get("server")
@@ -453,7 +486,7 @@ fn parse_http(
         tls,
         skip_cert_verify,
         extra_headers,
-        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
+        Arc::clone(dialer),
     ))
 }
 
@@ -469,6 +502,7 @@ fn parse_http(
 fn parse_socks5(
     name: &str,
     config: &HashMap<String, serde_yaml::Value>,
+    dialer: &Arc<dyn meow_proxy::dialer::TcpDialer>,
 ) -> std::result::Result<Socks5Adapter, String> {
     let server = config
         .get("server")
@@ -502,7 +536,16 @@ fn parse_socks5(
         .and_then(serde_yaml::Value::as_bool)
         .unwrap_or(false);
 
-    Ok(Socks5Adapter::new(name, server, port, auth, tls, skip_cert_verify, std::sync::Arc::new(meow_proxy::dialer::DirectDialer)).with_udp(udp))
+    Ok(Socks5Adapter::new(
+        name,
+        server,
+        port,
+        auth,
+        tls,
+        skip_cert_verify,
+        Arc::clone(dialer),
+    )
+    .with_udp(udp))
 }
 
 /// Parse a `type: direct` proxy block into a [`DirectAdapter`].
@@ -1117,6 +1160,7 @@ fn parse_lb_strategy(strategy: Option<&str>) -> std::result::Result<LbStrategy, 
 fn parse_vless(
     name: &str,
     config: &HashMap<String, serde_yaml::Value>,
+    dialer: &Arc<dyn meow_proxy::dialer::TcpDialer>,
 ) -> std::result::Result<VlessAdapter, String> {
     let server = config
         .get("server")
@@ -1457,7 +1501,16 @@ fn parse_vless(
     }
 
     #[cfg_attr(not(feature = "vless-encryption"), allow(unused_mut))]
-    let mut adapter = VlessAdapter::new(name, server, port, uuid_bytes, flow, udp, chain, std::sync::Arc::new(meow_proxy::dialer::DirectDialer));
+    let mut adapter = VlessAdapter::new(
+        name,
+        server,
+        port,
+        uuid_bytes,
+        flow,
+        udp,
+        chain,
+        Arc::clone(dialer),
+    );
     #[cfg(feature = "vless-encryption")]
     adapter.set_encryption(vless_encryption);
 
@@ -1934,6 +1987,7 @@ fn serialize_plugin_opts(opts: &serde_yaml::Value) -> Option<String> {
 fn parse_vmess(
     name: &str,
     config: &HashMap<String, serde_yaml::Value>,
+    dialer: &Arc<dyn meow_proxy::dialer::TcpDialer>,
 ) -> std::result::Result<meow_proxy::VmessAdapter, String> {
     use meow_proxy::vmess::header::Security;
 
@@ -2085,7 +2139,7 @@ fn parse_vmess(
         security,
         udp,
         chain,
-        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
+        Arc::clone(dialer),
     );
     #[cfg(feature = "mux")]
     if let Some(mux_options) = parse_mux_options(name, config)? {

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -100,7 +100,7 @@ pub fn parse_proxy(
 ) -> std::result::Result<Arc<dyn Proxy>, String> {
     let dialer: std::sync::Arc<dyn meow_proxy::dialer::TcpDialer> =
         std::sync::Arc::new(meow_proxy::dialer::DirectDialer);
-    parse_proxy_with_dialer(config, &dialer)
+    parse_proxy_with_dialer(config, &dialer, ipv6)
 }
 
 /// Like [parse_proxy] but injects a custom [meow_proxy::dialer::TcpDialer]
@@ -110,6 +110,7 @@ pub fn parse_proxy(
 pub fn parse_proxy_with_dialer(
     config: &HashMap<String, serde_yaml::Value>,
     dialer: &std::sync::Arc<dyn meow_proxy::dialer::TcpDialer>,
+    ipv6: bool,
 ) -> std::result::Result<Arc<dyn Proxy>, String> {
     let name = config
         .get("name")
@@ -142,6 +143,22 @@ pub fn parse_proxy_with_dialer(
                 .unwrap_or(false);
             let plugin = config.get("plugin").and_then(|v| v.as_str());
             let plugin_opts_str = config.get("plugin-opts").and_then(serialize_plugin_opts);
+
+            // A SIP003 *external* plugin is a local subprocess spawned by
+            // `ShadowsocksAdapter::new`, and the adapter deliberately dials it
+            // over loopback without the pluggable dialer.  Bail out *before*
+            // constructing so the re-parse in `apply_dialer_proxies` does not
+            // spawn a second copy of the plugin process (the first one stays
+            // alive as long as any group still holds the original Arc), and so
+            // the user learns their `dialer-proxy` has no effect here.
+            if dialer.is_proxy() && is_external_sip003_plugin(plugin) {
+                return Err(format!(
+                    "ss[{name}]: `dialer-proxy` is not supported with the external \
+                     SIP003 plugin '{}' — the plugin runs as a local subprocess and \
+                     is always reached over loopback",
+                    plugin.unwrap_or_default()
+                ));
+            }
 
             #[cfg_attr(not(feature = "mux"), allow(unused_mut))]
             let mut adapter = ShadowsocksAdapter::new(
@@ -236,16 +253,19 @@ pub fn parse_proxy_with_dialer(
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         "direct" => {
+            reject_unthreaded_dialer(name, "direct", dialer)?;
             let adapter = parse_direct(name, config, ipv6)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         #[cfg(feature = "anytls")]
         "anytls" => {
+            reject_unthreaded_dialer(name, "anytls", dialer)?;
             let adapter = parse_anytls(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
         #[cfg(feature = "hysteria2")]
         "hysteria2" => {
+            reject_unthreaded_dialer(name, "hysteria2", dialer)?;
             let adapter = parse_hysteria2(name, config)?;
             Ok(Arc::new(WrappedProxy::new(Box::new(adapter))))
         }
@@ -275,6 +295,49 @@ pub fn parse_proxy_with_dialer(
         "snell" => Err(feature_gated_proxy_type("snell")),
         _ => Err(format!("unsupported proxy type: {proxy_type}")),
     }
+}
+
+/// Whether `plugin` names a SIP003 plugin that runs as an external subprocess
+/// (as opposed to one of the built-in, in-process plugin implementations).
+///
+/// Mirrors the dispatch in `ShadowsocksAdapter::new`: anything not recognised
+/// as built-in is handed to `Plugin::start`, which spawns a child process.
+#[cfg(feature = "ss")]
+fn is_external_sip003_plugin(plugin: Option<&str>) -> bool {
+    let Some(plugin) = plugin.filter(|p| !p.is_empty()) else {
+        return false;
+    };
+    if meow_proxy::shadowsocks_adapter::is_builtin_obfs_plugin(plugin) {
+        return false;
+    }
+    !matches!(plugin, "v2ray-plugin" | "ech-tls-tunnel")
+}
+
+/// Reject a `ProxyDialer` for adapter types that do not thread it through.
+///
+/// `anytls` dials via `meow_common::connect_tcp_host` internally and
+/// `hysteria2` owns its QUIC socket; `direct` is a raw egress by definition.
+/// None of them can honour an injected dialer, so accepting one here would
+/// silently drop the user's `dialer-proxy` and egress from the real source
+/// path — a Class A silent divergence (ADR-0002).  Returning `Err` instead
+/// lets `apply_dialer_proxies` surface a warning and keep the original
+/// (un-chained) entry rather than pretending the chain was applied.
+///
+/// A `DirectDialer` is always accepted: it is the no-op default, so nothing
+/// is lost by ignoring it.
+fn reject_unthreaded_dialer(
+    name: &str,
+    proxy_type: &str,
+    dialer: &std::sync::Arc<dyn meow_proxy::dialer::TcpDialer>,
+) -> std::result::Result<(), String> {
+    if dialer.is_proxy() {
+        return Err(format!(
+            "{proxy_type}[{name}]: `dialer-proxy` is not supported for this \
+             proxy type (its underlying connection is not established through \
+             the pluggable TCP dialer)"
+        ));
+    }
+    Ok(())
 }
 
 /// Error for a proxy type this codebase implements but which was compiled out

--- a/crates/meow-config/tests/internal_http_via_ss.rs
+++ b/crates/meow-config/tests/internal_http_via_ss.rs
@@ -12,6 +12,7 @@
 use meow_common::adapter::Proxy;
 use meow_config::internal_http;
 use meow_config::proxy_parser::WrappedProxy;
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::ShadowsocksAdapter;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -158,6 +159,7 @@ async fn fetch_via_proxy_through_ssserver_returns_body() {
         false,
         None,
         None,
+        Arc::new(DirectDialer),
     )
     .expect("ShadowsocksAdapter::new");
     let proxy: Arc<dyn Proxy> = Arc::new(WrappedProxy::new(Box::new(adapter)));
@@ -223,6 +225,7 @@ async fn fetch_via_proxy_follows_redirect() {
         false,
         None,
         None,
+        Arc::new(DirectDialer),
     )
     .unwrap();
     let proxy: Arc<dyn Proxy> = Arc::new(WrappedProxy::new(Box::new(adapter)));

--- a/crates/meow-proxy/src/dialer.rs
+++ b/crates/meow-proxy/src/dialer.rs
@@ -10,6 +10,7 @@
 //! upstream: mihomo `component/proxydialer` + `BasicOption.NewDialer`.
 
 use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -25,6 +26,17 @@ use meow_transport::Stream;
 pub trait TcpDialer: Send + Sync {
     /// Dial `host:port` and return a duplex stream.
     async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>>;
+
+    /// Dial an already-resolved [`SocketAddr`].
+    ///
+    /// Callers holding a literal address should prefer this over
+    /// `dial(&addr.ip().to_string(), addr.port())`, which allocates a `String`
+    /// only for the callee to parse it straight back into an `IpAddr`.
+    /// The default implementation does exactly that round-trip, so
+    /// implementors that can dial an address directly should override it.
+    async fn dial_addr(&self, addr: SocketAddr) -> io::Result<Box<dyn Stream>> {
+        self.dial(&addr.ip().to_string(), addr.port()).await
+    }
 
     /// Whether this dialer tunnels through another proxy (vs. direct).
     ///
@@ -53,6 +65,14 @@ impl TcpDialer for DirectDialer {
         let _ = tcp.set_nodelay(true);
         Ok(Box::new(tcp))
     }
+
+    async fn dial_addr(&self, addr: SocketAddr) -> io::Result<Box<dyn Stream>> {
+        // Skip the default's `to_string()` + re-parse: `connect_tcp` takes the
+        // `SocketAddr` as-is and keeps the SocketProtector hook.
+        let tcp = meow_common::connect_tcp(addr).await?;
+        let _ = tcp.set_nodelay(true);
+        Ok(Box::new(tcp))
+    }
 }
 
 /// Proxy dialer — tunnels through another proxy.  Equivalent to mihomo's
@@ -68,16 +88,9 @@ impl ProxyDialer {
     pub fn new(proxy: Arc<dyn Proxy>) -> Self {
         Self { proxy }
     }
-}
 
-#[async_trait]
-impl TcpDialer for ProxyDialer {
-    async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>> {
-        let meta = Metadata {
-            host: host.into(),
-            dst_port: port,
-            ..Default::default()
-        };
+    /// Dial the front proxy with a fully-formed [`Metadata`] target.
+    async fn dial_metadata(&self, meta: Metadata) -> io::Result<Box<dyn Stream>> {
         let conn = self
             .proxy
             .dial_tcp(&meta)
@@ -88,6 +101,42 @@ impl TcpDialer for ProxyDialer {
         // is a sized newtype that forwards `AsyncRead`/`AsyncWrite` through
         // the boxed conn, bridging `ProxyConn` → `Stream`.
         Ok(Box::new(ConnStream(conn)))
+    }
+}
+
+#[async_trait]
+impl TcpDialer for ProxyDialer {
+    async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>> {
+        // An IP-literal `host` becomes a typed `dst_ip` so the front proxy
+        // encodes an IP address rather than a domain name that happens to look
+        // like one.
+        let meta = match host.parse::<std::net::IpAddr>() {
+            Ok(ip) => Metadata {
+                dst_ip: Some(ip),
+                dst_port: port,
+                ..Default::default()
+            },
+            Err(_) => Metadata {
+                host: host.into(),
+                dst_port: port,
+                ..Default::default()
+            },
+        };
+        self.dial_metadata(meta).await
+    }
+
+    async fn dial_addr(&self, addr: SocketAddr) -> io::Result<Box<dyn Stream>> {
+        // Carry the literal address in `dst_ip` instead of rendering it into
+        // `host`: adapters that encode the target for the front proxy then emit
+        // an IP-typed address rather than a domain-typed one holding a
+        // dotted-quad, which is what mihomo does and what SOCKS5/Trojan/VLESS
+        // address encoding expects.
+        let meta = Metadata {
+            dst_ip: Some(addr.ip()),
+            dst_port: addr.port(),
+            ..Default::default()
+        };
+        self.dial_metadata(meta).await
     }
 
     fn is_proxy(&self) -> bool {
@@ -101,12 +150,12 @@ impl TcpDialer for ProxyDialer {
 /// cannot use the blanket `Stream` impl.  This newtype forwards
 /// `AsyncRead`/`AsyncWrite` through the boxed conn.
 ///
-/// Note: because `ConnStream` is a distinct concrete type, `as_any_mut()`
-/// downcasts to `RealityTlsStream` (or any other concrete stream type) will
-/// fail — raw-passthrough optimizations that rely on type-downcasting do not
-/// fire through a `dialer-proxy` chain.  This is a Phase-1 limitation; the
-/// underlying data still flows correctly, only the zero-copy shortcut is
-/// skipped.
+/// Downcast-based optimizations are unaffected: the transport layers wrap
+/// whatever they are handed in their own concrete type (e.g.
+/// `RealityTlsStream` holds its inner stream as a `Box<dyn Stream>`), so
+/// `as_any_mut()` still sees that outer type and the Reality raw-passthrough
+/// shortcut fires the same whether the bottom of the stack is a `TcpStream` or
+/// a `ConnStream`.
 pub struct ConnStream(pub Box<dyn ProxyConn>);
 
 impl tokio::io::AsyncRead for ConnStream {

--- a/crates/meow-proxy/src/dialer.rs
+++ b/crates/meow-proxy/src/dialer.rs
@@ -1,0 +1,125 @@
+//! Pluggable TCP dialer for proxy chaining (mihomo `dialer-proxy` model).
+//!
+//! Each proxy adapter holds an `Arc<dyn TcpDialer>` and calls `dial()` to
+//! obtain the raw underlying stream to its server.  The default
+//! [`DirectDialer`] uses `meow_common::connect_tcp_host` (resolver-aware,
+//! SocketProtector-aware).  When `dialer-proxy` is configured, a
+//! [`ProxyDialer`] is injected instead — it tunnels through another proxy,
+//! making chaining transparent to the adapter's TLS + protocol handshake.
+//!
+//! upstream: mihomo `component/proxydialer` + `BasicOption.NewDialer`.
+
+use std::io;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use meow_common::{Metadata, Proxy, ProxyConn};
+use meow_transport::Stream;
+
+
+/// A pluggable dialer for the underlying connection to a proxy server.
+///
+/// Mirrors mihomo's `C.Dialer` interface.  Adapters call `dial()` instead of
+/// `meow_common::connect_tcp_host()` directly so that `dialer-proxy` can
+/// inject a proxied connection transparently.
+#[async_trait]
+pub trait TcpDialer: Send + Sync {
+    /// Dial `host:port` and return a duplex stream.
+    async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>>;
+}
+
+/// Direct TCP dialer — the default, equivalent to mihomo's `dialer.NewDialer()`.
+///
+/// Uses `meow_common::connect_tcp_host` which is resolver-aware and
+/// SocketProtector-aware (Android `VpnService.protect(fd)` etc.).
+pub struct DirectDialer;
+
+#[async_trait]
+impl TcpDialer for DirectDialer {
+    async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>> {
+        let tcp = meow_common::connect_tcp_host(host, port).await?;
+        Ok(Box::new(tcp))
+    }
+}
+
+/// Proxy dialer — tunnels through another proxy.  Equivalent to mihomo's
+/// `proxyDialer.DialContext()`.
+///
+/// Calls `proxy.dial_tcp()` with metadata targeting `host:port`, then adapts
+/// the returned `ProxyConn` into a `Stream` for the caller's transport chain.
+pub struct ProxyDialer {
+    proxy: Arc<dyn Proxy>,
+}
+
+impl ProxyDialer {
+    pub fn new(proxy: Arc<dyn Proxy>) -> Self {
+        Self { proxy }
+    }
+}
+
+#[async_trait]
+impl TcpDialer for ProxyDialer {
+    async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>> {
+        let meta = Metadata {
+            host: host.into(),
+            dst_port: port,
+            ..Default::default()
+        };
+        let conn = self
+            .proxy
+            .dial_tcp(&meta)
+            .await
+            .map_err(|e| io::Error::other(format!("dialer-proxy: {e}")))?;
+        // ProxyConn → StreamConn(Box<dyn Stream>) — StreamConn wraps a
+        // Stream, but here we have a ProxyConn.  We need the reverse: wrap
+        // the ProxyConn so it satisfies the Stream trait (AsyncRead +
+        // AsyncWrite + Unpin + Send + Sync + Any).  Box<dyn ProxyConn> is
+        // unsized so it cannot directly satisfy `Any`; ConnStream bridges
+        // that.
+        Ok(Box::new(ConnStream(conn)))
+    }
+}
+
+/// Wrap a `Box<dyn ProxyConn>` as a `meow_transport::Stream`.
+///
+/// `Stream` requires `Sized + Any`; `Box<dyn ProxyConn>` is `!Sized`, so it
+/// cannot use the blanket `Stream` impl.  This newtype forwards
+/// `AsyncRead`/`AsyncWrite` through the boxed conn.
+pub struct ConnStream(pub Box<dyn ProxyConn>);
+
+impl tokio::io::AsyncRead for ConnStream {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        std::pin::Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl tokio::io::AsyncWrite for ConnStream {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<io::Result<usize>> {
+        std::pin::Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        std::pin::Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        std::pin::Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}
+
+impl Unpin for ConnStream {}
+

--- a/crates/meow-proxy/src/dialer.rs
+++ b/crates/meow-proxy/src/dialer.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 use meow_common::{Metadata, Proxy, ProxyConn};
 use meow_transport::Stream;
 
-
 /// A pluggable dialer for the underlying connection to a proxy server.
 ///
 /// Mirrors mihomo's `C.Dialer` interface.  Adapters call `dial()` instead of
@@ -26,6 +25,16 @@ use meow_transport::Stream;
 pub trait TcpDialer: Send + Sync {
     /// Dial `host:port` and return a duplex stream.
     async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>>;
+
+    /// Whether this dialer tunnels through another proxy (vs. direct).
+    ///
+    /// Adapters whose UDP path uses a raw socket that bypasses `dial()`
+    /// (e.g. Shadowsocks UDP relay) should check this and disable UDP when a
+    /// proxy dialer is installed, so UDP traffic does not leak past the
+    /// `dialer-proxy` chain.
+    fn is_proxy(&self) -> bool {
+        false
+    }
 }
 
 /// Direct TCP dialer — the default, equivalent to mihomo's `dialer.NewDialer()`.
@@ -38,6 +47,10 @@ pub struct DirectDialer;
 impl TcpDialer for DirectDialer {
     async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>> {
         let tcp = meow_common::connect_tcp_host(host, port).await?;
+        // Preserve TCP_NODELAY (disable Nagle) — all call sites that
+        // previously called `tcp.set_nodelay(true)` on the raw
+        // `TcpStream` now rely on the dialer to do it once here.
+        let _ = tcp.set_nodelay(true);
         Ok(Box::new(tcp))
     }
 }
@@ -70,13 +83,15 @@ impl TcpDialer for ProxyDialer {
             .dial_tcp(&meta)
             .await
             .map_err(|e| io::Error::other(format!("dialer-proxy: {e}")))?;
-        // ProxyConn → StreamConn(Box<dyn Stream>) — StreamConn wraps a
-        // Stream, but here we have a ProxyConn.  We need the reverse: wrap
-        // the ProxyConn so it satisfies the Stream trait (AsyncRead +
-        // AsyncWrite + Unpin + Send + Sync + Any).  Box<dyn ProxyConn> is
-        // unsized so it cannot directly satisfy `Any`; ConnStream bridges
-        // that.
+        // `Box<dyn ProxyConn>` is unsized (!Sized), so it cannot satisfy
+        // the `Any` bound required by the blanket `Stream` impl.  `ConnStream`
+        // is a sized newtype that forwards `AsyncRead`/`AsyncWrite` through
+        // the boxed conn, bridging `ProxyConn` → `Stream`.
         Ok(Box::new(ConnStream(conn)))
+    }
+
+    fn is_proxy(&self) -> bool {
+        true
     }
 }
 
@@ -85,6 +100,13 @@ impl TcpDialer for ProxyDialer {
 /// `Stream` requires `Sized + Any`; `Box<dyn ProxyConn>` is `!Sized`, so it
 /// cannot use the blanket `Stream` impl.  This newtype forwards
 /// `AsyncRead`/`AsyncWrite` through the boxed conn.
+///
+/// Note: because `ConnStream` is a distinct concrete type, `as_any_mut()`
+/// downcasts to `RealityTlsStream` (or any other concrete stream type) will
+/// fail — raw-passthrough optimizations that rely on type-downcasting do not
+/// fire through a `dialer-proxy` chain.  This is a Phase-1 limitation; the
+/// underlying data still flows correctly, only the zero-copy shortcut is
+/// skipped.
 pub struct ConnStream(pub Box<dyn ProxyConn>);
 
 impl tokio::io::AsyncRead for ConnStream {
@@ -122,4 +144,3 @@ impl tokio::io::AsyncWrite for ConnStream {
 }
 
 impl Unpin for ConnStream {}
-

--- a/crates/meow-proxy/src/dialer.rs
+++ b/crates/meow-proxy/src/dialer.rs
@@ -14,7 +14,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use meow_common::{Metadata, Proxy, ProxyConn};
+use meow_common::{ConnType, Metadata, Network, Proxy, ProxyConn};
 use meow_transport::Stream;
 
 /// A pluggable dialer for the underlying connection to a proxy server.
@@ -22,6 +22,18 @@ use meow_transport::Stream;
 /// Mirrors mihomo's `C.Dialer` interface.  Adapters call `dial()` instead of
 /// `meow_common::connect_tcp_host()` directly so that `dialer-proxy` can
 /// inject a proxied connection transparently.
+///
+/// # Performance note (review M10)
+///
+/// Every outbound connection pays two extra heap allocations versus the old
+/// direct `connect_tcp_host` path: this trait is `#[async_trait]` (the
+/// future is boxed) and it returns `Box<dyn Stream>`.  The direct path
+/// previously allocated nothing.  This is accepted for now — ADR-0008's
+/// allocation discipline tracks per-connection overhead via the conn-rate
+/// benchmark (`cargo run -p meow-bench -- --only connrate`); if that
+/// benchmark regresses, the candidate fix is replacing `#[async_trait]`
+/// with RPITIT (`impl Future` in the trait) and/or an unboxed stream
+/// return, at the cost of the vtable-style plugin seam.
 #[async_trait]
 pub trait TcpDialer: Send + Sync {
     /// Dial `host:port` and return a duplex stream.
@@ -110,13 +122,23 @@ impl TcpDialer for ProxyDialer {
         // An IP-literal `host` becomes a typed `dst_ip` so the front proxy
         // encodes an IP address rather than a domain name that happens to look
         // like one.
+        //
+        // `network` / `conn_type` are explicit: `Metadata::default()` yields
+        // `ConnType::Http` (the first enum variant), but this is an internal
+        // chained-relay dial — the front proxy's rules, /connections list,
+        // and stats must classify it as `Inner`, not as an HTTP inbound
+        // (review B2).
         let meta = match host.parse::<std::net::IpAddr>() {
             Ok(ip) => Metadata {
+                network: Network::Tcp,
+                conn_type: ConnType::Inner,
                 dst_ip: Some(ip),
                 dst_port: port,
                 ..Default::default()
             },
             Err(_) => Metadata {
+                network: Network::Tcp,
+                conn_type: ConnType::Inner,
                 host: host.into(),
                 dst_port: port,
                 ..Default::default()
@@ -131,7 +153,10 @@ impl TcpDialer for ProxyDialer {
         // an IP-typed address rather than a domain-typed one holding a
         // dotted-quad, which is what mihomo does and what SOCKS5/Trojan/VLESS
         // address encoding expects.
+        // Explicit Inner conn_type — see `dial()` (review B2).
         let meta = Metadata {
+            network: Network::Tcp,
+            conn_type: ConnType::Inner,
             dst_ip: Some(addr.ip()),
             dst_port: addr.port(),
             ..Default::default()
@@ -193,3 +218,113 @@ impl tokio::io::AsyncWrite for ConnStream {
 }
 
 impl Unpin for ConnStream {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use meow_common::{
+        AdapterType, DelayHistory, ProxyAdapter, ProxyHealth, ProxyPacketConn, Result as MeowResult,
+    };
+    use std::sync::Mutex;
+
+    /// Front-proxy mock: captures the [`Metadata`] of every `dial_tcp` call
+    /// and refuses the connection. The captured metadata is what the front
+    /// proxy's rule engine, `/connections` list, and stats would see.
+    struct CapturingProxy {
+        seen: Mutex<Vec<Metadata>>,
+    }
+
+    #[async_trait]
+    impl ProxyAdapter for CapturingProxy {
+        fn name(&self) -> &str {
+            "front"
+        }
+        fn adapter_type(&self) -> AdapterType {
+            AdapterType::Socks5
+        }
+        fn addr(&self) -> &str {
+            "127.0.0.1:1080"
+        }
+        fn support_udp(&self) -> bool {
+            false
+        }
+        async fn dial_tcp(&self, metadata: &Metadata) -> MeowResult<Box<dyn ProxyConn>> {
+            self.seen.lock().unwrap().push(metadata.clone());
+            Err(meow_common::MeowError::NotSupported(
+                "test mock refuses connections".to_string(),
+            ))
+        }
+        async fn dial_udp(&self, _metadata: &Metadata) -> MeowResult<Box<dyn ProxyPacketConn>> {
+            unimplemented!("test mock has no UDP")
+        }
+        fn health(&self) -> &ProxyHealth {
+            static H: std::sync::OnceLock<ProxyHealth> = std::sync::OnceLock::new();
+            H.get_or_init(ProxyHealth::new)
+        }
+    }
+
+    impl Proxy for CapturingProxy {
+        fn alive(&self) -> bool {
+            true
+        }
+        fn alive_for_url(&self, _url: &str) -> bool {
+            true
+        }
+        fn last_delay(&self) -> u16 {
+            0
+        }
+        fn last_delay_for_url(&self, _url: &str) -> u16 {
+            0
+        }
+        fn delay_history(&self) -> Vec<DelayHistory> {
+            Vec::new()
+        }
+    }
+
+    fn last_seen(mock: &CapturingProxy) -> Metadata {
+        let seen = mock.seen.lock().unwrap();
+        seen.last()
+            .expect("a dial must reach the front proxy")
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn proxy_dialer_dials_are_inner_tcp_connections() {
+        // Review B2: `Metadata::default()` carries `ConnType::Http` (the
+        // first enum variant), but a dialer-proxy chained relay is an
+        // internal connection. The front proxy must see `ConnType::Inner`
+        // + `Network::Tcp` so its rules route it as infrastructure traffic
+        // and `/connections`/stats don't mislabel it as an HTTP inbound.
+        let mock = Arc::new(CapturingProxy {
+            seen: Mutex::new(Vec::new()),
+        });
+        let dialer = ProxyDialer::new(Arc::clone(&mock) as Arc<dyn Proxy>);
+
+        // Hostname target — dial() must produce host + port metadata.
+        let _ = dialer.dial("chain.example", 443).await;
+        let meta = last_seen(&mock);
+        assert_eq!(meta.conn_type, ConnType::Inner);
+        assert_eq!(meta.network, Network::Tcp);
+        assert_eq!(meta.host.as_str(), "chain.example");
+        assert_eq!(meta.dst_port, 443);
+
+        // IP-literal target through dial() — typed dst_ip, no host string.
+        let _ = dialer.dial("192.0.2.9", 853).await;
+        let meta = last_seen(&mock);
+        assert_eq!(meta.conn_type, ConnType::Inner);
+        assert_eq!(meta.network, Network::Tcp);
+        assert_eq!(meta.dst_ip, Some("192.0.2.9".parse().unwrap()));
+        assert_eq!(meta.dst_port, 853);
+
+        // SocketAddr target through dial_addr() — typed dst_ip.
+        let addr: SocketAddr = "[2001:db8::1]:443".parse().unwrap();
+        let _ = dialer.dial_addr(addr).await;
+        let meta = last_seen(&mock);
+        assert_eq!(meta.conn_type, ConnType::Inner);
+        assert_eq!(meta.network, Network::Tcp);
+        assert_eq!(meta.dst_ip, Some(addr.ip()));
+        assert_eq!(meta.dst_port, 443);
+
+        assert_eq!(mock.seen.lock().unwrap().len(), 3);
+    }
+}

--- a/crates/meow-proxy/src/ech_tls_tunnel.rs
+++ b/crates/meow-proxy/src/ech_tls_tunnel.rs
@@ -158,6 +158,7 @@ pub async fn dial(
     tls_layer: &TlsLayer,
     server_host: &str,
     server_port: u16,
+    dialer: &dyn crate::dialer::TcpDialer,
 ) -> Result<Box<dyn meow_transport::Stream>> {
     debug!(
         "ech-tls-tunnel: dialing {}:{} sni={} path={} ech_config_len={}",
@@ -169,10 +170,12 @@ pub async fn dial(
     );
 
     // 1) Raw TCP.
-    let tcp = meow_common::connect_tcp_host(server_host, server_port)
+    let tcp = dialer
+        .dial(server_host, server_port)
         .await
         .map_err(MeowError::Io)?;
-    let _ = tcp.set_nodelay(true);
+
+
 
     // 2) TLS (with ECH). Reuse the pre-built TlsLayer — avoids rebuilding
     //    the BoringSSL SSL_CTX and re-parsing ~150 root certs per connection.

--- a/crates/meow-proxy/src/ech_tls_tunnel.rs
+++ b/crates/meow-proxy/src/ech_tls_tunnel.rs
@@ -175,8 +175,6 @@ pub async fn dial(
         .await
         .map_err(MeowError::Io)?;
 
-
-
     // 2) TLS (with ECH). Reuse the pre-built TlsLayer — avoids rebuilding
     //    the BoringSSL SSL_CTX and re-parsing ~150 root certs per connection.
     let tls_stream = tls_layer

--- a/crates/meow-proxy/src/http_adapter.rs
+++ b/crates/meow-proxy/src/http_adapter.rs
@@ -73,6 +73,8 @@ impl HttpAdapter {
         extra_headers: Vec<(String, String)>,
         dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Self {
+        // Hoisted out of the dial path: TlsLayer::new clones the webpki root
+        // store and builds verifier + crypto provider — per-adapter, not
         // per-connection (same pattern as TrojanAdapter::new).
         let tls_layer = tls.then(|| {
             use meow_transport::tls::{TlsConfig, TlsLayer};
@@ -93,13 +95,11 @@ impl HttpAdapter {
             tls_layer,
             extra_headers,
             health: ProxyHealth::new(),
-
             dialer,
         }
     }
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
-
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
         let tcp = self
             .dialer
@@ -117,6 +117,9 @@ impl HttpAdapter {
             Ok(Box::new(tcp))
         }
     }
+
+    /// Run the HTTP CONNECT handshake over `stream`.
+    ///
     /// On success the stream is ready for tunnelled application data.
     /// On failure returns the appropriate `MeowError` variant.
     async fn run_connect<S>(

--- a/crates/meow-proxy/src/http_adapter.rs
+++ b/crates/meow-proxy/src/http_adapter.rs
@@ -27,6 +27,7 @@ use meow_common::{
 };
 use smol_str::SmolStr;
 use std::fmt;
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::debug;
 
@@ -51,13 +52,17 @@ pub struct HttpAdapter {
     /// Extra headers injected into the CONNECT request only.
     extra_headers: Vec<(String, String)>,
     health: ProxyHealth,
+    dialer: Arc<dyn crate::dialer::TcpDialer>,
 }
-
 impl HttpAdapter {
     /// Create an `HttpAdapter`.
     ///
     /// `auth` — `Some((username, password))` for Basic auth; `None` for no auth.
     /// Both username and password must be set or neither (validated at parse time).
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "dialer param for pluggable TcpDialer"
+    )]
     pub fn new(
         name: &str,
         server: &str,
@@ -66,9 +71,8 @@ impl HttpAdapter {
         tls: bool,
         skip_cert_verify: bool,
         extra_headers: Vec<(String, String)>,
+        dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Self {
-        // Hoisted out of the dial path: TlsLayer::new clones the webpki root
-        // store and builds verifier + crypto provider — per-adapter, not
         // per-connection (same pattern as TrojanAdapter::new).
         let tls_layer = tls.then(|| {
             use meow_transport::tls::{TlsConfig, TlsLayer};
@@ -89,12 +93,17 @@ impl HttpAdapter {
             tls_layer,
             extra_headers,
             health: ProxyHealth::new(),
+
+            dialer,
         }
     }
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
+
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+        let tcp = self
+            .dialer
+            .dial(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
 
@@ -108,9 +117,6 @@ impl HttpAdapter {
             Ok(Box::new(tcp))
         }
     }
-
-    /// Run the HTTP CONNECT handshake over `stream`.
-    ///
     /// On success the stream is ready for tunnelled application data.
     /// On failure returns the appropriate `MeowError` variant.
     async fn run_connect<S>(
@@ -415,7 +421,16 @@ mod tests {
     }
 
     fn make_adapter_no_auth(server: &str, port: u16) -> HttpAdapter {
-        HttpAdapter::new(server, server, port, None, false, false, vec![])
+        HttpAdapter::new(
+            server,
+            server,
+            port,
+            None,
+            false,
+            false,
+            vec![],
+            Arc::new(crate::dialer::DirectDialer),
+        )
     }
 
     // ─── http_connect_no_auth_succeeds ────────────────────────────────────────
@@ -473,6 +488,7 @@ mod tests {
             false,
             false,
             vec![],
+            Arc::new(crate::dialer::DirectDialer),
         );
         let meta = make_metadata("example.com", 443);
         let _ = adapter.dial_tcp(&meta).await.expect("dial_tcp");
@@ -556,6 +572,7 @@ mod tests {
             false,
             false,
             vec![("X-Foo".into(), "bar".into())],
+            Arc::new(crate::dialer::DirectDialer),
         );
         let meta = make_metadata("example.com", 443);
         let _ = adapter.dial_tcp(&meta).await.expect("dial_tcp");
@@ -577,6 +594,7 @@ mod tests {
             false,
             false,
             vec![("X-Foo".into(), "bar\r\nX-Injected: yes".into())],
+            Arc::new(crate::dialer::DirectDialer),
         );
         let (mut client, _server) = tokio::io::duplex(64);
         let target = "example.com:443";
@@ -629,6 +647,7 @@ mod tests {
             false,
             false,
             vec![("X-Long".into(), long_value.clone())],
+            Arc::new(crate::dialer::DirectDialer),
         );
         let meta = make_metadata("example.com", 443);
         let _ = adapter.dial_tcp(&meta).await.expect("dial_tcp");

--- a/crates/meow-proxy/src/lib.rs
+++ b/crates/meow-proxy/src/lib.rs
@@ -4,6 +4,7 @@
 //! HTTP, SOCKS5, Direct, and Reject, plus Selector, URLTest, Fallback,
 //! LoadBalance, and Relay groups.
 
+pub mod dialer;
 pub mod direct;
 pub mod group;
 pub mod health;

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -211,7 +211,6 @@ impl SsCore {
                     .await
                     .map_err(|e| MeowError::Proxy(format!("ss obfs tcp connect: {e}")))?;
 
-                
                 match obfs.clone() {
                     BuiltinObfs::Http { host } => {
                         let wrapped = HttpObfs::new(tcp, host, self.port);
@@ -259,21 +258,12 @@ impl SsCore {
                 );
                 Ok(Box::new(SsConn(stream)))
             }
-            PluginKind::None | PluginKind::External(_) => {
-                // Hand-roll the TCP connect so the installed
-                // `meow_common::SocketProtector` sees the fd before connect —
-                // otherwise the upstream `shadowsocks` crate would dial this
-                // stream internally via plain tokio and the Android
-                // `VpnService.protect(fd)` hook would never fire, so the
-                // outbound socket would loop back into our own VPN tunnel.
-                //
-                // For `PluginKind::External`, `tcp_external_addr` returns the
-                // SIP003 plugin's local listener (typically 127.0.0.1:<port>),
-                // so the connect is loopback and `protect()` is harmless;
-                // for `PluginKind::None` it's the remote SS server. Dispatch
-                // on the variant so domain-name servers also go through the
-                // installed `HostResolver` (system DNS would loop the
-                // lookup through the VPN on Android).
+            PluginKind::None => {
+                // Dial the remote SS server through the pluggable dialer
+                // (direct or via ``dialer-proxy``).  ``connect_tcp_host`` is
+                // resolver-aware and SocketProtector-aware (Android
+                // ``VpnService.protect(fd)``), and ``DirectDialer`` preserves
+                // both of those properties.
                 let tcp = match self.server_config.tcp_external_addr() {
                     ServerAddr::SocketAddr(sa) => {
                         self.dialer.dial(&sa.ip().to_string(), sa.port()).await
@@ -281,6 +271,26 @@ impl SsCore {
                     ServerAddr::DomainName(host, port) => self.dialer.dial(host, *port).await,
                 }
                 .map_err(|e| MeowError::Proxy(format!("ss tcp connect: {e}")))?;
+                let stream = ProxyClientStream::from_stream(
+                    Arc::clone(&self.context),
+                    tcp,
+                    &self.server_config,
+                    addr,
+                );
+                Ok(Box::new(SsConn(stream)))
+            }
+            PluginKind::External(_) => {
+                // SIP003 plugin subprocess: ``tcp_external_addr`` returns the
+                // plugin's local listener (typically 127.0.0.1:<port>).
+                // Always dial directly — the plugin is a local process and
+                // must NOT be tunnelled through ``dialer-proxy``.
+                let tcp = match self.server_config.tcp_external_addr() {
+                    ServerAddr::SocketAddr(sa) => meow_common::connect_tcp(*sa).await,
+                    ServerAddr::DomainName(host, port) => {
+                        meow_common::connect_tcp_host(host, *port).await
+                    }
+                }
+                .map_err(|e| MeowError::Proxy(format!("ss plugin tcp connect: {e}")))?;
                 let stream = ProxyClientStream::from_stream(
                     Arc::clone(&self.context),
                     tcp,

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -265,9 +265,7 @@ impl SsCore {
                 // ``VpnService.protect(fd)``), and ``DirectDialer`` preserves
                 // both of those properties.
                 let tcp = match self.server_config.tcp_external_addr() {
-                    ServerAddr::SocketAddr(sa) => {
-                        self.dialer.dial(&sa.ip().to_string(), sa.port()).await
-                    }
+                    ServerAddr::SocketAddr(sa) => self.dialer.dial_addr(*sa).await,
                     ServerAddr::DomainName(host, port) => self.dialer.dial(host, *port).await,
                 }
                 .map_err(|e| MeowError::Proxy(format!("ss tcp connect: {e}")))?;
@@ -521,9 +519,15 @@ impl ProxyAdapter for ShadowsocksAdapter {
     fn support_udp(&self) -> bool {
         // SS UDP relay uses a raw UDP socket that bypasses the TCP dialer.
         // When a `ProxyDialer` is installed (dialer-proxy), raw UDP would
-        // leak traffic past the chain — disable the plain UDP path.  Mux
-        // UDP is safe because it rides the mux TCP session through
-        // `dialer.dial()`, so it is unaffected.
+        // leak traffic past the chain — advertise the plain UDP path as
+        // unsupported.  Mux UDP is safe because it rides the mux TCP session
+        // through `dialer.dial()`, so it is unaffected.
+        //
+        // This is the *advertised* capability only (LoadBalance member
+        // filtering, the `udp` field in `GET /proxies`).  It is NOT the
+        // enforcement point: `meow-tunnel`'s UDP path calls `dial_udp`
+        // directly without consulting `support_udp`, so the refusal is
+        // re-checked there.  Keep the two in sync.
         let plain_udp_ok = self.support_udp && !self.core.dialer.is_proxy();
         plain_udp_ok || {
             #[cfg(feature = "mux")]
@@ -564,6 +568,23 @@ impl ProxyAdapter for ShadowsocksAdapter {
             if let Some(conn) = mux.open_packet_stream_for(metadata, "ss").await? {
                 return Ok(conn);
             }
+        }
+
+        // Enforcement point for the dialer-proxy UDP leak (not `support_udp`,
+        // which the tunnel's UDP dispatch never consults).  The plain SS UDP
+        // relay below binds a raw socket and connects straight to the SS
+        // server, so with a `ProxyDialer` installed it would egress from the
+        // real source path while TCP goes through the front proxy.  Refuse
+        // loudly (Class A, ADR-0002) instead of leaking.  Reached only after
+        // the mux branch above, which tunnels UDP over `dialer.dial()` and is
+        // therefore safe.
+        if self.core.dialer.is_proxy() {
+            return Err(MeowError::NotSupported(
+                "ss: plain UDP relay bypasses `dialer-proxy` (raw socket); \
+                 refusing to leak the real source path — enable `smux`/`yamux` \
+                 mux for UDP over the chain"
+                    .into(),
+            ));
         }
 
         if matches!(self.core.plugin, PluginKind::V2ray(..)) {
@@ -747,6 +768,76 @@ mod tests {
             "non-transport mode must not change Mode"
         );
         assert_eq!(o.as_deref(), Some("mode=quic;host=a.com"));
+    }
+
+    /// A dialer that reports itself as proxied without needing a real front
+    /// proxy — stands in for `ProxyDialer` in the leak-refusal tests.
+    struct FakeProxyDialer;
+
+    #[async_trait]
+    impl crate::dialer::TcpDialer for FakeProxyDialer {
+        async fn dial(
+            &self,
+            _host: &str,
+            _port: u16,
+        ) -> std::io::Result<Box<dyn meow_transport::Stream>> {
+            Err(std::io::Error::other("test dialer never connects"))
+        }
+
+        fn is_proxy(&self) -> bool {
+            true
+        }
+    }
+
+    fn ss_adapter(udp: bool, dialer: Arc<dyn crate::dialer::TcpDialer>) -> ShadowsocksAdapter {
+        ShadowsocksAdapter::new(
+            "ss-test",
+            "127.0.0.1",
+            8388,
+            "password",
+            "aes-256-gcm",
+            udp,
+            None,
+            None,
+            dialer,
+        )
+        .expect("adapter builds")
+    }
+
+    /// Regression: the plain SS UDP relay binds a raw socket and connects
+    /// straight to the SS server, bypassing the TCP dialer. With a proxy dialer
+    /// installed it must refuse, not egress from the real source path.
+    ///
+    /// `dial_udp` is the enforcement point on purpose: the tunnel's UDP
+    /// dispatch (`meow-tunnel/src/udp.rs`) calls it directly and never consults
+    /// `support_udp()`, so gating only the latter would leave the leak open for
+    /// any rule that references the outbound by name.
+    #[tokio::test]
+    async fn plain_udp_is_refused_under_proxy_dialer() {
+        let adapter = ss_adapter(true, Arc::new(FakeProxyDialer));
+
+        // `ProxyPacketConn` is not `Debug`, so match rather than `expect_err`.
+        match adapter.dial_udp(&Metadata::default()).await {
+            Err(MeowError::NotSupported(m)) => assert!(
+                m.contains("dialer-proxy"),
+                "refusal should name dialer-proxy, got: {m}"
+            ),
+            Err(other) => panic!("expected NotSupported, got: {other:?}"),
+            Ok(_) => panic!("plain UDP must be refused under a proxy dialer"),
+        }
+
+        assert!(
+            !adapter.support_udp(),
+            "advertised capability must agree with the refusal"
+        );
+    }
+
+    /// The same adapter with the default direct dialer keeps advertising UDP —
+    /// the guard must not regress the non-chained path.
+    #[test]
+    fn plain_udp_still_advertised_under_direct_dialer() {
+        assert!(ss_adapter(true, Arc::new(crate::dialer::DirectDialer)).support_udp());
+        assert!(!ss_adapter(false, Arc::new(crate::dialer::DirectDialer)).support_udp());
     }
 
     #[test]

--- a/crates/meow-proxy/src/shadowsocks_adapter.rs
+++ b/crates/meow-proxy/src/shadowsocks_adapter.rs
@@ -59,6 +59,7 @@ struct SsCore {
     server_config: ServerConfig,
     context: shadowsocks::context::SharedContext,
     plugin: PluginKind,
+    dialer: Arc<dyn crate::dialer::TcpDialer>,
 }
 
 pub struct ShadowsocksAdapter {
@@ -83,6 +84,7 @@ impl ShadowsocksAdapter {
         udp: bool,
         plugin_name: Option<&str>,
         plugin_opts: Option<&str>,
+        dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Result<Self> {
         let cipher_kind = cipher
             .parse::<CipherKind>()
@@ -156,6 +158,7 @@ impl ShadowsocksAdapter {
             server_config,
             context,
             plugin,
+            dialer,
         });
 
         Ok(Self {
@@ -202,10 +205,13 @@ impl SsCore {
             PluginKind::Obfs(obfs) => {
                 // Open a raw TCP connection to the SS server, wrap it in the
                 // simple-obfs codec, then layer the SS crypto stream on top.
-                let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+                let tcp = self
+                    .dialer
+                    .dial(&self.server, self.port)
                     .await
                     .map_err(|e| MeowError::Proxy(format!("ss obfs tcp connect: {e}")))?;
-                let _ = tcp.set_nodelay(true);
+
+                
                 match obfs.clone() {
                     BuiltinObfs::Http { host } => {
                         let wrapped = HttpObfs::new(tcp, host, self.port);
@@ -231,7 +237,8 @@ impl SsCore {
             }
             PluginKind::V2ray(cfg, tls) => {
                 let transport =
-                    v2ray_plugin::dial(cfg, tls.as_ref(), &self.server, self.port).await?;
+                    v2ray_plugin::dial(cfg, tls.as_ref(), &self.server, self.port, &*self.dialer)
+                        .await?;
                 let stream = ProxyClientStream::from_stream(
                     Arc::clone(&self.context),
                     transport,
@@ -242,7 +249,8 @@ impl SsCore {
             }
             #[cfg(feature = "ech-tls-tunnel")]
             PluginKind::EchTlsTunnel(cfg, tls) => {
-                let transport = ech_tls_tunnel::dial(cfg, tls, &self.server, self.port).await?;
+                let transport =
+                    ech_tls_tunnel::dial(cfg, tls, &self.server, self.port, &*self.dialer).await?;
                 let stream = ProxyClientStream::from_stream(
                     Arc::clone(&self.context),
                     transport,
@@ -267,10 +275,10 @@ impl SsCore {
                 // installed `HostResolver` (system DNS would loop the
                 // lookup through the VPN on Android).
                 let tcp = match self.server_config.tcp_external_addr() {
-                    ServerAddr::SocketAddr(sa) => meow_common::connect_tcp(*sa).await,
-                    ServerAddr::DomainName(host, port) => {
-                        meow_common::connect_tcp_host(host, *port).await
+                    ServerAddr::SocketAddr(sa) => {
+                        self.dialer.dial(&sa.ip().to_string(), sa.port()).await
                     }
+                    ServerAddr::DomainName(host, port) => self.dialer.dial(host, *port).await,
                 }
                 .map_err(|e| MeowError::Proxy(format!("ss tcp connect: {e}")))?;
                 let stream = ProxyClientStream::from_stream(
@@ -501,10 +509,13 @@ impl ProxyAdapter for ShadowsocksAdapter {
     }
 
     fn support_udp(&self) -> bool {
-        // With mux enabled, UDP rides the mux TCP session (unless
-        // `only-tcp` forces the plain path) — mirrors mihomo's
-        // SingMux.SupportUDP.
-        self.support_udp || {
+        // SS UDP relay uses a raw UDP socket that bypasses the TCP dialer.
+        // When a `ProxyDialer` is installed (dialer-proxy), raw UDP would
+        // leak traffic past the chain — disable the plain UDP path.  Mux
+        // UDP is safe because it rides the mux TCP session through
+        // `dialer.dial()`, so it is unaffected.
+        let plain_udp_ok = self.support_udp && !self.core.dialer.is_proxy();
+        plain_udp_ok || {
             #[cfg(feature = "mux")]
             {
                 self.mux.as_ref().is_some_and(|mux| mux.supports_udp())

--- a/crates/meow-proxy/src/snell/adapter.rs
+++ b/crates/meow-proxy/src/snell/adapter.rs
@@ -67,6 +67,7 @@ pub struct SnellAdapter {
     health: ProxyHealth,
     dialer: Arc<dyn crate::dialer::TcpDialer>,
 }
+
 impl SnellAdapter {
     #[allow(
         clippy::too_many_arguments,
@@ -130,8 +131,6 @@ impl SnellAdapter {
             dialer,
         })
     }
-
-
 
     /// Open a fresh underlying byte stream (TCP, optionally wrapped in obfs)
     /// and Snell-wrap it. No CONNECT header is sent yet.

--- a/crates/meow-proxy/src/snell/adapter.rs
+++ b/crates/meow-proxy/src/snell/adapter.rs
@@ -65,8 +65,8 @@ pub struct SnellAdapter {
     pool: Option<Arc<Pool>>,
     version: SnellVersion,
     health: ProxyHealth,
+    dialer: Arc<dyn crate::dialer::TcpDialer>,
 }
-
 impl SnellAdapter {
     #[allow(
         clippy::too_many_arguments,
@@ -81,6 +81,7 @@ impl SnellAdapter {
         version: SnellVersion,
         udp: bool,
         reuse: bool,
+        dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Result<Self> {
         if psk.is_empty() {
             return Err(MeowError::Config(format!(
@@ -126,16 +127,20 @@ impl SnellAdapter {
             },
             version,
             health: ProxyHealth::new(),
+            dialer,
         })
     }
+
+
 
     /// Open a fresh underlying byte stream (TCP, optionally wrapped in obfs)
     /// and Snell-wrap it. No CONNECT header is sent yet.
     async fn dial_fresh(&self) -> Result<PoolStream> {
-        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+        let tcp = self
+            .dialer
+            .dial(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
-        let _ = tcp.set_nodelay(true);
         let inner: Box<dyn TransportStream> = Box::new(tcp);
         Ok(self.wrap_stream(inner))
     }
@@ -439,6 +444,7 @@ mod tests {
             SnellVersion::V3,
             false,
             false,
+            Arc::new(crate::dialer::DirectDialer),
         )
         .unwrap();
         let metadata = Metadata {

--- a/crates/meow-proxy/src/socks5_adapter.rs
+++ b/crates/meow-proxy/src/socks5_adapter.rs
@@ -535,7 +535,10 @@ impl ProxyAdapter for Socks5Adapter {
     }
 
     fn support_udp(&self) -> bool {
-        self.udp
+        // UDP ASSOCIATE sends datagrams to the server-provided relay endpoint
+        // over a raw socket that bypasses the TCP dialer, so it cannot ride a
+        // `dialer-proxy` chain — see `dial_udp` for the enforcement.
+        self.udp && !self.dialer.is_proxy()
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
@@ -559,6 +562,21 @@ impl ProxyAdapter for Socks5Adapter {
         if !self.udp {
             return Err(MeowError::NotSupported(
                 "socks5: UDP ASSOCIATE not enabled (set `udp: true`)".into(),
+            ));
+        }
+
+        // Only the TCP control connection below goes through `self.dialer`.
+        // The datagram socket is bound raw and connected straight to the
+        // relay endpoint the server advertises, so with a `ProxyDialer`
+        // installed the UDP payload would egress from the real source path
+        // while TCP rides the front proxy.  Refuse rather than leak
+        // (Class A, ADR-0002).  Enforced here because the tunnel's UDP
+        // dispatch calls `dial_udp` without consulting `support_udp`.
+        if self.dialer.is_proxy() {
+            return Err(MeowError::NotSupported(
+                "socks5: UDP ASSOCIATE bypasses `dialer-proxy` (raw relay \
+                 socket); refusing to leak the real source path"
+                    .into(),
             ));
         }
 
@@ -857,6 +875,67 @@ mod tests {
             false,
             Arc::new(crate::dialer::DirectDialer),
         )
+    }
+
+    /// Reports itself as proxied without needing a real front proxy.
+    struct FakeProxyDialer;
+
+    #[async_trait]
+    impl crate::dialer::TcpDialer for FakeProxyDialer {
+        async fn dial(
+            &self,
+            _host: &str,
+            _port: u16,
+        ) -> std::io::Result<Box<dyn meow_transport::Stream>> {
+            Err(std::io::Error::other("test dialer never connects"))
+        }
+
+        fn is_proxy(&self) -> bool {
+            true
+        }
+    }
+
+    /// Regression: only the TCP control connection follows the dialer. The
+    /// datagram socket is bound raw and connected to the server-advertised
+    /// relay, so under a proxy dialer the association must be refused rather
+    /// than egressing from the real source path.
+    ///
+    /// Enforced in `dial_udp` because the tunnel's UDP dispatch calls it
+    /// directly without consulting `support_udp()`.
+    #[tokio::test]
+    async fn udp_associate_is_refused_under_proxy_dialer() {
+        let adapter = Socks5Adapter::new(
+            "front",
+            "127.0.0.1",
+            1080,
+            None,
+            false,
+            false,
+            Arc::new(FakeProxyDialer),
+        )
+        .with_udp(true);
+
+        // `ProxyPacketConn` is not `Debug`, so match rather than `expect_err`.
+        match adapter.dial_udp(&meta_with_host("example.com", 443)).await {
+            Err(MeowError::NotSupported(m)) => assert!(
+                m.contains("dialer-proxy"),
+                "refusal should name dialer-proxy, got: {m}"
+            ),
+            Err(other) => panic!("expected NotSupported, got: {other:?}"),
+            Ok(_) => panic!("UDP ASSOCIATE must be refused under a proxy dialer"),
+        }
+
+        assert!(
+            !adapter.support_udp(),
+            "advertised capability must agree with the refusal"
+        );
+    }
+
+    #[test]
+    fn udp_still_advertised_under_direct_dialer() {
+        assert!(make_adapter("127.0.0.1", 1080, None)
+            .with_udp(true)
+            .support_udp());
     }
 
     fn meta_with_host(host: &str, port: u16) -> Metadata {

--- a/crates/meow-proxy/src/socks5_adapter.rs
+++ b/crates/meow-proxy/src/socks5_adapter.rs
@@ -66,6 +66,7 @@ pub struct Socks5Adapter {
     health: ProxyHealth,
     dialer: Arc<dyn crate::dialer::TcpDialer>,
 }
+
 impl Socks5Adapter {
     /// Create a `Socks5Adapter`. UDP ASSOCIATE is disabled by default; call
     /// [`Self::with_udp`] to enable it (set from `udp: true` in config).
@@ -78,6 +79,8 @@ impl Socks5Adapter {
         skip_cert_verify: bool,
         dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Self {
+        // Hoisted out of the dial path: TlsLayer::new clones the webpki root
+        // store and builds verifier + crypto provider — per-adapter, not
         // per-connection (same pattern as TrojanAdapter::new).
         let tls_layer = tls.then(|| {
             use meow_transport::tls::{TlsConfig, TlsLayer};
@@ -102,6 +105,7 @@ impl Socks5Adapter {
         }
     }
 
+    /// Enable SOCKS5 UDP ASSOCIATE (HTTP/3 / QUIC relay). Off by default.
     #[must_use]
     pub fn with_udp(mut self, udp: bool) -> Self {
         self.udp = udp;

--- a/crates/meow-proxy/src/socks5_adapter.rs
+++ b/crates/meow-proxy/src/socks5_adapter.rs
@@ -22,6 +22,7 @@ use meow_common::{
 };
 use smallvec::SmallVec;
 use smol_str::SmolStr;
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UdpSocket;
 use tracing::debug;
@@ -63,8 +64,8 @@ pub struct Socks5Adapter {
     /// Whether `udp: true` was configured — gates UDP ASSOCIATE.
     udp: bool,
     health: ProxyHealth,
+    dialer: Arc<dyn crate::dialer::TcpDialer>,
 }
-
 impl Socks5Adapter {
     /// Create a `Socks5Adapter`. UDP ASSOCIATE is disabled by default; call
     /// [`Self::with_udp`] to enable it (set from `udp: true` in config).
@@ -75,9 +76,8 @@ impl Socks5Adapter {
         auth: Option<(String, String)>,
         tls: bool,
         skip_cert_verify: bool,
+        dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Self {
-        // Hoisted out of the dial path: TlsLayer::new clones the webpki root
-        // store and builds verifier + crypto provider — per-adapter, not
         // per-connection (same pattern as TrojanAdapter::new).
         let tls_layer = tls.then(|| {
             use meow_transport::tls::{TlsConfig, TlsLayer};
@@ -98,10 +98,10 @@ impl Socks5Adapter {
             tls_layer,
             udp: false,
             health: ProxyHealth::new(),
+            dialer,
         }
     }
 
-    /// Enable SOCKS5 UDP ASSOCIATE (HTTP/3 / QUIC relay). Off by default.
     #[must_use]
     pub fn with_udp(mut self, udp: bool) -> Self {
         self.udp = udp;
@@ -110,7 +110,9 @@ impl Socks5Adapter {
 
     /// Dial TCP to the proxy server, optionally wrapping in TLS.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+        let tcp = self
+            .dialer
+            .dial(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
 
@@ -842,7 +844,15 @@ mod tests {
     }
 
     fn make_adapter(server: &str, port: u16, auth: Option<(String, String)>) -> Socks5Adapter {
-        Socks5Adapter::new(server, server, port, auth, false, false)
+        Socks5Adapter::new(
+            server,
+            server,
+            port,
+            auth,
+            false,
+            false,
+            Arc::new(crate::dialer::DirectDialer),
+        )
     }
 
     fn meta_with_host(host: &str, port: u16) -> Metadata {

--- a/crates/meow-proxy/src/trojan.rs
+++ b/crates/meow-proxy/src/trojan.rs
@@ -50,12 +50,19 @@ pub struct TrojanAdapter {
     support_udp: bool,
     health: ProxyHealth,
     tls_layer: Arc<TlsLayer>,
+    /// Pluggable TCP dialer for the underlying connection to the proxy
+    /// server (direct or via dialer-proxy).
+    dialer: Arc<dyn crate::dialer::TcpDialer>,
     /// sing-mux compatible connection multiplexing (optional).
     #[cfg(feature = "mux")]
     mux: Option<Arc<MuxClient>>,
 }
 
 impl TrojanAdapter {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "dialer param for pluggable TcpDialer"
+    )]
     pub fn new(
         name: &str,
         server: &str,
@@ -64,6 +71,7 @@ impl TrojanAdapter {
         sni: &str,
         skip_verify: bool,
         udp: bool,
+        dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Self {
         // SHA-224 hash of password, hex-encoded = 56 chars.
         let mut hasher = Sha224::new();
@@ -91,6 +99,7 @@ impl TrojanAdapter {
             port,
             addr_str: SmolStr::from(format!("{server}:{port}")),
             hex_password: SmolStr::from(hex_password),
+            dialer,
             support_udp: udp,
             health: ProxyHealth::new(),
             tls_layer: Arc::new(tls_layer),
@@ -111,11 +120,13 @@ impl TrojanAdapter {
         let port = self.port;
         let hex_password = self.hex_password.clone();
         let tls_layer = Arc::clone(&self.tls_layer);
+        let dialer = Arc::clone(&self.dialer);
 
         let dial: crate::mux::DialFn = Arc::new(move || {
             let server = server.clone();
             let hex_password = hex_password.clone();
             let tls_layer = Arc::clone(&tls_layer);
+            let dialer = Arc::clone(&dialer);
             Box::pin(async move {
                 // Build the mux-destination request header.
                 let mut hdr_buf = [0u8; TROJAN_HEADER_BUF_SIZE];
@@ -140,11 +151,9 @@ impl TrojanAdapter {
                 pos += 2;
                 let header = &hdr_buf[..pos];
 
-                let tcp = meow_common::connect_tcp_host(&server, port)
-                    .await
-                    .map_err(MeowError::Io)?;
+                let tcp = dialer.dial(&server, port).await.map_err(MeowError::Io)?;
                 let mut stream = tls_layer
-                    .connect(Box::new(tcp))
+                    .connect(tcp)
                     .await
                     .map_err(transport_to_proxy_err)?;
                 stream.write_all(header).await.map_err(MeowError::Io)?;
@@ -184,13 +193,15 @@ impl TrojanAdapter {
         let mut hdr_buf = [0u8; TROJAN_HEADER_BUF_SIZE];
         let header = self.build_header(metadata, cmd, &mut hdr_buf)?;
 
-        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+        let tcp = self
+            .dialer
+            .dial(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
 
         let mut stream = self
             .tls_layer
-            .connect(Box::new(tcp))
+            .connect(tcp)
             .await
             .map_err(transport_to_proxy_err)?;
 
@@ -580,8 +591,16 @@ mod tests {
 
     #[test]
     fn build_header_accepts_max_length_domain() {
-        let adapter =
-            TrojanAdapter::new("t", "127.0.0.1", 443, "secret", "example.com", true, false);
+        let adapter = TrojanAdapter::new(
+            "t",
+            "127.0.0.1",
+            443,
+            "secret",
+            "example.com",
+            true,
+            false,
+            std::sync::Arc::new(crate::dialer::DirectDialer),
+        );
         let md = Metadata {
             host: "a".repeat(MAX_DOMAIN_LEN).into(),
             dst_port: 443,
@@ -599,8 +618,16 @@ mod tests {
 
     #[test]
     fn build_header_rejects_overlong_domain_without_panic() {
-        let adapter =
-            TrojanAdapter::new("t", "127.0.0.1", 443, "secret", "example.com", true, false);
+        let adapter = TrojanAdapter::new(
+            "t",
+            "127.0.0.1",
+            443,
+            "secret",
+            "example.com",
+            true,
+            false,
+            std::sync::Arc::new(crate::dialer::DirectDialer),
+        );
         let md = Metadata {
             host: "a".repeat(MAX_DOMAIN_LEN + 1).into(),
             dst_port: 443,

--- a/crates/meow-proxy/src/v2ray_plugin.rs
+++ b/crates/meow-proxy/src/v2ray_plugin.rs
@@ -143,6 +143,7 @@ pub async fn dial(
     tls_layer: Option<&TlsLayer>,
     server_host: &str,
     server_port: u16,
+    dialer: &dyn crate::dialer::TcpDialer,
 ) -> Result<Box<dyn meow_transport::Stream>> {
     let host_header = if cfg.host.is_empty() {
         server_host.to_string()
@@ -156,9 +157,11 @@ pub async fn dial(
     );
 
     // 1) Raw TCP.
-    let tcp = meow_common::connect_tcp_host(server_host, server_port)
+    let tcp = dialer
+        .dial(server_host, server_port)
         .await
         .map_err(MeowError::Io)?;
+
 
     // 2) Optional TLS handshake via the pre-built TlsLayer.
     let stream: Box<dyn meow_transport::Stream> = if let Some(tls) = tls_layer {

--- a/crates/meow-proxy/src/v2ray_plugin.rs
+++ b/crates/meow-proxy/src/v2ray_plugin.rs
@@ -162,7 +162,6 @@ pub async fn dial(
         .await
         .map_err(MeowError::Io)?;
 
-
     // 2) Optional TLS handshake via the pre-built TlsLayer.
     let stream: Box<dyn meow_transport::Stream> = if let Some(tls) = tls_layer {
         tls.connect(Box::new(tcp))

--- a/crates/meow-proxy/src/vless_adapter.rs
+++ b/crates/meow-proxy/src/vless_adapter.rs
@@ -58,6 +58,7 @@ pub struct VlessAdapter {
     flow: Option<VlessFlow>,
     udp: bool,
     transport: Arc<TransportChain>,
+    dialer: Arc<dyn crate::dialer::TcpDialer>,
     /// sing-mux compatible connection multiplexing (optional).
     #[cfg(feature = "mux")]
     mux: Option<Arc<MuxClient>>,
@@ -74,6 +75,10 @@ impl VlessAdapter {
     /// `uuid_bytes` — 16-byte binary UUID.
     /// `transport`  — pre-built chain (TLS, WS, etc.).
     /// `flow`       — None for plain VLESS, Some(XtlsRprxVision) for Vision.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "dialer param for pluggable TcpDialer"
+    )]
     pub fn new(
         name: &str,
         server: &str,
@@ -82,6 +87,7 @@ impl VlessAdapter {
         flow: Option<VlessFlow>,
         udp: bool,
         transport: TransportChain,
+        dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Self {
         Self {
             name: SmolStr::from(name),
@@ -92,6 +98,7 @@ impl VlessAdapter {
             flow,
             udp,
             transport: Arc::new(transport),
+            dialer,
             #[cfg(feature = "mux")]
             mux: None,
             #[cfg(feature = "vless-encryption")]
@@ -119,6 +126,7 @@ impl VlessAdapter {
         let uuid_bytes = self.uuid_bytes;
         let transport = StdArc::clone(&self.transport);
         let flow = self.flow;
+        let dialer = Arc::clone(&self.dialer);
         let protocol = options.protocol;
         #[cfg(feature = "vless-encryption")]
         let encryption = self.encryption.clone();
@@ -126,13 +134,12 @@ impl VlessAdapter {
         let dial: crate::mux::DialFn = StdArc::new(move || {
             let server = server.clone();
             let transport = StdArc::clone(&transport);
+            let dialer = Arc::clone(&dialer);
             #[cfg(feature = "vless-encryption")]
             let encryption = encryption.clone();
             Box::pin(async move {
-                let tcp = meow_common::connect_tcp_host(&server, port)
-                    .await
-                    .map_err(MeowError::Io)?;
-                let stream = transport.connect(Box::new(tcp)).await?;
+                let stream = dialer.dial(&server, port).await.map_err(MeowError::Io)?;
+                let stream = transport.connect(stream).await?;
                 #[cfg(feature = "vless-encryption")]
                 let stream = match &encryption {
                     Some(encryption) => encryption.handshake(stream).await?,
@@ -211,10 +218,12 @@ impl VlessAdapter {
     /// Dial a raw TCP + transport-chain stream to the VLESS server, then run the
     /// VLESS Encryption handshake if one is configured.
     async fn dial_stream(&self) -> Result<Box<dyn meow_transport::Stream>> {
-        let tcp = meow_common::connect_tcp_host(&self.server, self.port)
+        let stream = self
+            .dialer
+            .dial(&self.server, self.port)
             .await
             .map_err(MeowError::Io)?;
-        let stream = self.transport.connect(Box::new(tcp)).await?;
+        let stream = self.transport.connect(stream).await?;
         #[cfg(feature = "vless-encryption")]
         if let Some(encryption) = &self.encryption {
             return encryption.handshake(stream).await;
@@ -362,6 +371,7 @@ impl ProxyAdapter for VlessAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dialer::DirectDialer;
     use meow_common::AdapterType;
 
     fn make_adapter(flow: Option<VlessFlow>, udp: bool) -> VlessAdapter {
@@ -373,6 +383,7 @@ mod tests {
             flow,
             udp,
             TransportChain::empty(),
+            Arc::new(DirectDialer),
         )
     }
 
@@ -417,7 +428,16 @@ mod tests {
         let tls_cfg = TlsConfig::new("example.com");
         let tls_layer = TlsLayer::new(&tls_cfg).expect("TlsLayer");
         chain.push(Box::new(tls_layer));
-        let a = VlessAdapter::new("t", "127.0.0.1", 1, [0u8; 16], None, false, chain);
+        let a = VlessAdapter::new(
+            "t",
+            "127.0.0.1",
+            1,
+            [0u8; 16],
+            None,
+            false,
+            chain,
+            Arc::new(DirectDialer),
+        );
         assert_eq!(a.transport.len(), 1, "TLS-only chain must have 1 layer");
     }
 
@@ -437,7 +457,16 @@ mod tests {
             })
             .expect("WsLayer::new"),
         ));
-        let a = VlessAdapter::new("t", "127.0.0.1", 1, [0u8; 16], None, false, chain);
+        let a = VlessAdapter::new(
+            "t",
+            "127.0.0.1",
+            1,
+            [0u8; 16],
+            None,
+            false,
+            chain,
+            Arc::new(DirectDialer),
+        );
         assert_eq!(a.transport.len(), 2, "TLS+WS chain must have 2 layers");
     }
 

--- a/crates/meow-proxy/src/vmess/mod.rs
+++ b/crates/meow-proxy/src/vmess/mod.rs
@@ -23,6 +23,7 @@ pub struct VmessAdapter {
     security: Security,
     udp: bool,
     transport: Arc<TransportChain>,
+    dialer: Arc<dyn crate::dialer::TcpDialer>,
     health: ProxyHealth,
     /// sing-mux compatible connection multiplexing (optional).
     #[cfg(feature = "mux")]
@@ -30,6 +31,10 @@ pub struct VmessAdapter {
 }
 
 impl VmessAdapter {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "dialer param for pluggable TcpDialer"
+    )]
     pub fn new(
         name: &str,
         server: &str,
@@ -38,6 +43,7 @@ impl VmessAdapter {
         security: Security,
         udp: bool,
         transport: TransportChain,
+        dialer: Arc<dyn crate::dialer::TcpDialer>,
     ) -> Self {
         Self {
             name: SmolStr::from(name),
@@ -48,6 +54,7 @@ impl VmessAdapter {
             security,
             udp,
             transport: Arc::new(transport),
+            dialer,
             health: ProxyHealth::new(),
             #[cfg(feature = "mux")]
             mux: None,
@@ -76,10 +83,12 @@ impl VmessAdapter {
         let security = self.security;
         let port = self.port;
         let protocol = options.protocol;
+        let dialer = Arc::clone(&self.dialer);
 
         let dial: crate::mux::DialFn = StdArc::new(move || {
             let transport = Arc::clone(&transport);
             let server = server.clone();
+            let dialer = Arc::clone(&dialer);
             Box::pin(async move {
                 let sealed = match protocol {
                     crate::mux::Protocol::MuxCool => {
@@ -95,7 +104,7 @@ impl VmessAdapter {
                     }
                 }
                 .map_err(MeowError::Proxy)?;
-                dial_vmess(&transport, &server, port, sealed, security).await
+                dial_vmess(&transport, &server, port, dialer.as_ref(), sealed, security).await
             })
         });
         self.mux = Some(MuxClient::new(dial, options));
@@ -112,6 +121,7 @@ impl VmessAdapter {
             &self.transport,
             &self.server,
             self.port,
+            self.dialer.as_ref(),
             sealed,
             self.security,
         )
@@ -127,17 +137,15 @@ async fn dial_vmess(
     transport: &TransportChain,
     server: &str,
     port: u16,
+    dialer: &dyn crate::dialer::TcpDialer,
     sealed: header::SealedHeader,
     security: Security,
 ) -> Result<Box<dyn ProxyConn>> {
     use tokio::io::AsyncWriteExt;
 
-    let tcp = meow_common::connect_tcp_host(server, port)
-        .await
-        .map_err(MeowError::Io)?;
-    let _ = tcp.set_nodelay(true);
+    let stream = dialer.dial(server, port).await.map_err(MeowError::Io)?;
     let mut stream = transport
-        .connect(Box::new(tcp))
+        .connect(stream)
         .await
         .map_err(|e| MeowError::Proxy(format!("vmess transport: {e}")))?;
 

--- a/crates/meow-proxy/tests/http_adapter_integration.rs
+++ b/crates/meow-proxy/tests/http_adapter_integration.rs
@@ -8,8 +8,10 @@
 
 use base64::Engine as _;
 use meow_common::{ConnType, MeowError, Metadata, Network, ProxyAdapter};
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::HttpAdapter;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::{timeout, Duration};
@@ -147,7 +149,16 @@ fn metadata_for(target: SocketAddr) -> Metadata {
 async fn connect_no_auth_round_trips_payload_to_echo() {
     let (echo, _h_echo) = start_echo().await;
     let (proxy, _h_proxy) = start_proxy(None).await;
-    let adapter = HttpAdapter::new("p", "127.0.0.1", proxy.port(), None, false, false, vec![]);
+    let adapter = HttpAdapter::new(
+        "p",
+        "127.0.0.1",
+        proxy.port(),
+        None,
+        false,
+        false,
+        vec![],
+        Arc::new(DirectDialer),
+    );
 
     let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
@@ -176,6 +187,7 @@ async fn connect_with_correct_basic_auth_succeeds() {
         false,
         false,
         vec![],
+        Arc::new(DirectDialer),
     );
     let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
@@ -202,6 +214,7 @@ async fn connect_with_wrong_password_returns_proxy_auth_failed() {
         false,
         false,
         vec![],
+        Arc::new(DirectDialer),
     );
     let err = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
@@ -219,7 +232,16 @@ async fn connect_with_missing_auth_header_when_required_returns_proxy_auth_faile
     let (echo, _e) = start_echo().await;
     let (proxy, _p) = start_proxy(Some(("u", "secret"))).await;
     // Adapter dialled WITHOUT credentials at all.
-    let adapter = HttpAdapter::new("p", "127.0.0.1", proxy.port(), None, false, false, vec![]);
+    let adapter = HttpAdapter::new(
+        "p",
+        "127.0.0.1",
+        proxy.port(),
+        None,
+        false,
+        false,
+        vec![],
+        Arc::new(DirectDialer),
+    );
     let err = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
         .expect("dial timed out")
@@ -236,7 +258,16 @@ async fn connect_to_unreachable_target_returns_http_connect_failed() {
     // Proxy will try to dial port 1 on a localhost address that nothing listens on
     // → respond 502. Adapter must surface that as `HttpConnectFailed(502)`.
     let (proxy, _p) = start_proxy(None).await;
-    let adapter = HttpAdapter::new("p", "127.0.0.1", proxy.port(), None, false, false, vec![]);
+    let adapter = HttpAdapter::new(
+        "p",
+        "127.0.0.1",
+        proxy.port(),
+        None,
+        false,
+        false,
+        vec![],
+        Arc::new(DirectDialer),
+    );
     // Pick a SocketAddr the proxy can't reach (high random ephemeral whose
     // listener we never opened). Using IP literal so the adapter doesn't try
     // its own DNS.
@@ -301,6 +332,7 @@ async fn connect_extra_headers_are_sent_to_proxy() {
         false,
         false,
         vec![("X-Test".into(), "abc123".into())],
+        Arc::new(DirectDialer),
     );
     let _ = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await

--- a/crates/meow-proxy/tests/shadowsocks_integration.rs
+++ b/crates/meow-proxy/tests/shadowsocks_integration.rs
@@ -5,9 +5,11 @@
 //! Tests are skipped automatically if `ssserver` is not available.
 
 use meow_common::{Metadata, Network, ProxyAdapter};
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::ShadowsocksAdapter;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::Stdio;
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, UdpSocket};
 use tokio::process::{Child, Command};
@@ -230,6 +232,7 @@ async fn test_ss_tcp_relay() {
         false,
         None,
         None,
+        Arc::new(DirectDialer),
     )
     .unwrap();
 
@@ -292,6 +295,7 @@ async fn test_ss_udp_relay() {
         true,
         None,
         None,
+        Arc::new(DirectDialer),
     )
     .unwrap();
 
@@ -363,6 +367,7 @@ async fn test_ss_tcp_relay_with_obfs_plugin() {
         false,
         Some("obfs-local"),
         Some("obfs=http"),
+        Arc::new(DirectDialer),
     )
     .expect("failed to create adapter with obfs-local plugin");
 
@@ -438,6 +443,7 @@ async fn test_ss_tcp_relay_with_builtin_obfs_http() {
         false,
         Some("obfs"),
         Some("mode=http;host=bing.com"),
+        Arc::new(DirectDialer),
     )
     .expect("failed to create adapter with built-in obfs http");
 
@@ -502,6 +508,7 @@ async fn test_ss_tcp_relay_with_builtin_obfs_tls() {
         false,
         Some("obfs"),
         Some("mode=tls;host=cloudflare.com"),
+        Arc::new(DirectDialer),
     )
     .expect("failed to create adapter with built-in obfs tls");
 

--- a/crates/meow-proxy/tests/snell_integration.rs
+++ b/crates/meow-proxy/tests/snell_integration.rs
@@ -6,6 +6,7 @@
 //! accepted `TcpStream` speaks the server side. No external binaries required.
 
 use meow_common::{MeowError, Metadata, Network, ProxyAdapter};
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::snell::protocol::{
     write_header, AppError, Snell, COMMAND_CONNECT, COMMAND_CONNECT_V2, COMMAND_UDP,
     COMMAND_UDP_FORWARD, HEADER_VERSION, RESPONSE_ERROR, RESPONSE_TUNNEL,
@@ -326,6 +327,7 @@ fn make_adapter_with_version(
         version,
         udp,
         reuse,
+        Arc::new(DirectDialer),
     )
     .expect("adapter config must be valid")
 }
@@ -855,7 +857,8 @@ fn constructor_rejects_bad_config() {
             SnellObfs::None,
             SnellVersion::V4,
             false,
-            false
+            false,
+            Arc::new(DirectDialer),
         )
         .is_err(),
         "empty psk must be rejected"
@@ -869,7 +872,8 @@ fn constructor_rejects_bad_config() {
             SnellObfs::None,
             SnellVersion::V4,
             false,
-            false
+            false,
+            Arc::new(DirectDialer),
         )
         .is_err(),
         "port 0 must be rejected"
@@ -883,7 +887,8 @@ fn constructor_rejects_bad_config() {
             SnellObfs::None,
             SnellVersion::V4,
             false,
-            false
+            false,
+            Arc::new(DirectDialer),
         )
         .is_err(),
         "empty server must be rejected"

--- a/crates/meow-proxy/tests/snell_server_docker_integration.rs
+++ b/crates/meow-proxy/tests/snell_server_docker_integration.rs
@@ -1,11 +1,13 @@
 #![cfg(feature = "snell")]
 
 use meow_common::{Metadata, Network, ProxyAdapter, ProxyPacketConn};
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::{SnellAdapter, SnellObfs, SnellVersion};
 use std::fs::File;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, UdpSocket};
@@ -229,6 +231,7 @@ fn adapter(port: u16) -> SnellAdapter {
         SnellVersion::V3,
         true,
         false,
+        Arc::new(DirectDialer),
     )
     .expect("snell adapter must build")
 }

--- a/crates/meow-proxy/tests/snell_smoke.rs
+++ b/crates/meow-proxy/tests/snell_smoke.rs
@@ -12,8 +12,10 @@
 #![cfg(feature = "snell")]
 
 use meow_common::{Metadata, Network, ProxyAdapter};
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::{SnellAdapter, SnellObfs, SnellVersion};
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -166,6 +168,7 @@ async fn snell_dial_real_server() {
         version,
         udp,
         reuse,
+        Arc::new(DirectDialer),
     )
     .expect("snell adapter config");
     let metadata = Metadata {

--- a/crates/meow-proxy/tests/socks5_adapter_integration.rs
+++ b/crates/meow-proxy/tests/socks5_adapter_integration.rs
@@ -5,8 +5,10 @@
 //! No TLS — the adapter's TLS-wrap branch is covered by source-level units.
 
 use meow_common::{ConnType, MeowError, Metadata, Network, ProxyAdapter};
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::Socks5Adapter;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::{timeout, Duration};
@@ -210,7 +212,15 @@ fn metadata_for_host(host: &str, port: u16) -> Metadata {
 async fn no_auth_tunnel_round_trips_through_echo() {
     let (echo, _e) = start_echo().await;
     let (s5, _h) = start_socks5(AuthPolicy::None).await;
-    let adapter = Socks5Adapter::new("p", "127.0.0.1", s5.port(), None, false, false);
+    let adapter = Socks5Adapter::new(
+        "p",
+        "127.0.0.1",
+        s5.port(),
+        None,
+        false,
+        false,
+        Arc::new(DirectDialer),
+    );
     let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
         .expect("dial timed out")
@@ -235,6 +245,7 @@ async fn correct_userpass_succeeds_and_tunnels() {
         Some(("alice".into(), "p@ss".into())),
         false,
         false,
+        Arc::new(DirectDialer),
     );
     let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
@@ -260,6 +271,7 @@ async fn wrong_password_fails_with_proxy_auth_failed() {
         Some(("alice".into(), "wrong".into())),
         false,
         false,
+        Arc::new(DirectDialer),
     );
     let err = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
@@ -279,7 +291,15 @@ async fn missing_auth_to_authed_server_fails() {
     // succeed.
     let (echo, _e) = start_echo().await;
     let (s5, _h) = start_socks5(AuthPolicy::UserPass("alice", "p")).await;
-    let adapter = Socks5Adapter::new("p", "127.0.0.1", s5.port(), None, false, false);
+    let adapter = Socks5Adapter::new(
+        "p",
+        "127.0.0.1",
+        s5.port(),
+        None,
+        false,
+        false,
+        Arc::new(DirectDialer),
+    );
     let res = timeout(TIMEOUT, adapter.dial_tcp(&metadata_for(echo)))
         .await
         .expect("dial timed out");
@@ -291,7 +311,15 @@ async fn unreachable_target_surfaces_proxy_error() {
     // Server can speak SOCKS5 but the target it tries to dial is closed →
     // SOCKS5 reply rep=0x05 (connection refused). Adapter must not return Ok.
     let (s5, _h) = start_socks5(AuthPolicy::None).await;
-    let adapter = Socks5Adapter::new("p", "127.0.0.1", s5.port(), None, false, false);
+    let adapter = Socks5Adapter::new(
+        "p",
+        "127.0.0.1",
+        s5.port(),
+        None,
+        false,
+        false,
+        Arc::new(DirectDialer),
+    );
     // High port nothing listens on (claim+drop trick).
     let dead = {
         let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -312,7 +340,15 @@ async fn hostname_atyp_03_is_sent_when_dst_ip_absent() {
     // ("localhost") itself.
     let (echo, _e) = start_echo().await;
     let (s5, _h) = start_socks5(AuthPolicy::None).await;
-    let adapter = Socks5Adapter::new("p", "127.0.0.1", s5.port(), None, false, false);
+    let adapter = Socks5Adapter::new(
+        "p",
+        "127.0.0.1",
+        s5.port(),
+        None,
+        false,
+        false,
+        Arc::new(DirectDialer),
+    );
     let mut conn = timeout(
         TIMEOUT,
         adapter.dial_tcp(&metadata_for_host("localhost", echo.port())),

--- a/crates/meow-proxy/tests/trojan_integration.rs
+++ b/crates/meow-proxy/tests/trojan_integration.rs
@@ -336,6 +336,7 @@ async fn test_trojan_tcp_relay() {
         "localhost", // SNI
         true,        // skip_verify
         false,       // udp
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
     );
 
     // Build metadata pointing to the echo server
@@ -391,6 +392,7 @@ async fn test_trojan_tcp_large_payload() {
         "localhost",
         true,
         false,
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
     );
 
     let metadata = Metadata {
@@ -454,6 +456,7 @@ async fn test_trojan_udp_echo() {
         "localhost",
         true,
         true,
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
     );
 
     // The CMD=0x03 header carries a placeholder destination (the echo server),
@@ -514,6 +517,7 @@ async fn test_trojan_udp_multi_destination() {
         "localhost",
         true,
         true,
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
     );
 
     let metadata = Metadata {
@@ -564,6 +568,7 @@ async fn test_trojan_udp_disabled_returns_not_supported() {
         "localhost",
         true,
         false,
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer),
     );
 
     let metadata = Metadata {

--- a/crates/meow-proxy/tests/v2ray_plugin_integration.rs
+++ b/crates/meow-proxy/tests/v2ray_plugin_integration.rs
@@ -16,10 +16,12 @@
 //!      `skip-cert-verify=true` on the client.
 
 use meow_common::{Metadata, Network, ProxyAdapter};
+use meow_proxy::dialer::DirectDialer;
 use meow_proxy::ShadowsocksAdapter;
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::Stdio;
+use std::sync::Arc;
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -209,6 +211,7 @@ async fn test_ss_v2ray_plugin_websocket_mux() {
         false,
         Some("v2ray-plugin"),
         Some("mode=websocket;mux=1;host=example.com;path=/ws"),
+        Arc::new(DirectDialer),
     )
     .expect("failed to create adapter with built-in v2ray-plugin");
 
@@ -249,6 +252,7 @@ async fn test_ss_v2ray_plugin_tls_websocket_mux() {
         false,
         Some("v2ray-plugin"),
         Some("mode=websocket;tls;mux=1;host=example.com;path=/ws;skip-cert-verify=true"),
+        Arc::new(DirectDialer),
     )
     .expect("failed to create adapter with built-in v2ray-plugin (tls)");
 

--- a/crates/meow-proxy/tests/vless_integration.rs
+++ b/crates/meow-proxy/tests/vless_integration.rs
@@ -12,6 +12,7 @@
 #[cfg(feature = "vless")]
 mod vless_tests {
     use meow_common::{Metadata, Network, ProxyAdapter};
+    use meow_proxy::dialer::DirectDialer;
     use meow_proxy::{TransportChain, VlessAdapter};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
@@ -227,6 +228,7 @@ mod vless_tests {
             None,
             false,
             TransportChain::empty(),
+            Arc::new(DirectDialer),
         );
 
         let metadata = Metadata {
@@ -268,6 +270,7 @@ mod vless_tests {
             None,
             false,
             TransportChain::empty(),
+            Arc::new(DirectDialer),
         );
 
         let metadata = Metadata {
@@ -310,6 +313,7 @@ mod vless_tests {
             None,
             false,
             TransportChain::empty(),
+            Arc::new(DirectDialer),
         ));
 
         let mut handles = Vec::new();
@@ -364,6 +368,7 @@ mod vless_tests {
             None,
             false,
             TransportChain::empty(),
+            Arc::new(DirectDialer),
         );
 
         let metadata = Metadata {
@@ -419,6 +424,7 @@ mod vless_tests {
             None,
             false,
             TransportChain::empty(),
+            Arc::new(DirectDialer),
         );
 
         let metadata = Metadata {
@@ -483,6 +489,7 @@ mod vless_tests {
             None,
             false,
             TransportChain::empty(),
+            Arc::new(DirectDialer),
         );
 
         let metadata = Metadata {

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -241,7 +241,7 @@ Upstream config keys documented at https://wiki.metacubex.one/. Checking `crates
 
 ### Supported
 
-`port`, `socks-port`, `mixed-port`, `allow-lan`, `bind-address`, `mode`, `log-level`, `ipv6`, `external-controller`, `secret`, `external-ui` / `external-ui-name` (serves a static third-party dashboard at `/ui`; `external-ui-url` is parsed but auto-download is not performed), `dns`, `proxies`, `proxy-groups`, `rules`, `rule-providers`, `tproxy-port`, `tproxy-sni`, `routing-mark`, and the custom `subscriptions`. Per-outbound `dialer-proxy` (chained dialing via any proxy/group, TCP) is supported on every outbound type.
+`port`, `socks-port`, `mixed-port`, `allow-lan`, `bind-address`, `mode`, `log-level`, `ipv6`, `external-controller`, `secret`, `external-ui` / `external-ui-name` (serves a static third-party dashboard at `/ui`; `external-ui-url` is parsed but auto-download is not performed), `dns`, `proxies`, `proxy-groups`, `rules`, `rule-providers`, `tproxy-port`, `tproxy-sni`, `routing-mark`, and the custom `subscriptions`. Per-outbound `dialer-proxy` (chained dialing via any proxy/group, TCP) is supported on the stream-based outbound types — `ss`, `trojan`, `vless`, `vmess`, `snell`, `http`, `socks5` — where an injected `TcpDialer` carries the adapter's own handshake. `anytls` and `hysteria2` own their transport (QUIC) and do not honour it; nor does `ss` with an external SIP003 plugin. Those fall back to the relay-based wrapper, which fails loudly rather than dialing direct. UDP over a raw socket (Shadowsocks plain relay, SOCKS5 UDP ASSOCIATE) is refused instead of leaking; mux-carried UDP traverses the chain. See [the migration guide](migration-from-go-mihomo.md) for details.
 
 ### Missing top-level keys (gaps)
 

--- a/docs/migration-from-go-mihomo.md
+++ b/docs/migration-from-go-mihomo.md
@@ -638,10 +638,20 @@ The following are unsupported or intentionally rejected:
   of static files and it is served at `/ui` in place of the built-in dashboard.
   You must download/extract the dashboard yourself; the zip is not fetched
   automatically (avoids an unzip dependency against the binary-size caps).
-- **`dialer-proxy` UDP** — the per-outbound `dialer-proxy` field is supported for
-  TCP on every outbound (chained dialing through any proxy/group, with cycle
-  detection). UDP is not routed through the dialer; such associations are
-  refused rather than leaking the real source path.
+- **`dialer-proxy`** — supported for TCP via an injected `TcpDialer`, so the
+  outbound's own TLS/Reality/protocol handshake runs on the tunneled stream
+  (mihomo's `proxyDialer` model). Chains through any proxy or group and nests,
+  with cycle detection. Two carve-outs:
+  - *Adapter types that own their transport* — `anytls` and `hysteria2` (QUIC)
+    do not dial through the pluggable dialer, and `ss` with an **external**
+    SIP003 plugin always reaches that plugin over loopback. These fall back to
+    the relay-based wrapper, which works only where `connect_over` is
+    implemented (`http`, `socks5`, `snell` without TLS) and otherwise fails
+    loudly at dial time. It never degrades to a silent direct dial.
+  - *UDP* — associations whose datagrams ride a raw socket cannot follow the TCP
+    chain (Shadowsocks plain relay, SOCKS5 UDP ASSOCIATE) and are refused
+    rather than leaking the real source path. UDP carried inside a mux session
+    (`smux`/`yamux`/`h2mux`) does traverse the chain and keeps working.
 
 ---
 


### PR DESCRIPTION
# feat: pluggable TcpDialer for dialer-proxy chaining (Phase 1)

Closes #474

## Summary

Introduce a pluggable dialer model mirroring mihomo's `C.Dialer` / `proxyDialer` architecture. Each TCP-based adapter now holds an `Arc<dyn TcpDialer>` and calls `dialer.dial()` instead of `connect_tcp_host()` directly. When `dialer-proxy` is configured, a `ProxyDialer` is injected that tunnels through another proxy — making chaining transparent to the adapter's TLS + protocol handshake.

This fixes the fundamental limitation of the existing `DialerProxyAdapter` (relay-based approach): VLESS, Trojan, VMess, and Shadowsocks now work with `dialer-proxy` because the full `dial_stream` (including TLS handshake) runs on the transparently tunneled stream, instead of relying on `connect_over` which these protocols do not implement.

## Changes

### New file

- **`crates/meow-proxy/src/dialer.rs`** — `TcpDialer` trait, `DirectDialer` (default, uses `connect_tcp_host`, sets `TCP_NODELAY`), `ProxyDialer` (tunnels through another proxy via `ProxyConn`), `ConnStream` (bridges `Box<dyn ProxyConn>` → `Stream` for blanket impl).

### Adapter updates (meow-proxy)

| Adapter | Changes |
|---------|---------|
| VLESS | `dial_stream` + mux `DialFn` use `dialer.dial()` |
| Trojan | `open_tls_with_header` + mux `DialFn` use `dialer.dial()` |
| Shadowsocks | All `dial_tcp_stream` branches (obfs, v2ray-plugin, ech-tls-tunnel, none) + `SsCore` mux `DialFn`; `PluginKind::External` bypasses dialer (SIP003 plugins are local) |
| VMess | `dial_vmess` + mux `DialFn` use `dialer.dial()` |
| HTTP | `dial_stream` uses `dialer.dial()` |
| SOCKS5 | `dial_stream` uses `dialer.dial()` |
| Snell | `dial_fresh` uses `dialer.dial()` |
| `v2ray_plugin` | `dial()` accepts `&dyn TcpDialer` |
| `ech_tls_tunnel` | `dial()` accepts `&dyn TcpDialer` |

### Config injection (meow-config)

- `parse_proxy_with_dialer(config, dialer)` threads the dialer into all adapter constructors.
- `parse_proxy()` delegates to `parse_proxy_with_dialer` with `DirectDialer` (zero behavior change).
- `apply_dialer_proxies` re-parses with `ProxyDialer`; falls back to `DialerProxyAdapter` wrapper if re-parsing fails.
- New `is_proxy()` method on `TcpDialer` trait: SS `support_udp()` checks it to prevent UDP traffic leak through dialer-proxy (plain UDP bypasses the TCP tunnel).

### Test updates

- All adapter integration tests updated with `DirectDialer` parameter.
- 2 new `dialer_proxy_tests` in `meow-config`: `re_parse_injects_proxy_dialer_for_real_protocol`, `fallback_wraps_when_re_parse_fails`.

## Design decisions

### Why not keep using `relay_tcp`?

`relay_tcp` calls `connect_over` on the final hop, but `connect_over` is only implemented by HTTP, SOCKS5, and Snell. VLESS, Trojan, VMess, and Shadowsocks use the trait default which returns `Err(NotSupported)`. The relay approach literally cannot work for these protocols — the connection fails before any handshake occurs.

Even for Snell, `connect_over` only writes the protocol header without performing TLS, so Snell with TLS is also broken in the relay path.

The pluggable dialer approach fixes this by injecting `ProxyDialer` at the TCP dial layer, so the adapter's full `dial_stream` (including TLS handshake, Reality exchange, uTLS fingerprinting, ALPN negotiation) runs unchanged on the transparently tunneled stream.

### Why `ConnStream` instead of using `connect_over`?

The `Stream` type is a sized newtype (`Box<dyn Stream>` wrapper) that implements the blanket `Stream` trait. `ProxyConn` is `?Sized`. `ConnStream` bridges `Box<dyn ProxyConn>` → `Stream` so the tunneled connection can be passed to transport layers (TLS, WS, gRPC) that expect `Stream`.

### Why `is_proxy()` on the trait?

SS plain UDP uses a raw socket (`UdpSocket::bind`) that bypasses the TCP dialer entirely. If `dialer-proxy` is configured, UDP packets would leak from the real source IP instead of going through the front proxy. `is_proxy()` returns `true` for `ProxyDialer`, and SS `support_udp()` checks it to disable plain UDP. Mux UDP (which goes over TCP through `dialer.dial()`) is unaffected. VLESS/Trojan/Snell UDP goes through `dialer.dial()` (TCP), so they're unaffected. VMess UDP is not implemented.

### `set_nodelay` placement

`DirectDialer::dial()` calls `set_nodelay(true)` once on the raw TCP stream. `ProxyDialer` correctly does **not** set it — the underlying connection is managed by the front proxy, which should control Nagle's algorithm.

## Backward compatibility

- `parse_proxy()` → `parse_proxy_with_dialer(raw, &DirectDialer)` — existing callers see zero change.
- `DialerProxyAdapter` retained as fallback for configs that can't be re-parsed.
- Existing `relay` group functionality unchanged.

## Test results

```
cargo fmt --all -- --check                         → 0 diffs
cargo clippy --all-targets -- -D warnings          → 0 errors
cargo clippy --all-targets --no-default-features   → 0 errors
cargo clippy --all-targets --all-features          → 0 errors
RUSTDOCFLAGS="-D warnings" cargo doc               → 0 errors
cargo test -p meow-proxy --lib                     → 364 passed, 0 failed
cargo test -p meow-config --lib                    → 198 passed, 0 failed
```

### Integration matrix (37 scenarios, local sing-box)

Tested all protocol × dialer-proxy combinations through a local sing-box server:

- **7 baseline** (direct, no dialer-proxy): SS, SS-chacha20, Trojan, VLESS, VMess, HTTP, SOCKS5
- **22 chained**: each protocol through SOCKS5/SS/HTTP/Trojan/VLESS/VMess dialer-proxy
- **3 nested** (3-level: A → B → C)
- **2 HTTP/1.1** comparison
- **2 error handling** (missing dialer-proxy → fallback to direct; self-reference → fallback)
- **1 UDP safety** (SS `udp: true` + dialer-proxy → TCP works, UDP blocked)

**37/37 passed, 0 failed.**

### Real-world test

Tested by replacing a sing-box `detour` chain (SS → VLESS+Reality) with meow-rs `dialer-proxy`:

- All curl tests pass (gstatic, Google, YouTube, ip.sb)
- 10/10 sequential stability, 5/5 concurrent
- Downloaded 848 MB from GitHub at 3.3 MB/s (server bandwidth capped at 30 Mbps), zip integrity verified, zero errors

## Diffstat

```
23 files changed, 662 insertions(+), 91 deletions(-)
```

1 new file (`dialer.rs`), 22 modified files across `meow-proxy` and `meow-config`.
