### PR TITLE
test(dns): make UDP timeout test hermetic via a silent loopback peer

### DIFF
--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -771,12 +771,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn udp_client_times_out_on_unroutable() {
-        // 192.0.2.1/24 is TEST-NET-1, guaranteed not to respond.
-        let client = DnsClient::udp("192.0.2.1:53".parse().unwrap())
-            .with_timeout(Duration::from_millis(200));
+    async fn udp_client_times_out_when_no_response() {
+        // A silent loopback peer makes the timeout path deterministic
+        // regardless of the host network. Using a "guaranteed unroutable"
+        // address like 192.0.2.1 is non-hermetic: many ISPs/routers hijack
+        // outbound UDP/53 and answer with a spoofed source (Ok/NXDOMAIN) or
+        // return ICMP unreachable (an Io error), so the client never reaches
+        // Timeout.
+        //
+        // The sink is never read and never writes a reply. It only has to stay
+        // bound for the duration of the query: a closed port would yield
+        // ECONNREFUSED on the client's connected socket instead of a timeout.
+        // The client sends a single datagram, so the kernel recv buffer never
+        // fills and no drain task is needed.
+        let sink = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let addr = sink.local_addr().unwrap();
+        let client = DnsClient::udp(addr).with_timeout(Duration::from_millis(200));
         let r = client.query("example.test", RecordType::A).await;
         assert!(matches!(r, Err(ClientError::Timeout(_))));
+        drop(sink);
     }
 
     #[tokio::test]

--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -783,13 +783,14 @@ mod tests {
         // bound for the duration of the query: a closed port would yield
         // ECONNREFUSED on the client's connected socket instead of a timeout.
         // The client sends a single datagram, so the kernel recv buffer never
-        // fills and no drain task is needed.
+        // fills and no drain task is needed. Binding for the whole test scope
+        // covers that; the sink needs no explicit drop at the end — the query
+        // has already completed by then (review low item).
         let sink = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let addr = sink.local_addr().unwrap();
         let client = DnsClient::udp(addr).with_timeout(Duration::from_millis(200));
         let r = client.query("example.test", RecordType::A).await;
         assert!(matches!(r, Err(ClientError::Timeout(_))));
-        drop(sink);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Make the `udp_client_times_out_on_unroutable` unit test hermetic so it no longer depends on the host network silently dropping packets to `192.0.2.1`.

Closes #475.

## Problem

`udp_client_times_out_on_unroutable` queries TEST-NET-1 (`192.0.2.1:53`) with a 200 ms timeout and asserts `Err(ClientError::Timeout(_))`. The test assumes `192.0.2.1` is a silent black hole. On many real networks that assumption is wrong:

- The upstream router/ISP hijacks outbound UDP/53 and answers with its own resolver, spoofing the source IP to the original destination. A direct probe to `192.0.2.1:53` returns a valid NXDOMAIN in ~1 ms, so the test receives `Ok(NXDOMAIN)` and the assertion panics.
- Other hosts get ICMP port-unreachable, producing an `Io` error (also non-Timeout).

Either way a green tree fails `cargo test --lib` purely because of the host network — no code defect. Reproduced on a clean tree via `git stash`.

## Fix

Replace the unroutable address with a bound-but-silent `127.0.0.1` UDP socket that never replies:

```rust
#[tokio::test]
async fn udp_client_times_out_when_no_response() {
    // A silent loopback peer makes the timeout path deterministic
    // regardless of the host network. Using a "guaranteed unroutable"
    // address like 192.0.2.1 is non-hermetic: many ISPs/routers hijack
    // outbound UDP/53 and answer with a spoofed source (Ok/NXDOMAIN) or
    // return ICMP unreachable (an Io error), so the client never reaches
    // Timeout.
    //
    // The sink is never read and never writes a reply. It only has to stay
    // bound for the duration of the query: a closed port would yield
    // ECONNREFUSED on the client's connected socket instead of a timeout.
    // The client sends a single datagram, so the kernel recv buffer never
    // fills and no drain task is needed.
    let sink = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
    let addr = sink.local_addr().unwrap();
    let client = DnsClient::udp(addr).with_timeout(Duration::from_millis(200));
    let r = client.query("example.test", RecordType::A).await;
    assert!(matches!(r, Err(ClientError::Timeout(_))));
    drop(sink);
}
```

Why this shape and not the alternatives:

- **Not `set_socket_factory` injection.** That is a process-global `OnceLock` that can be set only once and never reset; using it in a `#[tokio::test]` (which runs in parallel with the rest of the suite in one process) would be racy and pollute other tests. A local loopback socket is per-test, no global state, safe under parallel execution.
- **No drain task.** The client sends exactly one datagram per query, so the sink's kernel recv buffer never fills. An earlier draft spawned an infinite drain loop that leaked the task + socket until process exit; it was unnecessary and has been removed. The sink's only job is to keep the port bound so the client's connected socket has a live peer (a closed port yields `ECONNREFUSED`, not a timeout).
- **No production-code change.** Downstream (`resolver.rs`) already maps every `ClientError` variant to a unified `LookupFailed`, so `Timeout` vs `Io` make no difference to callers. Mapping ICMP-unreachable to `Timeout` in `udp_exchange` would change product semantics and is out of scope for a test fix.

## Verification

- Target test: 10/10 consecutive runs pass, each ~200 ms (the timeout boundary), confirming determinism with no network jitter.
- `cargo test -p meow-dns --lib`: 138 passed / 0 failed — no regression.
- `cargo clippy -p meow-dns --lib --tests`: clean.
- `cargo fmt -p meow-dns --check`: clean.