### PR TITLE
chore(release): 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "base64",
  "futures",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "meow-lwip"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "bindgen",
  "bytes",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "criterion",
  "proptest",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
-repository = "https://github.com/madeye/meow-rs"
+repository = "https://github.com/meow-rs/meow-rs"
 homepage = "https://madeye.github.io/meow-rs/"
 
 [workspace.lints.clippy]
@@ -128,7 +128,7 @@ tun-rs = { version = "2.8", features = ["async_tokio"] }
 # poll_next UAF / poll_flush deadlock / FIN_WAIT_2 leak / livelock fixes that
 # upstream `lwip` lacks. Registry version, not a `git =` pin — crates.io
 # forbids git deps in a published manifest (see docs/RELEASING.md).
-lwip = { package = "meow-lwip", path = "crates/meow-lwip", version = "0.21.0" }
+lwip = { package = "meow-lwip", path = "crates/meow-lwip", version = "0.21.1" }
 route_manager = "0.2"
 
 # Crypto
@@ -237,16 +237,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.21.0" }
-meow-trie = { path = "crates/meow-trie", version = "0.21.0" }
+meow-common = { path = "crates/meow-common", version = "0.21.1" }
+meow-trie = { path = "crates/meow-trie", version = "0.21.1" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.21.0" }
-meow-dns = { path = "crates/meow-dns", version = "0.21.0", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.21.0" }
-meow-transport = { path = "crates/meow-transport", version = "0.21.0" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.21.0", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.21.0" }
-meow-listener = { path = "crates/meow-listener", version = "0.21.0", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.21.0" }
-meow-config = { path = "crates/meow-config", version = "0.21.0", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.21.1" }
+meow-dns = { path = "crates/meow-dns", version = "0.21.1", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.21.1" }
+meow-transport = { path = "crates/meow-transport", version = "0.21.1" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.21.1", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.21.1" }
+meow-listener = { path = "crates/meow-listener", version = "0.21.1", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.21.1" }
+meow-config = { path = "crates/meow-config", version = "0.21.1", default-features = false }

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,12 +12,12 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
 license = "MIT"
-repository = "https://github.com/madeye/meow-rs"
+repository = "https://github.com/meow-rs/meow-rs"
 homepage = "https://madeye.github.io/meow-rs/"
 readme = "README.md"
 
@@ -26,7 +26,7 @@ name = "anytls_rs"
 path = "src/lib.rs"
 
 [dependencies]
-meow-common = { path = "../meow-common", version = "0.21.0" }
+meow-common = { path = "../meow-common", version = "0.21.1" }
 tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",

--- a/crates/meow-lwip/Cargo.toml
+++ b/crates/meow-lwip/Cargo.toml
@@ -34,7 +34,7 @@ description = "Vendored lwIP TCP/IP stack bindings (madeye fork, single-owner co
 # upstream declares it rather than restating it as the workspace's plain MIT.
 license = "MIT/Apache-2.0"
 authors = ["@ssrlive", "@madeye"]
-repository = "https://github.com/madeye/meow-rs"
+repository = "https://github.com/meow-rs/meow-rs"
 homepage = "https://madeye.github.io/meow-rs/"
 readme = "README.md"
 


### PR DESCRIPTION
Bump the workspace version and in-tree pins from 0.21.0 to 0.21.1 so GitHub Release and crates.io can publish a new version.

- `[workspace.package]` + `[workspace.dependencies]` (including `lwip`/`meow-lwip`)
- `crates/meow-anytls` (does not inherit workspace version)
- `Cargo.lock` refreshed via `cargo update -w`
- crate `repository` metadata now points at https://github.com/meow-rs/meow-rs

Unreleased on `main` since `v0.21.0`: anytls single-TLS-record auth fix + bindgen 0.72 Windows fix.

After merge, tag `v0.21.1` on the merge commit to trigger `Release` and `Publish to crates.io`.