### PR TITLE
fix(snell): make connection reuse lifecycle stateful

### DIFF
--- a/crates/meow-proxy/src/snell/adapter.rs
+++ b/crates/meow-proxy/src/snell/adapter.rs
@@ -9,15 +9,16 @@ use meow_common::{
     AdapterType, MeowError, Metadata, ProxyAdapter, ProxyConn, ProxyHealth, ProxyPacketConn, Result,
 };
 use meow_transport::Stream as TransportStream;
+use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tracing::debug;
 
 use meow_transport::simple_obfs::client::{HttpObfs, TlsObfs};
 
-use super::pool::{drain_for_reuse, Pool, PoolStream};
+use super::pool::{Pool, PoolStream};
 use super::protocol::{write_header, write_udp_header, Snell};
 use super::udp::SnellPacketConn;
 
@@ -160,8 +161,8 @@ impl SnellAdapter {
 
     /// Number of idle connections currently parked in the reuse pool.
     /// Returns 0 when reuse is disabled. Exposed so integration tests can
-    /// synchronize with the background drain-and-return task that runs after
-    /// a pooled connection is dropped, instead of sleeping.
+    /// synchronize with the pool return that runs after a session completes,
+    /// instead of sleeping.
     pub fn idle_pool_size(&self) -> usize {
         self.pool.as_ref().map_or(0, |pool| pool.idle_count())
     }
@@ -286,6 +287,19 @@ struct PooledConn {
     inner: Option<PoolStream>,
     pool: Option<Arc<Pool>>,
     uses: u32,
+    local_half_close: LocalHalfClose,
+    reuse_failed: bool,
+}
+
+#[derive(Clone, Copy)]
+enum LocalHalfClose {
+    Open,
+    WritingZero,
+    FlushingZero,
+    Sent,
+    ClosingTransport,
+    Closed,
+    Failed,
 }
 
 impl PooledConn {
@@ -294,7 +308,33 @@ impl PooledConn {
             inner: Some(snell),
             pool,
             uses,
+            local_half_close: LocalHalfClose::Open,
+            reuse_failed: false,
         }
+    }
+}
+
+/// Finish the protocol-level half-close after the peer has already sent its
+/// zero-chunk. `WritingZero` may represent either a partially-written zero
+/// frame or an older pending payload frame, so keep polling empty writes until
+/// the codec reports that the zero-byte input itself completed.
+async fn finish_local_half_close(snell: &mut PoolStream, state: LocalHalfClose) -> io::Result<()> {
+    match state {
+        LocalHalfClose::Open | LocalHalfClose::WritingZero => {
+            loop {
+                let n =
+                    std::future::poll_fn(|cx| Pin::new(&mut *snell).poll_write(cx, &[])).await?;
+                if n == 0 {
+                    break;
+                }
+            }
+            snell.flush().await
+        }
+        LocalHalfClose::FlushingZero => snell.flush().await,
+        LocalHalfClose::Sent => Ok(()),
+        LocalHalfClose::ClosingTransport | LocalHalfClose::Closed | LocalHalfClose::Failed => Err(
+            io::Error::other("snell: pooled connection cannot finish protocol half-close"),
+        ),
     }
 }
 
@@ -308,7 +348,11 @@ impl AsyncRead for PooledConn {
             .inner
             .as_mut()
             .expect("PooledConn::poll_read after take");
-        Pin::new(inner).poll_read(cx, buf)
+        let result = Pin::new(inner).poll_read(cx, buf);
+        if matches!(&result, Poll::Ready(Err(_))) {
+            self.reuse_failed = true;
+        }
+        result
     }
 }
 
@@ -322,27 +366,95 @@ impl AsyncWrite for PooledConn {
             .inner
             .as_mut()
             .expect("PooledConn::poll_write after take");
-        Pin::new(inner).poll_write(cx, buf)
+        let result = Pin::new(inner).poll_write(cx, buf);
+        if matches!(&result, Poll::Ready(Err(_))) {
+            self.reuse_failed = true;
+        }
+        result
     }
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         let inner = self
             .inner
             .as_mut()
             .expect("PooledConn::poll_flush after take");
-        Pin::new(inner).poll_flush(cx)
+        let result = Pin::new(inner).poll_flush(cx);
+        if matches!(&result, Poll::Ready(Err(_))) {
+            self.reuse_failed = true;
+        }
+        result
     }
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let inner = self
-            .inner
-            .as_mut()
-            .expect("PooledConn::poll_shutdown after take");
-        // Send the half-close zero chunk via the v4 codec (empty write =>
-        // zero-chunk frame). After the frame drains we report Ready, and
-        // the pool-return logic runs in `Drop`.
-        match Pin::new(inner).poll_write(cx, &[]) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
+        let this = &mut *self;
+        loop {
+            match this.local_half_close {
+                LocalHalfClose::Open => {
+                    this.local_half_close = LocalHalfClose::WritingZero;
+                }
+                LocalHalfClose::WritingZero => {
+                    let inner = this
+                        .inner
+                        .as_mut()
+                        .expect("PooledConn::poll_shutdown after take");
+                    match Pin::new(inner).poll_write(cx, &[]) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => {
+                            this.local_half_close = LocalHalfClose::Failed;
+                            return Poll::Ready(Err(e));
+                        }
+                        // A non-zero result completes an older buffered
+                        // payload. Poll once more to stage the zero-chunk.
+                        Poll::Ready(Ok(n)) if n > 0 => continue,
+                        Poll::Ready(Ok(_)) => {
+                            this.local_half_close = LocalHalfClose::FlushingZero;
+                        }
+                    }
+                }
+                LocalHalfClose::FlushingZero => {
+                    let inner = this
+                        .inner
+                        .as_mut()
+                        .expect("PooledConn::poll_shutdown after take");
+                    match Pin::new(inner).poll_flush(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => {
+                            this.local_half_close = LocalHalfClose::Failed;
+                            return Poll::Ready(Err(e));
+                        }
+                        Poll::Ready(Ok(())) => {
+                            this.local_half_close = LocalHalfClose::Sent;
+                        }
+                    }
+                }
+                LocalHalfClose::Sent if this.pool.is_some() => return Poll::Ready(Ok(())),
+                LocalHalfClose::Sent => {
+                    // Non-pooled sessions still need the underlying write
+                    // side closed after their protocol zero-chunk is flushed.
+                    this.local_half_close = LocalHalfClose::ClosingTransport;
+                }
+                LocalHalfClose::ClosingTransport => {
+                    let inner = this
+                        .inner
+                        .as_mut()
+                        .expect("PooledConn::poll_shutdown after take");
+                    match Pin::new(inner).poll_shutdown(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => {
+                            this.local_half_close = LocalHalfClose::Failed;
+                            return Poll::Ready(Err(e));
+                        }
+                        Poll::Ready(Ok(())) => {
+                            this.local_half_close = LocalHalfClose::Closed;
+                        }
+                    }
+                }
+                LocalHalfClose::Closed => return Poll::Ready(Ok(())),
+                LocalHalfClose::Failed => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "snell: previous shutdown attempt failed",
+                    )));
+                }
+            }
         }
     }
 }
@@ -356,23 +468,38 @@ impl Drop for PooledConn {
             return;
         };
         let uses = self.uses;
-        // Spawn a background task to drain the server's tail bytes + the
-        // zero-chunk half-close, then push the conn back. Failures simply
-        // drop the conn — its underlying TCP is closed by `Snell`'s drop.
-        //
-        // Requires an active tokio runtime; the meow-rs binary always runs
-        // inside #[tokio::main], so this is safe in production. In unit
-        // tests that drop a PooledConn outside any runtime, `tokio::spawn`
-        // panics — those tests should use a #[tokio::test] runtime.
+
+        // A raw TCP EOF or unread server tail is not reusable. In particular,
+        // never drain arbitrary bytes here: doing so can swallow an old
+        // session and then feed the next CONNECT_V2 header into that session.
+        if self.reuse_failed || !snell.peer_half_closed() {
+            return;
+        }
+
+        if matches!(self.local_half_close, LocalHalfClose::Sent) {
+            let mut snell = snell;
+            snell.reset_reply_state();
+            pool.put(snell, uses);
+            return;
+        }
+
+        let state = self.local_half_close;
+        if matches!(
+            state,
+            LocalHalfClose::ClosingTransport | LocalHalfClose::Closed | LocalHalfClose::Failed
+        ) {
+            return;
+        }
         if tokio::runtime::Handle::try_current().is_err() {
             return;
         }
         tokio::spawn(async move {
             let mut snell = snell;
-            if drain_for_reuse(&mut snell).await {
-                snell.reset_reply_state();
-                pool.put(snell, uses);
+            if finish_local_half_close(&mut snell, state).await.is_err() {
+                return;
             }
+            snell.reset_reply_state();
+            pool.put(snell, uses);
         });
     }
 }

--- a/crates/meow-proxy/src/snell/pool.rs
+++ b/crates/meow-proxy/src/snell/pool.rs
@@ -9,18 +9,16 @@
 //!
 //! 1. `Pool::get` either pops the most-recently-returned idle conn (LIFO,
 //!    warmest cache) or asks the factory to dial a fresh one.
-//! 2. The caller writes the snell `CommandConnectV2` header, relays data,
-//!    and on success calls `PooledConn::into_returnable(...)` to send a
-//!    zero-chunk half-close and put the conn back.
-//! 3. On error the caller drops the `PooledConn` and the underlying TCP is
-//!    closed.
+//! 2. The caller writes the snell `CommandConnectV2` header and relays data.
+//! 3. `PooledConn` returns the stream only after both peers have completed
+//!    their zero-chunk half-close handshake. Incomplete sessions are dropped.
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use meow_transport::Stream as TransportStream;
 
-use super::protocol::{is_zero_chunk, Snell};
+use super::protocol::Snell;
 
 /// Type-erased snell stream used inside the pool. The underlying byte
 /// stream may be a plain TCP connection or an obfs-wrapped one — the pool
@@ -30,10 +28,6 @@ pub type PoolStream = Snell<Box<dyn TransportStream>>;
 const DEFAULT_MAX_SIZE: usize = 10;
 const DEFAULT_MAX_AGE: Duration = Duration::from_secs(15);
 const DEFAULT_MAX_USES_PER_CONN: u32 = 2;
-/// Time budget for draining the server's trailing zero-chunk before
-/// returning a conn to the pool. Mirrors opensnell's 500ms.
-const DRAIN_DEADLINE: Duration = Duration::from_millis(500);
-
 struct PooledEntry {
     conn: PoolStream,
     expires_at: Instant,
@@ -79,8 +73,8 @@ impl Pool {
 
     /// Number of idle entries currently parked (expired entries included —
     /// they are lazily discarded by [`Pool::take_idle`]). Exposed so callers
-    /// (and integration tests) can observe when the background
-    /// drain-and-return task has replenished the pool.
+    /// (and integration tests) can observe when a completed session has
+    /// replenished the pool.
     pub fn idle_count(&self) -> usize {
         self.items
             .lock()
@@ -115,44 +109,10 @@ impl Default for Pool {
     }
 }
 
-/// Drain trailing data + the server's zero-chunk so the conn is clean for
-/// reuse. Returns `true` when the zero-chunk was observed within
-/// `DRAIN_DEADLINE`, `false` otherwise (caller should discard the conn).
-///
-/// Reads via the raw version-specific codec (not the `Snell` wrapper): the
-/// wrapper maps the zero-chunk into a clean EOF, which is indistinguishable
-/// from the peer closing the TCP stream.
-pub async fn drain_for_reuse(conn: &mut PoolStream) -> bool {
-    let mut scratch = [0u8; 4096];
-    let deadline = tokio::time::sleep(DRAIN_DEADLINE);
-    tokio::pin!(deadline);
-    loop {
-        tokio::select! {
-            biased;
-            () = &mut deadline => return false,
-            res = conn.read_raw_for_reuse(&mut scratch) => {
-                match res {
-                    Ok(0) => return false, // peer closed underlying TCP
-                    Ok(_) => continue,
-                    Err(e) if is_zero_chunk(&e) => return true,
-                    Err(_) => return false,
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::pin::Pin;
     use std::sync::Arc;
-    use tokio::io::{AsyncWrite, AsyncWriteExt};
-    use tokio::time::timeout;
-
-    use crate::snell::v4::V4Conn;
-
-    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// Build a pool-typed snell stream over an in-memory duplex. The peer
     /// half is returned so tests can keep the underlying stream open (or
@@ -220,55 +180,5 @@ mod tests {
             );
         }
         assert!(pool.take_idle().is_none(), "pool is capped at 10 entries");
-    }
-
-    #[tokio::test]
-    async fn drain_for_reuse_true_on_zero_chunk() {
-        let (mut conn, peer) = make_stream();
-        // Skip the status-byte handshake — the pool drains mid-session
-        // streams whose reply has already been consumed.
-        conn.mark_reply_consumed();
-
-        // The v4 codec is symmetric (each direction sends its own salt), so
-        // a V4Conn over the peer half acts as the mock server.
-        let mut server = V4Conn::new(peer, Arc::from(b"k".as_slice()));
-        server.write_all(b"tail").await.unwrap();
-        // `write_all(&[])` short-circuits in tokio without polling, so drive
-        // `poll_write(&[])` by hand to emit the zero-chunk frame.
-        std::future::poll_fn(|cx| Pin::new(&mut server).poll_write(cx, &[]))
-            .await
-            .unwrap();
-        server.flush().await.unwrap();
-
-        let drained = timeout(TEST_TIMEOUT, drain_for_reuse(&mut conn))
-            .await
-            .expect("drain must finish within the deadline");
-        assert!(drained, "trailing data + zero chunk should mark conn clean");
-        drop(server);
-    }
-
-    #[tokio::test]
-    async fn drain_for_reuse_false_on_peer_close() {
-        let (mut conn, peer) = make_stream();
-        conn.mark_reply_consumed();
-        drop(peer); // peer closes without sending anything
-
-        let drained = timeout(TEST_TIMEOUT, drain_for_reuse(&mut conn))
-            .await
-            .expect("drain must finish within the deadline");
-        assert!(!drained, "closed peer must not be marked reusable");
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn drain_for_reuse_false_on_timeout() {
-        let (mut conn, _peer) = make_stream();
-        conn.mark_reply_consumed();
-
-        // Peer stays alive but silent; paused time auto-advances past the
-        // 500ms drain deadline as soon as the runtime is otherwise idle.
-        let drained = timeout(TEST_TIMEOUT, drain_for_reuse(&mut conn))
-            .await
-            .expect("drain must finish within the deadline");
-        assert!(!drained, "a silent peer must hit the drain deadline");
     }
 }

--- a/crates/meow-proxy/src/snell/protocol.rs
+++ b/crates/meow-proxy/src/snell/protocol.rs
@@ -96,7 +96,15 @@ pub async fn write_udp_header<W: AsyncWrite + Unpin>(stream: &mut W) -> io::Resu
 /// half-close signal recognized by the peer. The Snell codecs turn a
 /// zero-byte `poll_write` into a zero-chunk frame, so this is a thin wrapper.
 pub async fn write_zero_chunk<W: AsyncWrite + Unpin>(stream: &mut W) -> io::Result<()> {
-    stream.write_all(&[]).await
+    // A codec may first finish an in-flight payload write and report that
+    // payload's consumed length. Keep polling until the empty input itself
+    // completes, which is reported as zero bytes consumed.
+    loop {
+        if std::future::poll_fn(|cx| Pin::new(&mut *stream).poll_write(cx, &[])).await? == 0 {
+            break;
+        }
+    }
+    stream.flush().await
 }
 
 // ─── Snell stream wrapper ────────────────────────────────────────────────────
@@ -163,6 +171,10 @@ pub struct Snell<S> {
     /// `false` by [`Snell::reset_reply_state`] when a pooled connection is
     /// re-used for a fresh request.
     reply_consumed: bool,
+    /// The current session ended with the peer's zero-chunk. Unlike a raw TCP
+    /// EOF, this makes a v4/v5 connection eligible for protocol-level reuse
+    /// once our own zero-chunk has also been sent.
+    peer_half_closed: bool,
 }
 
 impl<S> Snell<S> {
@@ -170,6 +182,7 @@ impl<S> Snell<S> {
         Self {
             inner: SnellInner::V4(inner),
             reply_consumed: false,
+            peer_half_closed: false,
         }
     }
 
@@ -177,6 +190,7 @@ impl<S> Snell<S> {
         Self {
             inner: SnellInner::V3(inner),
             reply_consumed: false,
+            peer_half_closed: false,
         }
     }
 
@@ -187,6 +201,7 @@ impl<S> Snell<S> {
         Self {
             inner: SnellInner::V4(V4Conn::new(inner, psk)),
             reply_consumed: false,
+            peer_half_closed: false,
         }
     }
 
@@ -197,6 +212,7 @@ impl<S> Snell<S> {
         Self {
             inner: SnellInner::V3(V3Conn::new(inner, psk)),
             reply_consumed: false,
+            peer_half_closed: false,
         }
     }
 
@@ -204,10 +220,11 @@ impl<S> Snell<S> {
     /// pending again — reset the flag so the next `read` consumes it.
     pub fn reset_reply_state(&mut self) {
         self.reply_consumed = false;
+        self.peer_half_closed = false;
     }
 
-    pub fn mark_reply_consumed(&mut self) {
-        self.reply_consumed = true;
+    pub fn peer_half_closed(&self) -> bool {
+        self.peer_half_closed
     }
 
     /// Stage a single frame carrying `buf` verbatim as a UDP datagram
@@ -302,18 +319,6 @@ impl<S> Snell<S> {
             }
         }
     }
-
-    /// Read from the raw version-specific codec without the status-byte
-    /// guard or zero-chunk-to-EOF mapping. The reuse pool needs this so it
-    /// can tell a peer half-close from a dead TCP stream.
-    pub async fn read_raw_for_reuse(&mut self, buf: &mut [u8]) -> io::Result<usize>
-    where
-        S: AsyncRead + AsyncWrite + Unpin,
-    {
-        let mut rb = ReadBuf::new(buf);
-        std::future::poll_fn(|cx| self.inner.poll_read_inner(cx, &mut rb)).await?;
-        Ok(rb.filled().len())
-    }
 }
 
 impl<S: AsyncRead + AsyncWrite + Unpin> Snell<S> {
@@ -379,6 +384,9 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for Snell<S> {
         // a tiny scratch buffer, then we recurse on the body read in the
         // same poll once the reply is consumed.
         let this = &mut *self;
+        if this.peer_half_closed {
+            return Poll::Ready(Ok(()));
+        }
         if !this.reply_consumed {
             let mut buf = [0u8; 1];
             let mut rb = ReadBuf::new(&mut buf);
@@ -418,7 +426,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for Snell<S> {
         // Map the v4 zero-chunk into a clean EOF for the caller.
         match this.inner.poll_read_inner(cx, out) {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(e)) if is_zero_chunk(&e) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(e)) if is_zero_chunk(&e) => {
+                this.peer_half_closed = true;
+                Poll::Ready(Ok(()))
+            }
             other => other,
         }
     }
@@ -462,12 +473,6 @@ mod tests {
         let (a, b) = tokio::io::duplex(1 << 16);
         let psk: Arc<[u8]> = Arc::from(b"test-psk".as_slice());
         (Snell::new(a, Arc::clone(&psk)), V4Conn::new(b, psk))
-    }
-
-    /// Emit a zero chunk by hand: tokio's `write_all(&[])` short-circuits
-    /// without calling `poll_write`, so drive the poll directly.
-    async fn emit_zero_chunk(conn: &mut V4Conn<DuplexStream>) -> io::Result<usize> {
-        std::future::poll_fn(|cx| Pin::new(&mut *conn).poll_write(cx, &[])).await
     }
 
     #[tokio::test]
@@ -580,8 +585,7 @@ mod tests {
         let (mut client, mut peer) = rig();
         within(peer.write_all(&[RESPONSE_TUNNEL])).await.unwrap();
         within(peer.flush()).await.unwrap();
-        within(emit_zero_chunk(&mut peer)).await.unwrap();
-        within(peer.flush()).await.unwrap();
+        within(write_zero_chunk(&mut peer)).await.unwrap();
 
         let mut buf = [0u8; 8];
         let n = within(client.read(&mut buf)).await.unwrap();

--- a/crates/meow-proxy/tests/snell_integration.rs
+++ b/crates/meow-proxy/tests/snell_integration.rs
@@ -32,6 +32,9 @@ enum Behavior {
     /// Reply `RESPONSE_TUNNEL`, then echo every chunk back. Honours the
     /// zero-chunk half-close handshake so reuse-mode sessions work.
     Echo,
+    /// Send a tail and the server zero-chunk before the client half-closes,
+    /// then require the client zero-chunk before accepting another session.
+    PeerClosesFirst,
     /// Reply `RESPONSE_ERROR` with the given code/message, then close.
     ErrorReply { code: u8, msg: &'static str },
     /// Reply a single raw status byte, then close.
@@ -201,13 +204,32 @@ async fn serve_conn(
                 let _ = conn.flush().await;
                 return Ok(());
             }
-            Behavior::Echo => {
+            Behavior::Echo | Behavior::PeerClosesFirst => {
                 if conn.write_all(&[RESPONSE_TUNNEL]).await.is_err() || conn.flush().await.is_err()
                 {
                     return Ok(());
                 }
                 if cmd == COMMAND_UDP {
                     return serve_udp_echo(&mut conn, is_zero_chunk).await;
+                }
+                if matches!(behavior, Behavior::PeerClosesFirst) {
+                    if conn.write_all(b"tail").await.is_err()
+                        || send_zero_chunk(&mut conn).await.is_err()
+                    {
+                        return Ok(());
+                    }
+                    let mut buf = [0u8; 1024];
+                    match conn.read(&mut buf).await {
+                        Ok(0) => return Ok(()),
+                        Ok(n) => {
+                            return Err(format!(
+                                "received {n} payload bytes after peer half-close"
+                            ));
+                        }
+                        Err(e) if is_zero_chunk(&e) => {}
+                        Err(_) => return Ok(()),
+                    }
+                    continue;
                 }
                 let mut buf = vec![0u8; 64 * 1024];
                 loop {
@@ -376,6 +398,57 @@ async fn wait_for_pool_size(adapter: &SnellAdapter, want: usize) {
     .expect("reuse pool was not replenished in time");
 }
 
+async fn wait_for_accepted(server: &MockServer, want: usize) {
+    timeout(TIMEOUT, async {
+        while server.accepted.load(Ordering::SeqCst) < want {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("mock server did not accept enough connections in time");
+}
+
+/// Exercise the adapter behind a bidirectional relay. The local side
+/// half-closes first; the relay sends the client zero-chunk, consumes the
+/// server zero-chunk as EOF, and only then drops the proxy connection.
+async fn relay_roundtrip(adapter: &SnellAdapter, metadata: &Metadata, payload: &[u8]) {
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(metadata))
+        .await
+        .expect("dial timed out")
+        .expect("dial failed");
+    let (mut client, mut relay_side) = tokio::io::duplex(64 * 1024);
+
+    let relay = async {
+        tokio::io::copy_bidirectional(&mut relay_side, &mut conn)
+            .await
+            .expect("bidirectional relay failed");
+    };
+    let client_io = async {
+        client
+            .write_all(payload)
+            .await
+            .expect("client write failed");
+        client.flush().await.expect("client flush failed");
+        let mut echoed = vec![0u8; payload.len()];
+        client
+            .read_exact(&mut echoed)
+            .await
+            .expect("client echo read failed");
+        assert_eq!(echoed, payload);
+        client.shutdown().await.expect("client shutdown failed");
+        let mut trailing = Vec::new();
+        client
+            .read_to_end(&mut trailing)
+            .await
+            .expect("client EOF read failed");
+        assert!(trailing.is_empty());
+    };
+
+    timeout(TIMEOUT, async { tokio::join!(relay, client_io) })
+        .await
+        .expect("relay lifecycle timed out");
+}
+
 #[tokio::test]
 async fn tcp_connect_roundtrip_no_reuse() {
     let server = start_mock_server(PSK, Behavior::Echo).await;
@@ -508,37 +581,17 @@ async fn reuse_pool_reuses_tcp_connection() {
     let metadata = tcp_metadata("reuse.example.com", 443);
 
     // Session 1 — fresh dial.
-    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
-        .await
-        .expect("dial 1 timed out")
-        .expect("dial 1 failed");
-    roundtrip(&mut conn, b"session-1").await;
-    timeout(TIMEOUT, conn.shutdown())
-        .await
-        .expect("shutdown 1 timed out")
-        .expect("shutdown 1 failed");
-    drop(conn); // Drop drains the server zero-chunk and pools the conn.
+    relay_roundtrip(&adapter, &metadata, b"session-1").await;
     wait_for_pool_size(&adapter, 1).await;
 
     // Session 2 — must reuse the pooled TCP connection.
-    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
-        .await
-        .expect("dial 2 timed out")
-        .expect("dial 2 failed");
-    roundtrip(&mut conn, b"session-2").await;
+    relay_roundtrip(&adapter, &metadata, b"session-2").await;
     assert_eq!(
         server.accepted.load(Ordering::SeqCst),
         1,
         "session 2 must reuse the pooled TCP connection"
     );
-    timeout(TIMEOUT, conn.shutdown())
-        .await
-        .expect("shutdown 2 timed out")
-        .expect("shutdown 2 failed");
-    drop(conn);
-    // No synchronization needed here: `Pool::put` discards a conn at the
-    // 2-uses cap without ever inserting it, so the pool is empty whether or
-    // not the background drain task has finished.
+    // `Pool::put` discards a conn at the 2-uses cap without inserting it.
 
     // Session 3 — the 2-uses-per-conn cap forces a fresh dial.
     let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
@@ -560,6 +613,95 @@ async fn reuse_pool_reuses_tcp_connection() {
             "reuse mode must always send COMMAND_CONNECT_V2, got {requests:?}"
         );
     }
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn peer_half_close_is_acknowledged_before_pooling() {
+    let server = start_mock_server(PSK, Behavior::PeerClosesFirst).await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, true);
+    let metadata = tcp_metadata("peer-close.example.com", 443);
+
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial 1 timed out")
+        .expect("dial 1 failed");
+    let mut tail = [0u8; 4];
+    timeout(TIMEOUT, conn.read_exact(&mut tail))
+        .await
+        .expect("tail read timed out")
+        .expect("tail read failed");
+    assert_eq!(&tail, b"tail");
+    assert_eq!(
+        timeout(TIMEOUT, conn.read(&mut tail))
+            .await
+            .unwrap()
+            .unwrap(),
+        0
+    );
+    drop(conn);
+    wait_for_pool_size(&adapter, 1).await;
+
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial 2 timed out")
+        .expect("dial 2 failed");
+    timeout(TIMEOUT, conn.read_exact(&mut tail))
+        .await
+        .expect("reused tail read timed out")
+        .expect("reused tail read failed");
+    assert_eq!(&tail, b"tail");
+    assert_eq!(
+        server.accepted.load(Ordering::SeqCst),
+        1,
+        "second session must reuse the clean TCP connection"
+    );
+    assert_eq!(
+        timeout(TIMEOUT, conn.read(&mut tail))
+            .await
+            .unwrap()
+            .unwrap(),
+        0
+    );
+    drop(conn);
+    server.assert_no_violations();
+}
+
+#[tokio::test]
+async fn unread_peer_tail_is_never_pooled() {
+    let server = start_mock_server(PSK, Behavior::PeerClosesFirst).await;
+    let adapter = make_adapter(server.addr.port(), PSK, false, true);
+    let metadata = tcp_metadata("dirty.example.com", 443);
+
+    let conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial 1 timed out")
+        .expect("dial 1 failed");
+    // Leave the response, tail and server zero-chunk unread. Draining these
+    // in Drop would incorrectly make the still-unacknowledged session look
+    // reusable.
+    drop(conn);
+    assert_eq!(adapter.idle_pool_size(), 0);
+
+    let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial 2 timed out")
+        .expect("dial 2 failed");
+    wait_for_accepted(&server, 2).await;
+    let mut tail = [0u8; 4];
+    timeout(TIMEOUT, conn.read_exact(&mut tail))
+        .await
+        .expect("fresh tail read timed out")
+        .expect("fresh tail read failed");
+    assert_eq!(&tail, b"tail");
+    assert_eq!(
+        timeout(TIMEOUT, conn.read(&mut tail))
+            .await
+            .unwrap()
+            .unwrap(),
+        0
+    );
+    drop(conn);
     server.assert_no_violations();
 }
 


### PR DESCRIPTION
## Summary

- track the peer's protocol zero-chunk separately from a raw TCP EOF, and keep that EOF sticky for the current session
- return a connection to the reuse pool only after both protocol half-closes complete; discard unread, transport-closed, or errored sessions instead of draining arbitrary tail bytes
- make empty-write zero-chunks actually poll the codec, flush them, and finish the transport shutdown for non-pooled sessions

Addresses the Snell connection-pool finding in #495.

## Validation

- `cargo test --lib`
- `cargo test -p meow-proxy --features snell --test snell_integration` (15 passed)
- `cargo test -p meow-proxy --features snell --lib snell::` (30 passed)
- `cargo clippy -p meow-proxy --features snell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- real-node Snell v3 smoke through the full app path:
  - default HTTPS: HTTP 204 over HTTP/2
  - forced HTTP/1.1: HTTP 204

The tested node uses Snell v3, so the live smoke validates the parser/listener/routing/adapter/server path but does not exercise connection reuse. The v4/v5 reuse lifecycle is covered by mock-server integration tests for a normal bidirectional relay, peer-first half-close acknowledgement, and rejection of unread dirty sessions.
