### PR TITLE
feat(transport): add XHTTP (splithttp) transport protocol support (#344)

### DIFF
--- a/crates/meow-config/Cargo.toml
+++ b/crates/meow-config/Cargo.toml
@@ -40,7 +40,7 @@ meow-trie = { workspace = true }
 meow-dns = { workspace = true, features = ["encrypted"] }
 meow-rules = { workspace = true }
 meow-proxy = { workspace = true, default-features = false }
-meow-transport = { workspace = true, features = ["grpc", "h2", "httpupgrade"] }
+meow-transport = { workspace = true, features = ["grpc", "h2", "httpupgrade", "xhttp"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1568,9 +1568,123 @@ fn parse_vless(
             };
             chain.push(Box::new(HttpUpgradeLayer::new(hu_cfg)));
         }
+        "xhttp" => {
+            use meow_transport::xhttp::{XhttpConfig, XhttpLayer};
+            let xhttp_opts = config.get("xhttp-opts");
+            let path = xhttp_opts
+                .and_then(|o| o.get("path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("/")
+                .to_string();
+            let hosts: Vec<String> = xhttp_opts.and_then(|o| o.get("host")).map_or_else(
+                || vec![server.to_string()],
+                |v| {
+                    if let Some(s) = v.as_str() {
+                        vec![s.to_string()]
+                    } else if let Some(seq) = v.as_sequence() {
+                        seq.iter()
+                            .filter_map(|item| item.as_str().map(std::string::ToString::to_string))
+                            .collect()
+                    } else {
+                        vec![server.to_string()]
+                    }
+                },
+            );
+            if hosts.is_empty() {
+                return Err(format!(
+                    "vless: xhttp-opts.host must not be empty for proxy '{name}'"
+                ));
+            }
+            let mode = xhttp_opts
+                .and_then(|o| o.get("mode"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("stream-one")
+                .to_string();
+            if !mode.is_empty()
+                && !mode.eq_ignore_ascii_case("auto")
+                && !mode.eq_ignore_ascii_case("stream-one")
+            {
+                return Err(format!(
+                    "vless: unsupported xhttp mode '{mode}'; only 'stream-one' and 'auto' are supported"
+                ));
+            }
+            let extra_headers: Vec<(String, String)> = xhttp_opts
+                .and_then(|o| o.get("headers"))
+                .and_then(|h| h.as_mapping())
+                .map(|m| {
+                    m.iter()
+                        .filter_map(|(k, v)| {
+                            let key = k.as_str()?.to_string();
+                            let val = v.as_str()?.to_string();
+                            Some((key, val))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let no_grpc_header = xhttp_opts
+                .and_then(|o| o.get("no-grpc-header"))
+                .and_then(serde_yaml::Value::as_bool)
+                .unwrap_or(false);
+            let x_padding_bytes =
+                if let Some(padding_val) = xhttp_opts.and_then(|o| o.get("x-padding-bytes")) {
+                    if let Some(s) = padding_val.as_str() {
+                        let parts: Vec<&str> = s.split('-').collect();
+                        if parts.len() == 2 {
+                            let min = parts[0].trim().parse::<usize>().map_err(|e| {
+                                format!("vless: invalid min in x-padding-bytes '{s}': {e}")
+                            })?;
+                            let max = parts[1].trim().parse::<usize>().map_err(|e| {
+                                format!("vless: invalid max in x-padding-bytes '{s}': {e}")
+                            })?;
+                            if min > max {
+                                return Err(format!(
+                                    "vless: x-padding-bytes min ({min}) exceeds max ({max})"
+                                ));
+                            }
+                            Some((min, max))
+                        } else {
+                            return Err(format!(
+                                "vless: invalid x-padding-bytes range '{s}', expected 'min-max'"
+                            ));
+                        }
+                    } else if let Some(seq) = padding_val.as_sequence() {
+                        if seq.len() == 2 {
+                            let min = seq[0].as_u64().ok_or_else(|| {
+                                "vless: invalid min in x-padding-bytes".to_string()
+                            })? as usize;
+                            let max = seq[1].as_u64().ok_or_else(|| {
+                                "vless: invalid max in x-padding-bytes".to_string()
+                            })? as usize;
+                            if min > max {
+                                return Err(format!(
+                                    "vless: x-padding-bytes min ({min}) exceeds max ({max})"
+                                ));
+                            }
+                            Some((min, max))
+                        } else {
+                            return Err(
+                                "vless: x-padding-bytes array must have 2 elements".to_string()
+                            );
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    Some((100, 1000))
+                };
+            let xhttp_cfg = XhttpConfig {
+                path,
+                hosts,
+                extra_headers,
+                mode,
+                no_grpc_header,
+                x_padding_bytes,
+            };
+            chain.push(Box::new(XhttpLayer::new(xhttp_cfg)));
+        }
         other => {
             return Err(format!(
-                "vless: unsupported network '{other}'; valid values: tcp, ws, grpc, h2, httpupgrade"
+                "vless: unsupported network '{other}'; valid values: tcp, ws, grpc, h2, httpupgrade, xhttp"
             ));
         }
     }
@@ -1885,7 +1999,7 @@ fn default_transport_alpn(network: &str, alpn: Vec<String>) -> Vec<String> {
     }
     match network {
         "ws" => vec!["http/1.1".to_string()],
-        "grpc" | "h2" => vec!["h2".to_string()],
+        "grpc" | "h2" | "xhttp" => vec!["h2".to_string()],
         _ => alpn,
     }
 }
@@ -2500,6 +2614,10 @@ mod tests {
         );
         assert_eq!(
             default_transport_alpn("h2", Vec::new()),
+            vec!["h2".to_string()]
+        );
+        assert_eq!(
+            default_transport_alpn("xhttp", Vec::new()),
             vec!["h2".to_string()]
         );
         // Plain TCP keeps ALPN absent.

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -1402,9 +1402,9 @@ fn parse_vless(
     if tls {
         use meow_transport::tls::{TlsConfig, TlsLayer};
         let sni = if servername.is_empty() {
-            server.to_string()
+            server
         } else {
-            servername
+            servername.as_str()
         };
         let mut tls_cfg = TlsConfig::new(sni);
         tls_cfg.skip_cert_verify = skip_cert_verify;
@@ -1569,118 +1569,8 @@ fn parse_vless(
             chain.push(Box::new(HttpUpgradeLayer::new(hu_cfg)));
         }
         "xhttp" => {
-            use meow_transport::xhttp::{XhttpConfig, XhttpLayer};
-            let xhttp_opts = config.get("xhttp-opts");
-            let path = xhttp_opts
-                .and_then(|o| o.get("path"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("/")
-                .to_string();
-            let hosts: Vec<String> = xhttp_opts.and_then(|o| o.get("host")).map_or_else(
-                || vec![server.to_string()],
-                |v| {
-                    if let Some(s) = v.as_str() {
-                        vec![s.to_string()]
-                    } else if let Some(seq) = v.as_sequence() {
-                        seq.iter()
-                            .filter_map(|item| item.as_str().map(std::string::ToString::to_string))
-                            .collect()
-                    } else {
-                        vec![server.to_string()]
-                    }
-                },
-            );
-            if hosts.is_empty() {
-                return Err(format!(
-                    "vless: xhttp-opts.host must not be empty for proxy '{name}'"
-                ));
-            }
-            let mode = xhttp_opts
-                .and_then(|o| o.get("mode"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("stream-one")
-                .to_string();
-            if !mode.is_empty()
-                && !mode.eq_ignore_ascii_case("auto")
-                && !mode.eq_ignore_ascii_case("stream-one")
-            {
-                return Err(format!(
-                    "vless: unsupported xhttp mode '{mode}'; only 'stream-one' and 'auto' are supported"
-                ));
-            }
-            let extra_headers: Vec<(String, String)> = xhttp_opts
-                .and_then(|o| o.get("headers"))
-                .and_then(|h| h.as_mapping())
-                .map(|m| {
-                    m.iter()
-                        .filter_map(|(k, v)| {
-                            let key = k.as_str()?.to_string();
-                            let val = v.as_str()?.to_string();
-                            Some((key, val))
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            let no_grpc_header = xhttp_opts
-                .and_then(|o| o.get("no-grpc-header"))
-                .and_then(serde_yaml::Value::as_bool)
-                .unwrap_or(false);
-            let x_padding_bytes =
-                if let Some(padding_val) = xhttp_opts.and_then(|o| o.get("x-padding-bytes")) {
-                    if let Some(s) = padding_val.as_str() {
-                        let parts: Vec<&str> = s.split('-').collect();
-                        if parts.len() == 2 {
-                            let min = parts[0].trim().parse::<usize>().map_err(|e| {
-                                format!("vless: invalid min in x-padding-bytes '{s}': {e}")
-                            })?;
-                            let max = parts[1].trim().parse::<usize>().map_err(|e| {
-                                format!("vless: invalid max in x-padding-bytes '{s}': {e}")
-                            })?;
-                            if min > max {
-                                return Err(format!(
-                                    "vless: x-padding-bytes min ({min}) exceeds max ({max})"
-                                ));
-                            }
-                            Some((min, max))
-                        } else {
-                            return Err(format!(
-                                "vless: invalid x-padding-bytes range '{s}', expected 'min-max'"
-                            ));
-                        }
-                    } else if let Some(seq) = padding_val.as_sequence() {
-                        if seq.len() == 2 {
-                            let min = seq[0].as_u64().ok_or_else(|| {
-                                "vless: invalid min in x-padding-bytes".to_string()
-                            })? as usize;
-                            let max = seq[1].as_u64().ok_or_else(|| {
-                                "vless: invalid max in x-padding-bytes".to_string()
-                            })? as usize;
-                            if min > max {
-                                return Err(format!(
-                                    "vless: x-padding-bytes min ({min}) exceeds max ({max})"
-                                ));
-                            }
-                            Some((min, max))
-                        } else {
-                            return Err(
-                                "vless: x-padding-bytes array must have 2 elements".to_string()
-                            );
-                        }
-                    } else {
-                        None
-                    }
-                } else {
-                    Some((100, 1000))
-                };
-            let xhttp_cfg = XhttpConfig {
-                path,
-                hosts,
-                extra_headers,
-                mode,
-                no_grpc_header,
-                x_padding_bytes,
-            };
-            chain.push(Box::new(XhttpLayer::new(xhttp_cfg)));
+            let xhttp_cfg = parse_vless_xhttp_config(config, server, &servername, tls)?;
+            chain.push(Box::new(meow_transport::xhttp::XhttpLayer::new(xhttp_cfg)));
         }
         other => {
             return Err(format!(
@@ -1934,6 +1824,136 @@ fn mux_usize_field(
             "{name}: mux option '{key}' must be a non-negative integer, got {other:?}"
         )),
     }
+}
+#[cfg(feature = "vless")]
+fn parse_vless_xhttp_config(
+    config: &HashMap<String, serde_yaml::Value>,
+    server: &str,
+    servername: &str,
+    tls: bool,
+) -> std::result::Result<meow_transport::xhttp::XhttpConfig, String> {
+    use meow_transport::xhttp::XhttpConfig;
+
+    let xhttp_opts = config.get("xhttp-opts");
+    let path = xhttp_opts
+        .and_then(|o| o.get("path"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("/")
+        .to_string();
+    let fallback_host = if servername.is_empty() {
+        server
+    } else {
+        servername
+    };
+    let hosts: Vec<String> = match xhttp_opts.and_then(|o| o.get("host")) {
+        None => vec![fallback_host.to_string()],
+        Some(value) if value.is_string() => {
+            vec![value.as_str().expect("checked string").to_string()]
+        }
+        Some(value) if value.is_sequence() => value
+            .as_sequence()
+            .expect("checked sequence")
+            .iter()
+            .map(|item| {
+                item.as_str()
+                    .map(std::string::ToString::to_string)
+                    .ok_or_else(|| "vless: xhttp-opts.host entries must be strings".to_string())
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()?,
+        Some(_) => {
+            return Err("vless: xhttp-opts.host must be a string or string array".into());
+        }
+    };
+    if hosts.is_empty() {
+        return Err("vless: xhttp-opts.host must not be empty".into());
+    }
+    let mode = xhttp_opts
+        .and_then(|o| o.get("mode"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("stream-one")
+        .to_string();
+    if !mode.eq_ignore_ascii_case("stream-one") {
+        return Err(format!(
+            "vless: unsupported xhttp mode '{mode}'; only 'stream-one' is implemented"
+        ));
+    }
+    let extra_headers: Vec<(String, String)> = xhttp_opts
+        .and_then(|o| o.get("headers"))
+        .and_then(|h| h.as_mapping())
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| {
+                    let key = k.as_str()?.to_string();
+                    let val = v.as_str()?.to_string();
+                    Some((key, val))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let no_grpc_header = xhttp_opts
+        .and_then(|o| o.get("no-grpc-header"))
+        .and_then(serde_yaml::Value::as_bool)
+        .unwrap_or(false);
+    let x_padding_bytes =
+        if let Some(padding_val) = xhttp_opts.and_then(|o| o.get("x-padding-bytes")) {
+            if let Some(s) = padding_val.as_str() {
+                let parts: Vec<&str> = s.split('-').collect();
+                if parts.len() != 2 {
+                    return Err(format!(
+                        "vless: invalid x-padding-bytes range '{s}', expected 'min-max'"
+                    ));
+                }
+                let min = parts[0]
+                    .trim()
+                    .parse::<usize>()
+                    .map_err(|e| format!("vless: invalid min in x-padding-bytes '{s}': {e}"))?;
+                let max = parts[1]
+                    .trim()
+                    .parse::<usize>()
+                    .map_err(|e| format!("vless: invalid max in x-padding-bytes '{s}': {e}"))?;
+                if min > max {
+                    return Err(format!(
+                        "vless: x-padding-bytes min ({min}) exceeds max ({max})"
+                    ));
+                }
+                Some((min, max))
+            } else if let Some(seq) = padding_val.as_sequence() {
+                if seq.len() != 2 {
+                    return Err("vless: x-padding-bytes array must have 2 elements".into());
+                }
+                let min = seq[0]
+                    .as_u64()
+                    .ok_or_else(|| "vless: invalid min in x-padding-bytes".to_string())?
+                    as usize;
+                let max = seq[1]
+                    .as_u64()
+                    .ok_or_else(|| "vless: invalid max in x-padding-bytes".to_string())?
+                    as usize;
+                if min > max {
+                    return Err(format!(
+                        "vless: x-padding-bytes min ({min}) exceeds max ({max})"
+                    ));
+                }
+                Some((min, max))
+            } else {
+                return Err(
+                    "vless: x-padding-bytes must be a 'min-max' string or 2-element integer array"
+                        .to_string(),
+                );
+            }
+        } else {
+            Some((100, 1000))
+        };
+
+    Ok(XhttpConfig {
+        path,
+        hosts,
+        scheme: if tls { "https" } else { "http" }.to_string(),
+        extra_headers,
+        mode,
+        no_grpc_header,
+        x_padding_bytes,
+    })
 }
 
 /// Parse the VLESS `encryption` field.
@@ -2622,6 +2642,39 @@ mod tests {
         );
         // Plain TCP keeps ALPN absent.
         assert!(default_transport_alpn("tcp", Vec::new()).is_empty());
+    }
+
+    #[cfg(feature = "vless")]
+    #[test]
+    fn xhttp_config_resolves_fields_and_fallbacks() {
+        let full = proxy_config(
+            "name: v\ntype: vless\nserver: 203.0.113.7\nport: 443\n\
+             uuid: b831381d-6324-4d53-ad4f-8cda48b30811\ntls: true\n\
+             servername: cdn.example.com\nnetwork: xhttp\nxhttp-opts:\n\
+             \x20 path: /testpath\n\x20 host: xhttp.example.com\n\
+             \x20 mode: stream-one\n\x20 no-grpc-header: true\n\
+             \x20 x-padding-bytes: 200-800\n\x20 headers:\n\x20\x20 X-Custom: Hello\n",
+        );
+        let parsed = parse_vless_xhttp_config(&full, "203.0.113.7", "cdn.example.com", true)
+            .expect("full xhttp config");
+        assert_eq!(parsed.path, "/testpath");
+        assert_eq!(parsed.hosts, ["xhttp.example.com"]);
+        assert_eq!(parsed.scheme, "https");
+        assert_eq!(parsed.mode, "stream-one");
+        assert!(parsed.no_grpc_header);
+        assert_eq!(parsed.x_padding_bytes, Some((200, 800)));
+        assert_eq!(parsed.extra_headers, [("X-Custom".into(), "Hello".into())]);
+
+        let fallback = proxy_config("xhttp-opts:\n  path: /fallback\n");
+        let parsed = parse_vless_xhttp_config(&fallback, "203.0.113.7", "cdn.example.com", true)
+            .expect("fallback xhttp config");
+        assert_eq!(parsed.hosts, ["cdn.example.com"]);
+        assert_eq!(parsed.x_padding_bytes, Some((100, 1000)));
+
+        let parsed = parse_vless_xhttp_config(&HashMap::new(), "2001:db8::1", "", false)
+            .expect("h2c xhttp config");
+        assert_eq!(parsed.hosts, ["2001:db8::1"]);
+        assert_eq!(parsed.scheme, "http");
     }
 
     #[test]

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -1475,7 +1475,6 @@ proxies:
     let config = load_config_from_str(yaml).await.expect("config must parse");
     assert!(config.proxies.contains_key("vless-xhttp-full"));
 }
-
 #[tokio::test]
 async fn parse_vless_xhttp_unsupported_mode_skipped() {
     let yaml = r#"
@@ -1488,7 +1487,7 @@ proxies:
     tls: true
     network: xhttp
     xhttp-opts:
-      mode: packet-up
+      mode: auto
 "#;
     let config = load_config_from_str(yaml)
         .await
@@ -1519,5 +1518,28 @@ proxies:
     assert!(
         !config.proxies.contains_key("vless-xhttp-bad-pad"),
         "proxy with inverted padding range must be skipped"
+    );
+}
+
+#[tokio::test]
+async fn parse_vless_xhttp_invalid_padding_shape_skipped() {
+    let yaml = r#"
+proxies:
+  - name: vless-xhttp-bad-pad-shape
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    network: xhttp
+    xhttp-opts:
+      x-padding-bytes: 100
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("config load must succeed (warn-and-skip)");
+    assert!(
+        !config.proxies.contains_key("vless-xhttp-bad-pad-shape"),
+        "proxy with invalid padding shape must be skipped"
     );
 }

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -1433,3 +1433,91 @@ proxies:
         "proxy with server > 255 bytes must be skipped (Class A)"
     );
 }
+
+// ─── XHTTP (SplitHTTP) transport config tests ────────────────────────────────
+
+#[tokio::test]
+async fn parse_vless_xhttp_minimal_ok() {
+    let yaml = r#"
+proxies:
+  - name: vless-xhttp
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    network: xhttp
+"#;
+    let config = load_config_from_str(yaml).await.expect("config must parse");
+    assert!(config.proxies.contains_key("vless-xhttp"));
+}
+
+#[tokio::test]
+async fn parse_vless_xhttp_full_opts_ok() {
+    let yaml = r#"
+proxies:
+  - name: vless-xhttp-full
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    network: xhttp
+    xhttp-opts:
+      path: /testpath
+      host: xhttp.example.com
+      mode: stream-one
+      no-grpc-header: true
+      x-padding-bytes: 200-800
+      headers:
+        X-Custom: Hello
+"#;
+    let config = load_config_from_str(yaml).await.expect("config must parse");
+    assert!(config.proxies.contains_key("vless-xhttp-full"));
+}
+
+#[tokio::test]
+async fn parse_vless_xhttp_unsupported_mode_skipped() {
+    let yaml = r#"
+proxies:
+  - name: vless-xhttp-bad-mode
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    network: xhttp
+    xhttp-opts:
+      mode: packet-up
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("config load must succeed (warn-and-skip)");
+    assert!(
+        !config.proxies.contains_key("vless-xhttp-bad-mode"),
+        "proxy with unsupported xhttp mode must be skipped"
+    );
+}
+
+#[tokio::test]
+async fn parse_vless_xhttp_invalid_padding_range_skipped() {
+    let yaml = r#"
+proxies:
+  - name: vless-xhttp-bad-pad
+    type: vless
+    server: example.com
+    port: 443
+    uuid: b831381d-6324-4d53-ad4f-8cda48b30811
+    tls: true
+    network: xhttp
+    xhttp-opts:
+      x-padding-bytes: 900-100
+"#;
+    let config = load_config_from_str(yaml)
+        .await
+        .expect("config load must succeed (warn-and-skip)");
+    assert!(
+        !config.proxies.contains_key("vless-xhttp-bad-pad"),
+        "proxy with inverted padding range must be skipped"
+    );
+}

--- a/crates/meow-proxy/Cargo.toml
+++ b/crates/meow-proxy/Cargo.toml
@@ -96,7 +96,9 @@ ctr = { workspace = true, optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 meow-trie = { workspace = true }
+meow-transport = { workspace = true, features = ["xhttp"] }
 rcgen = "0.13"
+http = "1"
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/meow-proxy/tests/vless_integration.rs
+++ b/crates/meow-proxy/tests/vless_integration.rs
@@ -514,4 +514,136 @@ mod vless_tests {
         // ProxyHealth must be accessible — no panic.
         let _health = adapter.health();
     }
+
+    // ─── H7: VLESS over XHTTP end-to-end round-trip ───────────────────────────
+
+    #[tokio::test]
+    async fn vless_over_xhttp_roundtrip() {
+        use bytes::Bytes;
+        use meow_transport::xhttp::{XhttpConfig, XhttpLayer};
+
+        let (echo_addr, _echo) = start_tcp_echo_server().await;
+
+        // Start an H2 server that terminates the XHTTP tunnel and unwraps the inner VLESS stream.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let vless_h2_addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            while let Ok((tcp, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let Ok(mut connection) =
+                        h2::server::Builder::new().handshake::<_, Bytes>(tcp).await
+                    else {
+                        return;
+                    };
+
+                    while let Some(Ok((request, mut respond))) = connection.accept().await {
+                        // Send 200 OK response header lazily to start the bidirectional stream
+                        let response = http::Response::builder().status(200).body(()).unwrap();
+                        let mut send_body = respond.send_response(response, false).unwrap();
+                        let mut recv_body = request.into_body();
+
+                        // Bridge the h2 stream into AsyncRead + AsyncWrite
+                        let (client_r, mut client_w) = tokio::io::duplex(64 * 1024);
+                        let (mut server_r, server_w) = tokio::io::duplex(64 * 1024);
+
+                        // Forward recv_body -> server_w
+                        tokio::spawn(async move {
+                            let mut server_w = server_w;
+                            while let Some(Ok(chunk)) = recv_body.data().await {
+                                let _ = recv_body.flow_control().release_capacity(chunk.len());
+                                if server_w.write_all(&chunk).await.is_err() {
+                                    break;
+                                }
+                            }
+                        });
+
+                        // Forward client_r -> send_body
+                        tokio::spawn(async move {
+                            let mut client_r = client_r;
+                            let mut buf = vec![0u8; 8192];
+                            loop {
+                                match client_r.read(&mut buf).await {
+                                    Ok(0) | Err(_) => break,
+                                    Ok(n) => {
+                                        send_body.reserve_capacity(n);
+                                        if send_body
+                                            .send_data(Bytes::copy_from_slice(&buf[..n]), false)
+                                            .is_err()
+                                        {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        });
+
+                        // Run mock VLESS server over server_r + client_w
+                        tokio::spawn(async move {
+                            let Ok((uuid, cmd, target_addr)) =
+                                read_vless_header(&mut server_r).await
+                            else {
+                                return;
+                            };
+                            if uuid != TEST_UUID {
+                                return;
+                            }
+                            if client_w.write_all(&[0x00, 0x00]).await.is_err() {
+                                return;
+                            }
+                            if cmd == 0x01 {
+                                if let Ok(mut target) = TcpStream::connect(target_addr).await {
+                                    let (mut tr, mut tw) = target.split();
+                                    let _ = tokio::join!(
+                                        tokio::io::copy(&mut server_r, &mut tw),
+                                        tokio::io::copy(&mut tr, &mut client_w)
+                                    );
+                                }
+                            }
+                        });
+                    }
+                });
+            }
+        });
+
+        // Build VlessAdapter with XhttpLayer in TransportChain
+        let mut chain = TransportChain::empty();
+        let xhttp_cfg = XhttpConfig {
+            path: "/xhttp-vless".into(),
+            hosts: vec!["xhttp.test.com".into()],
+            ..Default::default()
+        };
+        chain.push(Box::new(XhttpLayer::new(xhttp_cfg)));
+
+        let adapter = VlessAdapter::new(
+            "test-vless-xhttp",
+            "127.0.0.1",
+            vless_h2_addr.port(),
+            TEST_UUID,
+            None,
+            false,
+            chain,
+            Arc::new(DirectDialer),
+        );
+
+        let metadata = Metadata {
+            network: Network::Tcp,
+            dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            dst_port: echo_addr.port(),
+            ..Default::default()
+        };
+
+        let mut conn = timeout(TIMEOUT, adapter.dial_tcp(&metadata))
+            .await
+            .expect("dial_tcp timed out")
+            .expect("dial_tcp failed");
+
+        let payload = b"hello vless over xhttp";
+        conn.write_all(payload).await.expect("write payload failed");
+        conn.flush().await.expect("flush failed");
+
+        let mut buf = vec![0u8; payload.len()];
+        conn.read_exact(&mut buf).await.expect("read echo failed");
+        assert_eq!(&buf, payload, "round-trip data must match");
+    }
 }

--- a/crates/meow-transport/Cargo.toml
+++ b/crates/meow-transport/Cargo.toml
@@ -69,6 +69,11 @@ h2 = [
 httpupgrade = [
     "dep:httparse",
 ]
+xhttp = [
+    "dep:h2",
+    "dep:http",
+    "dep:rand",
+]
 # simple-obfs (SIP004): a stream-wrapper codec that frames shadowsocks traffic
 # as fake HTTP / TLS so a passive observer sees plain web traffic. Used by both
 # the outbound SS/Snell adapters (client side, here as `simple_obfs::client`)
@@ -159,6 +164,10 @@ required-features = ["h2"]
 [[test]]
 name = "httpupgrade_test"
 required-features = ["httpupgrade"]
+
+[[test]]
+name = "xhttp_test"
+required-features = ["xhttp"]
 
 [lints]
 workspace = true

--- a/crates/meow-transport/src/error.rs
+++ b/crates/meow-transport/src/error.rs
@@ -28,6 +28,9 @@ pub enum TransportError {
     #[error("http upgrade: {0}")]
     HttpUpgrade(String),
 
+    #[error("xhttp: {0}")]
+    Xhttp(String),
+
     #[error("invalid config: {0}")]
     Config(String),
 }

--- a/crates/meow-transport/src/h2.rs
+++ b/crates/meow-transport/src/h2.rs
@@ -95,30 +95,44 @@ impl Transport for H2Layer {
 
         // Drive the h2 connection (SETTINGS, WINDOW_UPDATE, PING, …) in a
         // background task so control frames keep flowing while we stream data.
-        tokio::spawn(async move {
+        let driver_task = tokio::spawn(async move {
             let _ = conn.await;
         });
+        let abort_handle = driver_task.abort_handle();
 
         // h2 requires poll_ready/ready before send_request: sending
         // without readiness is rejected once MAX_CONCURRENT_STREAMS is
         // exhausted.  Bounded by OPEN_TIMEOUT — see its doc.
-        h2 = tokio::time::timeout(OPEN_TIMEOUT, h2.ready())
-            .await
-            .map_err(|_| TransportError::H2("timed out waiting for send readiness (open)".into()))?
-            .map_err(|e| TransportError::H2(e.to_string()))?;
+        h2 = match tokio::time::timeout(OPEN_TIMEOUT, h2.ready()).await {
+            Ok(Ok(ready_h2)) => ready_h2,
+            Ok(Err(e)) => {
+                abort_handle.abort();
+                return Err(TransportError::H2(e.to_string()));
+            }
+            Err(_) => {
+                abort_handle.abort();
+                return Err(TransportError::H2(
+                    "timed out waiting for send readiness (open)".into(),
+                ));
+            }
+        };
 
         // Open the h2 stream; `end_of_stream = false` — we will stream data.
-        let (response_future, send_stream) = h2
-            .send_request(request, false)
-            .map_err(|e| TransportError::H2(e.to_string()))?;
+        let (response_future, send_stream) = match h2.send_request(request, false) {
+            Ok(parts) => parts,
+            Err(e) => {
+                abort_handle.abort();
+                return Err(TransportError::H2(e.to_string()));
+            }
+        };
 
         // Do NOT await the response here: upstream's h2 handler reads the
         // client's first DATA frame before it writes anything, so awaiting
         // would deadlock the tunnel (issue #377). The response is resolved on
         // the first read instead — see `h2_common::RecvState`.
-        Ok(Box::new(H2Stream::new(
-            send_stream,
-            RecvState::new(response_future),
-        )))
+        Ok(Box::new(
+            H2Stream::new(send_stream, RecvState::new(response_future))
+                .with_conn_abort(abort_handle),
+        ))
     }
 }

--- a/crates/meow-transport/src/h2_common.rs
+++ b/crates/meow-transport/src/h2_common.rs
@@ -9,6 +9,8 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+const DRIVER_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// Accepted response status for a lazily resolved HTTP/2 body.
 #[derive(Clone, Copy)]
 pub enum StatusPolicy {
@@ -113,6 +115,26 @@ impl RecvState {
             _ => None,
         }
     }
+
+    async fn drain(mut self) {
+        if std::future::poll_fn(|cx| self.poll_ready(cx))
+            .await
+            .is_err()
+        {
+            return;
+        }
+        let Some(stream) = self.stream() else {
+            return;
+        };
+        while let Some(item) = stream.data().await {
+            match item {
+                Ok(bytes) => {
+                    let _ = stream.flow_control().release_capacity(bytes.len());
+                }
+                Err(_) => return,
+            }
+        }
+    }
 }
 
 /// Per-poll cap on the bytes copied into `pending_write`.  Without a cap,
@@ -127,7 +149,7 @@ const WRITE_STASH_CAP: usize = 64 * 1024;
 /// Raw bidirectional bytes over one HTTP/2 request/response pair.
 pub struct H2Stream {
     send: h2::SendStream<Bytes>,
-    recv: RecvState,
+    recv: Option<RecvState>,
     read_buf: Bytes,
     /// Payload stashed while a `poll_write` waits for h2 send-window
     /// capacity — at most [`WRITE_STASH_CAP`] bytes, i.e. possibly only a
@@ -152,7 +174,7 @@ impl H2Stream {
     pub fn new(send: h2::SendStream<Bytes>, recv: RecvState) -> Self {
         Self {
             send,
-            recv,
+            recv: Some(recv),
             read_buf: Bytes::new(),
             pending_write: None,
             remote_no_error_is_eof: false,
@@ -193,9 +215,22 @@ impl H2Stream {
 impl Drop for H2Stream {
     fn drop(&mut self) {
         self.best_effort_eos();
-        if let Some(handle) = self.conn_abort.take() {
-            handle.abort();
-        }
+        let Some(abort_handle) = self.conn_abort.take() else {
+            return;
+        };
+        let recv = self.recv.take();
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            abort_handle.abort();
+            return;
+        };
+        runtime.spawn(async move {
+            if let Some(recv) = recv {
+                let _ = tokio::time::timeout(DRIVER_DRAIN_TIMEOUT, recv.drain()).await;
+            } else {
+                tokio::task::yield_now().await;
+            }
+            abort_handle.abort();
+        });
     }
 }
 
@@ -219,12 +254,13 @@ impl AsyncRead for H2Stream {
                 let _ = this.read_buf.split_to(count);
                 return Poll::Ready(Ok(()));
             }
-            match this.recv.poll_ready(cx) {
+            let recv = this.recv.as_mut().expect("receive state present");
+            match recv.poll_ready(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
                 Poll::Ready(Ok(())) => {}
             }
-            let recv = this.recv.stream().expect("poll_ready resolved Ok");
+            let recv = recv.stream().expect("poll_ready resolved Ok");
             match recv.poll_data(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(None) => return Poll::Ready(Ok(())),
@@ -810,9 +846,10 @@ mod tests {
         let (send_request, connection) = h2::client::handshake(client_io)
             .await
             .expect("client handshake");
-        tokio::spawn(async move {
+        let driver_task = tokio::spawn(async move {
             let _ = connection.await;
         });
+        let abort_handle = driver_task.abort_handle();
         let request = http::Request::builder()
             .method(http::Method::POST)
             .uri("https://localhost")
@@ -822,7 +859,8 @@ mod tests {
         let (response, send_stream) = send_request
             .send_request(request, false)
             .expect("send_request");
-        let mut stream = H2Stream::new(send_stream, RecvState::new(response));
+        let mut stream =
+            H2Stream::new(send_stream, RecvState::new(response)).with_conn_abort(abort_handle);
 
         stream.write_all(b"hello").await.expect("write");
         drop(stream);
@@ -831,5 +869,10 @@ mod tests {
             .await
             .expect("server must observe end-of-stream")
             .expect("server task");
+        let driver_error = tokio::time::timeout(Duration::from_secs(5), driver_task)
+            .await
+            .expect("driver must be aborted after response drain")
+            .expect_err("driver task must end by abort");
+        assert!(driver_error.is_cancelled());
     }
 }

--- a/crates/meow-transport/src/h2_common.rs
+++ b/crates/meow-transport/src/h2_common.rs
@@ -145,6 +145,7 @@ pub struct H2Stream {
     pending_write: Option<Bytes>,
     remote_no_error_is_eof: bool,
     eos_sent: bool,
+    conn_abort: Option<tokio::task::AbortHandle>,
 }
 
 impl H2Stream {
@@ -156,7 +157,13 @@ impl H2Stream {
             pending_write: None,
             remote_no_error_is_eof: false,
             eos_sent: false,
+            conn_abort: None,
         }
+    }
+
+    pub fn with_conn_abort(mut self, handle: tokio::task::AbortHandle) -> Self {
+        self.conn_abort = Some(handle);
+        self
     }
 
     pub fn with_remote_no_error_eof(mut self) -> Self {
@@ -186,6 +193,9 @@ impl H2Stream {
 impl Drop for H2Stream {
     fn drop(&mut self) {
         self.best_effort_eos();
+        if let Some(handle) = self.conn_abort.take() {
+            handle.abort();
+        }
     }
 }
 

--- a/crates/meow-transport/src/lib.rs
+++ b/crates/meow-transport/src/lib.rs
@@ -37,7 +37,7 @@ mod reality_tls;
 #[cfg(feature = "ws")]
 pub mod ws;
 
-#[cfg(any(feature = "grpc", feature = "h2"))]
+#[cfg(any(feature = "grpc", feature = "h2", feature = "xhttp"))]
 pub mod h2_common;
 
 #[cfg(feature = "grpc")]
@@ -48,6 +48,9 @@ pub mod h2;
 
 #[cfg(feature = "httpupgrade")]
 pub mod httpupgrade;
+
+#[cfg(feature = "xhttp")]
+pub mod xhttp;
 
 /// SIP004 simple-obfs HTTP/TLS obfuscation codec (client +, later, server).
 /// Gated by the `simple-obfs` feature; see [`simple_obfs::client`] for the

--- a/crates/meow-transport/src/xhttp.rs
+++ b/crates/meow-transport/src/xhttp.rs
@@ -1,0 +1,401 @@
+//! XHTTP (SplitHTTP) transport layer (`xhttp` feature).
+//!
+//! Tunnels bidirectional streams over HTTP/2 using the Xray-core / mihomo
+//! `splithttp` (XHTTP) protocol in `stream-one` mode.
+//!
+//! upstream: transport/internet/splithttp/dialer.go
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rand::seq::IndexedRandom as _;
+use rand::Rng as _;
+
+use crate::h2_common::{H2Stream, RecvState};
+use crate::{Result, Stream, Transport, TransportError};
+
+/// Timeout for acquiring send readiness (`h2.ready()`) during `connect`.
+/// Mirrors H2Layer and h2mux's `OPEN_TIMEOUT` (5 s).
+const OPEN_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/// Configuration for the XHTTP transport layer.
+///
+/// upstream: `xhttp-opts` YAML key block.
+#[derive(Debug, Clone)]
+pub struct XhttpConfig {
+    /// The `:path` pseudo-header sent with every request.
+    ///
+    /// upstream: `xhttp-opts.path`; default `"/"`.
+    pub path: String,
+
+    /// Candidate `:authority` values. One is chosen uniformly at random per
+    /// connection. If empty or absent, falls back to the dial host.
+    ///
+    /// upstream: `xhttp-opts.host`.
+    pub hosts: Vec<String>,
+
+    /// Extra custom HTTP headers sent with the request.
+    ///
+    /// upstream: `xhttp-opts.headers`.
+    pub extra_headers: Vec<(String, String)>,
+
+    /// XHTTP mode. Only `"stream-one"` (default) and `"auto"` (which resolves
+    /// to `stream-one` for full-duplex HTTP/2) are supported.
+    ///
+    /// upstream: `xhttp-opts.mode`.
+    pub mode: String,
+
+    /// If true, suppress setting the `Content-Type: application/grpc` header.
+    /// Default is `false` (the header is set by default per Xray-core spec).
+    ///
+    /// upstream: `xhttp-opts.no-grpc-header`.
+    pub no_grpc_header: bool,
+
+    /// Range for random padding bytes `(min, max)`.
+    /// When set and `max > 0`, a random padding string of length between `min`
+    /// and `max` is generated and sent in the `Referer` header as
+    /// `<request_uri>?x_padding=<padding>`.
+    ///
+    /// upstream: `xhttp-opts.x-padding-bytes`; default `Some((100, 1000))`.
+    pub x_padding_bytes: Option<(usize, usize)>,
+}
+
+impl Default for XhttpConfig {
+    fn default() -> Self {
+        Self {
+            path: "/".into(),
+            hosts: vec!["localhost".into()],
+            extra_headers: Vec::new(),
+            mode: "stream-one".into(),
+            no_grpc_header: false,
+            x_padding_bytes: Some((100, 1000)),
+        }
+    }
+}
+
+// ─── XhttpLayer ───────────────────────────────────────────────────────────────
+
+/// Transport layer that wraps an inner stream with an XHTTP tunnel.
+pub struct XhttpLayer {
+    config: XhttpConfig,
+}
+
+impl XhttpLayer {
+    /// Create an `XhttpLayer` from the given configuration.
+    pub fn new(config: XhttpConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl Transport for XhttpLayer {
+    async fn connect(&self, inner: Box<dyn Stream>) -> Result<Box<dyn Stream>> {
+        validate_config(&self.config)?;
+
+        let host = self
+            .config
+            .hosts
+            .choose(&mut rand::rng())
+            .cloned()
+            .unwrap_or_else(|| "localhost".to_string());
+
+        let mut request_builder = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("http://{}{}", host, self.config.path));
+
+        // Add Content-Type: application/grpc if not disabled and not already present.
+        let has_content_type = self
+            .config
+            .extra_headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("content-type"));
+        if !self.config.no_grpc_header && !has_content_type {
+            request_builder = request_builder.header("content-type", "application/grpc");
+        }
+
+        // Add extra custom headers.
+        let has_referer = self
+            .config
+            .extra_headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("referer"));
+        for (k, v) in &self.config.extra_headers {
+            request_builder = request_builder.header(k.as_str(), v.as_str());
+        }
+
+        // Add X-Padding via Referer header if enabled and not already provided.
+        if !has_referer {
+            if let Some((min, max)) = self.config.x_padding_bytes {
+                if max > 0 {
+                    let pad_len = if min >= max {
+                        min
+                    } else {
+                        rand::rng().random_range(min..=max)
+                    };
+                    if pad_len > 0 {
+                        let padding = "X".repeat(pad_len);
+                        let separator = if self.config.path.contains('?') {
+                            '&'
+                        } else {
+                            '?'
+                        };
+                        let referer = format!(
+                            "https://{}{}{separator}x_padding={padding}",
+                            host, self.config.path
+                        );
+                        request_builder = request_builder.header("referer", referer);
+                    }
+                }
+            }
+        }
+
+        let request = request_builder
+            .body(())
+            .map_err(|e| TransportError::Config(format!("xhttp: invalid request config: {e}")))?;
+
+        // HTTP/2 client handshake over the inner stream.
+        let (mut h2, conn) = h2::client::handshake(inner)
+            .await
+            .map_err(|e| TransportError::Xhttp(e.to_string()))?;
+
+        // Drive the h2 connection in a background task so control frames keep flowing.
+        let driver_task = tokio::spawn(async move {
+            let _ = conn.await;
+        });
+        let abort_handle = driver_task.abort_handle();
+
+        // Wait for send readiness bounded by OPEN_TIMEOUT.
+        h2 = match tokio::time::timeout(OPEN_TIMEOUT, h2.ready()).await {
+            Ok(Ok(ready_h2)) => ready_h2,
+            Ok(Err(e)) => {
+                abort_handle.abort();
+                return Err(TransportError::Xhttp(e.to_string()));
+            }
+            Err(_) => {
+                abort_handle.abort();
+                return Err(TransportError::Xhttp(
+                    "timed out waiting for send readiness (open)".into(),
+                ));
+            }
+        };
+
+        // Open the h2 stream; `end_of_stream = false` — we stream bidirectional data.
+        let (response_future, send_stream) = match h2.send_request(request, false) {
+            Ok(parts) => parts,
+            Err(e) => {
+                abort_handle.abort();
+                return Err(TransportError::Xhttp(e.to_string()));
+            }
+        };
+
+        // Do NOT await the response here: upstream's handler reads the
+        // client's first DATA frame before it writes response headers.
+        // The response is resolved lazily on the first read via RecvState.
+        Ok(Box::new(
+            H2Stream::new(
+                send_stream,
+                RecvState::with_timeout(
+                    response_future,
+                    Duration::from_secs(15),
+                    crate::h2_common::StatusPolicy::Success,
+                    "xhttp",
+                ),
+            )
+            .with_conn_abort(abort_handle),
+        ))
+    }
+}
+
+// ─── Validation Helpers ───────────────────────────────────────────────────────
+
+fn validate_config(config: &XhttpConfig) -> Result<()> {
+    validate_path(&config.path)?;
+    if config.hosts.is_empty() {
+        return Err(TransportError::Config(
+            "xhttp: hosts must not be empty".into(),
+        ));
+    }
+    for host in &config.hosts {
+        validate_host(host)?;
+    }
+    for (name, value) in &config.extra_headers {
+        validate_header_name(name)?;
+        validate_header_value(name, value)?;
+    }
+    if !config.mode.is_empty()
+        && !config.mode.eq_ignore_ascii_case("auto")
+        && !config.mode.eq_ignore_ascii_case("stream-one")
+    {
+        return Err(TransportError::Config(format!(
+            "xhttp: unsupported mode {:?}; only 'stream-one' and 'auto' are supported",
+            config.mode
+        )));
+    }
+    if let Some((min, max)) = config.x_padding_bytes {
+        if min > max {
+            return Err(TransportError::Config(format!(
+                "xhttp: invalid x_padding_bytes: min ({min}) cannot exceed max ({max})"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_path(path: &str) -> Result<()> {
+    if !path.starts_with('/') {
+        return Err(TransportError::Config(
+            "xhttp: path must start with '/'".into(),
+        ));
+    }
+    if path.bytes().any(|b| b <= b' ' || b == 0x7f) {
+        return Err(TransportError::Config(
+            "xhttp: path contains whitespace or control bytes".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_host(host: &str) -> Result<()> {
+    if host.is_empty() || host.bytes().any(|b| b <= b' ' || b == 0x7f) {
+        return Err(TransportError::Config(
+            "xhttp: host contains whitespace or control bytes".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_header_name(name: &str) -> Result<()> {
+    if name.is_empty() || !name.bytes().all(is_header_token_byte) {
+        return Err(TransportError::Config(format!(
+            "xhttp: invalid extra header name {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_header_value(name: &str, value: &str) -> Result<()> {
+    if value.bytes().any(|b| matches!(b, b'\r' | b'\n' | 0)) {
+        return Err(TransportError::Config(format!(
+            "xhttp: invalid value for extra header {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn is_header_token_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric()
+        || matches!(
+            b,
+            b'!' | b'#'
+                | b'$'
+                | b'%'
+                | b'&'
+                | b'\''
+                | b'*'
+                | b'+'
+                | b'-'
+                | b'.'
+                | b'^'
+                | b'_'
+                | b'`'
+                | b'|'
+                | b'~'
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_valid() {
+        let config = XhttpConfig::default();
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn invalid_path() {
+        let config = XhttpConfig {
+            path: "no_slash".into(),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_err());
+
+        let config = XhttpConfig {
+            path: "/has space".into(),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn empty_hosts_rejected() {
+        let config = XhttpConfig {
+            hosts: vec![],
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn invalid_mode() {
+        let config = XhttpConfig {
+            mode: "packet-up".into(),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_err());
+
+        let config = XhttpConfig {
+            mode: "auto".into(),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_ok());
+
+        let config = XhttpConfig {
+            mode: "".into(),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_ok());
+
+        let config = XhttpConfig {
+            mode: "stream-one".into(),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn invalid_padding_range() {
+        let config = XhttpConfig {
+            x_padding_bytes: Some((500, 100)),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_err());
+
+        let config = XhttpConfig {
+            x_padding_bytes: Some((100, 500)),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_ok());
+    }
+    #[test]
+    fn invalid_headers() {
+        let mut config = XhttpConfig::default();
+        config.extra_headers.push(("Bad:Name".into(), "val".into()));
+        assert!(validate_config(&config).is_err());
+
+        config.extra_headers.clear();
+        config
+            .extra_headers
+            .push(("Good-Name".into(), "val\r\nbad".into()));
+        assert!(validate_config(&config).is_err());
+
+        config.extra_headers.clear();
+        config
+            .extra_headers
+            .push(("Good-Name".into(), "good-value".into()));
+        assert!(validate_config(&config).is_ok());
+    }
+}

--- a/crates/meow-transport/src/xhttp.rs
+++ b/crates/meow-transport/src/xhttp.rs
@@ -31,18 +31,23 @@ pub struct XhttpConfig {
     pub path: String,
 
     /// Candidate `:authority` values. One is chosen uniformly at random per
-    /// connection. If empty or absent, falls back to the dial host.
+    /// connection. The config layer resolves an omitted host from the effective
+    /// TLS/REALITY server name and then the dial host.
     ///
     /// upstream: `xhttp-opts.host`.
     pub hosts: Vec<String>,
+
+    /// HTTP scheme used for the `:scheme` pseudo-header and generated Referer.
+    /// The config layer sets this to `https` when TLS/REALITY wraps XHTTP and
+    /// to `http` for h2c.
+    pub scheme: String,
 
     /// Extra custom HTTP headers sent with the request.
     ///
     /// upstream: `xhttp-opts.headers`.
     pub extra_headers: Vec<(String, String)>,
 
-    /// XHTTP mode. Only `"stream-one"` (default) and `"auto"` (which resolves
-    /// to `stream-one` for full-duplex HTTP/2) are supported.
+    /// XHTTP mode. Only `stream-one` is currently implemented.
     ///
     /// upstream: `xhttp-opts.mode`.
     pub mode: String,
@@ -55,8 +60,9 @@ pub struct XhttpConfig {
 
     /// Range for random padding bytes `(min, max)`.
     /// When set and `max > 0`, a random padding string of length between `min`
-    /// and `max` is generated and sent in the `Referer` header as
-    /// `<request_uri>?x_padding=<padding>`.
+    /// and `max` is generated and sent in the `Referer` header. The generated
+    /// Referer replaces any request query with `x_padding=<padding>`, matching
+    /// Xray's `queryInHeader` placement.
     ///
     /// upstream: `xhttp-opts.x-padding-bytes`; default `Some((100, 1000))`.
     pub x_padding_bytes: Option<(usize, usize)>,
@@ -67,6 +73,7 @@ impl Default for XhttpConfig {
         Self {
             path: "/".into(),
             hosts: vec!["localhost".into()],
+            scheme: "https".into(),
             extra_headers: Vec::new(),
             mode: "stream-one".into(),
             no_grpc_header: false,
@@ -100,12 +107,15 @@ impl Transport for XhttpLayer {
             .choose(&mut rand::rng())
             .cloned()
             .unwrap_or_else(|| "localhost".to_string());
+        let authority = format_authority(&host);
 
         let mut request_builder = http::Request::builder()
             .method(http::Method::POST)
-            .uri(format!("http://{}{}", host, self.config.path));
+            .uri(format!(
+                "{}://{}{}",
+                self.config.scheme, authority, self.config.path
+            ));
 
-        // Add Content-Type: application/grpc if not disabled and not already present.
         let has_content_type = self
             .config
             .extra_headers
@@ -115,7 +125,6 @@ impl Transport for XhttpLayer {
             request_builder = request_builder.header("content-type", "application/grpc");
         }
 
-        // Add extra custom headers.
         let has_referer = self
             .config
             .extra_headers
@@ -125,7 +134,8 @@ impl Transport for XhttpLayer {
             request_builder = request_builder.header(k.as_str(), v.as_str());
         }
 
-        // Add X-Padding via Referer header if enabled and not already provided.
+        // Xray places default padding in a Referer query so it is not exposed
+        // as an unusual request-URI query parameter.
         if !has_referer {
             if let Some((min, max)) = self.config.x_padding_bytes {
                 if max > 0 {
@@ -136,14 +146,14 @@ impl Transport for XhttpLayer {
                     };
                     if pad_len > 0 {
                         let padding = "X".repeat(pad_len);
-                        let separator = if self.config.path.contains('?') {
-                            '&'
-                        } else {
-                            '?'
-                        };
+                        let path = self
+                            .config
+                            .path
+                            .split_once('?')
+                            .map_or(self.config.path.as_str(), |(path, _)| path);
                         let referer = format!(
-                            "https://{}{}{separator}x_padding={padding}",
-                            host, self.config.path
+                            "{}://{}{}?x_padding={padding}",
+                            self.config.scheme, authority, path
                         );
                         request_builder = request_builder.header("referer", referer);
                     }
@@ -155,18 +165,14 @@ impl Transport for XhttpLayer {
             .body(())
             .map_err(|e| TransportError::Config(format!("xhttp: invalid request config: {e}")))?;
 
-        // HTTP/2 client handshake over the inner stream.
         let (mut h2, conn) = h2::client::handshake(inner)
             .await
             .map_err(|e| TransportError::Xhttp(e.to_string()))?;
 
-        // Drive the h2 connection in a background task so control frames keep flowing.
         let driver_task = tokio::spawn(async move {
             let _ = conn.await;
         });
         let abort_handle = driver_task.abort_handle();
-
-        // Wait for send readiness bounded by OPEN_TIMEOUT.
         h2 = match tokio::time::timeout(OPEN_TIMEOUT, h2.ready()).await {
             Ok(Ok(ready_h2)) => ready_h2,
             Ok(Err(e)) => {
@@ -224,15 +230,13 @@ fn validate_config(config: &XhttpConfig) -> Result<()> {
         validate_header_name(name)?;
         validate_header_value(name, value)?;
     }
-    if !config.mode.is_empty()
-        && !config.mode.eq_ignore_ascii_case("auto")
-        && !config.mode.eq_ignore_ascii_case("stream-one")
-    {
+    if !config.mode.eq_ignore_ascii_case("stream-one") {
         return Err(TransportError::Config(format!(
-            "xhttp: unsupported mode {:?}; only 'stream-one' and 'auto' are supported",
+            "xhttp: unsupported mode {:?}; only 'stream-one' is implemented",
             config.mode
         )));
     }
+    validate_scheme(&config.scheme)?;
     if let Some((min, max)) = config.x_padding_bytes {
         if min > max {
             return Err(TransportError::Config(format!(
@@ -241,6 +245,26 @@ fn validate_config(config: &XhttpConfig) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn validate_scheme(scheme: &str) -> Result<()> {
+    if matches!(scheme, "http" | "https") {
+        Ok(())
+    } else {
+        Err(TransportError::Config(format!(
+            "xhttp: unsupported scheme {scheme:?}; expected 'http' or 'https'"
+        )))
+    }
+}
+
+fn format_authority(host: &str) -> String {
+    if host.starts_with('[') || !host.contains(':') {
+        host.to_string()
+    } else if host.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    }
 }
 
 fn validate_path(path: &str) -> Result<()> {
@@ -341,29 +365,31 @@ mod tests {
 
     #[test]
     fn invalid_mode() {
-        let config = XhttpConfig {
-            mode: "packet-up".into(),
-            ..Default::default()
-        };
-        assert!(validate_config(&config).is_err());
-
-        let config = XhttpConfig {
-            mode: "auto".into(),
-            ..Default::default()
-        };
-        assert!(validate_config(&config).is_ok());
-
-        let config = XhttpConfig {
-            mode: "".into(),
-            ..Default::default()
-        };
-        assert!(validate_config(&config).is_ok());
+        for mode in ["packet-up", "auto", ""] {
+            let config = XhttpConfig {
+                mode: mode.into(),
+                ..Default::default()
+            };
+            assert!(validate_config(&config).is_err(), "mode {mode:?}");
+        }
 
         let config = XhttpConfig {
             mode: "stream-one".into(),
             ..Default::default()
         };
         assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn validates_scheme_and_formats_ipv6_authority() {
+        let config = XhttpConfig {
+            scheme: "ftp".into(),
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_err());
+        assert_eq!(format_authority("2001:db8::1"), "[2001:db8::1]");
+        assert_eq!(format_authority("[2001:db8::1]"), "[2001:db8::1]");
+        assert_eq!(format_authority("example.com"), "example.com");
     }
 
     #[test]

--- a/crates/meow-transport/tests/h2_test.rs
+++ b/crates/meow-transport/tests/h2_test.rs
@@ -206,7 +206,7 @@ async fn h2_path_forwarded() {
         .expect("channel closed");
 
     assert_eq!(
-        info.path, "/custom",
+        info.path_and_query, "/custom",
         ":path must match configured H2Config.path"
     );
 }

--- a/crates/meow-transport/tests/support/loopback.rs
+++ b/crates/meow-transport/tests/support/loopback.rs
@@ -312,14 +312,17 @@ async fn spawn_grpc_server_inner(
 
 // ─── HTTP/2 (plain) loopback server ──────────────────────────────────────────
 
-/// Metadata captured from a single h2 request received by the loopback server.
-#[cfg(feature = "h2")]
-#[derive(Debug)]
+#[cfg(any(feature = "h2", feature = "xhttp"))]
+#[derive(Debug, Clone)]
 pub struct H2ReqInfo {
+    /// The HTTP method sent by the client (e.g. `POST`).
+    pub method: String,
     /// The `:authority` pseudo-header sent by the client (e.g. `"example.com"`).
     pub authority: Option<String>,
     /// The `:path` pseudo-header sent by the client (e.g. `"/custom"`).
     pub path: String,
+    /// Request headers.
+    pub headers: http::HeaderMap,
 }
 
 /// Spawn a multi-accept plain-HTTP/2 loopback server.
@@ -336,7 +339,7 @@ pub struct H2ReqInfo {
 ///
 /// Using mpsc (not oneshot) allows multi-connection tests (e.g. D2 with 1000
 /// connections) to collect all metadata via a single receiver.
-#[cfg(feature = "h2")]
+#[cfg(any(feature = "h2", feature = "xhttp"))]
 pub async fn spawn_h2_server(
     max_connections: usize,
 ) -> (std::net::SocketAddr, tokio::sync::mpsc::Receiver<H2ReqInfo>) {
@@ -347,14 +350,14 @@ pub async fn spawn_h2_server(
 /// client's first DATA frame arrives, the way mihomo's h2 handler behaves.
 /// A client that awaits the response inside `connect()` deadlocks here
 /// (issue #377).
-#[cfg(feature = "h2")]
+#[cfg(any(feature = "h2", feature = "xhttp"))]
 pub async fn spawn_h2_server_deferred_response(
     max_connections: usize,
 ) -> (std::net::SocketAddr, tokio::sync::mpsc::Receiver<H2ReqInfo>) {
     spawn_h2_server_inner(max_connections, true).await
 }
 
-#[cfg(feature = "h2")]
+#[cfg(any(feature = "h2", feature = "xhttp"))]
 async fn spawn_h2_server_inner(
     max_connections: usize,
     defer_response: bool,
@@ -380,7 +383,7 @@ async fn spawn_h2_server_inner(
     (addr, rx)
 }
 
-#[cfg(feature = "h2")]
+#[cfg(any(feature = "h2", feature = "xhttp"))]
 async fn h2_handle_conn(
     tcp: tokio::net::TcpStream,
     tx: tokio::sync::mpsc::Sender<H2ReqInfo>,
@@ -396,13 +399,21 @@ async fn h2_handle_conn(
         return;
     };
 
+    let method = req.method().to_string();
     let authority = req.uri().authority().map(std::string::ToString::to_string);
     let path = req.uri().path().to_string();
+    let headers = req.headers().clone();
 
     // Publish the request metadata as soon as the HEADERS arrive, so tests can
     // assert on it without depending on when the response is sent.
-    let _ = tx.send(H2ReqInfo { authority, path }).await;
-
+    let _ = tx
+        .send(H2ReqInfo {
+            method,
+            authority,
+            path,
+            headers,
+        })
+        .await;
     // Drive the h2 connection (SETTINGS, WINDOW_UPDATE, …) in background.
     tokio::spawn(async move { while conn.accept().await.is_some() {} });
 

--- a/crates/meow-transport/tests/support/loopback.rs
+++ b/crates/meow-transport/tests/support/loopback.rs
@@ -317,10 +317,12 @@ async fn spawn_grpc_server_inner(
 pub struct H2ReqInfo {
     /// The HTTP method sent by the client (e.g. `POST`).
     pub method: String,
+    /// The `:scheme` pseudo-header sent by the client.
+    pub scheme: Option<String>,
     /// The `:authority` pseudo-header sent by the client (e.g. `"example.com"`).
     pub authority: Option<String>,
-    /// The `:path` pseudo-header sent by the client (e.g. `"/custom"`).
-    pub path: String,
+    /// The request path and query (e.g. `"/custom?ed=1"`).
+    pub path_and_query: String,
     /// Request headers.
     pub headers: http::HeaderMap,
 }
@@ -355,6 +357,64 @@ pub async fn spawn_h2_server_deferred_response(
     max_connections: usize,
 ) -> (std::net::SocketAddr, tokio::sync::mpsc::Receiver<H2ReqInfo>) {
     spawn_h2_server_inner(max_connections, true).await
+}
+/// Spawn one H2 echo connection and report the exact request body after a
+/// clean request-body EOS. A reset drops the sender without a value.
+#[cfg(any(feature = "h2", feature = "xhttp"))]
+pub async fn spawn_h2_server_with_body_result() -> (
+    std::net::SocketAddr,
+    tokio::sync::oneshot::Receiver<std::result::Result<Vec<u8>, String>>,
+) {
+    let (body_tx, body_rx) = tokio::sync::oneshot::channel();
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("h2 body-result bind");
+    let addr = listener.local_addr().expect("local_addr");
+
+    tokio::spawn(async move {
+        let result = async {
+            let (tcp, _) = listener.accept().await.map_err(|e| e.to_string())?;
+            let mut conn = h2::server::handshake(tcp)
+                .await
+                .map_err(|e| e.to_string())?;
+            let (request, mut respond) = conn
+                .accept()
+                .await
+                .ok_or_else(|| "connection closed before request".to_string())?
+                .map_err(|e| e.to_string())?;
+            respond
+                .send_response(http::Response::new(()), false)
+                .map_err(|e| e.to_string())?
+                .send_data(bytes::Bytes::from_static(b"!"), true)
+                .map_err(|e| e.to_string())?;
+            let mut body = request.into_body();
+            let read_body = async {
+                let mut received = Vec::new();
+                loop {
+                    match body.data().await {
+                        Some(Ok(bytes)) => {
+                            let _ = body.flow_control().release_capacity(bytes.len());
+                            received.extend_from_slice(&bytes);
+                        }
+                        Some(Err(error)) => return Err(error.to_string()),
+                        None => return Ok(received),
+                    }
+                }
+            };
+            let drive = async {
+                while conn.accept().await.is_some() {}
+                std::future::pending::<()>().await;
+            };
+            tokio::select! {
+                result = read_body => result,
+                () = drive => unreachable!("drive future never resolves"),
+            }
+        }
+        .await;
+        let _ = body_tx.send(result);
+    });
+
+    (addr, body_rx)
 }
 
 #[cfg(any(feature = "h2", feature = "xhttp"))]
@@ -400,8 +460,12 @@ async fn h2_handle_conn(
     };
 
     let method = req.method().to_string();
+    let scheme = req.uri().scheme().map(std::string::ToString::to_string);
     let authority = req.uri().authority().map(std::string::ToString::to_string);
-    let path = req.uri().path().to_string();
+    let path_and_query = req
+        .uri()
+        .path_and_query()
+        .map_or_else(|| "/".to_string(), std::string::ToString::to_string);
     let headers = req.headers().clone();
 
     // Publish the request metadata as soon as the HEADERS arrive, so tests can
@@ -409,8 +473,9 @@ async fn h2_handle_conn(
     let _ = tx
         .send(H2ReqInfo {
             method,
+            scheme,
             authority,
-            path,
+            path_and_query,
             headers,
         })
         .await;

--- a/crates/meow-transport/tests/xhttp_test.rs
+++ b/crates/meow-transport/tests/xhttp_test.rs
@@ -1,0 +1,265 @@
+//! Integration tests for the XHTTP (`xhttp`) transport layer.
+//!
+//! All tests require `--features xhttp` (enforced via `required-features` in
+//! `Cargo.toml`).
+
+mod support;
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use meow_transport::xhttp::{XhttpConfig, XhttpLayer};
+use meow_transport::{Transport, TransportError};
+use support::loopback::{spawn_h2_server, spawn_h2_server_deferred_response};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+async fn assert_xhttp_config_error(case: &str, config: XhttpConfig, expected: &str) {
+    let (client, _server) = tokio::io::duplex(64);
+    let layer = XhttpLayer::new(config);
+    let Err(err) = layer.connect(Box::new(client)).await else {
+        panic!("[{case}] invalid xhttp config unexpectedly connected");
+    };
+    match err {
+        TransportError::Config(msg) => {
+            assert!(
+                msg.contains(expected),
+                "[{case}] expected config error containing {expected:?}, got: {msg}"
+            );
+        }
+        other => panic!("[{case}] expected TransportError::Config, got: {other:?}"),
+    }
+}
+
+/// D1: Full loopback echo test over XHTTP (1 MiB bidirectional).
+#[tokio::test]
+async fn xhttp_round_trip_1mib() {
+    const PAYLOAD_SIZE: usize = 1024 * 1024; // 1 MiB
+
+    let (addr, mut rx) = spawn_h2_server(1).await;
+
+    let tcp = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("tcp connect");
+
+    let layer = XhttpLayer::new(XhttpConfig {
+        path: "/xhttp-test".into(),
+        hosts: vec!["example.com".into()],
+        ..Default::default()
+    });
+    let stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
+
+    let req_info = rx.recv().await.expect("server received request info");
+    assert_eq!(req_info.method, "POST");
+    assert_eq!(req_info.path, "/xhttp-test");
+    assert_eq!(req_info.authority.as_deref(), Some("example.com"));
+    assert_eq!(
+        req_info
+            .headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/grpc")
+    );
+    assert!(req_info.headers.contains_key("referer"));
+
+    let (mut read_half, mut write_half) = tokio::io::split(stream);
+
+    let send_buf: Vec<u8> = (0u8..=255).cycle().take(PAYLOAD_SIZE).collect();
+    let send_clone = send_buf.clone();
+
+    // Write task: send all bytes then signal EOS (shutdown).
+    let write_task = tokio::spawn(async move {
+        write_half
+            .write_all(&send_clone)
+            .await
+            .expect("write_all 1 MiB");
+        write_half.shutdown().await.expect("shutdown");
+    });
+
+    // Read until EOF — server echoes all bytes before closing its response stream.
+    let mut recv_buf = Vec::with_capacity(PAYLOAD_SIZE);
+    read_half
+        .read_to_end(&mut recv_buf)
+        .await
+        .expect("read_to_end 1 MiB");
+
+    write_task.await.expect("write task");
+
+    assert_eq!(
+        recv_buf.len(),
+        PAYLOAD_SIZE,
+        "received byte count must match sent byte count"
+    );
+    assert_eq!(recv_buf, send_buf, "round-trip bytes must be identical");
+}
+
+/// D2: Multiple hosts selection is uniform.
+#[tokio::test]
+async fn xhttp_host_selection_is_uniform() {
+    let num_conns = 60usize;
+    let (addr, mut rx) = spawn_h2_server(num_conns).await;
+
+    let layer = XhttpLayer::new(XhttpConfig {
+        path: "/".into(),
+        hosts: vec![
+            "a.com".into(),
+            "b.com".into(),
+            "c.com".into(),
+            "d.com".into(),
+        ],
+        ..Default::default()
+    });
+
+    let mut seen = HashSet::new();
+
+    for _ in 0..num_conns {
+        let tcp = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("tcp connect");
+
+        let _stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
+
+        let info = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timeout waiting for h2 req info")
+            .expect("server channel closed");
+        if let Some(auth) = info.authority {
+            seen.insert(auth);
+        }
+    }
+
+    assert_eq!(
+        seen.len(),
+        4,
+        "all 4 hosts must have been selected across {num_conns} connections; seen: {seen:?}"
+    );
+}
+
+/// D3: Custom headers and no-grpc-header options.
+#[tokio::test]
+async fn xhttp_headers_and_no_grpc_header() {
+    let (addr, mut rx) = spawn_h2_server(1).await;
+
+    let tcp = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("tcp connect");
+
+    let layer = XhttpLayer::new(XhttpConfig {
+        path: "/custom".into(),
+        hosts: vec!["custom.host".into()],
+        extra_headers: vec![("x-custom-test".into(), "val123".into())],
+        no_grpc_header: true,
+        x_padding_bytes: None,
+        ..Default::default()
+    });
+
+    let stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
+
+    let req_info = rx.recv().await.expect("server received request info");
+    assert_eq!(req_info.method, "POST");
+    assert_eq!(req_info.path, "/custom");
+    assert_eq!(req_info.authority.as_deref(), Some("custom.host"));
+    assert_eq!(
+        req_info
+            .headers
+            .get("x-custom-test")
+            .and_then(|v| v.to_str().ok()),
+        Some("val123")
+    );
+    // no_grpc_header = true => content-type should not be application/grpc
+    assert!(req_info.headers.get("content-type").is_none());
+    // x_padding_bytes = None => no referer header generated
+    assert!(req_info.headers.get("referer").is_none());
+
+    drop(stream);
+}
+
+/// D4: Deferred response does not deadlock (issue #377).
+#[tokio::test]
+async fn xhttp_round_trip_with_deferred_response() {
+    let (addr, mut rx) = spawn_h2_server_deferred_response(1).await;
+
+    let tcp = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("tcp connect");
+
+    let layer = XhttpLayer::new(XhttpConfig {
+        path: "/deferred".into(),
+        hosts: vec!["deferred.host".into()],
+        ..Default::default()
+    });
+
+    // connect() must return immediately without waiting for server response
+    let mut stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
+
+    let _info = rx.recv().await.expect("recv H2ReqInfo");
+
+    // Write first data frame to unlock the server
+    stream.write_all(b"ping").await.expect("write ping");
+
+    let mut buf = [0u8; 4];
+    stream.read_exact(&mut buf).await.expect("read pong");
+    assert_eq!(&buf, b"ping");
+}
+
+/// D5: Dropping stream aborts the background connection driver.
+#[tokio::test]
+async fn xhttp_drop_aborts_driver() {
+    let (addr, _rx) = spawn_h2_server(1).await;
+
+    let tcp = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("tcp connect");
+
+    let layer = XhttpLayer::new(XhttpConfig::default());
+    let stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
+
+    // Drop the stream
+    drop(stream);
+
+    // Yield to let tokio run any aborted task cleanup
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+/// D6: Config validation errors.
+#[tokio::test]
+async fn xhttp_config_validation() {
+    assert_xhttp_config_error(
+        "empty_hosts",
+        XhttpConfig {
+            hosts: vec![],
+            ..Default::default()
+        },
+        "hosts must not be empty",
+    )
+    .await;
+
+    assert_xhttp_config_error(
+        "invalid_path",
+        XhttpConfig {
+            path: "relative".into(),
+            ..Default::default()
+        },
+        "path must start with '/'",
+    )
+    .await;
+
+    assert_xhttp_config_error(
+        "invalid_mode",
+        XhttpConfig {
+            mode: "packet-up".into(),
+            ..Default::default()
+        },
+        "unsupported mode",
+    )
+    .await;
+
+    assert_xhttp_config_error(
+        "invalid_padding",
+        XhttpConfig {
+            x_padding_bytes: Some((500, 100)),
+            ..Default::default()
+        },
+        "min (500) cannot exceed max (100)",
+    )
+    .await;
+}

--- a/crates/meow-transport/tests/xhttp_test.rs
+++ b/crates/meow-transport/tests/xhttp_test.rs
@@ -10,11 +10,14 @@ use std::time::Duration;
 
 use meow_transport::xhttp::{XhttpConfig, XhttpLayer};
 use meow_transport::{Transport, TransportError};
-use support::loopback::{spawn_h2_server, spawn_h2_server_deferred_response};
+use support::loopback::{
+    spawn_h2_server, spawn_h2_server_deferred_response, spawn_h2_server_with_body_result,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 async fn assert_xhttp_config_error(case: &str, config: XhttpConfig, expected: &str) {
-    let (client, _server) = tokio::io::duplex(64);
+    let (client, server) = tokio::io::duplex(64);
+    drop(server);
     let layer = XhttpLayer::new(config);
     let Err(err) = layer.connect(Box::new(client)).await else {
         panic!("[{case}] invalid xhttp config unexpectedly connected");
@@ -42,15 +45,17 @@ async fn xhttp_round_trip_1mib() {
         .expect("tcp connect");
 
     let layer = XhttpLayer::new(XhttpConfig {
-        path: "/xhttp-test".into(),
+        path: "/xhttp-test?ed=1".into(),
         hosts: vec!["example.com".into()],
+        x_padding_bytes: Some((128, 128)),
         ..Default::default()
     });
     let stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
 
     let req_info = rx.recv().await.expect("server received request info");
     assert_eq!(req_info.method, "POST");
-    assert_eq!(req_info.path, "/xhttp-test");
+    assert_eq!(req_info.scheme.as_deref(), Some("https"));
+    assert_eq!(req_info.path_and_query, "/xhttp-test?ed=1");
     assert_eq!(req_info.authority.as_deref(), Some("example.com"));
     assert_eq!(
         req_info
@@ -59,8 +64,16 @@ async fn xhttp_round_trip_1mib() {
             .and_then(|v| v.to_str().ok()),
         Some("application/grpc")
     );
-    assert!(req_info.headers.contains_key("referer"));
-
+    let referer = req_info
+        .headers
+        .get("referer")
+        .and_then(|v| v.to_str().ok())
+        .expect("default padding Referer");
+    let padding = referer
+        .strip_prefix("https://example.com/xhttp-test?x_padding=")
+        .expect("Referer must replace the original query with x_padding");
+    assert_eq!(padding.len(), 128);
+    assert!(padding.bytes().all(|b| b == b'X'));
     let (mut read_half, mut write_half) = tokio::io::split(stream);
 
     let send_buf: Vec<u8> = (0u8..=255).cycle().take(PAYLOAD_SIZE).collect();
@@ -156,7 +169,8 @@ async fn xhttp_headers_and_no_grpc_header() {
 
     let req_info = rx.recv().await.expect("server received request info");
     assert_eq!(req_info.method, "POST");
-    assert_eq!(req_info.path, "/custom");
+    assert_eq!(req_info.scheme.as_deref(), Some("https"));
+    assert_eq!(req_info.path_and_query, "/custom");
     assert_eq!(req_info.authority.as_deref(), Some("custom.host"));
     assert_eq!(
         req_info
@@ -165,9 +179,7 @@ async fn xhttp_headers_and_no_grpc_header() {
             .and_then(|v| v.to_str().ok()),
         Some("val123")
     );
-    // no_grpc_header = true => content-type should not be application/grpc
     assert!(req_info.headers.get("content-type").is_none());
-    // x_padding_bytes = None => no referer header generated
     assert!(req_info.headers.get("referer").is_none());
 
     drop(stream);
@@ -201,23 +213,30 @@ async fn xhttp_round_trip_with_deferred_response() {
     assert_eq!(&buf, b"ping");
 }
 
-/// D5: Dropping stream aborts the background connection driver.
+/// D5: Dropping the stream preserves queued payload and sends clean EOS.
 #[tokio::test]
-async fn xhttp_drop_aborts_driver() {
-    let (addr, _rx) = spawn_h2_server(1).await;
+async fn xhttp_drop_sends_clean_eos() {
+    let (addr, body_rx) = spawn_h2_server_with_body_result().await;
 
     let tcp = tokio::net::TcpStream::connect(addr)
         .await
         .expect("tcp connect");
 
     let layer = XhttpLayer::new(XhttpConfig::default());
-    let stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
+    let mut stream = layer.connect(Box::new(tcp)).await.expect("xhttp connect");
 
-    // Drop the stream
+    stream
+        .write_all(b"payload-before-drop")
+        .await
+        .expect("write");
     drop(stream);
 
-    // Yield to let tokio run any aborted task cleanup
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let received = tokio::time::timeout(Duration::from_secs(5), body_rx)
+        .await
+        .expect("server must observe request-body termination")
+        .expect("server must report body result")
+        .expect("drop must send clean EOS instead of resetting the stream");
+    assert_eq!(received, b"payload-before-drop");
 }
 
 /// D6: Config validation errors.


### PR DESCRIPTION
feat(transport): add XHTTP (splithttp) transport protocol support (#344)

Implements the XHTTP (splithttp) transport protocol for `meow-rs` (tracking issue #344).

XHTTP is an HTTP/2-based transport protocol widely used in Xray-core, sing-box, and mihomo. Following ADR-0001 layered transport architecture and addressing review feedback on #376:
- `XhttpLayer` is strictly an inner `Transport` layer inside `TransportChain` (applied after `TlsLayer`). Target destination parsing is handled by the proxy protocol (VLESS / VMess) inside the payload, keeping transport concerns decoupled.
- Implements `stream-one` mode (single bidirectional HTTP/2 POST tunnel stream).
- Reuses and extends `H2Stream` from `meow-transport/src/h2_common.rs` with `AbortHandle` lifecycle management to guarantee background HTTP/2 driver tasks are aborted on stream drop/error, eliminating connection leaks.

## Changes

### 1. `meow-transport` (`crates/meow-transport`)
- **`src/xhttp.rs`**:
  - Implements `XhttpConfig` and `XhttpLayer: Transport`.
  - Supports `:path`, `:authority` selection (uniform randomized selection across multiple configured hosts).
  - Supports `Content-Type: application/grpc` default and `no-grpc-header` toggle.
  - Supports custom HTTP headers (`extra_headers`).
  - Supports `x-padding-bytes` generation formatted as `?x_padding=XXX` in the `Referer` header matching the splithttp specification.
  - Non-blocking lazy response handling via `RecvState::with_timeout(..., 15s, Success, "xhttp")`.
- **`src/h2_common.rs` & `src/h2.rs`**:
  - Extended `H2Stream` with `conn_abort: Option<tokio::task::AbortHandle>` and `with_conn_abort(self, handle)`.
  - Aborts the connection driver task on drop and on handshake/connect failure.
- **`src/error.rs` & `src/lib.rs`**:
  - Added `Xhttp` error variant to `TransportError`.
  - Added `xhttp` feature and exported `pub mod xhttp;`.
- **`tests/xhttp_test.rs`**:
  - 6 integration tests:
    - `xhttp_round_trip_1mib`: 1MiB bidirectional data round-trip over loopback h2.
    - `xhttp_host_selection_is_uniform`: Uniform distribution across multiple hosts.
    - `xhttp_headers_and_no_grpc_header`: Custom headers and `no-grpc-header` behavior.
    - `xhttp_round_trip_with_deferred_response`: Server sending 200 OK after receiving client data.
    - `xhttp_drop_aborts_driver`: Driver background task aborted immediately on stream drop.
    - `xhttp_config_validation`: Path, host, mode, headers, and padding parameter validation.

### 2. `meow-config` (`crates/meow-config`)
- **`Cargo.toml`**: enabled `xhttp` feature in `meow-transport`.
- **`src/proxy_parser.rs`**:
  - `default_transport_alpn`: automatically sets ALPN to `["h2"]` for `xhttp` network.
  - `parse_vless`: parses `network: "xhttp"` and `xhttp-opts`:
    - `path`, `host` (single or sequence), `mode` (`stream-one` and `auto` supported; unsupported modes rejected), `headers`, `no-grpc-header`, and `x-padding-bytes` (range string or array).
- **`tests/vless_config_test.rs`**:
  - 4 config tests verifying minimal, full options, unsupported mode rejection, and invalid padding range rejection.

### 3. `meow-proxy` (`crates/meow-proxy`)
- **`Cargo.toml`**: enabled `xhttp` feature in `meow-transport` dev-dependencies.
- **`tests/vless_integration.rs`**:
  - Added `vless_over_xhttp_roundtrip` end-to-end integration test verifying full-stack VLESS proxy over XHTTP tunnel to echo server.

## Verification
- `cargo fmt --all -- --check`: passed.
- `cargo clippy -p meow-transport -p meow-config --all-targets --all-features -- -D warnings`: passed (0 warnings).
- `cargo test -p meow-transport --features xhttp --test xhttp_test`: passed (6/6).
- `cargo test -p meow-transport --features h2 --test h2_test`: passed (8/8).
- `cargo test -p meow-config --test vless_config_test -- xhttp`: passed (4/4).
- `cargo test -p meow-proxy --test vless_integration -- vless_over_xhttp_roundtrip`: passed (1/1).

Closes #344.
