### PR TITLE
fix(release): prevent minimal build from overwriting full artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,22 +117,21 @@ jobs:
 
       - name: Build minimal release binary (stripped, for size check)
         if: matrix.minimal_budget_bytes != 0 && runner.os == 'Linux'
+        env:
+          # Keep the size-check build separate from the full release artifact.
+          # Cargo otherwise reuses target/<triple>/release/meow and the
+          # minimal build replaces the binary that is packaged below.
+          CARGO_TARGET_DIR: target/minimal
         run: |
           cargo zigbuild --release --locked \
             --no-default-features --features minimal \
             --target ${{ matrix.target }} \
             --bin meow
-          # Copy minimal binary aside before default binary overwrites artifact.
-          # Binary is already stripped via [profile.release] strip = true in
-          # the workspace Cargo.toml — no post-build strip needed (and the
-          # host `strip` cannot read aarch64 ELF anyway).
-          cp "target/${{ matrix.target }}/release/meow" \
-             "target/${{ matrix.target }}/release/meow-minimal"
 
       - name: Minimal binary size check
         if: matrix.minimal_budget_bytes != 0 && runner.os == 'Linux'
         run: |
-          SIZE=$(stat -c%s "target/${{ matrix.target }}/release/meow-minimal")
+          SIZE=$(stat -c%s "target/minimal/${{ matrix.target }}/release/meow")
           BUDGET=${{ matrix.minimal_budget_bytes }}
           echo "Minimal binary size: ${SIZE} bytes (budget: ${BUDGET} bytes)"
           if [ "${SIZE}" -gt "${BUDGET}" ]; then


### PR DESCRIPTION
## Summary

The release workflow builds the full binary first and then builds the `minimal`
feature set in the same Cargo target directory. The minimal build overwrites the
full binary, so the tarball and OpenWrt IPK published afterward contain the
minimal feature set instead of the advertised full release.

This is especially visible for `aarch64-unknown-linux-musl`, which runs the
minimal size gate and is used to package the official OpenWrt AArch64 IPKs.

## Changes

- Build the minimal size-check binary with a separate
  `CARGO_TARGET_DIR=target/minimal`.
- Measure the minimal binary from that isolated directory.
- Keep the full binary in the normal target directory for archive and IPK
  packaging.

## Impact

No runtime source code or feature definitions are changed. This only fixes
release artifact selection: published archives and OpenWrt IPKs will contain
the full feature set as intended.

## Verification

- `git diff --check`
- Confirmed the full packaging paths remain unchanged.
- GitHub Actions should verify the AArch64 minimal size gate and package the
  full binary independently.
