### PR TITLE
ci: cap PR feature powerset at depth 2, deeper combos nightly

### DIFF
--- a/.github/workflows/feature-powerset-daily.yml
+++ b/.github/workflows/feature-powerset-daily.yml
@@ -1,0 +1,82 @@
+# Deeper feature-powerset compile checks, run nightly so they never block a
+# PR. The PR-time `features` job in test.yml only checks combinations of up
+# to two features (--depth 2, the same trade-off tokio and quinn make in
+# their PR CI); this workflow pushes deeper: up to 4-feature combos for
+# meow-proxy and meow-transport, and fully exhaustive powersets for the two
+# small crates. rustls likewise keeps its powerset off the PR path
+# (daily-tests.yml).
+#
+# The per-crate depths are runner budgets, not style. Leg counts below are
+# what cargo-hack actually reports after deduplicating subsets that resolve
+# to identical builds (feature implication collapses many of them, e.g.
+# vless-vision -> vless, listener-mixed -> listener-http + listener-socks5):
+#   meow-proxy      depth 4 = 437 legs
+#   meow-transport  depth 4 = 167 legs (boring-tls excluded)
+#   meow-listener   full powerset = 22 legs
+#   meow-dns        full powerset = 5 legs
+# With a warm cache each leg costs ~10-15s of incremental `cargo check`, so
+# the heaviest job (meow-proxy) lands around ~2h worst case — inside the
+# 180-minute timeout and well under the 360-minute hosted-runner cap. An
+# unbounded powerset of meow-proxy (4096 nominal legs) cannot fit a hosted
+# runner at all, which is why depth is capped even on the nightly.
+name: Feature Powerset (daily)
+
+on:
+  schedule:
+    # 04:17 UTC daily — offset after coverage (02:17) and bench-daily (03:17)
+    # to stagger shared-runner load and avoid scheduler congestion. Note that
+    # GitHub only fires `schedule` from the default branch.
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: feature-powerset-daily
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  powerset:
+    name: Powerset — ${{ matrix.crate }}
+    runs-on: ubuntu-latest
+    # Generous per-crate cap; the leg budgets above target well under this.
+    timeout-minutes: 180
+    strategy:
+      # One crate failing must not cancel the others: the point of the daily
+      # run is to report every broken combination.
+      fail-fast: false
+      matrix:
+        include:
+          - crate: meow-proxy
+            hack_args: --depth 4
+          - crate: meow-transport
+            # boring-tls vendors BoringSSL and needs a C++ toolchain; that
+            # leg is covered by clippy --all-features in test.yml's lint job.
+            hack_args: --depth 4 --exclude-features boring-tls
+          - crate: meow-listener
+            hack_args: ""
+          - crate: meow-dns
+            hack_args: ""
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: powerset-daily
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      # --no-dev-deps: dev-dependencies are irrelevant to a compile check and
+      # dominate per-leg build time (rustls and quinn do the same).
+      # --keep-going: collect every failing combination in one run instead of
+      # stopping at the first (tokio uses it the same way).
+      - name: Feature powerset — ${{ matrix.crate }}
+        run: cargo hack check -p ${{ matrix.crate }} --feature-powerset --no-dev-deps --keep-going ${{ matrix.hack_args }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,25 +171,30 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
-      # These powersets subsume the hand-rolled per-crate feature matrices
-      # that used to run in the test job (transport G1-G6, VLESS G1/G2/G4,
-      # DNS D1-D3): the powerset checks every feature subset with
-      # --no-default-features, including the empty set. The --all-features
-      # legs (transport G7, VLESS G3) are covered by clippy --all-features
-      # in the lint job.
-      - name: Feature powerset — meow-transport
+      # Capped powerset: --depth 2 covers the empty set, every single feature,
+      # and every pair — enough for the real-world cfg-interaction bugs while
+      # keeping the leg count ~n^2 instead of ~2^n (meow-proxy: 66 legs,
+      # ~129 across the four crates — cargo-hack dedups subsets that resolve
+      # to identical builds). Same trade-off tokio (--depth 2 --keep-going)
+      # and quinn (--depth 3 --no-dev-deps) make in their PR CI.
+      # --no-dev-deps: dev-dependencies are irrelevant to a compile check and
+      # dominate per-leg build time. Deeper combinations (3+ features) run
+      # nightly in .github/workflows/feature-powerset-daily.yml; the
+      # --all-features legs (transport G7, VLESS G3) are covered by clippy
+      # --all-features in the lint job.
+      - name: Feature powerset (depth 2) — meow-transport
         # boring-tls excluded: requires C++ toolchain at build time; covered
         # via clippy --all-features in the lint job.
-        run: cargo hack check -p meow-transport --feature-powerset --exclude-features boring-tls
+        run: cargo hack check -p meow-transport --feature-powerset --depth 2 --no-dev-deps --exclude-features boring-tls
 
-      - name: Feature powerset — meow-proxy
-        run: cargo hack check -p meow-proxy --feature-powerset
+      - name: Feature powerset (depth 2) — meow-proxy
+        run: cargo hack check -p meow-proxy --feature-powerset --depth 2 --no-dev-deps
 
-      - name: Feature powerset — meow-listener
-        run: cargo hack check -p meow-listener --feature-powerset
+      - name: Feature powerset (depth 2) — meow-listener
+        run: cargo hack check -p meow-listener --feature-powerset --depth 2 --no-dev-deps
 
-      - name: Feature powerset — meow-dns
-        run: cargo hack check -p meow-dns --feature-powerset
+      - name: Feature powerset (depth 2) — meow-dns
+        run: cargo hack check -p meow-dns --feature-powerset --depth 2 --no-dev-deps
 
   msrv:
     runs-on: ubuntu-latest

--- a/docs/ci-status.md
+++ b/docs/ci-status.md
@@ -50,11 +50,18 @@ Runs on Ubuntu after `lint`:
 Runs on Ubuntu after `lint`:
 
 - Installs `cargo-hack`.
-- Runs feature-powerset checks for `meow-transport`, `meow-proxy`, and
-  `meow-listener`.
+- Runs feature-powerset checks (`--feature-powerset --depth 2 --no-dev-deps`)
+  for `meow-transport`, `meow-proxy`, `meow-listener`, and `meow-dns`: the
+  empty set, every single feature, and every pair — capped at depth 2 so the
+  leg count stays ~n^2 instead of ~2^n per PR.
 - Excludes `boring-tls` from the `meow-transport` powerset because that backend
   needs a C++/BoringSSL toolchain; the broader transport matrix still covers
   the normal feature combinations.
+- Deeper combinations run nightly in
+  `.github/workflows/feature-powerset-daily.yml` instead of on every PR: up to
+  4-feature combos for `meow-proxy` and `meow-transport`, and fully
+  exhaustive powersets for `meow-listener` and `meow-dns` — depths chosen so
+  each crate fits a hosted runner's 360-minute job cap with margin.
 
 ### `msrv`
 


### PR DESCRIPTION
## Summary

- The `features` job ran unbounded `cargo hack check --feature-powerset` on every PR: ~6200 nominal legs across four crates (meow-proxy alone: 12 features = 4096 legs), which can never complete within the 360-minute hosted-runner cap (~10h+ of legs).
- PR path is now `--feature-powerset --depth 2 --no-dev-deps` (empty set, every single feature, every pair): **129 legs total** after cargo-hack dedups identical builds — same trade-off tokio (`--depth 2 --keep-going`) and quinn (`--depth 3 --no-dev-deps`) make in their PR CI.
- New nightly `feature-powerset-daily.yml` (04:17 UTC, staggered after coverage/bench-daily, plus `workflow_dispatch`) covers deeper combinations: one parallel matrix job per crate with `fail-fast: false` and `--keep-going`, so a broken combo in one crate can't mask the others. Depths are measured runner budgets: `meow-proxy`/`meow-transport` at `--depth 4` (437/167 legs after dedup), `meow-listener`/`meow-dns` fully exhaustive (22/5 legs). `boring-tls` stays excluded from the transport powerset; `--all-features` legs remain covered by clippy in the lint job.
- `docs/ci-status.md` synced (also fixes the stale crate list that predated `meow-dns` joining the powerset).

Fixes #486.

## Test plan

- [x] Both workflow YAMLs parse cleanly (PyYAML) and the matrix expansion was verified
- [x] Measured real leg counts locally with cargo-hack 0.6.45: `meow-dns` full powerset ran green (5/5 legs), `meow-listener` full powerset ran green (22 legs), proxy/transport flag combinations accepted with exact `(1/N)` totals captured
- [x] Triggered `Feature Powerset (daily)` via `workflow_dispatch` on this branch: **all four matrix jobs green** (run [33537706836](https://github.com/aimkiray/meow-rs/actions/runs/33537706836)) — proxy 437 legs in 14m28s, transport 167 legs in 2m22s, listener 1m18s, dns 45s; ~12x margin against the 180-minute timeout even for the heaviest job
- [ ] After merge, confirm the PR `features` job runtime drops accordingly