### PR TITLE
feat(proxy): mark failing group members dead, aligned with mihomo onDialFailed

### DIFF
--- a/crates/meow-proxy/src/group/fallback.rs
+++ b/crates/meow-proxy/src/group/fallback.rs
@@ -1,5 +1,5 @@
 use super::selector_store::SelectorStore;
-use super::UsageTracker;
+use super::{DialFailureTracker, UsageTracker};
 use async_trait::async_trait;
 use meow_common::{
     AdapterType, DelayHistory, MeowError, Metadata, ProviderSlot, Proxy, ProxyAdapter, ProxyConn,
@@ -19,6 +19,7 @@ pub struct FallbackGroup {
     expected_status: String,
     health: ProxyHealth,
     usage: UsageTracker,
+    dial_failures: DialFailureTracker,
 }
 
 impl FallbackGroup {
@@ -33,6 +34,7 @@ impl FallbackGroup {
             expected_status: String::new(),
             health: ProxyHealth::new(),
             usage: UsageTracker::new(),
+            dial_failures: DialFailureTracker::new(),
         }
     }
 
@@ -51,6 +53,7 @@ impl FallbackGroup {
             expected_status: String::new(),
             health: ProxyHealth::new(),
             usage: UsageTracker::new(),
+            dial_failures: DialFailureTracker::new(),
         }
     }
 
@@ -166,7 +169,16 @@ impl ProxyAdapter for FallbackGroup {
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        proxy.dial_tcp(metadata).await
+        match proxy.dial_tcp(metadata).await {
+            Ok(conn) => {
+                self.dial_failures.on_success();
+                Ok(conn)
+            }
+            Err(err) => {
+                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
+                Err(err)
+            }
+        }
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
@@ -174,7 +186,16 @@ impl ProxyAdapter for FallbackGroup {
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        proxy.dial_udp(metadata).await
+        match proxy.dial_udp(metadata).await {
+            Ok(conn) => {
+                self.dial_failures.on_success();
+                Ok(conn)
+            }
+            Err(err) => {
+                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
+                Err(err)
+            }
+        }
     }
 
     fn unwrap_proxy(&self, _metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
@@ -383,5 +404,65 @@ mod tests {
         b_ref.set_alive(false);
         assert_eq!(g.first_alive().unwrap().name(), "a");
         assert_eq!(ProxySelection::fixed(&g).as_deref(), Some(""));
+    }
+
+    #[tokio::test]
+    async fn repeated_dial_failures_mark_member_dead() {
+        // mihomo GroupBase.onDialFailed: five failures within the window
+        // escalate; the escalation marks the failed member dead so routing
+        // skips it until the next probe revives it.
+        let a = MockProxy::new_failing("a", AdapterType::Shadowsocks, "dial timed out");
+        let b = MockProxy::new_failing("b", AdapterType::Shadowsocks, "dial timed out");
+        let a_ref = Arc::clone(&a);
+        let b_ref = Arc::clone(&b);
+        let g = FallbackGroup::new("fb", vec![a, b]);
+
+        for i in 1..5 {
+            let _ = g.dial_tcp(&Metadata::default()).await;
+            assert!(
+                a_ref.alive(),
+                "failure {i} is below the escalation threshold"
+            );
+        }
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert!(
+            !a_ref.alive(),
+            "the repeatedly failing member is marked dead"
+        );
+        assert!(b_ref.alive(), "the untouched member stays alive");
+
+        // The dead member is skipped: the next dial reaches b instead.
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert_eq!(b_ref.dials(), 1, "routing moved past the dead member");
+        assert_eq!(a_ref.dials(), 5);
+    }
+
+    #[tokio::test]
+    async fn connection_refused_marks_member_dead_immediately() {
+        // mihomo escalates "connection refused" without waiting for the
+        // failure streak.
+        let a = MockProxy::new_failing("a", AdapterType::Shadowsocks, "connection refused");
+        let a_ref = Arc::clone(&a);
+        let g = FallbackGroup::new("fb", vec![a, MockProxy::new("b")]);
+
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert!(!a_ref.alive(), "refused escalates on the first failure");
+    }
+
+    #[tokio::test]
+    async fn direct_member_failures_are_exempt_from_escalation() {
+        // mihomo exempts Direct/Reject-family members: their dial errors
+        // describe the target, not the member.
+        let a = MockProxy::new_failing("d", AdapterType::Direct, "connection refused");
+        let a_ref = Arc::clone(&a);
+        let g = FallbackGroup::new("fb", vec![a]);
+
+        for _ in 0..10 {
+            let _ = g.dial_tcp(&Metadata::default()).await;
+        }
+        assert!(
+            a_ref.alive(),
+            "direct members are exempt from failure tracking"
+        );
     }
 }

--- a/crates/meow-proxy/src/group/fallback.rs
+++ b/crates/meow-proxy/src/group/fallback.rs
@@ -465,4 +465,23 @@ mod tests {
             "direct members are exempt from failure tracking"
         );
     }
+
+    #[tokio::test]
+    async fn udp_unsupported_member_failures_are_exempt_from_escalation() {
+        // mihomo ignores ErrNotSupport failures; meow surfaces them as
+        // MeowError::UdpNotSupported (relay chains, dialer proxies). They
+        // describe a capability, not health, so UDP traffic must never mark
+        // an otherwise healthy member dead.
+        let a = MockProxy::new_udp_unsupported("r", AdapterType::Relay);
+        let a_ref = Arc::clone(&a);
+        let g = FallbackGroup::new("fb", vec![a]);
+
+        for _ in 0..10 {
+            let _ = g.dial_udp(&Metadata::default()).await;
+        }
+        assert!(
+            a_ref.alive(),
+            "structural UdpNotSupported errors are exempt from failure tracking"
+        );
+    }
 }

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -74,13 +74,16 @@ impl DialFailureTracker {
     /// Record a failed dial; returns `true` when the failure should escalate
     /// (the caller then marks the failed member dead).
     pub(super) fn on_failure(&self, err: &MeowError) -> bool {
-        // mihomo ignores C.ErrNotSupport failures outright.
-        if matches!(err, MeowError::NotSupported(_)) {
+        // mihomo ignores C.ErrNotSupport failures outright; meow splits that
+        // sentinel into `NotSupported` and `UdpNotSupported`. Both describe a
+        // member's capabilities, not its health (e.g. a relay chain without
+        // UDP support), so neither may count toward marking a member dead.
+        if matches!(err, MeowError::NotSupported(_) | MeowError::UdpNotSupported) {
             return false;
         }
-        // mihomo escalates immediately on "connection refused".
+        // mihomo escalates immediately on "connection refused" and leaves the
+        // streak untouched.
         if err.to_string().contains("refused") {
-            self.on_success();
             return true;
         }
         let mut state = self.state.lock();
@@ -177,6 +180,20 @@ mod tests {
     }
 
     #[test]
+    fn connection_refused_leaves_the_streak_intact() {
+        // mihomo's refused fast path does not touch failedTimes.
+        let tracker = DialFailureTracker::new();
+        for _ in 1..DIAL_FAILURE_THRESHOLD {
+            tracker.on_failure(&io_err("dial timed out"));
+        }
+        assert!(tracker.on_failure(&io_err("connection refused")));
+        assert!(
+            tracker.on_failure(&io_err("dial timed out")),
+            "the pre-refused streak still counts toward the threshold"
+        );
+    }
+
+    #[test]
     fn success_resets_the_streak() {
         let tracker = DialFailureTracker::new();
         for _ in 1..DIAL_FAILURE_THRESHOLD {
@@ -197,6 +214,14 @@ mod tests {
         let tracker = DialFailureTracker::new();
         for _ in 0..100 {
             assert!(!tracker.on_failure(&MeowError::NotSupported("udp".into())));
+        }
+    }
+
+    #[test]
+    fn udp_unsupported_failures_never_escalate() {
+        let tracker = DialFailureTracker::new();
+        for _ in 0..100 {
+            assert!(!tracker.on_failure(&MeowError::UdpNotSupported));
         }
     }
 

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -1,5 +1,10 @@
 use meow_common::atomic::AtomicU;
+use meow_common::{AdapterType, MeowError, Proxy};
+use parking_lot::Mutex;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tracing::debug;
 
 /// Lock-free traffic-use generation shared by automatic proxy groups. A lazy
 /// health-check loop remembers the last generation it probed and sleeps until
@@ -24,6 +29,111 @@ impl UsageTracker {
     }
 }
 
+/// Escalation threshold and window, matching mihomo's `GroupBase` defaults
+/// (`maxFailedTimes = 5`, `testTimeout = 5000` ms —
+/// adapter/outboundgroup/groupbase.go).
+const DIAL_FAILURE_THRESHOLD: u32 = 5;
+const DIAL_FAILURE_WINDOW: Duration = Duration::from_secs(5);
+
+/// Dial-failure escalation state shared by the automatic groups, modeled on
+/// mihomo's `GroupBase.onDialFailed`.
+///
+/// mihomo's terminal action on escalation is to force a provider health
+/// check. The group layer here cannot trigger probes (the health-check loop
+/// lives in meow-app), so the local equivalent is to mark the failed member
+/// dead: routing stops selecting it immediately, and the next scheduled
+/// group probe — guaranteed to run for a lazy group, because a dial bumps
+/// the usage generation — revives members that failed only transiently.
+pub(super) struct DialFailureTracker {
+    state: Mutex<DialFailureState>,
+}
+
+struct DialFailureState {
+    count: u32,
+    first_at: Option<Instant>,
+}
+
+impl DialFailureTracker {
+    pub(super) fn new() -> Self {
+        Self {
+            state: Mutex::new(DialFailureState {
+                count: 0,
+                first_at: None,
+            }),
+        }
+    }
+
+    /// mihomo resets the failure streak on dial success
+    /// (`GroupBase.onDialSuccess`).
+    pub(super) fn on_success(&self) {
+        let mut state = self.state.lock();
+        state.count = 0;
+        state.first_at = None;
+    }
+
+    /// Record a failed dial; returns `true` when the failure should escalate
+    /// (the caller then marks the failed member dead).
+    pub(super) fn on_failure(&self, err: &MeowError) -> bool {
+        // mihomo ignores C.ErrNotSupport failures outright.
+        if matches!(err, MeowError::NotSupported(_)) {
+            return false;
+        }
+        // mihomo escalates immediately on "connection refused".
+        if err.to_string().contains("refused") {
+            self.on_success();
+            return true;
+        }
+        let mut state = self.state.lock();
+        state.count += 1;
+        if state.count == 1 {
+            state.first_at = Some(Instant::now());
+            return false;
+        }
+        if state
+            .first_at
+            .is_some_and(|at| Instant::now().duration_since(at) > DIAL_FAILURE_WINDOW)
+        {
+            // mihomo drops the stale streak and starts a fresh window.
+            state.count = 0;
+            state.first_at = None;
+            return false;
+        }
+        if state.count >= DIAL_FAILURE_THRESHOLD {
+            state.count = 0;
+            state.first_at = None;
+            return true;
+        }
+        false
+    }
+}
+
+/// Shared dial-failure policy for automatic groups, mirroring the exemptions
+/// in mihomo's `GroupBase.onDialFailed`: adapter types whose dial errors
+/// describe the *target* (Direct / Reject family) are never tracked, and
+/// everything else escalates through the group's [`DialFailureTracker`].
+/// Escalation marks the failed member dead — see [`DialFailureTracker`] for
+/// why this stands in for mihomo's forced health check.
+pub(super) fn record_dial_failure(
+    group_name: &str,
+    tracker: &DialFailureTracker,
+    member: &Arc<dyn Proxy>,
+    err: &MeowError,
+) {
+    if matches!(
+        member.adapter_type(),
+        AdapterType::Direct | AdapterType::Reject | AdapterType::RejectDrop
+    ) {
+        return;
+    }
+    if tracker.on_failure(err) {
+        debug!(
+            "proxy-group '{group_name}': marking member '{}' dead after repeated dial failures",
+            member.name()
+        );
+        member.health().set_alive(false);
+    }
+}
+
 pub mod dialer_proxy;
 pub mod fallback;
 pub mod load_balance;
@@ -34,3 +144,79 @@ pub mod urltest;
 
 #[cfg(test)]
 pub(crate) mod test_support;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn io_err(msg: &str) -> MeowError {
+        MeowError::Proxy(msg.into())
+    }
+
+    #[test]
+    fn five_failures_within_window_escalate() {
+        let tracker = DialFailureTracker::new();
+        for i in 1..DIAL_FAILURE_THRESHOLD {
+            assert!(
+                !tracker.on_failure(&io_err("dial timed out")),
+                "failure {i} is below the threshold"
+            );
+        }
+        assert!(
+            tracker.on_failure(&io_err("dial timed out")),
+            "the 5th failure within the window escalates"
+        );
+        // Escalation resets the streak, so a fresh window starts over.
+        assert!(!tracker.on_failure(&io_err("dial timed out")));
+    }
+
+    #[test]
+    fn connection_refused_escalates_immediately() {
+        let tracker = DialFailureTracker::new();
+        assert!(tracker.on_failure(&io_err("connection refused")));
+    }
+
+    #[test]
+    fn success_resets_the_streak() {
+        let tracker = DialFailureTracker::new();
+        for _ in 1..DIAL_FAILURE_THRESHOLD {
+            tracker.on_failure(&io_err("dial timed out"));
+        }
+        tracker.on_success();
+        for i in 1..DIAL_FAILURE_THRESHOLD {
+            assert!(
+                !tracker.on_failure(&io_err("dial timed out")),
+                "failure {i} after a success does not escalate"
+            );
+        }
+        assert!(tracker.on_failure(&io_err("dial timed out")));
+    }
+
+    #[test]
+    fn not_supported_failures_never_escalate() {
+        let tracker = DialFailureTracker::new();
+        for _ in 0..100 {
+            assert!(!tracker.on_failure(&MeowError::NotSupported("udp".into())));
+        }
+    }
+
+    #[test]
+    fn window_expiry_drops_the_streak() {
+        let tracker = DialFailureTracker::new();
+        for _ in 1..DIAL_FAILURE_THRESHOLD {
+            tracker.on_failure(&io_err("dial timed out"));
+        }
+        // Age the window without sleeping in the test.
+        tracker.state.lock().first_at =
+            Some(Instant::now() - DIAL_FAILURE_WINDOW - Duration::from_millis(50));
+        assert!(
+            !tracker.on_failure(&io_err("dial timed out")),
+            "a streak older than the window is dropped"
+        );
+        // A fresh window needs a full new streak to escalate.
+        for _ in 1..DIAL_FAILURE_THRESHOLD {
+            assert!(!tracker.on_failure(&io_err("dial timed out")));
+        }
+        assert!(tracker.on_failure(&io_err("dial timed out")));
+    }
+}

--- a/crates/meow-proxy/src/group/test_support.rs
+++ b/crates/meow-proxy/src/group/test_support.rs
@@ -22,6 +22,8 @@ pub struct MockProxy {
     name: String,
     health: ProxyHealth,
     udp: bool,
+    adapter_type: AdapterType,
+    dial_error: Option<String>,
     pub dial_count: AtomicUsize,
 }
 
@@ -31,6 +33,8 @@ impl MockProxy {
             name: name.to_string(),
             health: ProxyHealth::new(),
             udp: false,
+            adapter_type: AdapterType::Direct,
+            dial_error: None,
             dial_count: AtomicUsize::new(0),
         })
     }
@@ -40,6 +44,25 @@ impl MockProxy {
             name: name.to_string(),
             health: ProxyHealth::new(),
             udp: true,
+            adapter_type: AdapterType::Direct,
+            dial_error: None,
+            dial_count: AtomicUsize::new(0),
+        })
+    }
+
+    /// Mock that fails every dial with `error` and reports `adapter_type`.
+    ///
+    /// The dial-failure escalation tests need a non-exempt adapter type
+    /// (Direct / Reject members are exempt from failure tracking) and an
+    /// error message they control — e.g. one containing "connection refused"
+    /// to exercise mihomo's immediate-escalation path.
+    pub fn new_failing(name: &str, adapter_type: AdapterType, error: &str) -> Arc<Self> {
+        Arc::new(Self {
+            name: name.to_string(),
+            health: ProxyHealth::new(),
+            udp: false,
+            adapter_type,
+            dial_error: Some(error.to_string()),
             dial_count: AtomicUsize::new(0),
         })
     }
@@ -66,7 +89,7 @@ impl ProxyAdapter for MockProxy {
         &self.name
     }
     fn adapter_type(&self) -> AdapterType {
-        AdapterType::Direct
+        self.adapter_type
     }
     fn addr(&self) -> &str {
         ""
@@ -76,11 +99,17 @@ impl ProxyAdapter for MockProxy {
     }
     async fn dial_tcp(&self, _m: &Metadata) -> Result<Box<dyn ProxyConn>> {
         self.dial_count.fetch_add(1, Ordering::Relaxed);
-        Err(MeowError::Proxy(format!("mock {} dial_tcp", self.name)))
+        match &self.dial_error {
+            Some(err) => Err(MeowError::Proxy(err.clone())),
+            None => Err(MeowError::Proxy(format!("mock {} dial_tcp", self.name))),
+        }
     }
     async fn dial_udp(&self, _m: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
         self.dial_count.fetch_add(1, Ordering::Relaxed);
-        Err(MeowError::Proxy(format!("mock {} dial_udp", self.name)))
+        match &self.dial_error {
+            Some(err) => Err(MeowError::Proxy(err.clone())),
+            None => Err(MeowError::Proxy(format!("mock {} dial_udp", self.name))),
+        }
     }
     fn health(&self) -> &ProxyHealth {
         &self.health

--- a/crates/meow-proxy/src/group/test_support.rs
+++ b/crates/meow-proxy/src/group/test_support.rs
@@ -24,6 +24,7 @@ pub struct MockProxy {
     udp: bool,
     adapter_type: AdapterType,
     dial_error: Option<String>,
+    udp_unsupported: bool,
     pub dial_count: AtomicUsize,
 }
 
@@ -35,6 +36,7 @@ impl MockProxy {
             udp: false,
             adapter_type: AdapterType::Direct,
             dial_error: None,
+            udp_unsupported: false,
             dial_count: AtomicUsize::new(0),
         })
     }
@@ -46,6 +48,7 @@ impl MockProxy {
             udp: true,
             adapter_type: AdapterType::Direct,
             dial_error: None,
+            udp_unsupported: false,
             dial_count: AtomicUsize::new(0),
         })
     }
@@ -63,6 +66,23 @@ impl MockProxy {
             udp: false,
             adapter_type,
             dial_error: Some(error.to_string()),
+            udp_unsupported: false,
+            dial_count: AtomicUsize::new(0),
+        })
+    }
+
+    /// Mock whose `dial_udp` returns the structural
+    /// [`MeowError::UdpNotSupported`] that relay chains and dialer-proxy
+    /// members produce when they cannot carry UDP. Such errors describe a
+    /// capability, not health, and must never mark the member dead.
+    pub fn new_udp_unsupported(name: &str, adapter_type: AdapterType) -> Arc<Self> {
+        Arc::new(Self {
+            name: name.to_string(),
+            health: ProxyHealth::new(),
+            udp: false,
+            adapter_type,
+            dial_error: None,
+            udp_unsupported: true,
             dial_count: AtomicUsize::new(0),
         })
     }
@@ -106,6 +126,9 @@ impl ProxyAdapter for MockProxy {
     }
     async fn dial_udp(&self, _m: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
         self.dial_count.fetch_add(1, Ordering::Relaxed);
+        if self.udp_unsupported {
+            return Err(MeowError::UdpNotSupported);
+        }
         match &self.dial_error {
             Some(err) => Err(MeowError::Proxy(err.clone())),
             None => Err(MeowError::Proxy(format!("mock {} dial_udp", self.name))),

--- a/crates/meow-proxy/src/group/urltest.rs
+++ b/crates/meow-proxy/src/group/urltest.rs
@@ -528,10 +528,14 @@ mod tests {
         let b_ref = Arc::clone(&b);
         let g = UrlTestGroup::new("ut", vec![a, b], 0);
 
-        for _ in 0..5 {
+        for i in 1..5 {
             let _ = g.dial_tcp(&Metadata::default()).await;
-            assert!(a_ref.alive() || b_ref.alive());
+            assert!(
+                a_ref.alive(),
+                "failure {i} is below the escalation threshold"
+            );
         }
+        let _ = g.dial_tcp(&Metadata::default()).await;
         // The first pick (a) has now failed five times in a row and is dead;
         // the next dial must be routed to b.
         assert!(

--- a/crates/meow-proxy/src/group/urltest.rs
+++ b/crates/meow-proxy/src/group/urltest.rs
@@ -1,5 +1,5 @@
 use super::selector_store::SelectorStore;
-use super::UsageTracker;
+use super::{DialFailureTracker, UsageTracker};
 use async_trait::async_trait;
 use meow_common::{
     AdapterType, DelayHistory, MeowError, Metadata, ProviderSlot, Proxy, ProxyAdapter, ProxyConn,
@@ -26,6 +26,7 @@ pub struct UrlTestGroup {
     fastest: RwLock<Option<SmolStr>>,
     health: ProxyHealth,
     usage: UsageTracker,
+    dial_failures: DialFailureTracker,
 }
 
 impl UrlTestGroup {
@@ -42,6 +43,7 @@ impl UrlTestGroup {
             fastest: RwLock::new(None),
             health: ProxyHealth::new(),
             usage: UsageTracker::new(),
+            dial_failures: DialFailureTracker::new(),
         }
     }
 
@@ -63,6 +65,7 @@ impl UrlTestGroup {
             fastest: RwLock::new(None),
             health: ProxyHealth::new(),
             usage: UsageTracker::new(),
+            dial_failures: DialFailureTracker::new(),
         }
     }
 
@@ -263,7 +266,16 @@ impl ProxyAdapter for UrlTestGroup {
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        proxy.dial_tcp(metadata).await
+        match proxy.dial_tcp(metadata).await {
+            Ok(conn) => {
+                self.dial_failures.on_success();
+                Ok(conn)
+            }
+            Err(err) => {
+                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
+                Err(err)
+            }
+        }
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
@@ -271,7 +283,16 @@ impl ProxyAdapter for UrlTestGroup {
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        proxy.dial_udp(metadata).await
+        match proxy.dial_udp(metadata).await {
+            Ok(conn) => {
+                self.dial_failures.on_success();
+                Ok(conn)
+            }
+            Err(err) => {
+                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
+                Err(err)
+            }
+        }
     }
 
     fn unwrap_proxy(&self, _metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
@@ -492,5 +513,47 @@ mod tests {
         ProxySelection::set(&g, "a").await.unwrap();
         assert_eq!(pick(&g), "b");
         assert_eq!(ProxySelection::fixed(&g).as_deref(), Some("a"));
+    }
+
+    #[tokio::test]
+    async fn repeated_dial_failures_mark_member_dead() {
+        // mihomo GroupBase.onDialFailed escalation, applied to the fastest
+        // member: five failures within the window mark it dead so routing
+        // moves to the next candidate until a probe revives it.
+        let a = MockProxy::new_failing("a", AdapterType::Shadowsocks, "dial timed out");
+        let b = MockProxy::new_failing("b", AdapterType::Shadowsocks, "dial timed out");
+        a.set_delay(10);
+        b.set_delay(20);
+        let a_ref = Arc::clone(&a);
+        let b_ref = Arc::clone(&b);
+        let g = UrlTestGroup::new("ut", vec![a, b], 0);
+
+        for _ in 0..5 {
+            let _ = g.dial_tcp(&Metadata::default()).await;
+            assert!(a_ref.alive() || b_ref.alive());
+        }
+        // The first pick (a) has now failed five times in a row and is dead;
+        // the next dial must be routed to b.
+        assert!(
+            !a_ref.alive(),
+            "the repeatedly failing member is marked dead"
+        );
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert_eq!(a_ref.dials(), 5, "the dead member no longer receives dials");
+        assert_eq!(b_ref.dials(), 1, "routing moved past the dead member");
+    }
+
+    #[tokio::test]
+    async fn connection_refused_marks_member_dead_immediately() {
+        let a = MockProxy::new_failing("a", AdapterType::Shadowsocks, "connection refused");
+        a.set_delay(10);
+        let a_ref = Arc::clone(&a);
+        let b = MockProxy::new("b");
+        b.set_delay(20);
+        let g = UrlTestGroup::new("ut", vec![a, b], 0);
+
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert!(!a_ref.alive(), "refused escalates on the first failure");
+        assert_eq!(pick(&g), "b", "the refused member is no longer selected");
     }
 }


### PR DESCRIPTION
## Summary

- fallback and url-test groups now track dial failures and mark the failed member dead on escalation, mirroring mihomo's `GroupBase.onDialFailed` policy (adapter/outboundgroup/groupbase.go)

## mihomo alignment

| `GroupBase.onDialFailed` (mihomo) | here |
|---|---|
| Direct / Reject-family members exempt (their dial errors describe the target) | same, via `adapter_type()` |
| `C.ErrNotSupport` failures ignored | `NotSupported` **and** `UdpNotSupported` ignored — meow splits that sentinel into two variants (relay chains and dialer-proxy members report the latter) |
| "connection refused" escalates immediately, streak untouched | same (error-string match, as upstream) |
| `maxFailedTimes = 5` within `testTimeout = 5000 ms` | same constants (`DIAL_FAILURE_THRESHOLD` / `DIAL_FAILURE_WINDOW`) |
| dial success resets the streak (`onDialSuccess`) | same |
| escalation keeps the count until the forced health check resets it | **divergence:** escalation resets the count, so re-escalation needs a fresh full streak |
| escalation forces a provider health check | **divergence:** escalation marks the failed member dead |

**Divergence rationale:** meow's group layer cannot trigger probes — the health-check loop lives in meow-app, outside the groups. Marking the member dead achieves the same routing correction immediately, and the next scheduled group probe — which a lazy group is guaranteed to run after a dial bumps its usage generation — revives members that failed only transiently. (ADR-0002-style documented divergence.)

**Known limitation:** for members that are themselves automatic groups (fallback / url-test / load-balance nested inside), `alive()` is derived from their own members and ignores the group's health state, so dead-marking them is a routing no-op (Relay members do read their own health and are affected). Harmless — the same stale-alive window inside the nested group is handled by its own tracker and probes.

## Motivation

Auditing #483's lazy semantics surfaced a stale-alive window: the first use of a long-idle lazy group can hit a member that died while the group was unprobed, and because nothing marks members dead on dial failure, the misses repeat until the next probe tick (up to one `interval`). The base kernel has the same window bounded by one interval for every group; this change shrinks it to at most one failed dial.

## Tests

- `DialFailureTracker` unit tests: threshold escalation, immediate "connection refused" (which leaves the streak intact), window expiry, success reset, `NotSupported` / `UdpNotSupported` exemptions
- group-level tests (fallback + urltest) with `MockProxy::new_failing` (configurable adapter type and dial error): escalation after five failures routes past the dead member; refused marks dead immediately; Direct-type members are exempt; `UdpNotSupported` `dial_udp` failures (via `MockProxy::new_udp_unsupported`) never mark a member dead

## Verification

- `cargo fmt --all -- --check`
- three-way `cargo clippy --all-targets` (default / no-default-features / all-features) with `-D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- full `cargo test` gate list — green (one pre-existing environment-dependent failure in meow-dns `udp_client_times_out_on_unroutable`, reproducible on pristine base)
