### PR TITLE
chore(release): 0.21.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,7 @@ jobs:
             --test tls_test \
             --test ws_test \
             --test crate_invariants_test \
+            --test crate_publish_metadata_test \
             -- --nocapture
 
       # ADR-0008 allocation-count gates. Release build: the thresholds are
@@ -269,6 +270,7 @@ jobs:
             --test trojan_integration \
             --test tls_test \
             --test ws_test \
+            --test crate_publish_metadata_test \
             -- --nocapture
 
       # TUN inbound tests: `listener-tun` is not a default feature, so the
@@ -306,6 +308,7 @@ jobs:
             --test trojan_integration \
             --test tls_test \
             --test ws_test \
+            --test crate_publish_metadata_test \
             -- --nocapture
 
       # `listener-tun` is not a default feature; this leg runs the tun

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,8 @@ cargo test --lib --bin meow \
   --test config_persistence_test --test systemd_config_test \
   --test trojan_integration --test vless_config_test --test vless_integration \
   --test v2ray_plugin_integration --test pre_resolve_test \
-  --test tls_test --test ws_test --test crate_invariants_test
+  --test tls_test --test ws_test --test crate_invariants_test \
+  --test crate_publish_metadata_test
 ```
 
 Keep the target list in sync with `.github/workflows/test.yml`; a new `tests/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "meow-bench"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "base64",
  "futures",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "meow-lwip"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "bindgen",
  "bytes",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "criterion",
  "ipnet",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "criterion",
  "proptest",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "meow-tunnel"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ debug = 1
 opt-level = 1
 
 [workspace.package]
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
 repository = "https://github.com/meow-rs/meow-rs"
-homepage = "https://madeye.github.io/meow-rs/"
+homepage = "https://meow-rs.github.io/meow-rs/"
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"
@@ -128,7 +128,7 @@ tun-rs = { version = "2.8", features = ["async_tokio"] }
 # poll_next UAF / poll_flush deadlock / FIN_WAIT_2 leak / livelock fixes that
 # upstream `lwip` lacks. Registry version, not a `git =` pin — crates.io
 # forbids git deps in a published manifest (see docs/RELEASING.md).
-lwip = { package = "meow-lwip", path = "crates/meow-lwip", version = "0.21.1" }
+lwip = { package = "meow-lwip", path = "crates/meow-lwip", version = "0.21.2" }
 route_manager = "0.2"
 
 # Crypto
@@ -237,16 +237,16 @@ proptest = "1"
 # Workspace crates
 # default-features = false on feature-gated crates so each consumer controls
 # which optional protocols/listeners are compiled (M2.E feature-flag infra).
-meow-common = { path = "crates/meow-common", version = "0.21.1" }
-meow-trie = { path = "crates/meow-trie", version = "0.21.1" }
+meow-common = { path = "crates/meow-common", version = "0.21.2" }
+meow-trie = { path = "crates/meow-trie", version = "0.21.2" }
 # Vendored anytls fork (lib name `anytls_rs`); optional, pulled in only by
 # meow-proxy's `anytls` feature.
-meow-anytls = { path = "crates/meow-anytls", version = "0.21.1" }
-meow-dns = { path = "crates/meow-dns", version = "0.21.1", default-features = false }
-meow-rules = { path = "crates/meow-rules", version = "0.21.1" }
-meow-transport = { path = "crates/meow-transport", version = "0.21.1" }
-meow-proxy = { path = "crates/meow-proxy", version = "0.21.1", default-features = false }
-meow-tunnel = { path = "crates/meow-tunnel", version = "0.21.1" }
-meow-listener = { path = "crates/meow-listener", version = "0.21.1", default-features = false }
-meow-api = { path = "crates/meow-api", version = "0.21.1" }
-meow-config = { path = "crates/meow-config", version = "0.21.1", default-features = false }
+meow-anytls = { path = "crates/meow-anytls", version = "0.21.2" }
+meow-dns = { path = "crates/meow-dns", version = "0.21.2", default-features = false }
+meow-rules = { path = "crates/meow-rules", version = "0.21.2" }
+meow-transport = { path = "crates/meow-transport", version = "0.21.2" }
+meow-proxy = { path = "crates/meow-proxy", version = "0.21.2", default-features = false }
+meow-tunnel = { path = "crates/meow-tunnel", version = "0.21.2" }
+meow-listener = { path = "crates/meow-listener", version = "0.21.2", default-features = false }
+meow-api = { path = "crates/meow-api", version = "0.21.2" }
+meow-config = { path = "crates/meow-config", version = "0.21.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://madeye.github.io/meow-rs/logo.png" alt="meow-rs — a ginger cat peeking over a wall" width="160">
+  <img src="https://meow-rs.github.io/meow-rs/logo.png" alt="meow-rs — a ginger cat peeking over a wall" width="160">
 </div>
 
 # meow-rs
@@ -321,7 +321,7 @@ tail -f ~/Library/Logs/meow/meow.log
 
 Official `.ipk` packages for aarch64 routers — including a
 `luci-app-meow` that embeds the built-in web panel in LuCI — are attached
-to every [release](https://github.com/madeye/meow-rs/releases). See
+to every [release](https://github.com/meow-rs/meow-rs/releases). See
 [docs/openwrt.md](docs/openwrt.md).
 
 ### Open the Web UI

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -12,13 +12,13 @@
 # dependents' `use anytls_rs::...` paths are unchanged.
 [package]
 name = "meow-anytls"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2024"
 rust-version = "1.89"
 description = "Vendored AnyTLS protocol implementation (madeye fork) for the meow-rs proxy kernel."
 license = "MIT"
 repository = "https://github.com/meow-rs/meow-rs"
-homepage = "https://madeye.github.io/meow-rs/"
+homepage = "https://meow-rs.github.io/meow-rs/"
 readme = "README.md"
 
 [lib]
@@ -26,7 +26,7 @@ name = "anytls_rs"
 path = "src/lib.rs"
 
 [dependencies]
-meow-common = { path = "../meow-common", version = "0.21.1" }
+meow-common = { path = "../meow-common", version = "0.21.2" }
 tokio = { version = "1.48", features = [
     "macros",
     "rt-multi-thread",

--- a/crates/meow-api/src/lib.rs
+++ b/crates/meow-api/src/lib.rs
@@ -1,3 +1,8 @@
+//! REST API server (Axum) for the meow-rs proxy kernel.
+//!
+//! Runtime control of proxies, rules, connections, config, traffic, and DNS,
+//! plus the built-in web dashboard.
+
 pub mod log_stream;
 pub mod routes;
 pub mod ui;

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -7,6 +7,7 @@ description = "A high-performance, rule-based tunneling proxy kernel in Rust, co
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme = "../../README.md"
 keywords = ["proxy", "clash", "mihomo", "vpn", "networking"]
 categories = ["network-programming", "command-line-utilities"]
 

--- a/crates/meow-app/src/lib.rs
+++ b/crates/meow-app/src/lib.rs
@@ -1,3 +1,9 @@
+//! CLI and service helpers for the meow-rs proxy kernel.
+//!
+//! Library surface used by the `meow` binary: systemd unit generation,
+//! geodata fetch, health checks, and subscription refresh. The binary wires
+//! configuration, the tunnel, listeners, DNS, and the REST API together.
+
 pub mod geodata_fetch;
 pub mod health_check;
 pub mod subscription_refresh;

--- a/crates/meow-bench/Cargo.toml
+++ b/crates/meow-bench/Cargo.toml
@@ -2,6 +2,7 @@
 name = "meow-bench"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [[bin]]
 name = "meow-bench"

--- a/crates/meow-common/Cargo.toml
+++ b/crates/meow-common/Cargo.toml
@@ -51,6 +51,7 @@ libc = "0.2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "net"] }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/meow-common/src/lib.rs
+++ b/crates/meow-common/src/lib.rs
@@ -1,3 +1,9 @@
+//! Core traits and types for the meow-rs proxy kernel.
+//!
+//! This is the workspace contract crate: [`ProxyAdapter`], [`Rule`],
+//! [`Metadata`], connection types, and shared error values used by every
+//! other meow crate.
+
 pub mod adapter;
 pub mod adapter_type;
 pub mod atomic;

--- a/crates/meow-common/tests/crate_publish_metadata_test.rs
+++ b/crates/meow-common/tests/crate_publish_metadata_test.rs
@@ -1,0 +1,256 @@
+//! Gates crate metadata and crate-level rustdoc for crates.io / docs.rs.
+//!
+//! Drives `cargo metadata --format-version 1` on the real workspace (not a
+//! re-typed copy of the TOMLs) and reads each publishable crate's library
+//! root from the paths metadata reports.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const EXPECTED_REPOSITORY: &str = "https://github.com/meow-rs/meow-rs";
+const EXPECTED_HOMEPAGE: &str = "https://meow-rs.github.io/meow-rs/";
+
+const PUBLISHABLE: &[&str] = &[
+    "meow-common",
+    "meow-trie",
+    "meow-anytls",
+    "meow-lwip",
+    "meow-transport",
+    "meow-rules",
+    "meow-dns",
+    "meow-proxy",
+    "meow-config",
+    "meow-tunnel",
+    "meow-listener",
+    "meow-api",
+    "meow-app",
+];
+
+const UNPUBLISHED: &[&str] = &["meow-bench"];
+
+fn workspace_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        let toml = dir.join("Cargo.toml");
+        if let Ok(text) = fs::read_to_string(&toml) {
+            if text.contains("[workspace]") && text.contains("members") {
+                return dir;
+            }
+        }
+        assert!(
+            dir.pop(),
+            "workspace root not found walking up from {}",
+            env!("CARGO_MANIFEST_DIR")
+        );
+    }
+}
+
+fn cargo_metadata() -> serde_json::Value {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .current_dir(workspace_root())
+        .output()
+        .expect("failed to spawn cargo metadata");
+    assert!(
+        output.status.success(),
+        "cargo metadata failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("cargo metadata JSON")
+}
+
+fn workspace_packages(meta: &serde_json::Value) -> Vec<&serde_json::Value> {
+    let members: HashSet<&str> = meta["workspace_members"]
+        .as_array()
+        .expect("workspace_members")
+        .iter()
+        .map(|id| id.as_str().expect("workspace member id"))
+        .collect();
+    meta["packages"]
+        .as_array()
+        .expect("packages")
+        .iter()
+        .filter(|pkg| members.contains(pkg["id"].as_str().expect("package id")))
+        .collect()
+}
+
+fn can_publish(pkg: &serde_json::Value) -> bool {
+    match pkg.get("publish") {
+        Some(serde_json::Value::Array(regs)) => !regs.is_empty(),
+        _ => true,
+    }
+}
+
+fn lib_src_path(pkg: &serde_json::Value) -> &Path {
+    let name = pkg["name"].as_str().unwrap();
+    let target = pkg["targets"]
+        .as_array()
+        .expect("targets")
+        .iter()
+        .find(|t| {
+            t["kind"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .any(|k| k.as_str() == Some("lib"))
+        })
+        .unwrap_or_else(|| panic!("{name} has no lib target"));
+    Path::new(target["src_path"].as_str().expect("src_path"))
+}
+
+/// Crate-level rustdoc that rustc will attach to the crate root: a leading
+/// `//!` block, or a leading `#![doc = include_str!("…")]` whose included
+/// file is read from disk.
+fn opening_crate_docs(src_path: &Path) -> String {
+    let src =
+        fs::read_to_string(src_path).unwrap_or_else(|e| panic!("read {}: {e}", src_path.display()));
+    let mut collected = String::new();
+    let mut saw_doc = false;
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            if saw_doc {
+                collected.push('\n');
+            }
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("//!") {
+            saw_doc = true;
+            collected.push_str(rest.strip_prefix(' ').unwrap_or(rest));
+            collected.push('\n');
+            continue;
+        }
+        if trimmed.starts_with("#![doc") {
+            if let Some(rel) = include_str_path(trimmed) {
+                let included = src_path.parent().expect("lib src parent").join(rel);
+                return fs::read_to_string(&included).unwrap_or_else(|e| {
+                    panic!(
+                        "read included rustdoc {} from {}: {e}",
+                        included.display(),
+                        src_path.display()
+                    )
+                });
+            }
+            saw_doc = true;
+            collected.push_str(trimmed);
+            collected.push('\n');
+            continue;
+        }
+        if saw_doc {
+            break;
+        }
+        panic!(
+            "{} must begin with crate-level rustdoc (`//!` or `#![doc = …]`), found: {trimmed}",
+            src_path.display()
+        );
+    }
+    assert!(
+        saw_doc && !collected.trim().is_empty(),
+        "{} has empty crate-level rustdoc",
+        src_path.display()
+    );
+    collected
+}
+
+fn include_str_path(attr: &str) -> Option<&str> {
+    let rest = attr.strip_prefix("#![doc")?;
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix('=')?.trim_start();
+    let rest = rest.strip_prefix("include_str!")?.trim_start();
+    let rest = rest.strip_prefix('(')?.trim_start();
+    let quote = rest.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let inner = rest[1..].split(quote).next()?;
+    Some(inner)
+}
+
+#[test]
+fn publishable_crates_advertise_org_urls() {
+    let meta = cargo_metadata();
+    let packages = workspace_packages(&meta);
+    let mut seen_publishable = HashSet::new();
+    let mut seen_unpublished = HashSet::new();
+
+    for pkg in &packages {
+        let name = pkg["name"].as_str().expect("package name");
+        if UNPUBLISHED.contains(&name) {
+            assert!(
+                !can_publish(pkg),
+                "{name} must stay unpublished (`publish = false`)"
+            );
+            seen_unpublished.insert(name);
+            continue;
+        }
+        assert!(
+            PUBLISHABLE.contains(&name),
+            "{name} is a workspace member that can publish but is not in the 13-crate crates.io set"
+        );
+        assert!(
+            can_publish(pkg),
+            "{name} is a publishable crate but cargo metadata reports publish disabled"
+        );
+        assert_eq!(
+            pkg["repository"].as_str(),
+            Some(EXPECTED_REPOSITORY),
+            "{name} repository"
+        );
+        assert_eq!(
+            pkg["homepage"].as_str(),
+            Some(EXPECTED_HOMEPAGE),
+            "{name} homepage"
+        );
+        seen_publishable.insert(name);
+    }
+
+    for name in PUBLISHABLE {
+        assert!(
+            seen_publishable.contains(name),
+            "{name} missing from cargo metadata workspace packages"
+        );
+    }
+    for name in UNPUBLISHED {
+        assert!(
+            seen_unpublished.contains(name),
+            "{name} missing from cargo metadata workspace packages"
+        );
+    }
+    assert_eq!(seen_publishable.len(), PUBLISHABLE.len());
+}
+
+#[test]
+fn publishable_library_roots_have_crate_level_rustdoc() {
+    let meta = cargo_metadata();
+    let packages = workspace_packages(&meta);
+    let mut checked = HashSet::new();
+
+    for pkg in &packages {
+        let name = pkg["name"].as_str().expect("package name");
+        if !PUBLISHABLE.contains(&name) {
+            continue;
+        }
+        let src_path = lib_src_path(pkg);
+        let docs = opening_crate_docs(src_path);
+        assert!(
+            !docs.trim().is_empty(),
+            "{name} crate-level rustdoc at {} is empty",
+            src_path.display()
+        );
+        eprintln!(
+            "{name}: crate-level rustdoc from {} ({} bytes)",
+            src_path.display(),
+            docs.len()
+        );
+        checked.insert(name);
+    }
+
+    for name in PUBLISHABLE {
+        assert!(
+            checked.contains(name),
+            "{name} missing from cargo metadata workspace packages"
+        );
+    }
+}

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -1,3 +1,8 @@
+//! YAML configuration parsing for the meow-rs proxy kernel.
+//!
+//! Turns a Clash Meta-style `config.yaml` into typed structs consumed by
+//! the tunnel, listeners, DNS, and API.
+
 pub mod auth;
 pub mod dns_parser;
 pub mod ech_dns;

--- a/crates/meow-dns/src/lib.rs
+++ b/crates/meow-dns/src/lib.rs
@@ -1,3 +1,8 @@
+//! DNS resolver, cache, snooping, and FakeIP for the meow-rs proxy kernel.
+//!
+//! Caching resolver with IP-to-domain reverse mapping, optional FakeIP
+//! allocation, and a DNS server used by transparent proxy and TUN.
+
 pub mod cache;
 pub mod client;
 pub mod fakeip;

--- a/crates/meow-listener/src/lib.rs
+++ b/crates/meow-listener/src/lib.rs
@@ -1,3 +1,8 @@
+//! Inbound protocol listeners for the meow-rs proxy kernel.
+//!
+//! Mixed, HTTP, SOCKS5, and TProxy acceptors, plus an optional TUN device
+//! inbound (feature `listener-tun`).
+
 pub mod sniffer;
 
 pub const DEFAULT_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);

--- a/crates/meow-lwip/Cargo.toml
+++ b/crates/meow-lwip/Cargo.toml
@@ -35,7 +35,7 @@ description = "Vendored lwIP TCP/IP stack bindings (madeye fork, single-owner co
 license = "MIT/Apache-2.0"
 authors = ["@ssrlive", "@madeye"]
 repository = "https://github.com/meow-rs/meow-rs"
-homepage = "https://madeye.github.io/meow-rs/"
+homepage = "https://meow-rs.github.io/meow-rs/"
 readme = "README.md"
 
 [lib]

--- a/crates/meow-proxy/src/lib.rs
+++ b/crates/meow-proxy/src/lib.rs
@@ -1,3 +1,9 @@
+//! Outbound proxy protocol implementations and groups for the meow-rs kernel.
+//!
+//! Adapters for Shadowsocks, Trojan, VLESS, VMess, Hysteria2, Snell, AnyTLS,
+//! HTTP, SOCKS5, Direct, and Reject, plus Selector, URLTest, Fallback,
+//! LoadBalance, and Relay groups.
+
 pub mod direct;
 pub mod group;
 pub mod health;

--- a/crates/meow-rules/src/lib.rs
+++ b/crates/meow-rules/src/lib.rs
@@ -1,3 +1,8 @@
+//! Rule matching engine and parser for the meow-rs proxy kernel.
+//!
+//! Domain, IP-CIDR, GeoIP, process, and logic (`AND`/`OR`/`NOT`) rules, plus
+//! the parser that turns Clash-style rule lines into matchers.
+
 pub mod asn_index;
 pub mod country_index;
 pub mod domain;

--- a/crates/meow-trie/src/lib.rs
+++ b/crates/meow-trie/src/lib.rs
@@ -1,2 +1,7 @@
+//! Domain trie for efficient pattern matching in the meow-rs proxy kernel.
+//!
+//! [`DomainTrie`] stores exact names and suffixes so rule matching can look
+//! up a hostname without scanning the full rule list.
+
 mod trie;
 pub use trie::DomainTrie;

--- a/crates/meow-tunnel/src/lib.rs
+++ b/crates/meow-tunnel/src/lib.rs
@@ -1,3 +1,8 @@
+//! Core routing engine for the meow-rs proxy kernel.
+//!
+//! TCP/UDP relay, rule-matching dispatch, and connection statistics.
+//! [`Tunnel`] is the shared engine listeners hand connections to.
+
 pub mod match_engine;
 pub mod relay;
 pub mod rule_ir;

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
 <meta property="og:title" content="meow-rs — always lands on its feet">
 <meta property="og:description" content="A high-performance proxy kernel in Rust. Rules in, packets out — over every wall.">
 <meta property="og:type" content="website">
-<meta property="og:image" content="https://madeye.github.io/meow-rs/appicon.png">
+<meta property="og:image" content="https://meow-rs.github.io/meow-rs/appicon.png">
 <link rel="icon" type="image/png" href="logo.png">
 <link rel="apple-touch-icon" href="appicon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -276,7 +276,7 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
       <a href="#features">Features</a>
       <a href="#architecture">Architecture</a>
       <a href="./guide/">Docs</a>
-      <a class="nav-cta" href="https://github.com/madeye/meow-rs">GitHub ↗</a>
+      <a class="nav-cta" href="https://github.com/meow-rs/meow-rs">GitHub ↗</a>
     </div>
   </div>
 </nav>
@@ -289,14 +289,14 @@ h2.title{font-family:var(--display);font-weight:700;font-size:clamp(1.7rem,3.4vw
     <p class="sub">meow-rs is a high-performance, rule-based tunneling proxy kernel in Rust — routing, transparent proxy, DNS snooping, and a built-in dashboard, packed into one&nbsp;~6&nbsp;MiB static binary.</p>
     <div class="cta-row">
       <a class="btn btn-primary" href="./guide/">Read the docs</a>
-      <a class="btn btn-ghost" href="https://github.com/madeye/meow-rs">View on GitHub</a>
+      <a class="btn btn-ghost" href="https://github.com/meow-rs/meow-rs">View on GitHub</a>
     </div>
     <div class="install-row">
       <div class="install">
         <span class="cmd"><span class="pfx">$</span> cargo install meow-app</span>
         <button type="button" data-copy="cargo install meow-app">Copy</button>
       </div>
-      <a class="install-alt" href="https://github.com/madeye/meow-rs/releases/latest">or grab a prebuilt binary →</a>
+      <a class="install-alt" href="https://github.com/meow-rs/meow-rs/releases/latest">or grab a prebuilt binary →</a>
     </div>
   </div>
 </header>
@@ -536,8 +536,8 @@ curl https://ipinfo.io</pre></div>
       <p>Crack open the tin, point it at your servers, and watch every connection land on the right side of the wall.</p>
       <div class="cta-row" style="margin:0">
         <a class="btn btn-primary" href="./guide/">Read the docs</a>
-        <a class="btn btn-ghost" href="https://github.com/madeye/meow-rs">Star it on GitHub</a>
-        <a class="btn btn-ghost" href="https://github.com/madeye/meow-rs/releases/latest">Grab a release</a>
+        <a class="btn btn-ghost" href="https://github.com/meow-rs/meow-rs">Star it on GitHub</a>
+        <a class="btn btn-ghost" href="https://github.com/meow-rs/meow-rs/releases/latest">Grab a release</a>
       </div>
     </div>
   </div>
@@ -550,8 +550,8 @@ curl https://ipinfo.io</pre></div>
       <img src="logo.png" width="20" height="20" alt="" aria-hidden="true">
       meow-rs
     </span>
-    <span>Licensed under <a href="https://github.com/madeye/meow-rs/blob/main/LICENSE">MIT</a>. A Rust take on the mihomo proxy kernel.</span>
-    <a href="https://github.com/madeye/meow-rs">GitHub ↗</a>
+    <span>Licensed under <a href="https://github.com/meow-rs/meow-rs/blob/main/LICENSE">MIT</a>. A Rust take on the mihomo proxy kernel.</span>
+    <a href="https://github.com/meow-rs/meow-rs">GitHub ↗</a>
   </div>
 </footer>
 

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 // The landing page (docs/index.html) is served at the Pages site root
-// (https://madeye.github.io/meow-rs/). This VitePress site is built into
+// (https://meow-rs.github.io/meow-rs/). This VitePress site is built into
 // docs/guide/ and therefore lives one level down, at /meow-rs/guide/.
 const base = '/meow-rs/guide/'
 
@@ -21,7 +21,7 @@ export default defineConfig({
     ['link', { rel: 'icon', type: 'image/png', href: `${base}logo.png` }],
     ['link', {
       rel: 'apple-touch-icon',
-      href: 'https://madeye.github.io/meow-rs/appicon.png',
+      href: 'https://meow-rs.github.io/meow-rs/appicon.png',
     }],
     ['meta', { name: 'theme-color', content: '#ED7E2B' }],
     ['meta', { property: 'og:type', content: 'website' }],
@@ -30,7 +30,7 @@ export default defineConfig({
       'meta',
       {
         property: 'og:image',
-        content: 'https://madeye.github.io/meow-rs/appicon.png',
+        content: 'https://meow-rs.github.io/meow-rs/appicon.png',
       },
     ],
     [
@@ -49,7 +49,7 @@ export default defineConfig({
     nav: [
       // The landing page lives at the Pages site root, one level above this
       // VitePress base — an absolute URL is the only reliable way back to it.
-      { text: '← Landing', link: 'https://madeye.github.io/meow-rs/' },
+      { text: '← Landing', link: 'https://meow-rs.github.io/meow-rs/' },
       { text: 'Guide', link: '/guide/what-is-meow-rs' },
       { text: 'Configuration', link: '/guide/configuration' },
       { text: 'Rules', link: '/guide/rules' },
@@ -57,10 +57,10 @@ export default defineConfig({
       {
         text: 'Links',
         items: [
-          { text: 'GitHub', link: 'https://github.com/madeye/meow-rs' },
+          { text: 'GitHub', link: 'https://github.com/meow-rs/meow-rs' },
           {
             text: 'Releases',
-            link: 'https://github.com/madeye/meow-rs/releases/latest',
+            link: 'https://github.com/meow-rs/meow-rs/releases/latest',
           },
           {
             text: 'mihomo (upstream)',
@@ -106,11 +106,11 @@ export default defineConfig({
       },
     ],
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/madeye/meow-rs' },
+      { icon: 'github', link: 'https://github.com/meow-rs/meow-rs' },
     ],
     editLink: {
       pattern:
-        'https://github.com/madeye/meow-rs/edit/main/website/:path',
+        'https://github.com/meow-rs/meow-rs/edit/main/website/:path',
       text: 'Edit this page on GitHub',
     },
     search: { provider: 'local' },

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -118,7 +118,7 @@ rules:
   - MATCH,Proxy
 ```
 
-The repository ships a fuller [`config.example.yaml`](https://github.com/madeye/meow-rs/blob/main/config.example.yaml)
+The repository ships a fuller [`config.example.yaml`](https://github.com/meow-rs/meow-rs/blob/main/config.example.yaml)
 you can copy as a starting point.
 
 ## Compatibility notes

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -12,7 +12,7 @@ This page takes you from a fresh clone to a running proxy with a live dashboard.
 ## Build
 
 ```bash
-git clone https://github.com/madeye/meow-rs.git
+git clone https://github.com/meow-rs/meow-rs.git
 cd meow-rs
 cargo build --release
 ```
@@ -22,7 +22,7 @@ roughly 6 MiB; you can copy it to any matching host and run it directly.
 
 ::: tip Prebuilt binaries
 If you don't want to compile, grab a build from the
-[releases page](https://github.com/madeye/meow-rs/releases/latest). Builds are published
+[releases page](https://github.com/meow-rs/meow-rs/releases/latest). Builds are published
 for Linux (x86_64/aarch64 gnu+musl, armv7 gnu, riscv64 musl), macOS
 (x86_64/aarch64), and Windows MSVC (x86_64/aarch64/i686). Every binary
 ships with the default feature set (`full` + `boring-tls`).

--- a/website/guide/transparent-proxy.md
+++ b/website/guide/transparent-proxy.md
@@ -45,7 +45,7 @@ v1 captures **domain-based** traffic only (the fake-IP range). Outbound dials
 always go to real IPs, so they cannot loop back into the adapter. IP-literal
 connections are not captured. Full field reference and the loop-freedom
 argument are in
-[docs/tun.md](https://github.com/madeye/meow-rs/blob/main/docs/tun.md).
+[docs/tun.md](https://github.com/meow-rs/meow-rs/blob/main/docs/tun.md).
 
 ## Linux / macOS tproxy
 
@@ -109,7 +109,7 @@ The repo ships `scripts/tproxy-gateway-linux.sh` (nftables) and
 `scripts/tproxy-gateway-macos.sh` (pf, experimental) to automate the gateway plumbing.
 The complete walkthrough — prerouting rules, DNS-mode trade-offs, and systemd wiring —
 is in
-[docs/tproxy-gateway.md](https://github.com/madeye/meow-rs/blob/main/docs/tproxy-gateway.md).
+[docs/tproxy-gateway.md](https://github.com/meow-rs/meow-rs/blob/main/docs/tproxy-gateway.md).
 :::
 
 ## Recovering domains

--- a/website/index.md
+++ b/website/index.md
@@ -17,7 +17,7 @@ hero:
       link: /guide/configuration
     - theme: alt
       text: View on GitHub
-      link: https://github.com/madeye/meow-rs
+      link: https://github.com/meow-rs/meow-rs
 
 features:
   - icon: 🧭


### PR DESCRIPTION
## Summary
- Point crate `homepage` at `https://meow-rs.github.io/meow-rs/` (repository was already `https://github.com/meow-rs/meow-rs`).
- Update user-facing clone / GitHub / Pages links in the README, landing page, and website.
- Add crate-level rustdoc on publishable library roots so docs.rs crate pages are not a bare module index.
- Gate both with `crate_publish_metadata_test` (drives `cargo metadata`, not a re-typed TOML).
- Bump the workspace version to 0.21.2 because 0.21.1 is already on crates.io.

## Test plan
- [x] `cargo test -p meow-common --test crate_publish_metadata_test`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` (twice)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib`
- [ ] crates.io `meow-app` 0.21.2 shows the new homepage/repository