### PR TITLE
fix(dns): dial loopback upstreams from a loopback-bound socket; log pool failures

### DIFF
--- a/crates/meow-dns/src/client.rs
+++ b/crates/meow-dns/src/client.rs
@@ -999,7 +999,25 @@ async fn udp_exchange(
     wire: &[u8],
     expected: &ExpectedResponse,
 ) -> Result<Message, ClientError> {
-    let sock = factory().bind_udp().await?;
+    // A loopback upstream (e.g. the resolver's own `dns.listen` socket,
+    // which some subscriptions name in `proxy-server-nameserver`) must be
+    // dialed from a loopback-bound socket, not the wildcard the factory
+    // binds for internet upstreams. Inside an iOS packet-tunnel extension
+    // the process's wildcard-bound sockets are scoped to the physical
+    // interface so they bypass the tunnel, and a scoped route lookup for
+    // 127.0.0.1 fails at once — the query never reaches the listener.
+    // Binding to the loopback address selects `lo0` explicitly; it also
+    // needs no VPN `protect()` on Android because loopback is never routed
+    // into the tunnel.
+    let sock = if addr.ip().is_loopback() {
+        let local: SocketAddr = match addr {
+            SocketAddr::V4(_) => SocketAddr::from(([127, 0, 0, 1], 0)),
+            SocketAddr::V6(_) => SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, 0)),
+        };
+        UdpSocket::bind(local).await?
+    } else {
+        factory().bind_udp().await?
+    };
     sock.connect(addr).await?;
     sock.send(wire).await?;
     let mut buf = vec![0u8; 4096];

--- a/crates/meow-dns/src/resolver.rs
+++ b/crates/meow-dns/src/resolver.rs
@@ -454,7 +454,10 @@ async fn query_pool_set(
     }
     let mut pending = FuturesUnordered::new();
     for client in clients {
-        pending.push(async move { client.lookup_set(host, want, ipv6_enabled).await });
+        pending.push(async move {
+            let result = client.lookup_set(host, want, ipv6_enabled).await;
+            (client, result)
+        });
     }
     let mut negative: Option<FamilySet> = None;
     let mut negative_deadline: Option<tokio::time::Instant> = None;
@@ -474,12 +477,23 @@ async fn query_pool_set(
         } else {
             pending.next().await
         };
-        let Some(result) = next else {
+        let Some((client, result)) = next else {
             break;
         };
         let set = match result {
             Ok(set) => set.clamped(),
-            Err(_) => continue,
+            Err(error) => {
+                // Upstream failures are otherwise invisible: the pool
+                // returns `None` and the caller reports "no address" with
+                // no hint of which server failed or why.
+                debug!(
+                    host,
+                    upstream = %client.upstream_label(),
+                    %error,
+                    "DNS upstream query failed"
+                );
+                continue;
+            }
         };
         if set.has_positive() {
             // A positive answer always wins, regardless of grace state.


### PR DESCRIPTION
## Problem

Some subscriptions (Nexitally) point `proxy-server-nameserver` at the resolver's own `dns.listen` socket so proxy server hostnames resolve through the listener. `udp_exchange` bound every upstream socket to `0.0.0.0:0` via the socket factory and then `connect()`ed to the loopback address. Inside an iOS packet-tunnel extension the process's wildcard-bound sockets are scoped to the physical interface (that is how the extension's own traffic bypasses the tunnel), and a scoped route lookup for 127.0.0.1 fails immediately. The query never reached the listener and every proxy dial failed within a millisecond with:

```
meow-dns resolver: no address for <server>
```

meow-ios's tun2socks already binds `127.0.0.1:0` explicitly for the same listener, which is why that path works. Verified on an iPhone 17 Pro: with this change the "no address" failures disappear.

## Fix

- `udp_exchange`: bind loopback upstreams to the matching loopback local address instead of going through the factory. Loopback never needs VPN `protect()` on Android either.
- `query_pool_set`: log each failed upstream at debug level with the upstream label and error. The pool swallowed every error, so "no address" gave no hint of which server failed or why.

## Local checks

- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets -- -D warnings` (workspace) → clean
- `cargo test -p meow-dns` (full, incl. integration) → all green
- `cargo test --lib` (workspace) → all green

https://claude.ai/code/session_01GgiSvJmZS7VDeMH8vTYqW4
