### PR TITLE
fix(mux): isolate stalled smux streams

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,6 +43,20 @@ jobs:
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends simple-obfs
 
+      # The real-server smux E2E (smux_singbox_integration) REFUSES to
+      # silently skip without this binary. Keep the version in sync with
+      # SINGBOX_VERSION in crates/meow-app/tests/smux_singbox_integration.rs
+      # and with the test.yml install step.
+      - name: Install sing-box (real-server smux E2E)
+        run: |
+          set -euo pipefail
+          SINGBOX_VERSION=1.14.0
+          curl -fsSL -o /tmp/sing-box.tar.gz \
+            "https://github.com/SagerNet/sing-box/releases/download/v${SINGBOX_VERSION}/sing-box-${SINGBOX_VERSION}-linux-amd64.tar.gz"
+          tar -xzf /tmp/sing-box.tar.gz -C /tmp
+          sudo install -m 755 "/tmp/sing-box-${SINGBOX_VERSION}-linux-amd64/sing-box" /usr/local/bin/sing-box
+          command -v sing-box
+
       - name: Collect coverage
         env:
           MIHOMO_REQUIRE_INTEGRATION_BINS: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,21 @@ jobs:
           command -v obfs-local
           command -v obfs-server
 
+      # Real-server smux E2E (smux_singbox_integration) runs against this
+      # pinned sing-box and REFUSES to silently skip when it is missing,
+      # so a green run always means real-server smux was exercised. Keep
+      # the version in sync with SINGBOX_VERSION in
+      # crates/meow-app/tests/smux_singbox_integration.rs.
+      - name: Install sing-box (real-server smux E2E)
+        run: |
+          set -euo pipefail
+          SINGBOX_VERSION=1.14.0
+          curl -fsSL -o /tmp/sing-box.tar.gz \
+            "https://github.com/SagerNet/sing-box/releases/download/v${SINGBOX_VERSION}/sing-box-${SINGBOX_VERSION}-linux-amd64.tar.gz"
+          tar -xzf /tmp/sing-box.tar.gz -C /tmp
+          sudo install -m 755 "/tmp/sing-box-${SINGBOX_VERSION}-linux-amd64/sing-box" /usr/local/bin/sing-box
+          command -v sing-box
+
       - name: Build
         run: cargo build --tests
 
@@ -117,6 +132,7 @@ jobs:
             --test ws_test \
             --test crate_invariants_test \
             --test crate_publish_metadata_test \
+            --test smux_singbox_integration \
             -- --nocapture
 
       - name: UDP routing regression (SOCKS5, Shadowsocks, TUN)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,16 @@ cargo test --lib --bin meow \
   --test trojan_integration --test vless_config_test --test vless_integration \
   --test v2ray_plugin_integration --test pre_resolve_test \
   --test tls_test --test ws_test --test crate_invariants_test \
-  --test crate_publish_metadata_test
+  --test crate_publish_metadata_test \
+  --test smux_singbox_integration
 ```
+
+`smux_singbox_integration` runs the full stack (config → mixed listener →
+tunnel → VLESS adapter + smux) against a real sing-box server and **fails**
+(never silently skips) when the binary is missing: install the pinned
+version from https://github.com/SagerNet/sing-box/releases or point
+`SINGBOX_BIN` at it. `MEOW_SMUX_E2E_ALLOW_SKIP=1` prints a loud explicit
+skip for local runs only — CI must never set it.
 
 Keep the target list in sync with `.github/workflows/test.yml`; a new `tests/`
 file that CI runs but this list omits is invisible to the local bar.

--- a/crates/meow-app/tests/smux_singbox_integration.rs
+++ b/crates/meow-app/tests/smux_singbox_integration.rs
@@ -348,9 +348,12 @@ async fn slow_reader_is_isolated_and_fast_readers_survive() {
     // A fast reader works while the slow one is stalled over its share.
     fast_roundtrip(mixed, echo_addr).await;
 
-    // Let the stall watchdog (500 ms grace) retire the slow stream.
+    // Let the stall watchdog (500 ms grace) retire the slow stream. The
+    // writer task's blocked write errors out once the relay tears the
+    // local connection down; the timeout is insurance so a pathological
+    // teardown can never hang the whole test binary.
     tokio::time::sleep(ISOLATION_WAIT).await;
-    let _ = slow_writer.await;
+    let _ = tokio::time::timeout(Duration::from_secs(10), slow_writer).await;
 
     // The retire stayed scoped: the session survived, and a fresh stream
     // multiplexed onto the same physical session works end-to-end.

--- a/crates/meow-app/tests/smux_singbox_integration.rs
+++ b/crates/meow-app/tests/smux_singbox_integration.rs
@@ -1,0 +1,374 @@
+// Real-server smux E2E (PR #491 review): the smux echo/pool/UDP suites all
+// use in-memory mock peers, and the v2ray-plugin integration test runs the
+// server with `mux=0`, so nothing validated smux against a real
+// sing-box/mihomo server. This suite closes that gap: every byte travels
+// config parsing → mixed listener → tunnel routing → VLESS adapter
+// (+ sing-mux smux) → a real sing-box process → direct outbound → a local
+// echo server, and back.
+//
+// It covers:
+//   * a 4 MiB bulk transfer — thirty-two times the per-stream receive
+//     share — with a continuously reading consumer, which must never be
+//     aborted;
+//   * a slow reader sharing the physical session (max-connections: 1)
+//     with fast readers: the slow stream is isolated, its peers and the
+//     session itself survive, and a fresh stream on the same session
+//     works afterwards.
+//
+// Server availability policy — the inverse of the SKIP-by-default suites:
+// this test FAILS when sing-box is missing, because a green CI run must
+// mean real-server smux was exercised. CI installs a pinned sing-box (see
+// .github/workflows/test.yml). To skip locally — never in CI — set
+// MEOW_SMUX_E2E_ALLOW_SKIP=1; the skip line is loud and explicit.
+//
+// Binary discovery: `$SINGBOX_BIN` overrides, otherwise `sing-box` must be
+// on PATH.
+#![cfg(all(feature = "vless", feature = "mux", feature = "listener-mixed"))]
+
+use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Pinned sing-box release this suite is validated against. Bump together
+/// with the CI install step in .github/workflows/test.yml.
+const SINGBOX_VERSION: &str = "1.14.0";
+/// VLESS user UUID shared by the client config and the sing-box inbound.
+const TEST_UUID: &str = "b831381d-6324-4d53-ad4f-8cda48b30811";
+/// Per-stream receive share in meow's smux (`MAX_RECEIVE_BUFFER / 32`).
+/// Duplicated here because the constant is private to meow-proxy.
+const MAX_STREAM_BUFFER: usize = 4 * 1024 * 1024 / 32;
+/// Wall-clock margin over meow's `STREAM_STALL_GRACE` (500 ms) for the
+/// slow-reader isolation to take effect against real sockets.
+const ISOLATION_WAIT: Duration = Duration::from_secs(2);
+
+// ─── sing-box server ──────────────────────────────────────────────────────
+
+/// Locate the sing-box binary: `$SINGBOX_BIN`, then PATH.
+fn singbox_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("SINGBOX_BIN") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Some(path);
+        }
+        panic!("SINGBOX_BIN is set but does not point at a file: {path:?}");
+    }
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let exe = if cfg!(windows) {
+            dir.join("sing-box.exe")
+        } else {
+            dir.join("sing-box")
+        };
+        if exe.is_file() {
+            return Some(exe);
+        }
+    }
+    None
+}
+
+/// Resolve sing-box, or fail the test. The explicit opt-out env var prints
+/// a loud SKIP line and lets the test return early; everything else —
+/// including CI — fails hard, so green always means "real-server smux was
+/// exercised".
+fn require_singbox() -> Option<PathBuf> {
+    match singbox_binary() {
+        Some(bin) => Some(bin),
+        None => {
+            if std::env::var_os("MEOW_SMUX_E2E_ALLOW_SKIP").is_some() {
+                eprintln!(
+                    "SKIP: sing-box (v{SINGBOX_VERSION}) not found and \
+                     MEOW_SMUX_E2E_ALLOW_SKIP is set — real-server smux E2E \
+                     NOT exercised"
+                );
+                None
+            } else {
+                panic!(
+                    "sing-box (v{SINGBOX_VERSION}) is required for the real-server \
+                     smux E2E and was not found (SINGBOX_BIN unset, not on PATH). \
+                     Install it from https://github.com/SagerNet/sing-box/releases — \
+                     a green CI run must exercise real-server smux, so this test \
+                     refuses to silently skip. Set MEOW_SMUX_E2E_ALLOW_SKIP=1 \
+                     only for a loud local skip."
+                )
+            }
+        }
+    }
+}
+
+struct SingBoxServer {
+    child: Child,
+    log_path: PathBuf,
+}
+
+impl Drop for SingBoxServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Start `sing-box run` with a VLESS inbound (multiplex enabled) and a
+/// direct outbound. The client selects smux via its sing-mux request header,
+/// so the server side needs only `"multiplex": {"enabled": true}`.
+fn start_singbox(bin: &Path, dir: &Path, port: u16) -> SingBoxServer {
+    let config = format!(
+        r#"{{
+  "log": {{"level": "info", "output": "singbox.log"}},
+  "inbounds": [{{
+    "type": "vless",
+    "tag": "vless-in",
+    "listen": "127.0.0.1",
+    "listen_port": {port},
+    "users": [{{"name": "e2e", "uuid": "{TEST_UUID}"}}],
+    "multiplex": {{"enabled": true}}
+  }}],
+  "outbounds": [{{"type": "direct", "tag": "out"}}]
+}}"#
+    );
+    let config_path = dir.join("singbox.json");
+    std::fs::write(&config_path, config).expect("write sing-box config");
+    let log_path = dir.join("singbox.log");
+
+    let child = Command::new(bin)
+        .arg("run")
+        .arg("-c")
+        .arg(&config_path)
+        .current_dir(dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn sing-box at {bin:?}: {e}"));
+    SingBoxServer { child, log_path }
+}
+
+/// Poll until sing-box's VLESS inbound accepts connections.
+async fn wait_listening(server: &SingBoxServer, port: u16) {
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    for _ in 0..100 {
+        if TcpStream::connect(addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    let log = std::fs::read_to_string(&server.log_path).unwrap_or_default();
+    panic!("sing-box did not listen on {addr} within 15s; log:\n{log}");
+}
+
+// ─── meow under test ─────────────────────────────────────────────────────
+
+/// Build the meow side exactly like `main.rs` does: parse the config, wire
+/// the tunnel, and serve a mixed listener on an ephemeral port. The config
+/// pins `max-connections: 1` so every logical connection shares one
+/// physical smux session.
+async fn start_meow(singbox_port: u16) -> SocketAddr {
+    let yaml = format!(
+        r#"
+mixed-port: 7890          # inert: the test binds its own ephemeral listener
+mode: rule
+log-level: warning
+ipv6: false
+allow-lan: false
+
+proxies:
+  - name: singbox-smux
+    type: vless
+    server: 127.0.0.1
+    port: {singbox_port}
+    uuid: {TEST_UUID}
+    smux:
+      enabled: true
+      protocol: smux
+      max-connections: 1
+
+rules:
+  - MATCH,singbox-smux
+"#
+    );
+    let config = meow_config::load_config_from_str(&yaml)
+        .await
+        .expect("parse smux e2e config");
+    let tunnel = meow_tunnel::Tunnel::new(std::sync::Arc::clone(&config.dns.resolver));
+    tunnel.set_mode(config.general.mode);
+    tunnel.update_routing(config.proxies, config.rules);
+    tunnel.spawn_background_tasks();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let mixed = meow_listener::MixedListener::new(tunnel, addr, "smux-e2e".to_string());
+    tokio::spawn(async move {
+        let _ = mixed.run_on(listener).await;
+    });
+    addr
+}
+
+/// SOCKS5 CONNECT through the mixed listener; returns the relayed stream.
+async fn socks5_connect(proxy: SocketAddr, target: SocketAddr) -> TcpStream {
+    let mut stream = TcpStream::connect(proxy).await.expect("connect mixed port");
+    stream.write_all(&[0x05, 0x01, 0x00]).await.unwrap();
+    let mut method = [0u8; 2];
+    stream.read_exact(&mut method).await.unwrap();
+    assert_eq!(&method, &[0x05, 0x00], "unexpected SOCKS5 greeting reply");
+    let mut request = vec![0x05, 0x01, 0x00, 0x01];
+    let IpAddr::V4(ip) = target.ip() else {
+        panic!("echo target must be IPv4");
+    };
+    request.extend_from_slice(&ip.octets());
+    request.extend_from_slice(&target.port().to_be_bytes());
+    stream.write_all(&request).await.unwrap();
+    let mut reply = [0u8; 10];
+    stream.read_exact(&mut reply).await.unwrap();
+    assert_eq!(reply[1], 0x00, "SOCKS5 CONNECT rejected: {}", reply[1]);
+    stream
+}
+
+/// A local TCP echo server accepting any number of connections.
+async fn start_echo_server() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 16 * 1024];
+                loop {
+                    let n = match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => n,
+                    };
+                    if stream.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+/// A deterministic 64 KiB pattern block, repeated to `total` bytes.
+fn pattern(total: usize) -> Vec<u8> {
+    let block: Vec<u8> = (0..64 * 1024).map(|i| (i * 31 % 251) as u8).collect();
+    let mut out = Vec::with_capacity(total);
+    while out.len() < total {
+        let take = block.len().min(total - out.len());
+        out.extend_from_slice(&block[..take]);
+    }
+    out
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────
+
+/// A 4 MiB bulk transfer — 32× the per-stream receive share — with a
+/// continuously reading consumer must complete byte-identical through the
+/// real server. This is the E2E twin of the buffered-burst regression: a
+/// healthy reader must never be aborted for going over its share, no
+/// matter how fast the real server pushes.
+#[tokio::test]
+async fn large_transfer_survives_a_real_smux_server() {
+    let Some(bin) = require_singbox() else {
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let singbox_port = free_port();
+    let server = start_singbox(&bin, dir.path(), singbox_port);
+    wait_listening(&server, singbox_port).await;
+
+    let echo_addr = start_echo_server().await;
+    let mixed = start_meow(singbox_port).await;
+
+    let total = 32 * MAX_STREAM_BUFFER;
+    let payload = pattern(total);
+    let conn = socks5_connect(mixed, echo_addr).await;
+    let (mut reader_half, mut writer_half) = conn.into_split();
+
+    let reader = tokio::spawn(async move {
+        let mut received = vec![0u8; total];
+        reader_half
+            .read_exact(&mut received)
+            .await
+            .expect("4 MiB must come back through the real smux server");
+        received
+    });
+    writer_half
+        .write_all(&payload)
+        .await
+        .expect("4 MiB must be accepted by the real smux server");
+    let received = tokio::time::timeout(Duration::from_secs(60), reader)
+        .await
+        .expect("echo roundtrip timed out")
+        .expect("reader task panicked");
+    assert_eq!(received.len(), total);
+    assert_eq!(received, payload, "echo payload corrupted over smux");
+}
+
+/// A slow reader sharing the physical session with fast readers: the slow
+/// stream is isolated — its relay parks the backlog until the stall
+/// watchdog retires the stream and the local connection is torn down —
+/// while every fast reader, before and after the isolation, completes fine
+/// on the very same session (max-connections: 1 pins them together).
+#[tokio::test]
+async fn slow_reader_is_isolated_and_fast_readers_survive() {
+    let Some(bin) = require_singbox() else {
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let singbox_port = free_port();
+    let server = start_singbox(&bin, dir.path(), singbox_port);
+    wait_listening(&server, singbox_port).await;
+
+    let echo_addr = start_echo_server().await;
+    let mixed = start_meow(singbox_port).await;
+
+    // The slow reader: 2 MiB requested (the writer blocks partway once
+    // every buffer in the chain fills — that is the point), and the client
+    // side never reads a byte, so the relay parks the backlog on the smux
+    // stream until the stall watchdog retires it.
+    let mut slow = socks5_connect(mixed, echo_addr).await;
+    let slow_writer = tokio::spawn(async move {
+        let big = pattern(2 * 1024 * 1024);
+        // Errors are expected once the stream is retired and the relay
+        // tears the local connection down; the amount pushed before that
+        // is what builds the over-share backlog.
+        let _ = slow.write_all(&big).await;
+    });
+
+    // A fast reader works while the slow one is stalled over its share.
+    fast_roundtrip(mixed, echo_addr).await;
+
+    // Let the stall watchdog (500 ms grace) retire the slow stream.
+    tokio::time::sleep(ISOLATION_WAIT).await;
+    let _ = slow_writer.await;
+
+    // The retire stayed scoped: the session survived, and a fresh stream
+    // multiplexed onto the same physical session works end-to-end.
+    fast_roundtrip(mixed, echo_addr).await;
+}
+
+/// One small echo roundtrip through the mixed listener.
+async fn fast_roundtrip(mixed: SocketAddr, echo_addr: SocketAddr) {
+    let mut conn = socks5_connect(mixed, echo_addr).await;
+    let payload = pattern(16 * 1024);
+    tokio::time::timeout(Duration::from_secs(20), async {
+        conn.write_all(&payload).await.expect("write fast stream");
+        let mut received = vec![0u8; payload.len()];
+        conn.read_exact(&mut received)
+            .await
+            .expect("read fast stream");
+        assert_eq!(received, payload, "fast stream corrupted");
+    })
+    .await
+    .expect("fast roundtrip must not be blocked by a slow sibling stream");
+}

--- a/crates/meow-proxy/src/mux/smux.rs
+++ b/crates/meow-proxy/src/mux/smux.rs
@@ -16,12 +16,14 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
-use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 use tokio_util::sync::{CancellationToken, PollSender};
+use tracing::debug;
 
 const CMD_SYN: u8 = 0;
 const CMD_FIN: u8 = 1;
@@ -32,11 +34,27 @@ const FRAME_HEADER_LEN: usize = 8;
 
 /// Largest frame payload — sagernet smux MaxFrameSize default (u16 length).
 const MAX_FRAME_SIZE: usize = 32768;
-/// Per-stream channel depth. A full inbox aborts only that stream rather
-/// than awaiting it in the session reader and blocking unrelated streams.
-const STREAM_QUEUE: usize = 32;
+/// Inbox depth. This is a bound on queue *overhead*, not a flow-control
+/// threshold: a frame count says nothing about how much data a consumer is
+/// behind by, so retiring on it disconnects streams that merely paused.
+/// [`MAX_STREAM_BUFFER`] is the real trigger; this depth is only reached
+/// first when the peer sends frames small enough that 2048 of them cost
+/// less payload than their queue slots.
+const STREAM_QUEUE: usize = 2048;
 /// Sagernet's default session-wide receive budget.
 const MAX_RECEIVE_BUFFER: usize = 4 * 1024 * 1024;
+/// One stream's share of [`MAX_RECEIVE_BUFFER`]. A stream is retired only
+/// once this much of its payload sits undelivered, so a slow consumer is
+/// buffered (and the session keeps dispatching its peers) rather than
+/// disconnected. sing-mux's own `MaxStreamBuffer` is 64 KiB, but that is a
+/// *blocking* threshold — reusing it as a retire threshold would kill
+/// streams for sub-millisecond stalls.
+const MAX_STREAM_BUFFER: usize = MAX_RECEIVE_BUFFER / 4;
+/// How long the reader waits for session receive budget before giving up on
+/// the session. Nothing below the mux layer reclaims budget held by a
+/// stalled consumer, so a wedged session cannot recover on its own; see
+/// `BUDGET_STALL_TIMEOUT` use in the reader.
+const BUDGET_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 /// Bounded outbound queue; stream writes wait when the physical writer lags.
 const OUTBOUND_QUEUE: usize = 64;
 /// Bounded overflow queue for FIN frames when the writer is backpressured.
@@ -118,11 +136,14 @@ struct InboundChunk {
     data: Bytes,
     /// Releases session receive capacity as the stream consumes or drops data.
     permit: Option<OwnedSemaphorePermit>,
+    /// Its stream's undelivered-payload counter; see [`StreamEntry::unread`].
+    unread: Arc<AtomicUsize>,
 }
 
 impl InboundChunk {
     fn advance(&mut self, n: usize) {
         self.data.advance(n);
+        self.unread.fetch_sub(n, Ordering::Release);
         if let Some(permit) = &mut self.permit {
             drop(
                 permit
@@ -133,10 +154,26 @@ impl InboundChunk {
     }
 }
 
+impl Drop for InboundChunk {
+    fn drop(&mut self) {
+        // `advance` already accounted for the bytes it handed over, so only
+        // the unread remainder is left. Together the two subtract exactly
+        // what the reader added when it enqueued the frame.
+        if !self.data.is_empty() {
+            self.unread.fetch_sub(self.data.len(), Ordering::Release);
+        }
+    }
+}
+
 #[derive(Clone)]
 struct StreamEntry {
     tx: mpsc::Sender<InboundChunk>,
     aborted: Arc<AtomicBool>,
+    /// Payload bytes enqueued for this stream and not yet handed to its
+    /// consumer. The reader stops accepting for the stream once this passes
+    /// [`MAX_STREAM_BUFFER`], which keeps one stream from monopolising the
+    /// session budget while leaving transient consumer pauses unaffected.
+    unread: Arc<AtomicUsize>,
 }
 
 /// One outbound writer request.  Flush requests travel the SAME bounded
@@ -257,8 +294,10 @@ impl Session {
             writer_cancel.cancel();
         });
 
-        // Reader task: a full stream inbox aborts that stream; it never
-        // awaits the inbox while holding up frame dispatch for its peers.
+        // Reader task: frame dispatch never awaits a stream inbox, so one
+        // stalled consumer cannot stop its peers receiving data. A stream is
+        // retired only once it holds more than its share of the receive
+        // budget — a consumer that merely paused is buffered, not cut off.
         let reader_state = Arc::clone(&state);
         let reader_cancel = cancel.clone();
         let reader_writer_tx = writer_tx.clone();
@@ -294,18 +333,17 @@ impl Session {
                             }
                             continue;
                         }
-                        // A zero capacity is a stable overflow signal because
-                        // this task is the inbox's sole producer. Retire the
-                        // stream before it borrows session receive capacity.
-                        if entry.tx.capacity() == 0 {
-                            entry.aborted.store(true, Ordering::Release);
-                            reader_state.remove_stream(stream_id);
-                            queue_fin(
+                        // Retire on undelivered BYTES. Checked before taking
+                        // budget so a hog cannot borrow capacity for a frame
+                        // that is about to be discarded.
+                        if entry.unread.load(Ordering::Acquire) + length > MAX_STREAM_BUFFER {
+                            retire_stream(
+                                &entry,
+                                &reader_state,
                                 &reader_writer_tx,
                                 &reader_deferred_fin_tx,
-                                &reader_state,
-                                &reader_cancel,
                                 stream_id,
+                                "per-stream receive buffer exhausted",
                             );
                             if !drain_frame(&mut reader, &reader_cancel, &mut discard, length).await
                             {
@@ -313,11 +351,37 @@ impl Session {
                             }
                             continue;
                         }
-                        let permit = tokio::select! {
-                            _ = reader_cancel.cancelled() => break,
-                            result = Arc::clone(&receive_budget).acquire_many_owned(length as u32) => match result {
-                                Ok(permit) => permit,
-                                Err(_) => break,
+                        // Try without blocking first: arming a timer on every
+                        // frame would tax the hot path, and the budget is
+                        // uncontended in the common case.
+                        let permit = match Arc::clone(&receive_budget)
+                            .try_acquire_many_owned(length as u32)
+                        {
+                            Ok(permit) => permit,
+                            Err(TryAcquireError::Closed) => break 'reader,
+                            Err(TryAcquireError::NoPermits) => tokio::select! {
+                                _ = reader_cancel.cancelled() => break 'reader,
+                                result = Arc::clone(&receive_budget)
+                                    .acquire_many_owned(length as u32) => match result {
+                                    Ok(permit) => permit,
+                                    Err(_) => break 'reader,
+                                },
+                                // Every budget holder has stalled. The budget
+                                // lives in chunks queued inside inboxes whose
+                                // consumers are not polling, and the relay
+                                // stops polling a read half whose write half
+                                // is blocked — so no layer below can reclaim
+                                // it and this session will never dispatch
+                                // again. Abandon it: the physical connection
+                                // closes, the server releases its side, and
+                                // the pool opens a fresh session.
+                                _ = tokio::time::sleep(BUDGET_STALL_TIMEOUT) => {
+                                    debug!(
+                                        "smux: session receive budget ({MAX_RECEIVE_BUFFER} bytes) \
+                                         held for {BUDGET_STALL_TIMEOUT:?}; abandoning session"
+                                    );
+                                    break 'reader;
+                                }
                             },
                         };
                         let mut payload = vec![0u8; length];
@@ -328,29 +392,53 @@ impl Session {
                         if payload_result.is_err() {
                             break;
                         }
+                        entry.unread.fetch_add(length, Ordering::Release);
                         match entry.tx.try_send(InboundChunk {
                             data: Bytes::from(payload),
                             permit: Some(permit),
+                            unread: Arc::clone(&entry.unread),
                         }) {
+                            // Depth bound, reached only when frames are small
+                            // enough that 2048 of them fit under the byte cap.
                             Err(mpsc::error::TrySendError::Full(_)) => {
-                                entry.aborted.store(true, Ordering::Release);
-                                reader_state.remove_stream(stream_id);
-                                queue_fin(
+                                retire_stream(
+                                    &entry,
+                                    &reader_state,
                                     &reader_writer_tx,
                                     &reader_deferred_fin_tx,
-                                    &reader_state,
-                                    &reader_cancel,
                                     stream_id,
+                                    "stream inbox depth exhausted",
                                 );
                             }
                             Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
                         }
                     }
-                    CMD_FIN if length == 0 => reader_state.remove_stream(stream_id),
-                    CMD_NOP if length == 0 => {}
-                    // SYN, unknown commands, and control frames with payload
-                    // are protocol errors; reject before allocating payload.
-                    _ => break,
+                    CMD_FIN | CMD_NOP => {
+                        // sagernet smux control frames carry no payload, but a
+                        // malformed one must not take down every stream on the
+                        // session: discard it and keep going.
+                        if length > 0
+                            && !drain_frame(&mut reader, &reader_cancel, &mut discard, length).await
+                        {
+                            break 'reader;
+                        }
+                        if cmd == CMD_FIN {
+                            // Peer half-closed: EOF the read side by dropping
+                            // the sender.
+                            reader_state.remove_stream(stream_id);
+                        }
+                    }
+                    // v1 has no UPD; a server-initiated SYN is unexpected in
+                    // client-only usage and anything else is a protocol error.
+                    // Reject before allocating payload.
+                    CMD_SYN => {
+                        debug!("smux: protocol error: unexpected SYN from server");
+                        break 'reader;
+                    }
+                    other => {
+                        debug!("smux: protocol error: unknown command {other}");
+                        break 'reader;
+                    }
                 }
             }
             reader_state.mark_dead();
@@ -376,6 +464,7 @@ impl Session {
             StreamEntry {
                 tx,
                 aborted: Arc::clone(&aborted),
+                unread: Arc::new(AtomicUsize::new(0)),
             },
         )?;
         // The guard removes the map entry if this future is cancelled
@@ -453,8 +542,6 @@ impl Drop for Session {
 fn queue_fin(
     writer_tx: &mpsc::Sender<OutMsg>,
     deferred_fin_tx: &mpsc::Sender<Bytes>,
-    state: &SessionState,
-    cancel: &CancellationToken,
     stream_id: u32,
 ) {
     let frame = encode_frame(CMD_FIN, stream_id, &[]);
@@ -462,9 +549,32 @@ fn queue_fin(
         return;
     }
     if deferred_fin_tx.try_send(frame).is_err() {
-        state.mark_dead();
-        cancel.cancel();
+        // Both bounded queues are full, so the physical writer is wedged.
+        // Dropping this FIN leaks one server-side stream until the session
+        // ends; tearing the session down here would kill every healthy
+        // stream on it, and this path is reachable from `Drop`.
+        debug!("smux: dropping FIN for stream {stream_id}: outbound queues full");
     }
+}
+
+/// Retire one stream: mark it aborted so its consumer surfaces an error
+/// instead of a clean EOF, drop its map entry, and tell the peer. The
+/// session and every other stream are untouched.
+fn retire_stream(
+    entry: &StreamEntry,
+    state: &SessionState,
+    writer_tx: &mpsc::Sender<OutMsg>,
+    deferred_fin_tx: &mpsc::Sender<Bytes>,
+    stream_id: u32,
+    reason: &str,
+) {
+    entry.aborted.store(true, Ordering::Release);
+    debug!(
+        "smux: retiring stream {stream_id}: {reason} ({} bytes undelivered)",
+        entry.unread.load(Ordering::Relaxed)
+    );
+    state.remove_stream(stream_id);
+    queue_fin(writer_tx, deferred_fin_tx, stream_id);
 }
 
 impl SessionState {
@@ -524,8 +634,6 @@ impl SmuxStream {
         queue_fin(
             &self.session.writer_tx,
             &self.session.deferred_fin_tx,
-            &self.session.state,
-            &self.session.cancel,
             self.id,
         );
     }
@@ -843,32 +951,158 @@ mod tests {
         assert_eq!(&buf, b"BBB");
     }
 
+    /// A 33-frame backlog is a normal burst, not a hog. Under a frame-count
+    /// trigger it retired the stream; the byte cap must leave it open, keep
+    /// the peer flowing, and let the consumer catch up on every byte.
     #[tokio::test]
-    async fn full_inbox_aborts_only_the_stalled_stream() {
+    async fn small_backlog_neither_aborts_nor_blocks_peers() {
+        const BACKLOG: usize = 33;
         let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
         let session = Arc::new(Session::client(client_io).unwrap());
-        let mut a = session.open_stream().await.unwrap();
-        let mut b = session.open_stream().await.unwrap();
+        let mut slow = session.open_stream().await.unwrap();
+        let mut peer = session.open_stream().await.unwrap();
 
         let mut wire = Vec::new();
-        for _ in 0..=STREAM_QUEUE {
-            wire.extend_from_slice(&encode_frame(CMD_PSH, a.id, b"x"));
+        for _ in 0..BACKLOG {
+            wire.extend_from_slice(&encode_frame(CMD_PSH, slow.id, b"x"));
         }
-        wire.extend_from_slice(&encode_frame(CMD_PSH, b.id, b"ready"));
+        wire.extend_from_slice(&encode_frame(CMD_PSH, peer.id, b"ready"));
         server_io.write_all(&wire).await.unwrap();
 
         let mut ready = [0u8; 5];
-        tokio::time::timeout(std::time::Duration::from_secs(1), b.read_exact(&mut ready))
-            .await
-            .expect("a full A inbox must not block B")
-            .unwrap();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            peer.read_exact(&mut ready),
+        )
+        .await
+        .expect("a backed-up stream must not block its peers")
+        .unwrap();
         assert_eq!(&ready, b"ready");
 
-        let mut drained = vec![0u8; STREAM_QUEUE];
-        a.read_exact(&mut drained).await.unwrap();
-        let error = a.read(&mut [0u8; 1]).await.unwrap_err();
+        let mut drained = vec![0u8; BACKLOG];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            slow.read_exact(&mut drained),
+        )
+        .await
+        .expect("the whole backlog must stay deliverable")
+        .unwrap();
+        assert!(drained.iter().all(|b| *b == b'x'));
+
+        // Still open: the next read parks instead of erroring.
+        let next = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            slow.read(&mut [0u8; 1]),
+        )
+        .await;
+        assert!(next.is_err(), "a small backlog must not retire the stream");
+        assert!(!session.is_dead());
+    }
+
+    /// Retiring is reserved for a stream that has taken more than its share
+    /// of the session receive budget. What it already buffered is still
+    /// delivered, the consumer then sees `ConnectionAborted`, and neither the
+    /// session nor its peers are affected.
+    #[tokio::test]
+    async fn per_stream_byte_cap_retires_only_the_hog() {
+        // One frame past the cap: the cap check is `unread + length > cap`.
+        let frames_over_cap = MAX_STREAM_BUFFER / MAX_FRAME_SIZE + 1;
+        let (client_io, mut server_io) = tokio::io::duplex(2 * MAX_STREAM_BUFFER);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut hog = session.open_stream().await.unwrap();
+        let mut peer = session.open_stream().await.unwrap();
+
+        let big = vec![0x5au8; MAX_FRAME_SIZE];
+        let mut wire = Vec::new();
+        for _ in 0..frames_over_cap {
+            wire.extend_from_slice(&encode_frame(CMD_PSH, hog.id, &big));
+        }
+        wire.extend_from_slice(&encode_frame(CMD_PSH, peer.id, b"ready"));
+        tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            server_io.write_all(&wire),
+        )
+        .await
+        .expect("wire write must not block")
+        .unwrap();
+
+        let mut ready = [0u8; 5];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            peer.read_exact(&mut ready),
+        )
+        .await
+        .expect("a hog stream must not block its peers")
+        .unwrap();
+        assert_eq!(&ready, b"ready");
+
+        let mut buffered = vec![0u8; MAX_STREAM_BUFFER];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            hog.read_exact(&mut buffered),
+        )
+        .await
+        .expect("data queued before the retire must still be delivered")
+        .unwrap();
+        assert!(buffered.iter().all(|b| *b == 0x5a));
+
+        let error = hog.read(&mut [0u8; 1]).await.unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::ConnectionAborted);
         assert!(!session.is_dead());
+    }
+
+    /// Streams pinned at the per-stream cap can exhaust the session receive
+    /// budget, and the consumers holding it are by definition not polling —
+    /// the relay stops polling a read half whose write half is blocked — so
+    /// nothing below can reclaim it. The reader must abandon the session
+    /// rather than leave it wedged forever.
+    #[tokio::test(start_paused = true)]
+    async fn wedged_receive_budget_abandons_the_session() {
+        let frames_per_stream = MAX_STREAM_BUFFER / MAX_FRAME_SIZE;
+        let hogs = MAX_RECEIVE_BUFFER / MAX_STREAM_BUFFER;
+        let (client_io, mut server_io) = tokio::io::duplex(MAX_RECEIVE_BUFFER + 64 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut streams = Vec::new();
+        for _ in 0..hogs + 1 {
+            streams.push(session.open_stream().await.unwrap());
+        }
+        let ids: Vec<u32> = streams.iter().map(|s| s.id).collect();
+
+        let big = vec![0x5au8; MAX_FRAME_SIZE];
+        let writer = tokio::spawn(async move {
+            for id in ids.iter().take(hogs) {
+                for _ in 0..frames_per_stream {
+                    if server_io
+                        .write_all(&encode_frame(CMD_PSH, *id, &big))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+            // Never acquired: the budget is already exhausted by the hogs.
+            let _ = server_io
+                .write_all(&encode_frame(CMD_PSH, ids[hogs], b"alive"))
+                .await;
+        });
+
+        // Paused time auto-advances once every task is idle, so the stall
+        // deadline resolves without a real wait. The victim's frame was never
+        // dispatched, so it sees the abandoned session instead of its data.
+        let error = streams[hogs].read(&mut [0u8; 1]).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+        assert!(
+            session.is_dead(),
+            "a session that cannot make progress must be abandoned"
+        );
+        // A hog was served in full, so the reader really did consume the
+        // whole budget and only then stop — pinning the teardown to the
+        // acquire rather than to some other session-death path.
+        let mut buffered = vec![0u8; MAX_STREAM_BUFFER];
+        streams[0].read_exact(&mut buffered).await.unwrap();
+        assert!(buffered.iter().all(|b| *b == 0x5a));
+        writer.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/meow-proxy/src/mux/smux.rs
+++ b/crates/meow-proxy/src/mux/smux.rs
@@ -580,15 +580,20 @@ fn queue_fin(
     stream_id: u32,
 ) {
     let frame = encode_frame(CMD_FIN, stream_id, &[]);
-    if writer_tx.try_send(OutMsg::Frame(frame.clone())).is_ok() {
-        return;
+    match writer_tx.try_send(OutMsg::Frame(frame.clone())) {
+        // Closed means the writer already broke out and marked the session dead.
+        Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => return,
+        Err(mpsc::error::TrySendError::Full(_)) => {}
     }
-    if deferred_fin_tx.try_send(frame).is_err() {
-        // Both bounded queues are full, so the physical writer is wedged.
-        // Dropping this FIN leaks one server-side stream until the session
-        // ends; tearing the session down here would kill every healthy
-        // stream on it, and this path is reachable from `Drop`.
-        debug!("smux: dropping FIN for stream {stream_id}: outbound queues full");
+    match deferred_fin_tx.try_send(frame) {
+        Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            // Both bounded queues are full, so the physical writer is wedged.
+            // Dropping this FIN leaks one server-side stream until the session
+            // ends; tearing the session down here would kill every healthy
+            // stream on it, and this path is reachable from `Drop`.
+            debug!("smux: dropping FIN for stream {stream_id}: outbound queues full");
+        }
     }
 }
 
@@ -1366,6 +1371,73 @@ mod tests {
         assert!(
             !saw_victim_fin,
             "both queues were full, so the FIN must have been dropped"
+        );
+    }
+
+    #[derive(Clone)]
+    struct CaptureSink(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureSink {
+        type Writer = CaptureSink;
+        fn make_writer(&'a self) -> CaptureSink {
+            self.clone()
+        }
+    }
+
+    /// Thread-local on purpose: a global subscriber races across parallel test binaries.
+    fn capture_logs(f: impl FnOnce()) -> String {
+        let sink = CaptureSink(Arc::new(std::sync::Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(sink.clone())
+            .with_ansi(false)
+            .with_max_level(tracing::Level::DEBUG)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        let captured = sink.0.lock().unwrap();
+        String::from_utf8_lossy(&captured).into_owned()
+    }
+
+    /// Blaming a wedge for a dead session points whoever reads the log at a live socket.
+    #[test]
+    fn dropped_fin_distinguishes_a_dead_session_from_a_wedge() {
+        const WEDGE: &str = "outbound queues full";
+
+        let (writer_tx, writer_rx) = mpsc::channel::<OutMsg>(OUTBOUND_QUEUE);
+        let (deferred_tx, deferred_rx) = mpsc::channel::<Bytes>(DEFERRED_FIN_QUEUE);
+        drop(writer_rx);
+        drop(deferred_rx);
+        let dead = capture_logs(|| queue_fin(&writer_tx, &deferred_tx, 7));
+        assert!(
+            !dead.contains(WEDGE),
+            "a dead session must not be reported as backpressure: {dead:?}"
+        );
+
+        let (writer_tx, _writer_rx) = mpsc::channel::<OutMsg>(OUTBOUND_QUEUE);
+        let (deferred_tx, _deferred_rx) = mpsc::channel::<Bytes>(DEFERRED_FIN_QUEUE);
+        for _ in 0..OUTBOUND_QUEUE {
+            writer_tx
+                .try_send(OutMsg::Frame(Bytes::from_static(b"x")))
+                .expect("the writer queue has room for this filler");
+        }
+        for _ in 0..DEFERRED_FIN_QUEUE {
+            deferred_tx
+                .try_send(Bytes::from_static(b"x"))
+                .expect("the deferred queue has room for this filler");
+        }
+        let wedged = capture_logs(|| queue_fin(&writer_tx, &deferred_tx, 7));
+        assert!(
+            wedged.contains(WEDGE),
+            "a genuinely wedged writer must still be reported: {wedged:?}"
         );
     }
 

--- a/crates/meow-proxy/src/mux/smux.rs
+++ b/crates/meow-proxy/src/mux/smux.rs
@@ -12,7 +12,7 @@
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use parking_lot::Mutex;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
-use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore, TryAcquireError};
+use tokio::sync::{mpsc, oneshot, Notify, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 use tokio_util::sync::{CancellationToken, PollSender};
 use tracing::{debug, info, warn};
 
@@ -34,21 +34,27 @@ const FRAME_HEADER_LEN: usize = 8;
 
 /// Largest frame payload — sagernet smux MaxFrameSize default (u16 length).
 const MAX_FRAME_SIZE: usize = 32768;
-/// Inbox depth. This is a bound on queue *overhead*, not a flow-control
-/// threshold: a frame count says nothing about how much data a consumer is
-/// behind by, so retiring on it disconnects streams that merely paused.
-/// [`MAX_STREAM_BUFFER`] is the real trigger; this depth is only reached
-/// first when the peer sends frames small enough that 2048 of them cost
-/// less payload than their queue slots.
+/// Inbox depth: a bound on the *frame-count overhead* of the per-stream
+/// fast-path queue. It is deliberately NOT a retire trigger on its own —
+/// a frame count says nothing about whether the consumer is stalled, and
+/// retiring on it cut off healthy streams mid-burst (see
+/// [`MAX_STREAM_BUFFER`] and [`STREAM_STALL_GRACE`] for the real policy).
 const STREAM_QUEUE: usize = 2048;
+/// Per-stream spill capacity beyond the inbox, in frames. A consumer that
+/// has not drained a single one of `STREAM_QUEUE + SPILL_QUEUE` frames is
+/// by construction an adversarial tiny-frame flood, never an ordinary
+/// burst — ordinary frames (>= 32 B payload on average) cross the
+/// grace-gated byte cap first. See the last-resort retire in the reader.
+const SPILL_QUEUE: usize = 2048;
 /// Sagernet's default session-wide receive budget.
 const MAX_RECEIVE_BUFFER: usize = 4 * 1024 * 1024;
 /// One stream's share of [`MAX_RECEIVE_BUFFER`]. A stream is retired only
-/// once this much of its payload sits undelivered, so a slow consumer is
-/// buffered (and the session keeps dispatching its peers) rather than
-/// disconnected. sing-mux's own `MaxStreamBuffer` is 64 KiB, but that is a
-/// *blocking* threshold — reusing it as a retire threshold would kill
-/// streams for sub-millisecond stalls.
+/// once this much of its payload sits undelivered for a whole
+/// [`STREAM_STALL_GRACE`] window — see [`stall_watchdog`] for why the
+/// decision must not be taken at frame-arrival time. sing-mux's own
+/// `MaxStreamBuffer` is 64 KiB, but that is a *blocking* threshold —
+/// reusing it as a retire threshold would kill streams for sub-millisecond
+/// stalls.
 ///
 /// The divisor has to leave headroom for many concurrent streams, not just
 /// a few: `MuxClient::offer` stops consulting `max-streams` once
@@ -57,6 +63,17 @@ const MAX_RECEIVE_BUFFER: usize = 4 * 1024 * 1024;
 /// budget and wedged the reader for every other stream on the session; at
 /// `/32` that takes thirty-two.
 const MAX_STREAM_BUFFER: usize = MAX_RECEIVE_BUFFER / 32;
+/// How long a stream may hold more than its receive share ([`MAX_STREAM_BUFFER`]
+/// bytes unread, or a non-empty spill) before it is retired. Retirement is
+/// deliberately NOT decided at frame-arrival time: in a buffered burst the
+/// reader task drains frames back-to-back without ever yielding to the
+/// consumer, so `unread` crosses any byte cap while a perfectly healthy,
+/// actively reading consumer is merely waiting to be scheduled. The
+/// watchdog re-checks the live watermark when it fires, so a consumer that
+/// gets back under its share inside the window — which every ordinary burst
+/// does — survives; only a stream still holding more than its share after
+/// the full window is cut off to release the budget for its peers.
+const STREAM_STALL_GRACE: Duration = Duration::from_millis(500);
 /// How long the reader waits for session receive budget before giving up on
 /// the session. Nothing below the mux layer reclaims budget held by a
 /// stalled consumer, so a wedged session cannot recover on its own. The
@@ -174,15 +191,52 @@ impl Drop for InboundChunk {
     }
 }
 
+/// Per-stream receive-side accounting and overflow parking, shared between
+/// the reader (producer) and the stream's consumer.
+///
+/// The `unread` counter lives in its own `Arc` (not inside this struct)
+/// because [`InboundChunk`] shares it: parking a chunk that held an
+/// `Arc<StreamStats>` would form a cycle (`StreamStats::spill` → chunk →
+/// `Arc<StreamStats>`) and leak the chunk's session-budget permits forever.
+struct StreamStats {
+    /// Payload bytes enqueued for this stream and not yet handed to its
+    /// consumer. Retiring is gated on this passing [`MAX_STREAM_BUFFER`]
+    /// for a whole [`STREAM_STALL_GRACE`] window, which keeps one stream
+    /// from monopolising the session budget while transient consumer
+    /// pauses — bursts, scheduler hiccups — ride through untouched.
+    unread: Arc<AtomicUsize>,
+    /// Overflow parking for chunks that arrive while the inbox is full.
+    /// FIFO is preserved by the reader (once the spill is non-empty every
+    /// later chunk parks there too) and by the consumer (which drains the
+    /// inbox to exhaustion before touching the spill).
+    spill: Mutex<VecDeque<InboundChunk>>,
+    /// Single-watchdog gate: the reader arms exactly one watchdog per
+    /// stream with a CAS on this flag; whichever watchdog owns the `true`
+    /// value is responsible for clearing it on exit.
+    armed: AtomicBool,
+    /// Wakes the consumer when a chunk is parked in the spill. The inbox
+    /// channel has its own wake-up path; this covers only the spill.
+    notify: Notify,
+}
+
+impl StreamStats {
+    fn pop_spill(&self) -> Option<InboundChunk> {
+        self.spill.lock().pop_front()
+    }
+
+    /// The retire condition: the stream holds more than its share of the
+    /// receive budget, or is carrying parked overflow, right now. Arming
+    /// uses the same predicate, so the watchdog's re-check is exact.
+    fn over_share(&self) -> bool {
+        self.unread.load(Ordering::Acquire) > MAX_STREAM_BUFFER || !self.spill.lock().is_empty()
+    }
+}
+
 #[derive(Clone)]
 struct StreamEntry {
     tx: mpsc::Sender<InboundChunk>,
     aborted: Arc<AtomicBool>,
-    /// Payload bytes enqueued for this stream and not yet handed to its
-    /// consumer. The reader stops accepting for the stream once this passes
-    /// [`MAX_STREAM_BUFFER`], which keeps one stream from monopolising the
-    /// session budget while leaving transient consumer pauses unaffected.
-    unread: Arc<AtomicUsize>,
+    stats: Arc<StreamStats>,
 }
 
 /// One outbound writer request.  Flush requests travel the SAME bounded
@@ -345,24 +399,12 @@ impl Session {
                             }
                             continue;
                         }
-                        // Retire on undelivered BYTES. Checked before taking
-                        // budget so a hog cannot borrow capacity for a frame
-                        // that is about to be discarded.
-                        if entry.unread.load(Ordering::Acquire) + length > MAX_STREAM_BUFFER {
-                            retire_stream(
-                                &entry,
-                                &reader_state,
-                                &reader_writer_tx,
-                                &reader_deferred_fin_tx,
-                                stream_id,
-                                "per-stream receive buffer exhausted",
-                            );
-                            if !drain_frame(&mut reader, &reader_cancel, &mut discard, length).await
-                            {
-                                break 'reader;
-                            }
-                            continue;
-                        }
+                        // The session receive budget is the hard bound on
+                        // bytes in flight; the per-stream share is enforced
+                        // by the stall watchdog AFTER this frame is
+                        // delivered, never here — at arrival time a healthy
+                        // consumer that simply has not been scheduled yet is
+                        // indistinguishable from a stalled one.
                         // Try without blocking first: arming a timer on every
                         // frame would tax the hot path, and the budget is
                         // uncontended in the common case.
@@ -427,25 +469,79 @@ impl Session {
                         if payload_result.is_err() {
                             break;
                         }
-                        entry.unread.fetch_add(length, Ordering::Release);
-                        match entry.tx.try_send(InboundChunk {
+                        entry.stats.unread.fetch_add(length, Ordering::Release);
+                        // Fast path: the inbox, whose bounded depth caps
+                        // queue *overhead*. A full inbox parks the chunk in
+                        // the spill instead of retiring the stream — FIFO is
+                        // preserved because later chunks park too while the
+                        // spill is non-empty, and the consumer drains the
+                        // inbox first.
+                        let chunk = InboundChunk {
                             data: Bytes::from(payload),
                             permit: Some(permit),
-                            unread: Arc::clone(&entry.unread),
-                        }) {
-                            // Depth bound, reached only when frames are small
-                            // enough that 2048 of them fit under the byte cap.
-                            Err(mpsc::error::TrySendError::Full(_)) => {
-                                retire_stream(
-                                    &entry,
-                                    &reader_state,
-                                    &reader_writer_tx,
-                                    &reader_deferred_fin_tx,
-                                    stream_id,
-                                    "stream inbox depth exhausted",
-                                );
+                            unread: Arc::clone(&entry.stats.unread),
+                        };
+                        let mut spill = entry.stats.spill.lock();
+                        let parked = if spill.is_empty() {
+                            match entry.tx.try_send(chunk) {
+                                // `Ok`: parked in the inbox. `Closed`: the
+                                // consumer is gone and `InboundChunk::drop`
+                                // releases the budget permits and unread
+                                // accounting — either way, no spill parking.
+                                Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => false,
+                                Err(mpsc::error::TrySendError::Full(chunk)) => {
+                                    spill.push_back(chunk);
+                                    true
+                                }
                             }
-                            Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+                        } else {
+                            spill.push_back(chunk);
+                            true
+                        };
+                        let spill_len = spill.len();
+                        drop(spill);
+                        if parked {
+                            entry.stats.notify.notify_one();
+                        }
+                        // Last-resort retire, the ONLY synchronous one: more
+                        // than inbox+spill frames parked against a consumer
+                        // that has not drained one of them is an adversarial
+                        // tiny-frame flood (see [`SPILL_QUEUE`]). Ordinary
+                        // traffic crosses the grace-gated byte cap long
+                        // before this fires.
+                        if spill_len > SPILL_QUEUE {
+                            retire_stream(
+                                &entry.aborted,
+                                &entry.stats,
+                                &reader_state,
+                                &reader_writer_tx,
+                                &reader_deferred_fin_tx,
+                                stream_id,
+                                "receive queue exhausted by frame flood",
+                            );
+                            continue;
+                        }
+                        // Arm the per-stream stall watchdog when this stream
+                        // crosses its receive share. The CAS keeps one
+                        // watchdog per stream; the running one owns the
+                        // re-arm until it exits.
+                        let over_share = entry.stats.unread.load(Ordering::Acquire)
+                            > MAX_STREAM_BUFFER
+                            || parked;
+                        if over_share && !entry.stats.armed.swap(true, Ordering::AcqRel) {
+                            let aborted = Arc::clone(&entry.aborted);
+                            let stats = Arc::clone(&entry.stats);
+                            let state = Arc::clone(&reader_state);
+                            let writer_tx = reader_writer_tx.clone();
+                            let deferred_fin_tx = reader_deferred_fin_tx.clone();
+                            tokio::spawn(stall_watchdog(
+                                aborted,
+                                stats,
+                                state,
+                                writer_tx,
+                                deferred_fin_tx,
+                                stream_id,
+                            ));
                         }
                     }
                     CMD_FIN | CMD_NOP => {
@@ -494,12 +590,18 @@ impl Session {
         let id = self.next_stream_id.fetch_add(2, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel(STREAM_QUEUE);
         let aborted = Arc::new(AtomicBool::new(false));
+        let stats = Arc::new(StreamStats {
+            unread: Arc::new(AtomicUsize::new(0)),
+            spill: Mutex::new(VecDeque::new()),
+            armed: AtomicBool::new(false),
+            notify: Notify::new(),
+        });
         self.state.register_stream(
             id,
             StreamEntry {
                 tx,
                 aborted: Arc::clone(&aborted),
-                unread: Arc::new(AtomicUsize::new(0)),
+                stats: Arc::clone(&stats),
             },
         )?;
         // The guard removes the map entry if this future is cancelled
@@ -541,6 +643,7 @@ impl Session {
             flush_rx: None,
             write_since_flush: false,
             aborted,
+            stats,
         })
     }
 }
@@ -599,22 +702,89 @@ fn queue_fin(
 
 /// Retire one stream: mark it aborted so its consumer surfaces an error
 /// instead of a clean EOF, drop its map entry, and tell the peer. The
-/// session and every other stream are untouched.
+/// session and every other stream are untouched. Data already buffered in
+/// the stream's inbox and spill is still delivered before the error shows.
 fn retire_stream(
-    entry: &StreamEntry,
+    aborted: &AtomicBool,
+    stats: &StreamStats,
     state: &SessionState,
     writer_tx: &mpsc::Sender<OutMsg>,
     deferred_fin_tx: &mpsc::Sender<Bytes>,
     stream_id: u32,
     reason: &str,
 ) {
-    entry.aborted.store(true, Ordering::Release);
+    aborted.store(true, Ordering::Release);
     info!(
         "smux: retiring stream {stream_id}: {reason} ({} bytes undelivered)",
-        entry.unread.load(Ordering::Relaxed)
+        stats.unread.load(Ordering::Relaxed)
     );
     state.remove_stream(stream_id);
     queue_fin(writer_tx, deferred_fin_tx, stream_id);
+}
+
+/// Per-stream stall watchdog, armed by the reader (CAS on
+/// [`StreamStats::armed`]) when a stream crosses its receive share.
+///
+/// Retirement must not be decided at frame-arrival time: in one buffered
+/// burst the reader task processes frames back-to-back without yielding to
+/// the consumer, so `unread` crosses any byte cap while a healthy,
+/// actively reading consumer is merely unscheduled — cutting the stream
+/// there is the exact regression this watchdog exists to prevent. Instead
+/// it re-checks the live watermark ([`StreamStats::over_share`]) after a
+/// full [`STREAM_STALL_GRACE`] window:
+///
+/// * drained back under the share inside the window — every ordinary
+///   burst — the watchdog disarms (with a re-check that closes the race
+///   against a concurrent re-arm by the reader) and the stream survives;
+/// * still holding more than the share after the full window — the
+///   consumer is stalled or structurally slower than the peer, with no
+///   v1 flow control to hold it back — the stream is retired so its
+///   budget reaches its peers instead of wedging the session until
+///   [`BUDGET_STALL_TIMEOUT`] kills it wholesale.
+async fn stall_watchdog(
+    aborted: Arc<AtomicBool>,
+    stats: Arc<StreamStats>,
+    state: Arc<SessionState>,
+    writer_tx: mpsc::Sender<OutMsg>,
+    deferred_fin_tx: mpsc::Sender<Bytes>,
+    stream_id: u32,
+) {
+    loop {
+        tokio::time::sleep(STREAM_STALL_GRACE).await;
+        // The stream may have been closed, FIN'd, or retired (by an earlier
+        // watchdog or the frame-flood last resort) while we slept: nothing
+        // left to guard. Deliberately checked BEFORE the share check so a
+        // post-FIN consumer draining slowly is never aborted — its budget
+        // release is bounded by BUDGET_STALL_TIMEOUT instead.
+        if state.dead.load(Ordering::SeqCst) || state.stream(stream_id).is_none() {
+            stats.armed.store(false, Ordering::Release);
+            return;
+        }
+        if !stats.over_share() {
+            // Drained inside the window: a burst, not a stall. Clear, then
+            // re-check: if the reader armed a fresh watchdog in between,
+            // that one owns the watch and we exit; if the share was crossed
+            // again first, we re-own it and watch another full window.
+            stats.armed.store(false, Ordering::Release);
+            if stats.over_share() && !stats.armed.swap(true, Ordering::AcqRel) {
+                continue;
+            }
+            return;
+        }
+        retire_stream(
+            &aborted,
+            &stats,
+            &state,
+            &writer_tx,
+            &deferred_fin_tx,
+            stream_id,
+            "consumer stalled: undelivered payload held over its receive share",
+        );
+        // Leave `armed` set: the map entry is gone so the reader can never
+        // arm again, and a stale `true` keeps any racing path from
+        // spawning a second watchdog for this dead stream.
+        return;
+    }
 }
 
 impl SessionState {
@@ -662,6 +832,9 @@ pub struct SmuxStream {
     /// `poll_flush` must send another request once the pending one lands.
     write_since_flush: bool,
     aborted: Arc<AtomicBool>,
+    /// Receive-side accounting + overflow parking shared with the reader;
+    /// see [`StreamStats`].
+    stats: Arc<StreamStats>,
 }
 
 impl SmuxStream {
@@ -686,6 +859,19 @@ impl Drop for SmuxStream {
     }
 }
 
+/// Hand one chunk to the caller's ReadBuf, keeping any unread remainder
+/// parked as `pending`. Must return `Ready` — returning `Pending` after
+/// writing into the caller's `ReadBuf` would lose those bytes (the buffer
+/// is recreated on the next poll).
+fn serve_chunk(this: &mut SmuxStream, mut chunk: InboundChunk, buf: &mut ReadBuf<'_>) {
+    let n = chunk.data.len().min(buf.remaining());
+    buf.put_slice(&chunk.data[..n]);
+    chunk.advance(n);
+    if !chunk.data.is_empty() {
+        this.pending = Some(chunk);
+    }
+}
+
 impl AsyncRead for SmuxStream {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -702,51 +888,83 @@ impl AsyncRead for SmuxStream {
         if buf.remaining() == 0 {
             return Poll::Ready(Ok(()));
         }
-        if let Some(mut chunk) = this.pending.take() {
-            let n = chunk.data.len().min(buf.remaining());
-            buf.put_slice(&chunk.data[..n]);
-            chunk.advance(n);
-            if !chunk.data.is_empty() {
-                this.pending = Some(chunk);
-            }
+        if let Some(chunk) = this.pending.take() {
+            serve_chunk(this, chunk, buf);
             Poll::Ready(Ok(()))
         } else if this.eof {
             Poll::Ready(Ok(()))
         } else {
             loop {
                 match this.rx.poll_recv(cx) {
-                    Poll::Ready(Some(mut chunk)) => {
+                    Poll::Ready(Some(chunk)) => {
                         if chunk.data.is_empty() {
                             // Zero-length PSH frames carry no payload (flush /
                             // ack signals from the peer); returning Ready with
                             // an empty ReadBuf would read as EOF to consumers.
                             continue;
                         }
-                        let n = chunk.data.len().min(buf.remaining());
-                        buf.put_slice(&chunk.data[..n]);
-                        chunk.advance(n);
-                        if !chunk.data.is_empty() {
-                            this.pending = Some(chunk);
-                        }
+                        serve_chunk(this, chunk, buf);
                         return Poll::Ready(Ok(()));
                     }
                     Poll::Ready(None) => {
-                        this.eof = true;
-                        if this.aborted.load(Ordering::Acquire) {
-                            return Poll::Ready(Err(io::Error::new(
-                                io::ErrorKind::ConnectionAborted,
-                                "smux stream receive buffer exceeded",
-                            )));
+                        // The inbox channel is closed (server FIN, retire,
+                        // session teardown) — everything parked in the spill
+                        // is still deliverable, so EOF only after the spill
+                        // drains too.
+                        match this.stats.pop_spill() {
+                            Some(chunk) => {
+                                if chunk.data.is_empty() {
+                                    continue;
+                                }
+                                serve_chunk(this, chunk, buf);
+                                return Poll::Ready(Ok(()));
+                            }
+                            None => {
+                                this.eof = true;
+                                if this.aborted.load(Ordering::Acquire) {
+                                    return Poll::Ready(Err(io::Error::new(
+                                        io::ErrorKind::ConnectionAborted,
+                                        "smux stream retired: consumer stalled past its receive share",
+                                    )));
+                                }
+                                if this.session.is_dead() {
+                                    return Poll::Ready(Err(io::Error::new(
+                                        io::ErrorKind::BrokenPipe,
+                                        "smux session closed",
+                                    )));
+                                }
+                                return Poll::Ready(Ok(()));
+                            }
                         }
-                        if this.session.is_dead() {
-                            return Poll::Ready(Err(io::Error::new(
-                                io::ErrorKind::BrokenPipe,
-                                "smux session closed",
-                            )));
-                        }
-                        return Poll::Ready(Ok(()));
                     }
-                    Poll::Pending => return Poll::Pending,
+                    Poll::Pending => {
+                        // The inbox is exhausted: serve the spill next (its
+                        // chunks are older than anything that can arrive
+                        // from now on — the reader only refills the inbox
+                        // once the spill is empty). When the spill is empty
+                        // too, park on its wake-up so a chunk parked between
+                        // the empty check and here cannot be missed:
+                        // `notify_one` stores a permit when no one is
+                        // waiting, which this poll consumes.
+                        match this.stats.pop_spill() {
+                            Some(chunk) => {
+                                if chunk.data.is_empty() {
+                                    continue;
+                                }
+                                serve_chunk(this, chunk, buf);
+                                return Poll::Ready(Ok(()));
+                            }
+                            None => {
+                                let mut notified = std::pin::pin!(this.stats.notify.notified());
+                                if notified.as_mut().poll(cx).is_ready() {
+                                    // A stored permit or a fresh wake:
+                                    // re-check the inbox and spill.
+                                    continue;
+                                }
+                                return Poll::Pending;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -766,7 +984,7 @@ impl AsyncWrite for SmuxStream {
         if this.aborted.load(Ordering::Acquire) {
             return Poll::Ready(Err(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                "smux stream receive buffer exceeded",
+                "smux stream retired: consumer stalled past its receive share",
             )));
         }
         if this.session.is_dead() {
@@ -850,7 +1068,7 @@ impl AsyncWrite for SmuxStream {
         if this.aborted.load(Ordering::Acquire) {
             return Poll::Ready(Err(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                "smux stream receive buffer exceeded",
+                "smux stream retired: consumer stalled past its receive share",
             )));
         }
         if this.fin_sent {
@@ -1039,14 +1257,17 @@ mod tests {
         assert!(!session.is_dead());
     }
 
-    /// Retiring is reserved for a stream that has taken more than its share
-    /// of the session receive budget. What it already buffered is still
-    /// delivered, the consumer then sees `ConnectionAborted`, and neither the
-    /// session nor its peers are affected.
-    #[tokio::test]
-    async fn per_stream_byte_cap_retires_only_the_hog() {
-        // One frame past the cap: the cap check is `unread + length > cap`.
+    /// A stream that holds more than its receive share is retired — but
+    /// only after a full [`STREAM_STALL_GRACE`] window, never at frame
+    /// arrival. What it already buffered is still delivered, the consumer
+    /// then sees `ConnectionAborted`, and neither the session nor its
+    /// peers are affected.
+    #[tokio::test(start_paused = true)]
+    async fn stalled_hog_retires_after_grace_and_only_the_hog() {
+        // Four 32 KiB frames land exactly at the share; the fifth crosses
+        // it and arms the watchdog.
         let frames_over_cap = MAX_STREAM_BUFFER / MAX_FRAME_SIZE + 1;
+        let hog_bytes = frames_over_cap * MAX_FRAME_SIZE;
         let (client_io, mut server_io) = tokio::io::duplex(2 * MAX_STREAM_BUFFER);
         let session = Arc::new(Session::client(client_io).unwrap());
         let mut hog = session.open_stream().await.unwrap();
@@ -1058,14 +1279,11 @@ mod tests {
             wire.extend_from_slice(&encode_frame(CMD_PSH, hog.id, &big));
         }
         wire.extend_from_slice(&encode_frame(CMD_PSH, peer.id, b"ready"));
-        tokio::time::timeout(
-            std::time::Duration::from_secs(20),
-            server_io.write_all(&wire),
-        )
-        .await
-        .expect("wire write must not block")
-        .unwrap();
+        server_io.write_all(&wire).await.unwrap();
 
+        // While the hog sits over its share — before any grace has elapsed
+        // — the peer still receives: the over-share condition alone must
+        // not disturb anyone.
         let mut ready = [0u8; 5];
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
@@ -1076,18 +1294,29 @@ mod tests {
         .unwrap();
         assert_eq!(&ready, b"ready");
 
-        let mut buffered = vec![0u8; MAX_STREAM_BUFFER];
-        tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            hog.read_exact(&mut buffered),
-        )
-        .await
-        .expect("data queued before the retire must still be delivered")
-        .unwrap();
-        assert!(buffered.iter().all(|b| *b == 0x5a));
+        // The consumer never drains a byte, so once the full grace window
+        // has elapsed the watchdog retires the stream. Paused time
+        // auto-advances to the watchdog timer once every task parks.
+        tokio::time::sleep(STREAM_STALL_GRACE * 2).await;
 
+        // Data queued before the retire must still be delivered, then the
+        // abort surfaces.
+        let mut buffered = vec![0u8; hog_bytes];
+        hog.read_exact(&mut buffered)
+            .await
+            .expect("data queued before the retire must still be delivered");
+        assert!(buffered.iter().all(|b| *b == 0x5a));
         let error = hog.read(&mut [0u8; 1]).await.unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::ConnectionAborted);
+
+        // The retire stayed scoped: the peer keeps its stream and the
+        // session survives.
+        let next = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            peer.read(&mut [0u8; 1]),
+        )
+        .await;
+        assert!(next.is_err(), "the peer stream must still be open");
         assert!(!session.is_dead());
     }
 
@@ -1156,12 +1385,15 @@ mod tests {
         writer.await.unwrap();
     }
 
-    /// The inbox depth is a real retire trigger, not just a comment: it fires
-    /// when frames are small enough that [`STREAM_QUEUE`] of them cost less
-    /// payload than [`MAX_STREAM_BUFFER`]. Retiring must stay scoped to the
-    /// stalled stream, and everything already queued must still be delivered.
-    #[tokio::test]
-    async fn inbox_depth_retires_only_the_stalled_stream() {
+    /// The inbox depth still matters, but through the spill and the
+    /// grace-gated watchdog rather than a synchronous cut: frames small
+    /// enough that [`STREAM_QUEUE`] of them cost less payload than their
+    /// queue slots fill the inbox, overflow into the spill, and retire the
+    /// stream only when the consumer has drained nothing for a whole
+    /// [`STREAM_STALL_GRACE`]. Retiring stays scoped, and everything
+    /// already queued — inbox and spill alike — is still delivered.
+    #[tokio::test(start_paused = true)]
+    async fn inbox_depth_overflow_retires_only_a_never_draining_consumer() {
         // Guards the premise: the depth bound has to be reached first, or
         // this test silently exercises the byte cap instead.
         const {
@@ -1170,43 +1402,167 @@ mod tests {
                 "inbox depth must bind before the byte cap, or this test proves nothing"
             );
         };
+        let frames = STREAM_QUEUE + 1;
         let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
         let session = Arc::new(Session::client(client_io).unwrap());
         let mut slow = session.open_stream().await.unwrap();
         let mut peer = session.open_stream().await.unwrap();
 
         let mut wire = Vec::new();
-        for _ in 0..=STREAM_QUEUE {
+        for _ in 0..frames {
             wire.extend_from_slice(&encode_frame(CMD_PSH, slow.id, b"x"));
         }
         wire.extend_from_slice(&encode_frame(CMD_PSH, peer.id, b"ready"));
         server_io.write_all(&wire).await.unwrap();
 
+        // The overflow is already parked while the peers keep flowing.
         let mut ready = [0u8; 5];
         tokio::time::timeout(
-            std::time::Duration::from_secs(1),
+            std::time::Duration::from_secs(5),
             peer.read_exact(&mut ready),
         )
         .await
-        .expect("a depth-capped stream must not block its peers")
+        .expect("an overflowing stream must not block its peers")
         .unwrap();
         assert_eq!(&ready, b"ready");
 
-        let mut drained = vec![0u8; STREAM_QUEUE];
-        tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            slow.read_exact(&mut drained),
-        )
-        .await
-        .expect("data queued before the retire must still be delivered")
-        .unwrap();
+        // The consumer never drains, so the full grace window retires it.
+        tokio::time::sleep(STREAM_STALL_GRACE * 2).await;
+
+        // Everything queued before the retire — inbox AND spill — is still
+        // delivered, then the abort surfaces.
+        let mut drained = vec![0u8; frames];
+        slow.read_exact(&mut drained)
+            .await
+            .expect("data queued before the retire must still be delivered");
         assert!(drained.iter().all(|b| *b == b'x'));
 
-        let error =
-            tokio::time::timeout(std::time::Duration::from_secs(1), slow.read(&mut [0u8; 1]))
-                .await
-                .expect("the retire must surface, not hang")
-                .unwrap_err();
+        let error = slow.read(&mut [0u8; 1]).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::ConnectionAborted);
+        assert!(!session.is_dead());
+    }
+
+    /// Regression (PR #491 review): the receive cap must not abort a
+    /// healthy, actively reading stream. In one buffered burst the reader
+    /// task processes frames back-to-back without ever yielding to the
+    /// consumer, so on a current-thread runtime sixteen 32 KiB frames push
+    /// `unread` past the cap while a consumer that is continuously
+    /// reading has simply not been scheduled. The arrival-time retire
+    /// returned `ConnectionAborted` after exactly 131072 bytes; the same
+    /// probe must now deliver the whole burst with a clean EOF.
+    #[tokio::test(flavor = "current_thread")]
+    async fn buffered_burst_does_not_abort_a_reading_consumer() {
+        const FRAMES: usize = 16;
+        let total = FRAMES * MAX_FRAME_SIZE;
+        let (client_io, mut server_io) = tokio::io::duplex(1024 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        // One buffered burst, fully written before the consumer task ever
+        // gets to poll: 16 PSH frames + FIN. The 1 MiB duplex absorbs it
+        // without yielding, which is exactly the harshest scheduling gap.
+        let big = vec![0xa5u8; MAX_FRAME_SIZE];
+        let mut wire = Vec::with_capacity((MAX_FRAME_SIZE + FRAME_HEADER_LEN) * FRAMES);
+        for _ in 0..FRAMES {
+            wire.extend_from_slice(&encode_frame(CMD_PSH, stream.id, &big));
+        }
+        wire.extend_from_slice(&encode_frame(CMD_FIN, stream.id, &[]));
+        server_io.write_all(&wire).await.unwrap();
+
+        // The consumer reads continuously; only the reader parking lets it
+        // run, which is the exact interleaving that used to be misread as
+        // a stall.
+        let mut received = Vec::new();
+        stream.read_to_end(&mut received).await.unwrap();
+        assert_eq!(received.len(), total);
+        assert!(received.iter().all(|b| *b == 0xa5));
+        assert!(!session.is_dead());
+    }
+
+    /// A consumer that crosses its share but drains back under it inside
+    /// the grace window is a burst, not a stall: the watchdog must disarm
+    /// and leave the stream fully usable.
+    #[tokio::test(start_paused = true)]
+    async fn over_share_recovered_within_the_grace_window_survives() {
+        let frames_over_cap = MAX_STREAM_BUFFER / MAX_FRAME_SIZE + 1;
+        let hog_bytes = frames_over_cap * MAX_FRAME_SIZE;
+        let (client_io, mut server_io) = tokio::io::duplex(2 * MAX_STREAM_BUFFER);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        let big = vec![0x5au8; MAX_FRAME_SIZE];
+        let mut wire = Vec::new();
+        for _ in 0..frames_over_cap {
+            wire.extend_from_slice(&encode_frame(CMD_PSH, stream.id, &big));
+        }
+        server_io.write_all(&wire).await.unwrap();
+
+        // Halfway through the grace window the consumer drains everything.
+        tokio::time::sleep(STREAM_STALL_GRACE / 2).await;
+        let mut buffered = vec![0u8; hog_bytes];
+        stream.read_exact(&mut buffered).await.unwrap();
+        assert!(buffered.iter().all(|b| *b == 0x5a));
+
+        // Past the original fire time the watchdog finds the stream back
+        // under its share and disarms instead of retiring.
+        tokio::time::sleep(STREAM_STALL_GRACE).await;
+
+        // The stream must still be usable end-to-end.
+        server_io
+            .write_all(&encode_frame(CMD_PSH, stream.id, b"still alive"))
+            .await
+            .unwrap();
+        let mut alive = [0u8; 11];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            stream.read_exact(&mut alive),
+        )
+        .await
+        .expect("a recovered stream must stay readable")
+        .unwrap();
+        assert_eq!(&alive, b"still alive");
+        assert!(!session.is_dead());
+    }
+
+    /// The frame-count last resort: a flood of tiny frames that the byte
+    /// cap can never catch (payload too small to cross the share) parks
+    /// more than inbox+spill frames against a consumer that has drained
+    /// nothing, and the stream is retired synchronously so queue-overhead
+    /// memory stays bounded. Ordinary traffic crosses the grace-gated byte
+    /// cap long before this fires.
+    #[tokio::test(start_paused = true)]
+    async fn tiny_frame_flood_beyond_inbox_and_spill_retires_immediately() {
+        // The 4097th frame makes the spill exceed SPILL_QUEUE.
+        let frames = STREAM_QUEUE + SPILL_QUEUE + 1;
+        let (client_io, mut server_io) = tokio::io::duplex(128 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut flood = session.open_stream().await.unwrap();
+        let mut peer = session.open_stream().await.unwrap();
+
+        let mut wire = Vec::new();
+        for _ in 0..frames {
+            wire.extend_from_slice(&encode_frame(CMD_PSH, flood.id, b"f"));
+        }
+        wire.extend_from_slice(&encode_frame(CMD_PSH, peer.id, b"ready"));
+        server_io.write_all(&wire).await.unwrap();
+
+        // The flood never blocks its peers.
+        let mut ready = [0u8; 5];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            peer.read_exact(&mut ready),
+        )
+        .await
+        .expect("a flood stream must not block its peers")
+        .unwrap();
+        assert_eq!(&ready, b"ready");
+
+        // Every parked frame is delivered, then the abort surfaces — the
+        // last resort fired during the flood, no grace wait involved.
+        let mut drained = vec![0u8; frames];
+        flood.read_exact(&mut drained).await.unwrap();
+        assert!(drained.iter().all(|b| *b == b'f'));
+        let error = flood.read(&mut [0u8; 1]).await.unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::ConnectionAborted);
         assert!(!session.is_dead());
     }

--- a/crates/meow-proxy/src/mux/smux.rs
+++ b/crates/meow-proxy/src/mux/smux.rs
@@ -11,6 +11,7 @@
 //! MaxReceiveBuffer=4 MiB.
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::future::Future;
 use std::io;
@@ -19,7 +20,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
-use tokio::sync::{mpsc, oneshot, Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::{CancellationToken, PollSender};
 
 const CMD_SYN: u8 = 0;
@@ -31,23 +32,15 @@ const FRAME_HEADER_LEN: usize = 8;
 
 /// Largest frame payload — sagernet smux MaxFrameSize default (u16 length).
 const MAX_FRAME_SIZE: usize = 32768;
-/// Per-stream channel depth.  The 4 MiB `receive_budget` semaphore bounds
-/// memory; the channel depth only controls how many frames buffer before a
-/// stalled consumer pauses the reader.  A depth of 2 (two max-sized frames)
-/// head-of-line blocks the entire session too easily — one slow tab stalls
-/// every other stream sharing the physical connection.  32 gives real
-/// headroom; the semaphore still caps total buffered memory.
-///
-/// The target architecture is muxcool's `deliver_now` / `Parked` pattern
-/// (PR 6 of this stack): a full queue parks the delivery and pauses the
-/// connection read (session-wide flow control) without blocking writers.
-/// Porting that to smux is a follow-up; this depth raise is the safe
-/// interim fix.
+/// Per-stream channel depth. A full inbox aborts only that stream rather
+/// than awaiting it in the session reader and blocking unrelated streams.
 const STREAM_QUEUE: usize = 32;
 /// Sagernet's default session-wide receive budget.
 const MAX_RECEIVE_BUFFER: usize = 4 * 1024 * 1024;
 /// Bounded outbound queue; stream writes wait when the physical writer lags.
 const OUTBOUND_QUEUE: usize = 64;
+/// Bounded overflow queue for FIN frames when the writer is backpressured.
+const DEFERRED_FIN_QUEUE: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Frame {
@@ -82,6 +75,29 @@ impl Frame {
     }
 }
 
+async fn drain_frame<R>(
+    reader: &mut R,
+    cancel: &CancellationToken,
+    scratch: &mut [u8],
+    mut remaining: usize,
+) -> bool
+where
+    R: AsyncRead + Unpin,
+{
+    while remaining > 0 {
+        let n = remaining.min(scratch.len());
+        let result = tokio::select! {
+            _ = cancel.cancelled() => return false,
+            result = reader.read_exact(&mut scratch[..n]) => result,
+        };
+        if result.is_err() {
+            return false;
+        }
+        remaining -= n;
+    }
+    true
+}
+
 fn encode_frame(cmd: u8, stream_id: u32, data: &[u8]) -> Bytes {
     // The u16 length field caps single frames; poll_write limits writes to
     // MAX_FRAME_SIZE, so this only guards future call sites.
@@ -100,9 +116,27 @@ fn encode_frame(cmd: u8, stream_id: u32, data: &[u8]) -> Bytes {
 
 struct InboundChunk {
     data: Bytes,
-    /// Releases session receive capacity when the stream consumes or drops
-    /// this chunk.
-    _permit: Option<OwnedSemaphorePermit>,
+    /// Releases session receive capacity as the stream consumes or drops data.
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl InboundChunk {
+    fn advance(&mut self, n: usize) {
+        self.data.advance(n);
+        if let Some(permit) = &mut self.permit {
+            drop(
+                permit
+                    .split(n)
+                    .expect("inbound permit must cover unread payload"),
+            );
+        }
+    }
+}
+
+#[derive(Clone)]
+struct StreamEntry {
+    tx: mpsc::Sender<InboundChunk>,
+    aborted: Arc<AtomicBool>,
 }
 
 /// One outbound writer request.  Flush requests travel the SAME bounded
@@ -119,7 +153,7 @@ enum OutMsg {
 
 struct SessionState {
     /// Streams keyed by stream ID; dropping the sender EOFs the stream.
-    streams: Mutex<HashMap<u32, mpsc::Sender<InboundChunk>>>,
+    streams: Mutex<HashMap<u32, StreamEntry>>,
     dead: AtomicBool,
 }
 
@@ -127,6 +161,7 @@ struct SessionState {
 pub struct Session {
     state: Arc<SessionState>,
     writer_tx: mpsc::Sender<OutMsg>,
+    deferred_fin_tx: mpsc::Sender<Bytes>,
     cancel: CancellationToken,
     next_stream_id: AtomicU32,
 }
@@ -146,12 +181,32 @@ impl Session {
     {
         let (mut reader, mut writer) = tokio::io::split(io);
         let (writer_tx, mut writer_rx) = mpsc::channel::<OutMsg>(OUTBOUND_QUEUE);
+        let (deferred_fin_tx, mut deferred_fin_rx) = mpsc::channel(DEFERRED_FIN_QUEUE);
         let state = Arc::new(SessionState {
             streams: Mutex::new(HashMap::new()),
             dead: AtomicBool::new(false),
         });
         let receive_budget = Arc::new(Semaphore::new(MAX_RECEIVE_BUFFER));
         let cancel = CancellationToken::new();
+
+        // A single forwarder waits for writer capacity, preserving the
+        // original FIFO without spawning one task per dropped stream.
+        let deferred_writer_tx = writer_tx.clone();
+        let deferred_cancel = cancel.clone();
+        tokio::spawn(async move {
+            while let Some(frame) = tokio::select! {
+                _ = deferred_cancel.cancelled() => None,
+                frame = deferred_fin_rx.recv() => frame,
+            } {
+                if tokio::select! {
+                    _ = deferred_cancel.cancelled() => false,
+                    sent = deferred_writer_tx.send(OutMsg::Frame(frame)) => sent.is_ok(),
+                } {
+                    continue;
+                }
+                break;
+            }
+        });
 
         // Writer task: outbound frames are already encoded, so the hot path
         // performs no second allocation or payload copy.
@@ -198,16 +253,20 @@ impl Session {
                     }
                 }
             }
-            writer_state.mark_dead().await;
+            writer_state.mark_dead();
             writer_cancel.cancel();
         });
 
-        // Reader task: parse frames, route PSH/FIN to streams.
+        // Reader task: a full stream inbox aborts that stream; it never
+        // awaits the inbox while holding up frame dispatch for its peers.
         let reader_state = Arc::clone(&state);
         let reader_cancel = cancel.clone();
+        let reader_writer_tx = writer_tx.clone();
+        let reader_deferred_fin_tx = deferred_fin_tx.clone();
         tokio::spawn(async move {
             let mut header = [0u8; FRAME_HEADER_LEN];
-            loop {
+            let mut discard = [0u8; 8 * 1024];
+            'reader: loop {
                 let header_result = tokio::select! {
                     _ = reader_cancel.cancelled() => break,
                     result = reader.read_exact(&mut header) => result,
@@ -218,51 +277,90 @@ impl Session {
                 let Ok((cmd, length, stream_id)) = Frame::decode_header(&header) else {
                     break;
                 };
-                let permit = if cmd == CMD_PSH && length > 0 {
-                    let permits = length as u32;
-                    match tokio::select! {
-                        _ = reader_cancel.cancelled() => break,
-                        result = Arc::clone(&receive_budget).acquire_many_owned(permits) => result,
-                    } {
-                        Ok(permit) => Some(permit),
-                        Err(_) => break,
-                    }
-                } else {
-                    None
-                };
-                let mut payload = vec![0u8; length];
-                if !payload.is_empty() {
-                    let payload_result = tokio::select! {
-                        _ = reader_cancel.cancelled() => break,
-                        result = reader.read_exact(&mut payload) => result,
-                    };
-                    if payload_result.is_err() {
-                        break;
-                    }
-                }
-                if reader_state
-                    .handle_frame(
-                        cmd,
-                        stream_id,
-                        InboundChunk {
+                match cmd {
+                    CMD_PSH if length == 0 => continue,
+                    CMD_PSH => {
+                        let Some(entry) = reader_state.stream(stream_id) else {
+                            if !drain_frame(&mut reader, &reader_cancel, &mut discard, length).await
+                            {
+                                break 'reader;
+                            }
+                            continue;
+                        };
+                        if entry.tx.is_closed() {
+                            if !drain_frame(&mut reader, &reader_cancel, &mut discard, length).await
+                            {
+                                break 'reader;
+                            }
+                            continue;
+                        }
+                        // A zero capacity is a stable overflow signal because
+                        // this task is the inbox's sole producer. Retire the
+                        // stream before it borrows session receive capacity.
+                        if entry.tx.capacity() == 0 {
+                            entry.aborted.store(true, Ordering::Release);
+                            reader_state.remove_stream(stream_id);
+                            queue_fin(
+                                &reader_writer_tx,
+                                &reader_deferred_fin_tx,
+                                &reader_state,
+                                &reader_cancel,
+                                stream_id,
+                            );
+                            if !drain_frame(&mut reader, &reader_cancel, &mut discard, length).await
+                            {
+                                break 'reader;
+                            }
+                            continue;
+                        }
+                        let permit = tokio::select! {
+                            _ = reader_cancel.cancelled() => break,
+                            result = Arc::clone(&receive_budget).acquire_many_owned(length as u32) => match result {
+                                Ok(permit) => permit,
+                                Err(_) => break,
+                            },
+                        };
+                        let mut payload = vec![0u8; length];
+                        let payload_result = tokio::select! {
+                            _ = reader_cancel.cancelled() => break,
+                            result = reader.read_exact(&mut payload) => result,
+                        };
+                        if payload_result.is_err() {
+                            break;
+                        }
+                        match entry.tx.try_send(InboundChunk {
                             data: Bytes::from(payload),
-                            _permit: permit,
-                        },
-                        &reader_cancel,
-                    )
-                    .await
-                    .is_err()
-                {
-                    break;
+                            permit: Some(permit),
+                        }) {
+                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                entry.aborted.store(true, Ordering::Release);
+                                reader_state.remove_stream(stream_id);
+                                queue_fin(
+                                    &reader_writer_tx,
+                                    &reader_deferred_fin_tx,
+                                    &reader_state,
+                                    &reader_cancel,
+                                    stream_id,
+                                );
+                            }
+                            Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+                        }
+                    }
+                    CMD_FIN if length == 0 => reader_state.remove_stream(stream_id),
+                    CMD_NOP if length == 0 => {}
+                    // SYN, unknown commands, and control frames with payload
+                    // are protocol errors; reject before allocating payload.
+                    _ => break,
                 }
             }
-            reader_state.mark_dead().await;
+            reader_state.mark_dead();
             reader_cancel.cancel();
         });
 
         Ok(Self {
             state,
             writer_tx,
+            deferred_fin_tx,
             cancel,
             next_stream_id: AtomicU32::new(1),
         })
@@ -270,15 +368,16 @@ impl Session {
 
     /// Open a new stream.  Client IDs count up by 2 from 1.
     pub async fn open_stream(self: &Arc<Self>) -> io::Result<SmuxStream> {
-        if self.is_dead() {
-            return Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "smux session is closed",
-            ));
-        }
         let id = self.next_stream_id.fetch_add(2, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel(STREAM_QUEUE);
-        self.state.streams.lock().await.insert(id, tx);
+        let aborted = Arc::new(AtomicBool::new(false));
+        self.state.register_stream(
+            id,
+            StreamEntry {
+                tx,
+                aborted: Arc::clone(&aborted),
+            },
+        )?;
         // The guard removes the map entry if this future is cancelled
         // while waiting for outbound capacity — otherwise the id stays
         // consumed and the entry lingers until a server FIN.
@@ -299,6 +398,12 @@ impl Session {
                 "smux writer gone",
             ));
         }
+        if self.is_dead() {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "smux session is closed",
+            ));
+        }
         guard.disarm();
         Ok(SmuxStream {
             id,
@@ -311,6 +416,7 @@ impl Session {
             shutdown_frame: None,
             flush_rx: None,
             write_since_flush: false,
+            aborted,
         })
     }
 }
@@ -332,81 +438,59 @@ impl MapEntryGuard {
 impl Drop for MapEntryGuard {
     fn drop(&mut self) {
         if self.armed {
-            let state = Arc::clone(&self.state);
-            let id = self.id;
-            // Detached: drop cannot await the map lock.
-            if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                handle.spawn(async move {
-                    state.streams.lock().await.remove(&id);
-                });
-            }
+            self.state.remove_stream(self.id);
         }
     }
 }
 
 impl Drop for Session {
     fn drop(&mut self) {
-        self.state.dead.store(true, Ordering::SeqCst);
+        self.state.mark_dead();
         self.cancel.cancel();
     }
 }
 
+fn queue_fin(
+    writer_tx: &mpsc::Sender<OutMsg>,
+    deferred_fin_tx: &mpsc::Sender<Bytes>,
+    state: &SessionState,
+    cancel: &CancellationToken,
+    stream_id: u32,
+) {
+    let frame = encode_frame(CMD_FIN, stream_id, &[]);
+    if writer_tx.try_send(OutMsg::Frame(frame.clone())).is_ok() {
+        return;
+    }
+    if deferred_fin_tx.try_send(frame).is_err() {
+        state.mark_dead();
+        cancel.cancel();
+    }
+}
+
 impl SessionState {
-    async fn mark_dead(&self) {
-        if !self.dead.swap(true, Ordering::SeqCst) {
-            // Close every stream.  The read side distinguishes this physical
-            // failure from a peer FIN by consulting `Session::is_dead`.
-            self.streams.lock().await.clear();
+    fn register_stream(&self, id: u32, entry: StreamEntry) -> io::Result<()> {
+        let mut streams = self.streams.lock();
+        if self.dead.load(Ordering::SeqCst) {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "smux session is closed",
+            ));
         }
+        streams.insert(id, entry);
+        Ok(())
     }
 
-    async fn handle_frame(
-        &self,
-        cmd: u8,
-        stream_id: u32,
-        chunk: InboundChunk,
-        cancel: &CancellationToken,
-    ) -> io::Result<()> {
-        match cmd {
-            CMD_PSH => {
-                // Data for an unknown stream is dropped rather than killing
-                // the session — an intentional divergence from xtaci (which
-                // closes the connection on protocol violation): the server
-                // may legitimately race a FIN (peer closed, stream removed)
-                // against in-flight PSH frames.
-                let tx = self.streams.lock().await.get(&stream_id).cloned();
-                if let Some(tx) = tx {
-                    tokio::select! {
-                        _ = cancel.cancelled() => {
-                            return Err(io::Error::new(
-                                io::ErrorKind::Interrupted,
-                                "smux session closed",
-                            ));
-                        }
-                        result = tx.send(chunk) => {
-                            let _ = result;
-                        }
-                    }
-                }
-                Ok(())
-            }
-            CMD_FIN => {
-                // Peer half-closed: EOF the read side by dropping the sender.
-                self.streams.lock().await.remove(&stream_id);
-                Ok(())
-            }
-            CMD_NOP => Ok(()),
-            // v1 has no UPD; a server-initiated SYN is unexpected in
-            // client-only usage and unsupported commands are protocol errors.
-            CMD_SYN => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "smux: unexpected SYN from server (client-only usage)",
-            )),
-            other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("smux: unknown command {other}"),
-            )),
-        }
+    fn stream(&self, stream_id: u32) -> Option<StreamEntry> {
+        self.streams.lock().get(&stream_id).cloned()
+    }
+
+    fn remove_stream(&self, stream_id: u32) {
+        self.streams.lock().remove(&stream_id);
+    }
+
+    fn mark_dead(&self) {
+        self.dead.store(true, Ordering::SeqCst);
+        self.streams.lock().clear();
     }
 }
 
@@ -427,55 +511,30 @@ pub struct SmuxStream {
     /// sent: the flush ack then no longer covers every write, so
     /// `poll_flush` must send another request once the pending one lands.
     write_since_flush: bool,
+    aborted: Arc<AtomicBool>,
 }
 
 impl SmuxStream {
     fn best_effort_fin(&mut self) {
-        if self.fin_sent {
+        if self.fin_sent || self.aborted.load(Ordering::Acquire) {
+            self.fin_sent = true;
             return;
         }
-        let frame = encode_frame(CMD_FIN, self.id, &[]);
-        match self
-            .session
-            .writer_tx
-            .try_send(OutMsg::Frame(frame.clone()))
-        {
-            Ok(()) => self.fin_sent = true,
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                // The outbound channel is full: queue the FIN
-                // asynchronously instead of dropping it.  Mark fin_sent
-                // now so a later poll_shutdown/drop does not double-send.
-                self.fin_sent = true;
-                let sender = self.session.writer_tx.clone();
-                if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                    handle.spawn(async move {
-                        let _ = sender.send(OutMsg::Frame(frame)).await;
-                    });
-                }
-            }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                // Session is gone; the connection is closing anyway.
-                self.fin_sent = true;
-            }
-        }
+        self.fin_sent = true;
+        queue_fin(
+            &self.session.writer_tx,
+            &self.session.deferred_fin_tx,
+            &self.session.state,
+            &self.session.cancel,
+            self.id,
+        );
     }
 }
 
 impl Drop for SmuxStream {
     fn drop(&mut self) {
         self.best_effort_fin();
-        // Remove the stream-map entry explicitly.  smux servers (notably
-        // sing-box) may not echo a FIN for a stream the client abandoned,
-        // so waiting for CMD_FIN would leak the entry for the session's
-        // lifetime.  The detached spawn mirrors MapEntryGuard's pattern:
-        // cleanup must not wait on outbound channel capacity.
-        let state = Arc::clone(&self.session.state);
-        let id = self.id;
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.spawn(async move {
-                state.streams.lock().await.remove(&id);
-            });
-        }
+        self.session.state.remove_stream(self.id);
     }
 }
 
@@ -498,7 +557,7 @@ impl AsyncRead for SmuxStream {
         if let Some(mut chunk) = this.pending.take() {
             let n = chunk.data.len().min(buf.remaining());
             buf.put_slice(&chunk.data[..n]);
-            chunk.data.advance(n);
+            chunk.advance(n);
             if !chunk.data.is_empty() {
                 this.pending = Some(chunk);
             }
@@ -517,7 +576,7 @@ impl AsyncRead for SmuxStream {
                         }
                         let n = chunk.data.len().min(buf.remaining());
                         buf.put_slice(&chunk.data[..n]);
-                        chunk.data.advance(n);
+                        chunk.advance(n);
                         if !chunk.data.is_empty() {
                             this.pending = Some(chunk);
                         }
@@ -525,6 +584,12 @@ impl AsyncRead for SmuxStream {
                     }
                     Poll::Ready(None) => {
                         this.eof = true;
+                        if this.aborted.load(Ordering::Acquire) {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::ConnectionAborted,
+                                "smux stream receive buffer exceeded",
+                            )));
+                        }
                         if this.session.is_dead() {
                             return Poll::Ready(Err(io::Error::new(
                                 io::ErrorKind::BrokenPipe,
@@ -550,6 +615,12 @@ impl AsyncWrite for SmuxStream {
             return Poll::Ready(Ok(0));
         }
         let this = self.get_mut();
+        if this.aborted.load(Ordering::Acquire) {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "smux stream receive buffer exceeded",
+            )));
+        }
         if this.session.is_dead() {
             return Poll::Ready(Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
@@ -628,6 +699,12 @@ impl AsyncWrite for SmuxStream {
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = self.get_mut();
+        if this.aborted.load(Ordering::Acquire) {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "smux stream receive buffer exceeded",
+            )));
+        }
         if this.fin_sent {
             return Poll::Ready(Ok(()));
         }
@@ -764,6 +841,34 @@ mod tests {
         assert_eq!(&buf, b"AAA");
         b.read_exact(&mut buf).await.unwrap();
         assert_eq!(&buf, b"BBB");
+    }
+
+    #[tokio::test]
+    async fn full_inbox_aborts_only_the_stalled_stream() {
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut a = session.open_stream().await.unwrap();
+        let mut b = session.open_stream().await.unwrap();
+
+        let mut wire = Vec::new();
+        for _ in 0..=STREAM_QUEUE {
+            wire.extend_from_slice(&encode_frame(CMD_PSH, a.id, b"x"));
+        }
+        wire.extend_from_slice(&encode_frame(CMD_PSH, b.id, b"ready"));
+        server_io.write_all(&wire).await.unwrap();
+
+        let mut ready = [0u8; 5];
+        tokio::time::timeout(std::time::Duration::from_secs(1), b.read_exact(&mut ready))
+            .await
+            .expect("a full A inbox must not block B")
+            .unwrap();
+        assert_eq!(&ready, b"ready");
+
+        let mut drained = vec![0u8; STREAM_QUEUE];
+        a.read_exact(&mut drained).await.unwrap();
+        let error = a.read(&mut [0u8; 1]).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::ConnectionAborted);
+        assert!(!session.is_dead());
     }
 
     #[tokio::test]
@@ -1133,7 +1238,7 @@ mod tests {
         // The cancellation guard removes the entry asynchronously.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(
-            session.state.streams.lock().await.is_empty(),
+            session.state.streams.lock().is_empty(),
             "the cancelled open must not leave its stream-map entry"
         );
         // Release the parked write and drain so the session can shut

--- a/crates/meow-proxy/src/mux/smux.rs
+++ b/crates/meow-proxy/src/mux/smux.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 use tokio_util::sync::{CancellationToken, PollSender};
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 const CMD_SYN: u8 = 0;
 const CMD_FIN: u8 = 1;
@@ -49,11 +49,20 @@ const MAX_RECEIVE_BUFFER: usize = 4 * 1024 * 1024;
 /// disconnected. sing-mux's own `MaxStreamBuffer` is 64 KiB, but that is a
 /// *blocking* threshold — reusing it as a retire threshold would kill
 /// streams for sub-millisecond stalls.
-const MAX_STREAM_BUFFER: usize = MAX_RECEIVE_BUFFER / 4;
+///
+/// The divisor has to leave headroom for many concurrent streams, not just
+/// a few: `MuxClient::offer` stops consulting `max-streams` once
+/// `max-connections` sessions exist, so one session carries an unbounded
+/// number of streams. At `/4`, four stalled streams exhausted the whole
+/// budget and wedged the reader for every other stream on the session; at
+/// `/32` that takes thirty-two.
+const MAX_STREAM_BUFFER: usize = MAX_RECEIVE_BUFFER / 32;
 /// How long the reader waits for session receive budget before giving up on
 /// the session. Nothing below the mux layer reclaims budget held by a
-/// stalled consumer, so a wedged session cannot recover on its own; see
-/// `BUDGET_STALL_TIMEOUT` use in the reader.
+/// stalled consumer, so a wedged session cannot recover on its own. The
+/// deadline is session-wide, not per frame: it is armed the first time an
+/// acquire blocks and cleared only by a successful one, so a trickle of
+/// permits cannot keep postponing it forever.
 const BUDGET_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 /// Bounded outbound queue; stream writes wait when the physical writer lags.
 const OUTBOUND_QUEUE: usize = 64;
@@ -305,6 +314,9 @@ impl Session {
         tokio::spawn(async move {
             let mut header = [0u8; FRAME_HEADER_LEN];
             let mut discard = [0u8; 8 * 1024];
+            // Expiry of the session-wide budget-stall deadline; `None` while
+            // the reader is making progress. See `BUDGET_STALL_TIMEOUT`.
+            let mut budget_deadline: Option<tokio::time::Instant> = None;
             'reader: loop {
                 let header_result = tokio::select! {
                     _ = reader_cancel.cancelled() => break,
@@ -357,32 +369,55 @@ impl Session {
                         let permit = match Arc::clone(&receive_budget)
                             .try_acquire_many_owned(length as u32)
                         {
-                            Ok(permit) => permit,
+                            Ok(permit) => {
+                                // Uncontended, so the session has real
+                                // headroom: this is the only progress signal
+                                // that clears the stall deadline.
+                                budget_deadline = None;
+                                permit
+                            }
                             Err(TryAcquireError::Closed) => break 'reader,
-                            Err(TryAcquireError::NoPermits) => tokio::select! {
-                                _ = reader_cancel.cancelled() => break 'reader,
-                                result = Arc::clone(&receive_budget)
-                                    .acquire_many_owned(length as u32) => match result {
-                                    Ok(permit) => permit,
-                                    Err(_) => break 'reader,
-                                },
-                                // Every budget holder has stalled. The budget
-                                // lives in chunks queued inside inboxes whose
-                                // consumers are not polling, and the relay
-                                // stops polling a read half whose write half
-                                // is blocked — so no layer below can reclaim
-                                // it and this session will never dispatch
-                                // again. Abandon it: the physical connection
-                                // closes, the server releases its side, and
-                                // the pool opens a fresh session.
-                                _ = tokio::time::sleep(BUDGET_STALL_TIMEOUT) => {
-                                    debug!(
-                                        "smux: session receive budget ({MAX_RECEIVE_BUFFER} bytes) \
-                                         held for {BUDGET_STALL_TIMEOUT:?}; abandoning session"
-                                    );
-                                    break 'reader;
+                            Err(TryAcquireError::NoPermits) => {
+                                // One deadline shared by every consecutive
+                                // blocked frame. A blocking acquire that
+                                // eventually succeeds deliberately leaves it
+                                // armed: scraping by means the budget is still
+                                // saturated, and clearing on that would let a
+                                // trickle of permits postpone abandonment
+                                // forever, parking the session in a near-wedged
+                                // state the pool still considers healthy.
+                                let deadline = *budget_deadline.get_or_insert_with(|| {
+                                    tokio::time::Instant::now() + BUDGET_STALL_TIMEOUT
+                                });
+                                let remaining =
+                                    deadline.saturating_duration_since(tokio::time::Instant::now());
+                                tokio::select! {
+                                    _ = reader_cancel.cancelled() => break 'reader,
+                                    result = Arc::clone(&receive_budget)
+                                        .acquire_many_owned(length as u32) => match result {
+                                        Ok(permit) => permit,
+                                        Err(_) => break 'reader,
+                                    },
+                                    // Every budget holder has stalled. The
+                                    // budget lives in chunks queued inside
+                                    // inboxes whose consumers are not polling,
+                                    // and the relay stops polling a read half
+                                    // whose write half is blocked — so no layer
+                                    // below can reclaim it and this session will
+                                    // never dispatch again. Abandon it: the
+                                    // physical connection closes, the server
+                                    // releases its side, and the pool opens a
+                                    // fresh session.
+                                    _ = tokio::time::sleep(remaining) => {
+                                        warn!(
+                                            "smux: session receive budget \
+                                             ({MAX_RECEIVE_BUFFER} bytes) saturated for \
+                                             {BUDGET_STALL_TIMEOUT:?}; abandoning session"
+                                        );
+                                        break 'reader;
+                                    }
                                 }
-                            },
+                            }
                         };
                         let mut payload = vec![0u8; length];
                         let payload_result = tokio::select! {
@@ -432,11 +467,11 @@ impl Session {
                     // client-only usage and anything else is a protocol error.
                     // Reject before allocating payload.
                     CMD_SYN => {
-                        debug!("smux: protocol error: unexpected SYN from server");
+                        warn!("smux: protocol error: unexpected SYN from server; dropping session");
                         break 'reader;
                     }
                     other => {
-                        debug!("smux: protocol error: unknown command {other}");
+                        warn!("smux: protocol error: unknown command {other}; dropping session");
                         break 'reader;
                     }
                 }
@@ -569,7 +604,7 @@ fn retire_stream(
     reason: &str,
 ) {
     entry.aborted.store(true, Ordering::Release);
-    debug!(
+    info!(
         "smux: retiring stream {stream_id}: {reason} ({} bytes undelivered)",
         entry.unread.load(Ordering::Relaxed)
     );
@@ -1060,6 +1095,17 @@ mod tests {
     async fn wedged_receive_budget_abandons_the_session() {
         let frames_per_stream = MAX_STREAM_BUFFER / MAX_FRAME_SIZE;
         let hogs = MAX_RECEIVE_BUFFER / MAX_STREAM_BUFFER;
+        // `hogs` is the session's concurrency headroom: this many streams
+        // have to pin themselves at the cap before the reader can wedge.
+        // `MuxClient::offer` places no bound on streams per session once
+        // max-connections is reached, so a small divisor would make the
+        // wedge reachable in ordinary traffic.
+        const {
+            assert!(
+                MAX_RECEIVE_BUFFER / MAX_STREAM_BUFFER >= 32,
+                "the receive budget must leave headroom for many streams per session"
+            );
+        };
         let (client_io, mut server_io) = tokio::io::duplex(MAX_RECEIVE_BUFFER + 64 * 1024);
         let session = Arc::new(Session::client(client_io).unwrap());
         let mut streams = Vec::new();
@@ -1096,13 +1142,231 @@ mod tests {
             session.is_dead(),
             "a session that cannot make progress must be abandoned"
         );
-        // A hog was served in full, so the reader really did consume the
-        // whole budget and only then stop — pinning the teardown to the
+        // The last hog was served in full, so the reader really did consume
+        // the whole budget and only then stop — pinning the teardown to the
         // acquire rather than to some other session-death path.
         let mut buffered = vec![0u8; MAX_STREAM_BUFFER];
-        streams[0].read_exact(&mut buffered).await.unwrap();
+        streams[hogs - 1].read_exact(&mut buffered).await.unwrap();
         assert!(buffered.iter().all(|b| *b == 0x5a));
         writer.await.unwrap();
+    }
+
+    /// The inbox depth is a real retire trigger, not just a comment: it fires
+    /// when frames are small enough that [`STREAM_QUEUE`] of them cost less
+    /// payload than [`MAX_STREAM_BUFFER`]. Retiring must stay scoped to the
+    /// stalled stream, and everything already queued must still be delivered.
+    #[tokio::test]
+    async fn inbox_depth_retires_only_the_stalled_stream() {
+        // Guards the premise: the depth bound has to be reached first, or
+        // this test silently exercises the byte cap instead.
+        const {
+            assert!(
+                STREAM_QUEUE + 1 < MAX_STREAM_BUFFER,
+                "inbox depth must bind before the byte cap, or this test proves nothing"
+            );
+        };
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut slow = session.open_stream().await.unwrap();
+        let mut peer = session.open_stream().await.unwrap();
+
+        let mut wire = Vec::new();
+        for _ in 0..=STREAM_QUEUE {
+            wire.extend_from_slice(&encode_frame(CMD_PSH, slow.id, b"x"));
+        }
+        wire.extend_from_slice(&encode_frame(CMD_PSH, peer.id, b"ready"));
+        server_io.write_all(&wire).await.unwrap();
+
+        let mut ready = [0u8; 5];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            peer.read_exact(&mut ready),
+        )
+        .await
+        .expect("a depth-capped stream must not block its peers")
+        .unwrap();
+        assert_eq!(&ready, b"ready");
+
+        let mut drained = vec![0u8; STREAM_QUEUE];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            slow.read_exact(&mut drained),
+        )
+        .await
+        .expect("data queued before the retire must still be delivered")
+        .unwrap();
+        assert!(drained.iter().all(|b| *b == b'x'));
+
+        let error =
+            tokio::time::timeout(std::time::Duration::from_secs(1), slow.read(&mut [0u8; 1]))
+                .await
+                .expect("the retire must surface, not hang")
+                .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::ConnectionAborted);
+        assert!(!session.is_dead());
+    }
+
+    /// Consuming data must return those bytes to the per-stream counter. A
+    /// counter that only ever grows would retire every long-lived stream once
+    /// it had transferred one cap's worth in total — the exact defect class
+    /// the byte cap replaced the frame count to avoid.
+    #[tokio::test]
+    async fn draining_a_stream_frees_its_receive_cap() {
+        let frames_per_batch = MAX_STREAM_BUFFER / MAX_FRAME_SIZE;
+        let (client_io, mut server_io) = tokio::io::duplex(2 * MAX_STREAM_BUFFER);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        let big = vec![0x5au8; MAX_FRAME_SIZE];
+        // Two consecutive full-cap batches. The second is only deliverable if
+        // draining the first gave the bytes back.
+        for batch in 0..2 {
+            let mut wire = Vec::new();
+            for _ in 0..frames_per_batch {
+                wire.extend_from_slice(&encode_frame(CMD_PSH, stream.id, &big));
+            }
+            server_io.write_all(&wire).await.unwrap();
+
+            let mut buf = vec![0u8; MAX_STREAM_BUFFER];
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                stream.read_exact(&mut buf),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("batch {batch} must be delivered in full"))
+            .unwrap();
+            assert!(buf.iter().all(|b| *b == 0x5a), "batch {batch} corrupted");
+        }
+
+        // Still open: the next read parks instead of erroring.
+        let next = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            stream.read(&mut [0u8; 1]),
+        )
+        .await;
+        assert!(
+            next.is_err(),
+            "a fully drained stream must not have been retired"
+        );
+        assert!(!session.is_dead());
+    }
+
+    /// smux v1 control frames carry no payload, but a malformed one must cost
+    /// only its own bytes. Treating it as fatal takes down every stream on the
+    /// session, which is a peer-visible failure for traffic this client should
+    /// simply skip.
+    #[tokio::test]
+    async fn malformed_control_frame_does_not_kill_the_session() {
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let session = Arc::new(Session::client(client_io).unwrap());
+        let mut stream = session.open_stream().await.unwrap();
+
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&encode_frame(CMD_NOP, 0, b"junk"));
+        // An unknown id, so the FIN's stream removal is a no-op and only the
+        // payload tolerance is under test.
+        wire.extend_from_slice(&encode_frame(CMD_FIN, 0xFFFF_FFFF, b"junk"));
+        wire.extend_from_slice(&encode_frame(CMD_PSH, stream.id, b"alive"));
+        server_io.write_all(&wire).await.unwrap();
+
+        let mut buf = [0u8; 5];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            stream.read_exact(&mut buf),
+        )
+        .await
+        .expect("the session must keep dispatching after a malformed control frame")
+        .unwrap();
+        assert_eq!(&buf, b"alive");
+        assert!(!session.is_dead());
+    }
+
+    /// Regression: when both outbound queues are full, `queue_fin` drops one
+    /// FIN. It used to call `mark_dead` + `cancel`, and because this path is
+    /// reachable from `Drop`, merely closing a stream during backpressure
+    /// killed every healthy stream on the session.
+    #[tokio::test]
+    async fn dropped_fin_does_not_kill_the_session() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let open = Arc::new(AtomicBool::new(false));
+        let waker = Arc::new(std::sync::Mutex::new(None));
+        let polled = Arc::new(AtomicBool::new(false));
+        let session = Arc::new(
+            Session::client(GatedIo {
+                inner: client_io,
+                open: Arc::clone(&open),
+                waker: Arc::clone(&waker),
+                polled: Arc::clone(&polled),
+            })
+            .unwrap(),
+        );
+        // Open both streams before wedging the writer: opening queues a SYN.
+        let victim = session.open_stream().await.unwrap();
+        let mut peer = session.open_stream().await.unwrap();
+        let victim_id = victim.id;
+
+        // Park the writer on the gate, then fill BOTH outbound queues so
+        // `queue_fin` has nowhere left to put the frame.
+        let filler = OutMsg::Frame(encode_frame(CMD_PSH, 0xFFFF, &[1]));
+        loop {
+            while session.writer_tx.capacity() > 0 {
+                session.writer_tx.try_send(filler.clone()).unwrap();
+            }
+            if polled.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let deferred_filler = encode_frame(CMD_PSH, 0xFFFF, &[1]);
+        while session.deferred_fin_tx.capacity() > 0 {
+            session
+                .deferred_fin_tx
+                .try_send(deferred_filler.clone())
+                .unwrap();
+        }
+
+        drop(victim);
+        assert!(
+            !session.is_dead(),
+            "an unqueueable FIN must cost one stream, not the session"
+        );
+
+        open.store(true, Ordering::SeqCst);
+        if let Some(w) = waker.lock().unwrap().take() {
+            w.wake();
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(1), peer.write_all(b"ping"))
+            .await
+            .expect("the session must still accept writes")
+            .unwrap();
+        assert!(!session.is_dead());
+
+        // The FIN really was dropped rather than slipping into a queue.
+        let mut io = server_io;
+        let mut hdr = [0u8; FRAME_HEADER_LEN];
+        let mut payload = [0u8; 64];
+        let mut saw_victim_fin = false;
+        let drain = async {
+            loop {
+                if io.read_exact(&mut hdr).await.is_err() {
+                    break;
+                }
+                let Ok((cmd, length, sid)) = Frame::decode_header(&hdr) else {
+                    break;
+                };
+                if length > 0 && io.read_exact(&mut payload[..length]).await.is_err() {
+                    break;
+                }
+                if cmd == CMD_FIN && sid == victim_id {
+                    saw_victim_fin = true;
+                }
+            }
+        };
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), drain).await;
+        assert!(
+            !saw_victim_fin,
+            "both queues were full, so the FIN must have been dropped"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the smux side of #425 by giving each stream a bounded inbox and isolating a stalled stream instead of pausing the whole session:

- Each stream has a 2048-frame inbox. The reader never awaits it; when an inbox is full the chunk is parked in a per-stream spill (FIFO preserved: the consumer drains the inbox first, then the spill, woken via a notify permit), so a busy-but-draining consumer is never aborted for queue depth alone. Spill bytes stay bounded by the session receive budget because every parked chunk holds its permits.
- The per-stream receive share (`MAX_STREAM_BUFFER`, 128 KiB, i.e. receive budget / 32) is enforced by a per-stream stall watchdog, not at frame arrival: a stream that crosses its share gets one full grace window (`STREAM_STALL_GRACE`, 500 ms), after which the watchdog re-checks the live watermark and retires the stream only if it is still holding more than its share. An ordinary buffered burst — even one that pushes `unread` far past the share while the consumer is momentarily unscheduled — drains inside the window and survives. A consumer still over its share after the window is structurally slower than the peer (smux v1 has no window update, so there is nothing else to hold it back) and is cut instead of pinning budget permits until the session-wide deadline kills the session wholesale.
- The only synchronous retirement left is the adversarial bound: more than inbox+spill (4096) frames parked against a consumer that drained none of them implies sub-32 B average frames — a tiny-frame flood — which ordinary traffic cannot produce before the grace-gated byte cap does.
- Payload for unknown or retired stream IDs is drained with a fixed 8 KiB scratch buffer before it can consume shared receive capacity.
- Stream-map cleanup is synchronous (`parking_lot::Mutex`), so drops outside a Tokio runtime no longer skip cleanup, and no per-drop task is spawned when the outbound queue is backpressured — a single deferred-FIN forwarder preserves FIFO instead.
- A retired stream surfaces `ConnectionAborted` after draining already-buffered data (inbox and spill). Every other stream on the session is untouched.
- If the session-wide 4 MiB receive budget stays saturated for 30 s (`BUDGET_STALL_TIMEOUT`), the reader abandons the whole session. The deadline is armed the first time an acquire blocks and cleared only by an *uncontested* acquire, so a trickle of permits cannot postpone abandonment forever and leave the session wedged while the pool still considers it healthy.
- Protocol errors and budget saturation log at `warn!`, stream retirement at `info!`, so these events survive the default filter. A dropped FIN distinguishes a dead session (channels `Closed`) from a wedged writer (queues `Full`), so the backpressure diagnostic no longer fires on a session that is simply gone.

### Why the per-stream cap is budget/32

`MuxClient::offer` computes `reuse = sessions.len() >= max_connections || load < min_streams` when `max_connections > 0`, and never consults `max_streams` on that path — so a single session can carry an unbounded number of streams. At the default 4/4/4 config, roughly seventeen concurrent connections already place five streams on one session. With an earlier `/4` cap, four stalled streams exhausted the entire budget and wedged the reader for every other stream on the session; at `/32` that takes thirty-two. A `const` assertion pins the divisor so the invariant breaks the build if the constants ever move.

### Failure-model change

This changes the failure model relative to the previous draft (and muxcool): instead of session-wide TCP-window-style backpressure, a stalled consumer is explicitly retired. That is the observable behavior change required to fix the "one stalled stream stalls every other stream" symptom in #425.

smux v1 has no window-update frame, so per-stream flow control is not expressible at all: the reader either parks the session behind a slow consumer (muxcool's choice, and the head-of-line blocking #425 reports) or cuts that consumer. This PR takes the second branch, grace-gated: the cut lands only after the consumer has been over its share for a full 500 ms window — recovery-based (watermark), not progress-based, so a slow-but-draining consumer that crosses the cap for under the window always survives, while one that holds the share for the full window is cut.

### Review revision: healthy bursts must not be aborted

The first revision retired a stream the moment `unread` exceeded its share, at frame arrival. That mis-fired on healthy, actively reading streams: the reader drains a buffered burst back-to-back without yielding to the consumer, so on a current-thread runtime sixteen 32 KiB frames in one burst pushed `unread` past the share while a consumer continuously calling `read_to_end` was merely unscheduled — it got `ConnectionAborted` after exactly 131072 bytes (the review's P1 repro). Retirement is no longer decided at arrival time; the grace-gated watchdog above fixes it deterministically, because the consumer being alive is exactly what clears the watermark inside the window.

## Test plan

- [x] 24 smux tests, including: the reviewer's 16×32 KiB buffered-burst repro (current-thread runtime, 512 KiB delivered with clean EOF); over-share recovery inside the grace window; a stalled hog retired only after the grace window while its peer and the session survive; a never-draining inbox overflow retired after the grace window with the 2049th byte preserved through the spill; the tiny-frame-flood last resort retiring immediately; draining a stream frees its receive cap so it parks rather than aborts; malformed control frames do not kill the session; a FIN dropped by full outbound queues does not kill the session; a FIN dropped by an already-dead session is not reported as backpressure; a wedged receive budget abandons the session
- [x] Mutation-tested: restoring arrival-time retirement fails the burst repro on its intended assertion; short-circuiting the watchdog hangs the stalled-hog test; dropping the spill loses the 2049th byte
- [x] Real-server E2E (`crates/meow-app/tests/smux_singbox_integration.rs`): the full stack — config parsing → mixed listener → tunnel routing → VLESS adapter + smux → a real sing-box 1.14.0 VLESS inbound with multiplex enabled → direct outbound → local echo server, and back:
  - a 4 MiB bulk transfer (32× the per-stream receive share) with a continuously reading consumer, byte-identical round trip — the E2E twin of the buffered-burst regression;
  - a slow reader sharing one physical session (`max-connections: 1`) with fast readers: the slow stream is isolated by the stall watchdog while fast readers complete before and after on the very same session.
  The suite **fails** (never silently skips) when sing-box is missing; CI installs the pinned binary in the test job.
- [x] `cargo fmt --all -- --check`; three-way `cargo clippy --all-targets` (default / no-default-features / all-features) — clean
- [x] `cargo test -p meow-proxy --features mux --lib` — 409 passed, 0 failed, 3 ignored
- [x] `cargo test --workspace --lib` — 1281 passed across 13 binaries
- [x] Flakiness: 10× serial iterations of the smux suite and 5× of the real-server E2E suite, 0 failures; the buffered-burst repro is stable 10×