### PR TITLE
fix(app): exclude listener-shadowsocks from the full bundle

### DIFF
--- a/crates/meow-app/Cargo.toml
+++ b/crates/meow-app/Cargo.toml
@@ -57,8 +57,9 @@ listener-mixed = ["meow-listener/listener-mixed"]
 # TUN inbound (issue #326) — transparent proxy without a tproxy/REDIRECT
 # firewall; the only transparent-proxy mode available on Windows.
 listener-tun = ["meow-listener/listener-tun", "meow-api/listener-tun"]
-# Shadowsocks encrypted-server inbound. Off by default (server scenario);
-# bundled into `full` but not `minimal` (ADR-0007 binary-size caps).
+# Shadowsocks encrypted-server inbound. Fully opt-in: excluded from `full`
+# and `minimal` (server scenario; ADR-0007 binary-size caps) — enable with
+# an explicit `--features listener-shadowsocks`.
 listener-shadowsocks = ["meow-listener/listener-shadowsocks"]
 
 # Convenience bundles
@@ -66,7 +67,7 @@ minimal = ["ss", "trojan", "dns-server", "listener-mixed"]
 full = [
     "ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel", "mux",
     "dns-server", "dns-encrypted",
-    "listener-http", "listener-socks5", "listener-tproxy", "listener-mixed", "listener-tun", "listener-shadowsocks",
+    "listener-http", "listener-socks5", "listener-tproxy", "listener-mixed", "listener-tun",
 ]
 
 [[bin]]

--- a/crates/meow-listener/Cargo.toml
+++ b/crates/meow-listener/Cargo.toml
@@ -28,7 +28,8 @@ listener-tun = [
 # Shadowsocks encrypted-server inbound. Reuses the `shadowsocks` crate's
 # server-side ProxyListener/ProxySocket (the same crate already used by the
 # outbound `ss` adapter) and the shared simple-obfs codec from meow-transport.
-# Off by default (server scenario); bundled into the app `full` profile.
+# Off by default (server scenario); excluded from the app's `full`/`minimal`
+# bundles — enable with an explicit `--features listener-shadowsocks`.
 listener-shadowsocks = [
     "dep:shadowsocks",
     "dep:meow-transport",

--- a/docs/ss-listener.md
+++ b/docs/ss-listener.md
@@ -40,16 +40,16 @@ listeners:
     udp: true                # default true (upstream parity)
 ```
 
-Run:
+Run (the feature is not part of any app bundle — build with it explicitly):
 
 ```bash
 cargo run -p meow-app --features listener-shadowsocks -- -f config.yaml
 ```
 
-or build the `full` profile (which bundles `listener-shadowsocks`):
+or for a release build:
 
 ```bash
-cargo build --release --features full
+cargo build --release --features listener-shadowsocks
 ./target/release/meow -f config.yaml
 ```
 
@@ -154,10 +154,11 @@ looping client DNS back through a proxy / the in-process resolver).
 
 ## Feature gating
 
-`listener-shadowsocks` is off by default (server scenario; ADR-0007
-binary-size caps). It's bundled into the app `full` profile but **not**
-`minimal`. Enabling it pulls in the `shadowsocks` workspace dep and
-`meow-transport/simple-obfs`.
+`listener-shadowsocks` is fully opt-in: off by default (server scenario;
+ADR-0007 binary-size caps) and excluded from both the app `full` and
+`minimal` bundles, so release binaries do not include it — build with an
+explicit `--features listener-shadowsocks`. Enabling it pulls in the
+`shadowsocks` workspace dep and `meow-transport/simple-obfs`.
 
 ## Differences from the other inbounds
 


### PR DESCRIPTION
## Summary

- Follow-up to #492: make `listener-shadowsocks` fully opt-in. It is no longer bundled into the app `full` profile (and was never in `minimal`), so release binaries stop carrying the SS encrypted-server inbound (ADR-0007 binary-size caps; niche server scenario).
- The feature still works as before when built explicitly: `cargo build --release --features listener-shadowsocks`.
- Builds without the feature keep the existing ADR-0002 Class B behavior: a `type: shadowsocks` listener in config logs `WARN listener '<name>': shadowsocks requires feature 'listener-shadowsocks'` and the app starts normally with the other listeners.
- Docs updated: `docs/ss-listener.md` build instructions and feature-gating section; comments in both `Cargo.toml` files.

Note: `shadowsocks` itself is still in `full` via the outbound `ss` feature — the removed weight is the listener module plus the `meow-transport/simple-obfs` server codec.

## Test plan

- [x] `cargo check -p meow-app` (default = `full` + `boring-tls`, feature off)
- [x] `cargo check -p meow-app --features listener-shadowsocks`
- [x] `cargo check -p meow-listener --no-default-features --features listener-shadowsocks`
- [x] Live smoke: default (feature-off) binary started with a `type: shadowsocks` listener config — expected WARN emitted, mixed listener started normally
- [ ] CI `features` job (per-feature standalone legs unaffected — no CI changes needed)