### PR TITLE
perf: suspend idle control-plane work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ name = "meow-app"
 version = "0.21.2"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64",
  "clap",
  "dashmap",
@@ -2374,10 +2375,12 @@ dependencies = [
  "meow-listener",
  "meow-proxy",
  "meow-rules",
+ "meow-trie",
  "meow-tunnel",
  "parking_lot",
  "rustls",
  "serde_yaml",
+ "smol_str",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/meow-api/src/lib.rs
+++ b/crates/meow-api/src/lib.rs
@@ -113,6 +113,7 @@ impl ApiServer {
             listeners: self.listeners.clone(),
             external_ui: self.resolve_external_ui(),
             config_mutation_lock: tokio::sync::Mutex::new(()),
+            traffic_feed: Default::default(),
         });
 
         let app = routes::create_router(state);

--- a/crates/meow-api/src/log_stream.rs
+++ b/crates/meow-api/src/log_stream.rs
@@ -72,6 +72,13 @@ impl<S: tracing::Subscriber> Layer<S> for LogBroadcastLayer {
         event: &tracing::Event<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        // The broadcast sender exists for the process lifetime, but most
+        // deployments have no active /logs consumer. Avoid formatting fields,
+        // reading the clock, and constructing a heap-backed message when there
+        // is nobody to receive it.
+        if self.tx.receiver_count() == 0 {
+            return;
+        }
         let level = match *event.metadata().level() {
             tracing::Level::TRACE | tracing::Level::DEBUG => LogLevel::Debug,
             tracing::Level::INFO => LogLevel::Info,
@@ -227,17 +234,20 @@ mod tests {
     }
 
     #[test]
-    fn layer_send_with_no_subscribers_does_not_panic() {
-        // Documented contract: a send Err (no subscribers / channel full) is
-        // acceptable — verify we don't regress to a panicking `.unwrap()`.
+    fn layer_skips_event_recording_with_no_subscribers() {
+        struct PanicOnFormat;
+        impl std::fmt::Debug for PanicOnFormat {
+            fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                panic!("event fields must not be formatted without log subscribers");
+            }
+        }
+
         let (tx, rx) = broadcast::channel(1);
         drop(rx);
         let layer = LogBroadcastLayer { tx };
         let registry = tracing_subscriber::registry().with(layer);
         subscriber::with_default(registry, || {
-            tracing::info!("payload");
-            tracing::error!("oh no");
+            tracing::info!(message = ?PanicOnFormat);
         });
-        // No panic = pass.
     }
 }

--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -56,6 +56,10 @@ where
         ))
     }
 }
+#[derive(Default)]
+pub struct TrafficFeed {
+    sender: std::sync::Mutex<Option<broadcast::Sender<Arc<str>>>>,
+}
 
 pub struct AppState {
     pub tunnel: Tunnel,
@@ -80,6 +84,9 @@ pub struct AppState {
     /// set_tun_handle has completed, leaving a running TUN device behind an
     /// `enable=false` config.
     pub config_mutation_lock: tokio::sync::Mutex<()>,
+    /// Shared on-demand traffic sampler. No timer runs until a client
+    /// subscribes to `/traffic`.
+    pub traffic_feed: TrafficFeed,
 }
 
 /// The API server owns one raw/runtime configuration, so all mutation
@@ -704,28 +711,89 @@ fn traffic_json(state: &AppState) -> String {
     .unwrap_or_default()
 }
 
+fn subscribe_traffic_feed(state: &Arc<AppState>) -> broadcast::Receiver<Arc<str>> {
+    let mut guard = state
+        .traffic_feed
+        .sender
+        .lock()
+        .expect("traffic feed lock poisoned");
+    if let Some(tx) = guard.as_ref() {
+        return tx.subscribe();
+    }
+
+    let (tx, rx) = broadcast::channel(2);
+    *guard = Some(tx.clone());
+    drop(guard);
+
+    // Establish a baseline before the first one-second window. Otherwise all
+    // traffic accumulated while nobody was subscribed would be reported as
+    // the first frame's instantaneous rate.
+    state.tunnel.statistics().sample_traffic();
+
+    let state = Arc::clone(state);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(1));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            if tx.receiver_count() == 0 {
+                let mut guard = state
+                    .traffic_feed
+                    .sender
+                    .lock()
+                    .expect("traffic feed lock poisoned");
+                if tx.receiver_count() == 0 {
+                    *guard = None;
+                    break;
+                }
+            }
+            state.tunnel.statistics().sample_traffic();
+            let frame: Arc<str> = Arc::from(traffic_json(&state));
+            let _ = tx.send(frame);
+        }
+    });
+    rx
+}
+
 async fn get_traffic(
     State(state): State<Arc<AppState>>,
     MaybeWebSocket(ws): MaybeWebSocket,
 ) -> Response {
+    let feed = subscribe_traffic_feed(&state);
     if let Some(ws) = ws {
         return ws.on_upgrade(move |mut socket| async move {
-            let mut ticker = tokio::time::interval(Duration::from_secs(1));
-            ticker.tick().await;
+            let mut feed = feed;
             loop {
-                ticker.tick().await;
-                let frame = traffic_json(&state);
-                if socket.send(Message::Text(frame.into())).await.is_err() {
+                let frame = match feed.recv().await {
+                    Ok(frame) => frame,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                };
+                if socket
+                    .send(Message::Text(frame.as_ref().into()))
+                    .await
+                    .is_err()
+                {
                     break;
                 }
             }
         });
     }
 
-    let stream = futures::stream::unfold(state, |state| async move {
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        let line = format!("{}\n", traffic_json(&state));
-        Some((Ok::<String, std::convert::Infallible>(line), state))
+    let stream = futures::stream::unfold(feed, |mut feed| async move {
+        loop {
+            match feed.recv().await {
+                Ok(frame) => {
+                    return Some((
+                        Ok::<String, std::convert::Infallible>(format!("{frame}\n")),
+                        feed,
+                    ));
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
     });
     Response::builder()
         .header(header::CONTENT_TYPE, "application/json")

--- a/crates/meow-api/tests/api_logs_ws_test.rs
+++ b/crates/meow-api/tests/api_logs_ws_test.rs
@@ -45,6 +45,7 @@ fn make_state_with_cap(cap: usize) -> (Arc<AppState>, broadcast::Sender<LogMessa
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
         external_ui: None,
+        traffic_feed: Default::default(),
     });
     (state, log_tx)
 }

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -63,6 +63,7 @@ fn test_state(raw: RawConfig) -> Arc<AppState> {
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
         external_ui: None,
+        traffic_feed: Default::default(),
     })
 }
 
@@ -98,6 +99,7 @@ fn test_state_with_route(raw: RawConfig, named: Vec<(&str, Arc<dyn Proxy>)>) -> 
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
         external_ui: None,
+        traffic_feed: Default::default(),
     })
 }
 
@@ -135,6 +137,7 @@ fn test_state_with_secret(secret: &str) -> Arc<AppState> {
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
         external_ui: None,
+        traffic_feed: Default::default(),
     })
 }
 
@@ -217,6 +220,7 @@ async fn external_ui_serves_static_directory() {
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
         external_ui: Some(dir.path().to_path_buf()),
+        traffic_feed: Default::default(),
     });
     let app = create_router(state);
 
@@ -418,6 +422,8 @@ async fn patch_configs_invalid_mode() {
 #[tokio::test]
 async fn get_traffic() {
     let state = test_state_default();
+    state.tunnel.statistics().add_upload(123);
+    state.tunnel.statistics().add_download(456);
     let app = create_router(state);
     let resp = app
         .oneshot(
@@ -438,8 +444,8 @@ async fn get_traffic() {
         serde_json::from_slice(frame.data_ref().expect("traffic data frame")).unwrap();
     assert_eq!(json["up"], 0);
     assert_eq!(json["down"], 0);
-    assert_eq!(json["upTotal"], 0);
-    assert_eq!(json["downTotal"], 0);
+    assert_eq!(json["upTotal"], 123);
+    assert_eq!(json["downTotal"], 456);
 }
 
 #[tokio::test]
@@ -1852,6 +1858,7 @@ mod delay_support {
             rule_providers: Arc::new(RwLock::new(HashMap::new())),
             listeners: vec![],
             external_ui: None,
+            traffic_feed: Default::default(),
         })
     }
 
@@ -1906,6 +1913,7 @@ mod delay_support {
             rule_providers: Arc::new(RwLock::new(HashMap::new())),
             listeners: vec![],
             external_ui: None,
+            traffic_feed: Default::default(),
         })
     }
 }
@@ -2805,6 +2813,7 @@ fn test_state_with_hosts_entry() -> Arc<AppState> {
         rule_providers: Arc::new(RwLock::new(HashMap::new())),
         listeners: vec![],
         external_ui: None,
+        traffic_feed: Default::default(),
     })
 }
 

--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -104,12 +104,16 @@ windows-service = "0.8.1"
 windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = "3"
 serde_yaml = { workspace = true }
 meow-config = { workspace = true }
 meow-rules = { workspace = true }
+meow-trie = { workspace = true }
 maxminddb = { workspace = true }
 libc = "0.2"
+async-trait = { workspace = true }
+smol_str = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -120,6 +120,7 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use meow_common::{Metadata, Proxy, ProxyAdapter};
 
     #[test]
     fn zero_interval_uses_safe_default() {
@@ -140,5 +141,311 @@ mod tests {
         assert!(!should_probe(true, 1, 1));
         assert!(should_probe(true, 2, 1));
         assert!(should_probe(false, 0, 0));
+    }
+
+    // --- End-to-end scheduler tests -------------------------------------------------
+    //
+    // These drive the real `run_health_check_loop` against a `Tunnel` whose
+    // group members are probe-answering mocks, so the tick → generation →
+    // probe/skip state machine is exercised instead of just `should_probe`.
+
+    /// A `ProxyConn` that answers any write with a canned `204 No Content`
+    /// response, so `probe_and_record` completes without network I/O — the
+    /// loop stays deterministic under `start_paused`.
+    struct Canned204Conn {
+        reply: &'static [u8],
+        pos: usize,
+    }
+
+    impl Canned204Conn {
+        fn new() -> Self {
+            Self {
+                reply: b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n",
+                pos: 0,
+            }
+        }
+    }
+
+    impl tokio::io::AsyncRead for Canned204Conn {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            if self.pos >= self.reply.len() {
+                return std::task::Poll::Ready(Ok(()));
+            }
+            let n = buf.remaining().min(self.reply.len() - self.pos);
+            let start = self.pos;
+            self.pos += n;
+            let reply = self.reply;
+            buf.put_slice(&reply[start..start + n]);
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    impl tokio::io::AsyncWrite for Canned204Conn {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    impl meow_common::ProxyConn for Canned204Conn {}
+
+    /// Leaf `Proxy` whose `dial_tcp` always succeeds and counts every dial,
+    /// so tests can tell probe dials apart from group-use dials.
+    struct ProbeMock {
+        name: String,
+        health: meow_common::ProxyHealth,
+        dials: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ProbeMock {
+        fn named(name: &str) -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                name: name.to_string(),
+                health: meow_common::ProxyHealth::new(),
+                dials: std::sync::atomic::AtomicUsize::new(0),
+            })
+        }
+
+        fn dials(&self) -> usize {
+            self.dials.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl meow_common::ProxyAdapter for ProbeMock {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn adapter_type(&self) -> meow_common::AdapterType {
+            meow_common::AdapterType::Shadowsocks
+        }
+
+        fn addr(&self) -> &str {
+            ""
+        }
+
+        fn support_udp(&self) -> bool {
+            false
+        }
+
+        async fn dial_tcp(
+            &self,
+            _metadata: &Metadata,
+        ) -> meow_common::Result<Box<dyn meow_common::ProxyConn>> {
+            self.dials
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(Box::new(Canned204Conn::new()))
+        }
+
+        async fn dial_udp(
+            &self,
+            _metadata: &Metadata,
+        ) -> meow_common::Result<Box<dyn meow_common::ProxyPacketConn>> {
+            Err(meow_common::MeowError::NotSupported(
+                "probe mock has no udp".into(),
+            ))
+        }
+
+        fn health(&self) -> &meow_common::ProxyHealth {
+            &self.health
+        }
+    }
+
+    impl meow_common::Proxy for ProbeMock {
+        fn alive(&self) -> bool {
+            self.health.alive()
+        }
+
+        fn alive_for_url(&self, _url: &str) -> bool {
+            self.health.alive()
+        }
+
+        fn last_delay(&self) -> u16 {
+            self.health.last_delay()
+        }
+
+        fn last_delay_for_url(&self, _url: &str) -> u16 {
+            self.health.last_delay()
+        }
+
+        fn delay_history(&self) -> Vec<meow_common::DelayHistory> {
+            self.health.delay_history()
+        }
+    }
+
+    /// Poll `cond` every 50 virtual ms until it holds; panic past `deadline`.
+    async fn until(deadline: Duration, cond: impl Fn() -> bool) {
+        let end = tokio::time::Instant::now() + deadline;
+        while !cond() {
+            assert!(
+                tokio::time::Instant::now() < end,
+                "condition not met within {deadline:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    fn tunnel_with_lazy_fallback(
+        tunnel: &Tunnel,
+        group: &std::sync::Arc<meow_proxy::group::fallback::FallbackGroup>,
+        members: &[(&str, std::sync::Arc<ProbeMock>)],
+    ) {
+        use std::collections::HashMap;
+        let mut proxies: HashMap<smol_str::SmolStr, std::sync::Arc<dyn Proxy>> = HashMap::new();
+        for (name, mock) in members {
+            proxies.insert((*name).into(), std::sync::Arc::<ProbeMock>::clone(mock));
+        }
+        proxies.insert(
+            "lazy-fb".into(),
+            std::sync::Arc::<meow_proxy::group::fallback::FallbackGroup>::clone(group),
+        );
+        tunnel.update_proxies(proxies);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lazy_loop_probes_only_after_new_group_use() {
+        let resolver = std::sync::Arc::new(meow_dns::Resolver::new(
+            vec![],
+            vec![],
+            meow_common::DnsMode::Normal,
+            meow_trie::DomainTrie::new(),
+            true,
+        ));
+        let tunnel = Tunnel::new(resolver);
+        let a = ProbeMock::named("a");
+        let b = ProbeMock::named("b");
+        let group = std::sync::Arc::new(meow_proxy::group::fallback::FallbackGroup::new(
+            "lazy-fb",
+            vec![
+                std::sync::Arc::clone(&a) as std::sync::Arc<dyn Proxy>,
+                std::sync::Arc::clone(&b) as std::sync::Arc<dyn Proxy>,
+            ],
+        ));
+        tunnel_with_lazy_fallback(
+            &tunnel,
+            &group,
+            &[
+                ("a", std::sync::Arc::clone(&a)),
+                ("b", std::sync::Arc::clone(&b)),
+            ],
+        );
+
+        let spec = HealthCheckSpec {
+            group_name: "lazy-fb".into(),
+            url: "http://probe.test/204".into(),
+            interval_secs: 1,
+            lazy: true,
+        };
+        let task = tokio::spawn(run_health_check_loop(tunnel.clone(), spec));
+
+        // Before the first interval elapses the loop has only consumed the
+        // immediate first tick — an unused lazy group must not probe.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert_eq!(a.dials(), 0, "unused lazy group must not probe");
+        assert_eq!(b.dials(), 0, "unused lazy group must not probe");
+        assert_eq!(group.usage_generation(), 0);
+
+        // First use: the dial itself reaches member a but is not a probe.
+        let _ = group
+            .dial_tcp(&Metadata::default())
+            .await
+            .expect("mock member dials succeed");
+        assert_eq!(a.dials(), 1, "use dial hit the first alive member");
+        assert_eq!(group.usage_generation(), 1, "dial records group use");
+
+        // The next tick probes both members (use since last probe).
+        until(Duration::from_secs(3), || a.dials() >= 2 && b.dials() >= 1).await;
+        assert_eq!(a.dials(), 2, "one probe dial in addition to the use dial");
+        assert_eq!(b.dials(), 1, "every member is probed");
+        assert!(a.last_delay() >= 1, "probe result recorded into health");
+
+        // No new use since the probe: later ticks must not probe again.
+        let a_before = a.dials();
+        let b_before = b.dials();
+        tokio::time::sleep(Duration::from_millis(2_500)).await;
+        assert_eq!(a.dials(), a_before, "no new use means no new probe");
+        assert_eq!(b.dials(), b_before, "no new use means no new probe");
+
+        // Use again — probing resumes at the next tick.
+        let _ = group
+            .dial_tcp(&Metadata::default())
+            .await
+            .expect("mock member dials succeed");
+        assert_eq!(a.dials(), a_before + 1, "second use dial");
+        until(Duration::from_secs(3), || {
+            a.dials() > a_before + 1 && b.dials() > b_before
+        })
+        .await;
+        assert_eq!(a.dials(), a_before + 2, "probe resumed after new use");
+        assert_eq!(b.dials(), b_before + 1, "probe resumed after new use");
+
+        task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn eager_loop_probes_without_use() {
+        let resolver = std::sync::Arc::new(meow_dns::Resolver::new(
+            vec![],
+            vec![],
+            meow_common::DnsMode::Normal,
+            meow_trie::DomainTrie::new(),
+            true,
+        ));
+        let tunnel = Tunnel::new(resolver);
+        let a = ProbeMock::named("a");
+        let b = ProbeMock::named("b");
+        let group = std::sync::Arc::new(meow_proxy::group::fallback::FallbackGroup::new(
+            "lazy-fb",
+            vec![
+                std::sync::Arc::clone(&a) as std::sync::Arc<dyn Proxy>,
+                std::sync::Arc::clone(&b) as std::sync::Arc<dyn Proxy>,
+            ],
+        ));
+        tunnel_with_lazy_fallback(
+            &tunnel,
+            &group,
+            &[
+                ("a", std::sync::Arc::clone(&a)),
+                ("b", std::sync::Arc::clone(&b)),
+            ],
+        );
+
+        let spec = HealthCheckSpec {
+            group_name: "lazy-fb".into(),
+            url: "http://probe.test/204".into(),
+            interval_secs: 1,
+            lazy: false,
+        };
+        let task = tokio::spawn(run_health_check_loop(tunnel, spec));
+
+        // Non-lazy: the first tick completes immediately and probes even
+        // though the group has never been used.
+        until(Duration::from_secs(5), || a.dials() >= 1 && b.dials() >= 1).await;
+        assert_eq!(a.dials(), 1, "immediate first tick probes unused members");
+        assert!(a.last_delay() >= 1);
+
+        task.abort();
     }
 }

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -44,6 +44,12 @@ fn should_probe(lazy: bool, generation: u64, last_probed_generation: u64) -> boo
 
 async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
     let mut ticker = tokio::time::interval(Duration::from_secs(spec.interval_secs));
+    // `Delay` (not tokio's default `Burst`) so a probe that outlives a short
+    // `interval` schedules the next tick a full interval from *now* instead
+    // of firing a back-to-back burst of catch-up probes. For the common
+    // `interval >= probe timeout` case (default 300 s vs 5 s) no tick is ever
+    // missed and the schedule is identical to before; this also prevents a
+    // missed-tick probe storm right after system suspend.
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut last_probed_generation = 0;
 

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -332,6 +332,7 @@ mod tests {
             meow_common::DnsMode::Normal,
             meow_trie::DomainTrie::new(),
             true,
+            false,
         ));
         let tunnel = Tunnel::new(resolver);
         let a = ProbeMock::named("a");
@@ -412,6 +413,7 @@ mod tests {
             meow_common::DnsMode::Normal,
             meow_trie::DomainTrie::new(),
             true,
+            false,
         ));
         let tunnel = Tunnel::new(resolver);
         let a = ProbeMock::named("a");

--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -38,8 +38,14 @@ pub fn spawn_health_checks(tunnel: &Tunnel, specs: Vec<HealthCheckSpec>) {
     }
 }
 
+fn should_probe(lazy: bool, generation: u64, last_probed_generation: u64) -> bool {
+    !lazy || (generation != 0 && generation != last_probed_generation)
+}
+
 async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
     let mut ticker = tokio::time::interval(Duration::from_secs(spec.interval_secs));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut last_probed_generation = 0;
 
     if spec.lazy {
         ticker.tick().await;
@@ -57,6 +63,15 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
             );
             continue;
         };
+        let generation = group.usage_generation();
+        if !should_probe(spec.lazy, generation, last_probed_generation) {
+            debug!(
+                "health-check: lazy group '{}' has no traffic since its last probe, skipping tick",
+                spec.group_name
+            );
+            continue;
+        }
+        last_probed_generation = generation;
         let Some(member_names) = group.members() else {
             continue;
         };
@@ -110,5 +125,14 @@ mod tests {
         };
         let specs = extract_specs(&[group]);
         assert_eq!(specs[0].interval_secs, DEFAULT_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn lazy_probe_requires_new_group_use() {
+        assert!(!should_probe(true, 0, 0));
+        assert!(should_probe(true, 1, 0));
+        assert!(!should_probe(true, 1, 1));
+        assert!(should_probe(true, 2, 1));
+        assert!(should_probe(false, 0, 0));
     }
 }

--- a/crates/meow-common/src/adapter.rs
+++ b/crates/meow-common/src/adapter.rs
@@ -221,6 +221,12 @@ pub trait Proxy: ProxyAdapter {
     fn expected_status(&self) -> Option<&str> {
         None
     }
+
+    /// Monotonic traffic-use generation for genuinely lazy health checks.
+    /// Leaf adapters return zero; automatic groups increment on every dial.
+    fn usage_generation(&self) -> u64 {
+        0
+    }
 }
 
 #[cfg(test)]

--- a/crates/meow-proxy/src/group/fallback.rs
+++ b/crates/meow-proxy/src/group/fallback.rs
@@ -1,4 +1,5 @@
 use super::selector_store::SelectorStore;
+use super::UsageTracker;
 use async_trait::async_trait;
 use meow_common::{
     AdapterType, DelayHistory, MeowError, Metadata, ProviderSlot, Proxy, ProxyAdapter, ProxyConn,
@@ -17,6 +18,7 @@ pub struct FallbackGroup {
     test_url: String,
     expected_status: String,
     health: ProxyHealth,
+    usage: UsageTracker,
 }
 
 impl FallbackGroup {
@@ -30,6 +32,7 @@ impl FallbackGroup {
             test_url: "http://www.gstatic.com/generate_204".to_string(),
             expected_status: String::new(),
             health: ProxyHealth::new(),
+            usage: UsageTracker::new(),
         }
     }
 
@@ -47,6 +50,7 @@ impl FallbackGroup {
             test_url: "http://www.gstatic.com/generate_204".to_string(),
             expected_status: String::new(),
             health: ProxyHealth::new(),
+            usage: UsageTracker::new(),
         }
     }
 
@@ -158,6 +162,7 @@ impl ProxyAdapter for FallbackGroup {
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        self.usage.touch();
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -165,6 +170,7 @@ impl ProxyAdapter for FallbackGroup {
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        self.usage.touch();
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -172,6 +178,7 @@ impl ProxyAdapter for FallbackGroup {
     }
 
     fn unwrap_proxy(&self, _metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
+        self.usage.touch();
         self.first_alive()
     }
 
@@ -221,6 +228,10 @@ impl Proxy for FallbackGroup {
 
     fn expected_status(&self) -> Option<&str> {
         Some(&self.expected_status)
+    }
+
+    fn usage_generation(&self) -> u64 {
+        self.usage.generation()
     }
 }
 
@@ -333,7 +344,9 @@ mod tests {
         let a_ref = Arc::clone(&a);
         let b_ref = Arc::clone(&b);
         let g = FallbackGroup::new("fb", vec![a, b]);
+        assert_eq!(g.usage_generation(), 0, "unused group has no use");
         let _ = g.dial_tcp(&Metadata::default()).await;
+        assert_eq!(g.usage_generation(), 1, "dial records group use");
         assert_eq!(a_ref.dials(), 0);
         assert_eq!(b_ref.dials(), 1);
     }

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -1,3 +1,29 @@
+use meow_common::atomic::AtomicU;
+use std::sync::atomic::Ordering;
+
+/// Lock-free traffic-use generation shared by automatic proxy groups. A lazy
+/// health-check loop remembers the last generation it probed and sleeps until
+/// another dial increments this counter.
+pub(super) struct UsageTracker(AtomicU);
+
+impl UsageTracker {
+    pub(super) fn new() -> Self {
+        Self(AtomicU::new(0))
+    }
+
+    pub(super) fn touch(&self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(super) fn generation(&self) -> u64 {
+        #[allow(
+            clippy::useless_conversion,
+            reason = "identity on 64-bit; u32→u64 widening on targets without 64-bit atomics"
+        )]
+        u64::from(self.0.load(Ordering::Relaxed))
+    }
+}
+
 pub mod dialer_proxy;
 pub mod fallback;
 pub mod load_balance;

--- a/crates/meow-proxy/src/group/urltest.rs
+++ b/crates/meow-proxy/src/group/urltest.rs
@@ -1,4 +1,5 @@
 use super::selector_store::SelectorStore;
+use super::UsageTracker;
 use async_trait::async_trait;
 use meow_common::{
     AdapterType, DelayHistory, MeowError, Metadata, ProviderSlot, Proxy, ProxyAdapter, ProxyConn,
@@ -24,6 +25,7 @@ pub struct UrlTestGroup {
     /// promotes a new best.
     fastest: RwLock<Option<SmolStr>>,
     health: ProxyHealth,
+    usage: UsageTracker,
 }
 
 impl UrlTestGroup {
@@ -39,6 +41,7 @@ impl UrlTestGroup {
             expected_status: String::new(),
             fastest: RwLock::new(None),
             health: ProxyHealth::new(),
+            usage: UsageTracker::new(),
         }
     }
 
@@ -59,6 +62,7 @@ impl UrlTestGroup {
             expected_status: String::new(),
             fastest: RwLock::new(None),
             health: ProxyHealth::new(),
+            usage: UsageTracker::new(),
         }
     }
 
@@ -255,6 +259,7 @@ impl ProxyAdapter for UrlTestGroup {
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        self.usage.touch();
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -262,6 +267,7 @@ impl ProxyAdapter for UrlTestGroup {
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        self.usage.touch();
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -269,6 +275,7 @@ impl ProxyAdapter for UrlTestGroup {
     }
 
     fn unwrap_proxy(&self, _metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
+        self.usage.touch();
         self.fastest_proxy()
     }
 
@@ -319,6 +326,10 @@ impl Proxy for UrlTestGroup {
 
     fn expected_status(&self) -> Option<&str> {
         Some(&self.expected_status)
+    }
+
+    fn usage_generation(&self) -> u64 {
+        self.usage.generation()
     }
 }
 
@@ -446,7 +457,9 @@ mod tests {
         let a_ref = Arc::clone(&a);
         let b_ref = Arc::clone(&b);
         let g = UrlTestGroup::new("ut", vec![a, b], 0);
+        assert_eq!(g.usage_generation(), 0, "unused group has no use");
         let _ = g.dial_tcp(&Metadata::default()).await;
+        assert_eq!(g.usage_generation(), 1, "dial records group use");
         assert_eq!(a_ref.dials(), 0);
         assert_eq!(b_ref.dials(), 1);
     }

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -413,17 +413,6 @@ impl Tunnel {
             udp::DEFAULT_UDP_IDLE,
             udp::DEFAULT_SWEEP_INTERVAL,
         );
-        let stats = Arc::clone(&self.inner.stats);
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(1));
-            // Consume tokio's immediate first tick; the first rate bucket is a
-            // real one-second interval, matching mihomo's statistic manager.
-            ticker.tick().await;
-            loop {
-                ticker.tick().await;
-                stats.sample_traffic();
-            }
-        });
     }
 
     /// Store a running TUN listener handle. If a previous TUN listener was
@@ -575,5 +564,21 @@ mod tun_handle_tests {
             tokio::task::yield_now().await;
         }
         assert!(!tunnel.has_tun());
+    }
+    #[tokio::test(start_paused = true)]
+    async fn background_tasks_do_not_sample_traffic_without_api_subscriber() {
+        let tunnel = test_tunnel();
+        tunnel.statistics().add_upload(123);
+        tunnel.statistics().add_download(456);
+        tunnel.spawn_background_tasks();
+
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        assert_eq!(
+            tunnel.statistics().traffic_snapshot(),
+            (0, 0, 0, 0),
+            "the API traffic feed owns sampling; an idle tunnel has no 1 Hz sampler"
+        );
+        assert_eq!(tunnel.statistics().snapshot(), (123, 456));
     }
 }


### PR DESCRIPTION
## Summary

- skip log event formatting and timestamp creation when `/logs` has no subscribers
- start one shared `/traffic` sampler only while clients are connected
- make lazy fallback/url-test health checks run only after new group traffic

## Behavior

- non-lazy health checks are unchanged
- continuously used lazy groups retain interval-based probing
- unused lazy groups perform no network probes
- `/traffic` clients share one sample and one serialized frame per second
- the first traffic frame establishes a fresh baseline, so historical totals are not reported as the current rate

## Verification

- `cargo test --lib` — 1152 passed, 3 ignored
- targeted log stream, traffic stream, health-check, proxy-group, and idle-sampler tests passed
- `cargo clippy -p meow-app -p meow-api -p meow-proxy -p meow-tunnel --all-targets -- -D warnings`