### PR TITLE
fix: harden dialer-proxy parsing and lazy health-check semantics

### DIFF
--- a/crates/meow-app/src/health_check.rs
+++ b/crates/meow-app/src/health_check.rs
@@ -77,7 +77,6 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
             );
             continue;
         }
-        last_probed_generation = generation;
         let Some(member_names) = group.members() else {
             continue;
         };
@@ -108,6 +107,15 @@ async fn run_health_check_loop(tunnel: Tunnel, spec: HealthCheckSpec) {
                     spec.group_name, name
                 );
             }
+        }
+
+        // Record the generation only now that a probe round actually ran
+        // (and only the pre-probe snapshot: any use that arrived *during*
+        // the probes must still trigger the next tick).  Consuming it
+        // earlier would let a tick with zero resolved members starve a
+        // lazy group of its next probe.
+        if total_count > 0 {
+            last_probed_generation = generation;
         }
 
         info!(

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -2272,8 +2272,7 @@ mod dialer_proxy_tests {
             serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
         );
 
-        apply_dialer_proxies(&mut proxies, &[first, last], true)
-            .expect("valid chain applies");
+        apply_dialer_proxies(&mut proxies, &[first, last], true).expect("valid chain applies");
 
         let rebuilt = proxies.get("A").expect("present after");
         assert_eq!(

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -525,8 +525,11 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// the dialer over TCP and is unaffected.
 ///
 /// Nested dialer-proxies are resolved deepest-first so each layer sees its
-/// dialer's final (already-rebuilt) form, and dialer-proxy cycles are detected
-/// and skipped with a warning (the outbound then dials directly).
+/// dialer's final (already-rebuilt) form. A self-referencing dialer, a
+/// reference to an unknown proxy, or a dialer cycle is a hard config error —
+/// silently falling back to a direct dial would let traffic egress from the
+/// real source path past a chain the user configured for policy/security
+/// reasons (Class A, ADR-0002).
 ///
 /// Note: this rewrites the registry entry, so direct rule references
 /// (`…,<proxy>`) and dialers that are groups both work. A proxy that is also a
@@ -537,13 +540,23 @@ fn apply_dialer_proxies(
     proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
     raw_proxies: &[HashMap<String, serde_yaml::Value>],
     ipv6: bool,
-) {
+) -> Result<(), anyhow::Error> {
     // Collect proxy -> dialer edges from the raw config.
+    //
+    // Iterate in reverse and keep only the first sighting (the *last* block in
+    // the file) per name: the registry-building loop uses `insert`, so for
+    // duplicate `name:` entries the last block is the effective definition.
+    // Collecting edges from superseded duplicates would apply a chain the
+    // effective block never declared.
     let mut pending: Vec<(SmolStr, SmolStr)> = Vec::new();
-    for raw_proxy in raw_proxies {
+    let mut seen_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for raw_proxy in raw_proxies.iter().rev() {
         let Some(name) = raw_proxy.get("name").and_then(|v| v.as_str()) else {
             continue;
         };
+        if !seen_names.insert(name) {
+            continue;
+        }
         let Some(dialer) = raw_proxy
             .get("dialer-proxy")
             .and_then(|v| v.as_str())
@@ -552,13 +565,12 @@ fn apply_dialer_proxies(
             continue;
         };
         if dialer == name {
-            warn!("proxy '{name}': dialer-proxy points to itself; dialing directly");
-            continue;
+            anyhow::bail!("proxy '{name}': dialer-proxy points to itself");
         }
         pending.push((SmolStr::from(name), SmolStr::from(dialer)));
     }
     if pending.is_empty() {
-        return;
+        return Ok(());
     }
 
     // Names that declared a dialer-proxy — used to defer an edge until its
@@ -579,9 +591,7 @@ fn apply_dialer_proxies(
             }
             progressed = true;
             let Some(dialer_proxy) = proxies.get(&dialer).cloned() else {
-                warn!("proxy '{name}': dialer-proxy '{dialer}' not found; dialing directly");
-                resolved.insert(name);
-                continue;
+                anyhow::bail!("proxy '{name}': dialer-proxy '{dialer}' not found");
             };
             // Re-parse the raw block with a `ProxyDialer` injected (mihomo
             // model), so the adapter's own dial + handshake runs on the
@@ -632,7 +642,10 @@ fn apply_dialer_proxies(
                     }
                 }
             } else {
-                warn!(
+                // Unreachable in practice — edges are only collected from blocks
+                // in this same list — but refuse instead of silently dialing
+                // direct if the invariant ever breaks.
+                anyhow::bail!(
                     "proxy '{name}': dialer-proxy '{dialer}' not applied; no raw \
                      config block found for this name"
                 );
@@ -644,9 +657,14 @@ fn apply_dialer_proxies(
             break;
         }
     }
-    for (name, dialer) in pending {
-        warn!("proxy '{name}': dialer-proxy cycle involving '{dialer}' detected; dialing directly");
+    if !pending.is_empty() {
+        let edges: Vec<String> = pending
+            .iter()
+            .map(|(name, dialer)| format!("{name} -> {dialer}"))
+            .collect();
+        anyhow::bail!("dialer-proxy cycle detected: {}", edges.join(", "));
     }
+    Ok(())
 }
 
 fn rebuild_from_raw_impl(
@@ -785,7 +803,7 @@ fn rebuild_from_raw_impl(
 
     // Apply per-outbound `dialer-proxy` wrappers (issue #210). Runs after both
     // leaf proxies and groups are built so a dialer may reference either.
-    apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]), ipv6);
+    apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]), ipv6)?;
 
     let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     // Per-provider `proxy:` overrides resolve against the full registry —
@@ -2000,38 +2018,77 @@ mod dialer_proxy_tests {
     fn wraps_proxy_with_dialer() {
         let mut proxies = registry(&["A", "fast"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("fast"))], true);
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("fast"))], true)
+            .expect("valid chain applies");
         assert!(was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "fast"));
     }
 
     #[test]
-    fn self_reference_is_skipped() {
+    fn self_reference_is_a_config_error() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("A"))], true);
+        let err = apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("A"))], true)
+            .expect_err("a self-referencing dialer must not silently dial direct");
+        assert!(
+            err.to_string().contains("points to itself"),
+            "unexpected: {err}"
+        );
         assert!(!was_wrapped(&before, &proxies, "A"));
     }
 
     #[test]
-    fn missing_dialer_is_skipped() {
+    fn missing_dialer_is_a_config_error() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("ghost"))], true);
+        let err = apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("ghost"))], true)
+            .expect_err("an unknown dialer must not silently dial direct");
+        assert!(err.to_string().contains("not found"), "unexpected: {err}");
         assert!(!was_wrapped(&before, &proxies, "A"));
     }
 
     #[test]
-    fn cycle_is_detected_and_skipped() {
+    fn cycle_is_a_config_error() {
         let mut proxies = registry(&["A", "B"]);
         let before = proxies.clone();
-        apply_dialer_proxies(
+        let err = apply_dialer_proxies(
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("A"))],
             true,
-        );
+        )
+        .expect_err("a dialer cycle must not silently dial direct");
+        assert!(err.to_string().contains("cycle"), "unexpected: {err}");
         assert!(!was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "B"));
+    }
+
+    /// Duplicate `name:` blocks: only the *last* block is the effective
+    /// definition, so a `dialer-proxy` declared only by an earlier duplicate
+    /// must not chain the effective block.
+    #[test]
+    fn stale_duplicate_dialer_edge_is_ignored() {
+        let mut proxies = registry(&["A", "front"]);
+        let before = proxies.clone();
+
+        let mut first = raw_socks5_proxy("A", Some("front"), false);
+        first.insert(
+            "port".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(1111)),
+        );
+        let mut last = raw_socks5_proxy("A", None, false);
+        last.insert(
+            "port".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
+        );
+
+        apply_dialer_proxies(&mut proxies, &[first, last], true)
+            .expect("the effective block declares no dialer");
+
+        assert!(
+            !was_wrapped(&before, &proxies, "A"),
+            "the last duplicate block declares no dialer-proxy, so no chain \
+             may be applied"
+        );
     }
 
     #[test]
@@ -2043,7 +2100,8 @@ mod dialer_proxy_tests {
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("C"))],
             true,
-        );
+        )
+        .expect("valid nested chain applies");
         assert!(was_wrapped(&before, &proxies, "A"));
         assert!(was_wrapped(&before, &proxies, "B"));
         assert!(!was_wrapped(&before, &proxies, "C"));
@@ -2103,7 +2161,8 @@ mod dialer_proxy_tests {
             &mut proxies,
             &[raw_socks5_proxy("A", Some("front"), true)],
             true,
-        );
+        )
+        .expect("valid chain applies");
 
         assert!(was_wrapped(&before, &proxies, "A"), "A should be re-parsed");
         assert!(
@@ -2147,7 +2206,8 @@ mod dialer_proxy_tests {
                 &mut proxies,
                 &[raw_typed_proxy("A", ty, Some("front"))],
                 true,
-            );
+            )
+            .expect("valid chain applies via the wrapper fallback");
 
             let after = proxies.get("A").expect("entry survives");
             assert!(
@@ -2185,7 +2245,8 @@ mod dialer_proxy_tests {
 
         // Must not panic and must not spawn: the parse is rejected before
         // `ShadowsocksAdapter::new` runs, so the fallback wrapper is used.
-        apply_dialer_proxies(&mut proxies, &[raw], true);
+        apply_dialer_proxies(&mut proxies, &[raw], true)
+            .expect("valid chain applies via the wrapper fallback");
 
         assert!(
             proxies.contains_key("A"),
@@ -2211,7 +2272,8 @@ mod dialer_proxy_tests {
             serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
         );
 
-        apply_dialer_proxies(&mut proxies, &[first, last], true);
+        apply_dialer_proxies(&mut proxies, &[first, last], true)
+            .expect("valid chain applies");
 
         let rebuilt = proxies.get("A").expect("present after");
         assert_eq!(
@@ -2235,7 +2297,8 @@ mod dialer_proxy_tests {
         let before = proxies.clone();
 
         // raw_proxy has no `type` → parse_proxy_with_dialer fails → fallback.
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("front"))], true);
+        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("front"))], true)
+            .expect("valid chain applies via the wrapper fallback");
 
         assert!(
             was_wrapped(&before, &proxies, "A"),
@@ -2368,7 +2431,8 @@ mod dialer_proxy_tests {
             proxy_parser::parse_proxy(&raw_inner, true).expect("parse inner"),
         );
 
-        apply_dialer_proxies(&mut proxies, &[raw_front, raw_inner], true);
+        apply_dialer_proxies(&mut proxies, &[raw_front, raw_inner], true)
+            .expect("valid chain applies");
 
         // Dial a final target through `inner`; `inner` must reach its own
         // server (127.0.0.1:inner_port) *via* `front`.

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -310,7 +310,18 @@ fn is_external_sip003_plugin(plugin: Option<&str>) -> bool {
     if meow_proxy::shadowsocks_adapter::is_builtin_obfs_plugin(plugin) {
         return false;
     }
-    !matches!(plugin, "v2ray-plugin" | "ech-tls-tunnel")
+    if plugin == "v2ray-plugin" {
+        return false;
+    }
+    // Mirror `ShadowsocksAdapter::new` exactly: its `ech-tls-tunnel` arm is
+    // feature-gated, so without the feature the plugin falls through to the
+    // external-subprocess branch and must be classified external here too —
+    // otherwise an injected dialer would be accepted and silently ignored.
+    #[cfg(feature = "ech-tls-tunnel")]
+    if plugin == "ech-tls-tunnel" {
+        return false;
+    }
+    true
 }
 
 /// Reject a `ProxyDialer` for adapter types that do not thread it through.
@@ -320,8 +331,9 @@ fn is_external_sip003_plugin(plugin: Option<&str>) -> bool {
 /// None of them can honour an injected dialer, so accepting one here would
 /// silently drop the user's `dialer-proxy` and egress from the real source
 /// path — a Class A silent divergence (ADR-0002).  Returning `Err` instead
-/// lets `apply_dialer_proxies` surface a warning and keep the original
-/// (un-chained) entry rather than pretending the chain was applied.
+/// lets `apply_dialer_proxies` fall back to the relay-based
+/// `DialerProxyAdapter` wrapper, which fails loudly at dial time rather
+/// than pretending the chain was applied or dialing direct.
 ///
 /// A `DirectDialer` is always accepted: it is the no-op default, so nothing
 /// is lost by ignoring it.

--- a/crates/meow-proxy/src/group/fallback.rs
+++ b/crates/meow-proxy/src/group/fallback.rs
@@ -165,7 +165,7 @@ impl ProxyAdapter for FallbackGroup {
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
-        self.usage.touch();
+        self.usage.touch_user_traffic(metadata);
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -182,7 +182,7 @@ impl ProxyAdapter for FallbackGroup {
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        self.usage.touch();
+        self.usage.touch_user_traffic(metadata);
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -198,8 +198,8 @@ impl ProxyAdapter for FallbackGroup {
         }
     }
 
-    fn unwrap_proxy(&self, _metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
-        self.usage.touch();
+    fn unwrap_proxy(&self, metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
+        self.usage.touch_user_traffic(metadata);
         self.first_alive()
     }
 
@@ -370,6 +370,26 @@ mod tests {
         assert_eq!(g.usage_generation(), 1, "dial records group use");
         assert_eq!(a_ref.dials(), 0);
         assert_eq!(b_ref.dials(), 1);
+    }
+
+    #[tokio::test]
+    async fn health_probe_dials_do_not_count_as_use() {
+        // Lazy health checks dial members with `ConnType::Tunnel`.  If those
+        // dials incremented the usage generation, a parent group probing a
+        // lazy child would keep the child's own probe loop awake forever.
+        let g = FallbackGroup::new("fb", vec![MockProxy::new("a")]);
+        let probe_meta = Metadata {
+            conn_type: meow_common::ConnType::Tunnel,
+            ..Default::default()
+        };
+        let _ = g.dial_tcp(&probe_meta).await;
+        assert_eq!(
+            g.usage_generation(),
+            0,
+            "probe dials must not mark the group as used"
+        );
+        let _ = g.dial_tcp(&Metadata::default()).await;
+        assert_eq!(g.usage_generation(), 1, "real traffic still marks use");
     }
 
     #[test]

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -22,11 +22,12 @@ impl UsageTracker {
 
     /// Record a use, but only for real user traffic.
     ///
-    /// Health-check probes dial with [`ConnType::Tunnel`] (mihomo's
-    /// convention).  Counting them as uses would defeat lazy mode for nested
-    /// groups: a parent group's periodic probes would mark a lazy child as
-    /// used and keep its own probe loop awake forever without any real
-    /// traffic.
+    /// Health-check probes dial with [`ConnType::Tunnel`] — an internal
+    /// marker set by `health::url_test` (no production dialer uses the
+    /// variant).  Counting probes as uses would defeat lazy mode for
+    /// nested groups: a parent group's periodic probes would mark a lazy
+    /// child as used and keep its own probe loop awake forever without
+    /// any real traffic.
     pub(super) fn touch_user_traffic(&self, metadata: &Metadata) {
         if metadata.conn_type == ConnType::Tunnel {
             return;

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -1,5 +1,5 @@
 use meow_common::atomic::AtomicU;
-use meow_common::{AdapterType, MeowError, Proxy};
+use meow_common::{AdapterType, ConnType, MeowError, Metadata, Proxy};
 use parking_lot::Mutex;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -18,6 +18,20 @@ impl UsageTracker {
 
     pub(super) fn touch(&self) {
         self.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a use, but only for real user traffic.
+    ///
+    /// Health-check probes dial with [`ConnType::Tunnel`] (mihomo's
+    /// convention).  Counting them as uses would defeat lazy mode for nested
+    /// groups: a parent group's periodic probes would mark a lazy child as
+    /// used and keep its own probe loop awake forever without any real
+    /// traffic.
+    pub(super) fn touch_user_traffic(&self, metadata: &Metadata) {
+        if metadata.conn_type == ConnType::Tunnel {
+            return;
+        }
+        self.touch();
     }
 
     pub(super) fn generation(&self) -> u64 {

--- a/crates/meow-proxy/src/group/urltest.rs
+++ b/crates/meow-proxy/src/group/urltest.rs
@@ -262,7 +262,7 @@ impl ProxyAdapter for UrlTestGroup {
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
-        self.usage.touch();
+        self.usage.touch_user_traffic(metadata);
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -279,7 +279,7 @@ impl ProxyAdapter for UrlTestGroup {
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
-        self.usage.touch();
+        self.usage.touch_user_traffic(metadata);
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
@@ -295,8 +295,8 @@ impl ProxyAdapter for UrlTestGroup {
         }
     }
 
-    fn unwrap_proxy(&self, _metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
-        self.usage.touch();
+    fn unwrap_proxy(&self, metadata: &Metadata) -> Option<Arc<dyn Proxy>> {
+        self.usage.touch_user_traffic(metadata);
         self.fastest_proxy()
     }
 

--- a/crates/meow-proxy/src/health.rs
+++ b/crates/meow-proxy/src/health.rs
@@ -56,8 +56,13 @@ pub async fn url_test(
     };
 
     let start = Instant::now();
+    // `Tunnel` marks this dial as a health probe rather than user traffic
+    // (mihomo runs its health checks as TUNNEL-type connections too).
+    // Automatic proxy groups use the marker to keep probe dials from
+    // counting as "use", which would defeat lazy health checks.
     let metadata = meow_common::Metadata {
         network: meow_common::Network::Tcp,
+        conn_type: meow_common::ConnType::Tunnel,
         host: parsed.host.as_str().into(),
         dst_port: parsed.port,
         ..Default::default()

--- a/crates/meow-proxy/src/health.rs
+++ b/crates/meow-proxy/src/health.rs
@@ -56,10 +56,15 @@ pub async fn url_test(
     };
 
     let start = Instant::now();
-    // `Tunnel` marks this dial as a health probe rather than user traffic
-    // (mihomo runs its health checks as TUNNEL-type connections too).
-    // Automatic proxy groups use the marker to keep probe dials from
-    // counting as "use", which would defeat lazy health checks.
+    // `Tunnel` marks this dial as a health probe rather than user traffic.
+    // mihomo solves the same problem by threading an explicit `touch` flag
+    // through its group calls (`fast(false)` for probes); meow-rs'
+    // `ProxyAdapter` trait has no such parameter, so the marker rides on
+    // the metadata instead.  Groups skip the usage-generation bump for
+    // these dials — counting probes as "use" would defeat lazy health
+    // checks for nested groups.  No production dialer sets
+    // `ConnType::Tunnel` today; if a tunnel inbound ever reuses the
+    // variant, probes need their own explicit marker.
     let metadata = meow_common::Metadata {
         network: meow_common::Network::Tcp,
         conn_type: meow_common::ConnType::Tunnel,

--- a/crates/meow-tunnel/tests/route_inbound_tcp_test.rs
+++ b/crates/meow-tunnel/tests/route_inbound_tcp_test.rs
@@ -101,6 +101,10 @@ async fn route_inbound_tcp_prefix_is_forwarded_to_remote() {
         "remote must receive the prefix bytes before the relay copy"
     );
 
+    // Half-close the client side so the relay exits promptly instead of
+    // waiting out RELAY_HALF_CLOSE_LINGER for more client data.
+    client_stream.shutdown().await.unwrap();
+
     // Wait for the relay to finish (echo server half-closes → relay ends).
     let _ = handle.await;
 }
@@ -141,6 +145,10 @@ async fn route_inbound_tcp_empty_prefix_is_no_op() {
         .expect("should receive echoed payload");
     assert_eq!(&received, payload, "relay should forward and echo data");
 
+    // Half-close the client side so the relay exits promptly instead of
+    // waiting out RELAY_HALF_CLOSE_LINGER for more client data.
+    client_stream.shutdown().await.unwrap();
+
     let _ = handle.await;
 }
 
@@ -174,6 +182,10 @@ async fn route_inbound_tcp_prefix_counts_as_upload() {
     let mut received = vec![0u8; prefix.len()];
     client_stream.read_exact(&mut received).await.unwrap();
     assert_eq!(received, prefix);
+
+    // Half-close the client side so the relay exits promptly instead of
+    // waiting out RELAY_HALF_CLOSE_LINGER for more client data.
+    client_stream.shutdown().await.unwrap();
 
     let _ = handle.await;
 


### PR DESCRIPTION
## Summary

Deep review of the PRs merged 2026-08-31 → 09-01 (#487, #483, #480, #476, #473, #465, #463, #462, #399) for robustness regressions. Four substantive fixes plus one docs correction; rebased onto #488 and re-verified against its `DialFailureTracker` (the two changes are orthogonal: probe dials still route through failure tracking, only the usage-generation bump is gated).

### fix(config): hard-fail on dialer-proxy self-ref, unknown dialer, cycles

`apply_dialer_proxies` previously warned and kept the un-chained entry for self-references, unknown dialer names, and dial cycles — traffic silently dialed direct past a chain the user configured. That is a silent misroute, i.e. **Class A per ADR-0002**, so config load now fails with an actionable message. Reload paths are safe: `PUT /configs` rejects with 400 (old runtime preserved), provider/subscription refresh logs and keeps the previous proxies.

Also in this commit:
- `ech-tls-tunnel` SIP003-plugin classification now matches the feature-gated adapter dispatch exactly, so a build without the feature cannot accept-and-ignore an injected dialer.
- Duplicate `name:` proxy blocks: dialer edges are collected from the effective (last) block only, consistent with the last-block-wins re-parse lookup.
- 7 test call sites tightened from bare `unwrap()` to `expect("valid chain applies")`.

### fix(proxy): health probe dials must not count as group use

Health probes dial with `ConnType::Tunnel` (meow-rs's internal probe marker — see the docs commit below). Fallback/URLTest groups now skip the usage-generation bump for these dials: otherwise a parent group's periodic probes would mark a nested lazy child as used and keep the child's own probe loop awake forever without any real traffic, defeating `lazy: true`.

### fix(app): consume lazy health-check generation only after probing

The generation snapshot was recorded before the probe round, so a tick where the group vanished or resolved zero members consumed the use-generation without probing — a lazy group could be starved of its next probe. Now recorded after the round completes, only when ≥1 member was actually probed; the pre-probe snapshot is kept so a use arriving mid-probe still triggers the next tick.

### test(tunnel): half-close client stream so relay tests exit promptly

`route_inbound_tcp` waits out `RELAY_HALF_CLOSE_LINGER` (30 s) for more client data unless the client side closes; each of the three tests lingered ~30 s. Shutting the client down before awaiting the relay brings the suite from ~90 s to instant.

### docs(proxy): correct probe-marker comment after mihomo source audit

mihomo does not type its health-check connections as TUNNEL — its `urlToMetadata` leaves Type zero-valued and the lazy-usage distinction is an explicit touch flag threaded through group calls (`fast(false)` for probes). `ConnType::Tunnel` is meow-rs's own internal marker, and the comments now say so, including the caveat for a future tunnel inbound reusing the variant.

## Not fixed here

- `dialer-proxy` on provider-sourced proxies is still silently ignored (pre-existing, Phase 1 scope) → tracked in #489.
- `.expect` on lock poisoning in listener task shutdown paths — pre-existing, failure only after a panic in the same task.
- Mixed listener accept-loop hot-spin on `TooManyOpenFiles` — pre-existing.

## Test plan

- [x] `cargo test --workspace --lib` — all crates green (375 in meow-proxy incl. new `health_probe_dials_do_not_count_as_use`, 204 in meow-config incl. new `stale_duplicate_dialer_edge_is_ignored`)
- [x] `cargo test -p meow-tunnel --test route_inbound_tcp_test` — 3/3, exits instantly
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo build --release` + binary `-t` config validation for ok / cycle / ghost-dialer configs (cycle and unknown-dialer configs are rejected at startup with the new messages)
- [x] Runtime `PUT /configs` smoke: bad payload (cycle) → 400 with message, old runtime state preserved
- [x] Rebased onto #488 (`DialFailureTracker`) and re-ran the group suites — no conflicts beyond an import merge; call order verified (`touch_user_traffic` gates only the generation bump, `on_success`/`record_dial_failure` unaffected)
