### PR TITLE
ci(coverage): skip sing-box live interop probes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,9 @@ jobs:
           # simple-obfs, embedded mock servers). Tests in
           # crates/meow-dns/tests/doh_dot_integration.rs require outbound
           # internet (Cloudflare/Google DoH/DoT) and are not reachable from
-          # GitHub-hosted runners — skip them by name.
+          # GitHub-hosted runners — skip them by name. The mux `live_singbox_*`
+          # interop probes require a manually started sing-box server
+          # (127.0.0.1:4411, see target/e2e/mux-interop/) — also skip.
           cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info \
             -- --include-ignored \
                --skip dot_resolves_example_com \
@@ -60,7 +62,8 @@ jobs:
                --skip doh_bogus_sni_fails_cert_validation \
                --skip dot_hostname_with_bootstrap_resolves \
                --skip geosite_rss_10k_rules_100k_queries \
-               --skip live_download_from_default_urls
+               --skip live_download_from_default_urls \
+               --skip live_singbox
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary
- The nightly Coverage workflow runs `cargo llvm-cov --include-ignored`, which pulls in the mux `live_singbox_*` interop probes added to main in 7d0225e. These are `#[ignore]` tests that require a manually started sing-box VLESS mux inbound (`127.0.0.1:4411`, see `target/e2e/mux-interop/`), so the run fails with ConnectionRefused ([example run](https://github.com/meow-rs/meow-rs/actions/runs/33601844659)).
- Add `--skip live_singbox` to the coverage invocation (libtest substring match covers all three probes: `mux::h2mux::tests::live_singbox_vless_probe`, `mux::muxcool::tests::live_singbox_vless_muxcool_probe`, `mux::packet::tests::live_singbox_vless_udp_probe`), consistent with the existing skip list for tests that cannot run on GitHub-hosted runners.

## Test plan
- [ ] After merge, dispatch Coverage via `workflow_dispatch` on main and confirm the job goes green (nightly cron alone would otherwise take until 02:17 UTC to verify)