### PR TITLE
fix(hysteria2): address fast-open, GRO, and auth cancellation bugs

### DIFF
--- a/crates/meow-proxy/src/hysteria2/client.rs
+++ b/crates/meow-proxy/src/hysteria2/client.rs
@@ -33,22 +33,30 @@ impl ReconnectableClient {
 
     pub async fn tcp_connect(&self, target: &str) -> Result<DuplexStream> {
         let client = self.connection().await?;
-        let (mut send, recv) = client
-            .connection
-            .open_bi()
+        let (mut send, mut recv) = timeout(CONNECT_TIMEOUT, client.connection.open_bi())
             .await
+            .map_err(|_| Error::Quic(format!("open stream timeout after {CONNECT_TIMEOUT:?}")))?
             .map_err(|e| Error::Quic(e.to_string()))?;
 
-        if !self.cfg.fast_open {
-            tcp::write_initial_request(&mut send, target).await?;
-        }
+        timeout(
+            CONNECT_TIMEOUT,
+            tcp::write_initial_request(&mut send, target),
+        )
+        .await
+        .map_err(|_| Error::Quic(format!("TCP request timeout after {CONNECT_TIMEOUT:?}")))??;
 
-        Ok(DuplexStream::new(
-            send,
-            recv,
-            target.to_string(),
-            !self.cfg.fast_open,
-        ))
+        let response_read = if self.cfg.fast_open {
+            false
+        } else {
+            timeout(CONNECT_TIMEOUT, tcp::read_initial_response(&mut recv))
+                .await
+                .map_err(|_| {
+                    Error::Quic(format!("TCP response timeout after {CONNECT_TIMEOUT:?}"))
+                })??;
+            true
+        };
+
+        Ok(DuplexStream::new(send, recv, response_read))
     }
 
     pub async fn udp(&self) -> Result<UdpSession> {
@@ -164,10 +172,31 @@ async fn connect_addr(
         .map_err(|_| Error::Quic(format!("connect timeout after {CONNECT_TIMEOUT:?}")))?
         .map_err(|e| Error::Quic(format!("connect: {e}")))?;
 
-    let (h3_conn, mut send_request) =
-        h3::client::new(h3_quinn::Connection::new(connection.clone()))
-            .await
-            .map_err(|e| Error::Http3(e.to_string()))?;
+    let (h3_conn, mut send_request) = timeout(
+        CONNECT_TIMEOUT,
+        h3::client::new(h3_quinn::Connection::new(connection.clone())),
+    )
+    .await
+    .map_err(|_| Error::Http3(format!("client setup timeout after {CONNECT_TIMEOUT:?}")))?
+    .map_err(|e| Error::Http3(e.to_string()))?;
+
+    let udp_enabled = match timeout(CONNECT_TIMEOUT, authenticate(&cfg, &mut send_request)).await {
+        Ok(Ok(udp_enabled)) => udp_enabled,
+        Ok(Err(e)) => {
+            connection.close(0u32.into(), b"auth failed");
+            return Err(e);
+        }
+        Err(_) => {
+            connection.close(0u32.into(), b"auth timeout");
+            return Err(Error::Http3(format!(
+                "authentication timeout after {CONNECT_TIMEOUT:?}"
+            )));
+        }
+    };
+
+    // Authentication owns `h3_conn` locally, so cancellation before this point
+    // drops every connection handle instead of detaching a task that keeps the
+    // unauthenticated QUIC session alive.
     let h3_driver = tokio::spawn(async move {
         // Keep the HTTP/3 session alive for the lifetime of the QUIC connection.
         // Driving `poll_close` here would tear down the connection and break
@@ -175,15 +204,6 @@ async fn connect_addr(
         let _ = h3_conn;
         pending::<()>().await;
     });
-
-    let udp_enabled = match authenticate(&cfg, &mut send_request).await {
-        Ok(udp_enabled) => udp_enabled,
-        Err(e) => {
-            connection.close(0u32.into(), b"auth failed");
-            h3_driver.abort();
-            return Err(e);
-        }
-    };
 
     let udp_router = Arc::new(UdpRouter::new());
     let udp_driver =
@@ -294,6 +314,24 @@ impl ServerTarget {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use tokio::sync::oneshot;
+
+    fn h3_server_config() -> quinn::ServerConfig {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let certified_key = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        let cert = CertificateDer::from(certified_key.cert.der().to_vec());
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+            certified_key.key_pair.serialize_der(),
+        ));
+        let mut tls = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .unwrap();
+        tls.alpn_protocols = vec![b"h3".to_vec()];
+        let crypto = quinn::crypto::rustls::QuicServerConfig::try_from(tls).unwrap();
+        quinn::ServerConfig::with_crypto(Arc::new(crypto))
+    }
 
     #[test]
     fn parses_domain_server_target() {
@@ -307,5 +345,61 @@ mod tests {
         let target = ServerTarget::parse("[::1]:443").unwrap();
         assert_eq!(target.host, "::1");
         assert_eq!(target.port, 443);
+    }
+
+    #[tokio::test]
+    async fn cancelling_authentication_closes_the_quic_connection() {
+        let endpoint =
+            Endpoint::server(h3_server_config(), "127.0.0.1:0".parse().unwrap()).unwrap();
+        let server_addr = endpoint.local_addr().unwrap();
+        let (auth_seen_tx, auth_seen_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let incoming = endpoint.accept().await.expect("client must connect");
+            let connection = incoming.await.expect("QUIC handshake must succeed");
+            let mut h3 = h3::server::Connection::<_, bytes::Bytes>::new(h3_quinn::Connection::new(
+                connection.clone(),
+            ))
+            .await
+            .expect("HTTP/3 handshake must succeed");
+            let resolver = h3
+                .accept()
+                .await
+                .expect("auth request must be accepted")
+                .expect("auth request stream must exist");
+            let (request, request_stream) = resolver
+                .resolve_request()
+                .await
+                .expect("auth request must be valid");
+            assert_eq!(request.uri().path(), "/auth");
+            auth_seen_tx.send(()).unwrap();
+
+            let reason = connection.closed().await;
+            drop((h3, request_stream));
+            reason
+        });
+
+        let cfg = Arc::new(Config {
+            server_addr: server_addr.to_string(),
+            server_name: "localhost".into(),
+            auth: "test-password".into(),
+            insecure: true,
+            rx_bps: 1_000_000,
+            ..Default::default()
+        });
+        let dial = tokio::spawn(connect_addr(cfg, server_addr, "localhost"));
+        timeout(Duration::from_secs(2), auth_seen_rx)
+            .await
+            .expect("authentication request timed out")
+            .expect("server stopped before receiving authentication");
+
+        dial.abort();
+        let Err(join_error) = dial.await else {
+            panic!("dial task completed before it could be cancelled")
+        };
+        assert!(join_error.is_cancelled());
+        timeout(Duration::from_secs(2), server)
+            .await
+            .expect("cancelled authentication leaked the QUIC connection")
+            .expect("server task failed");
     }
 }

--- a/crates/meow-proxy/src/hysteria2/socket.rs
+++ b/crates/meow-proxy/src/hysteria2/socket.rs
@@ -7,6 +7,7 @@ use quinn::{
     udp::{RecvMeta, Transmit},
     AsyncUdpSocket, Runtime, UdpPoller,
 };
+use smallvec::SmallVec;
 use std::{
     fmt,
     io::{self, IoSliceMut},
@@ -18,7 +19,6 @@ use std::{
 };
 
 const SALAMANDER_SALT_LEN: usize = 8;
-const MAX_DATAGRAM_SIZE: usize = 65_535;
 const HY2_MIN_HOP_INTERVAL_SECS: u64 = 5;
 const HY2_DEFAULT_HOP_INTERVAL_SECS: u64 = 30;
 
@@ -28,6 +28,7 @@ pub struct Hy2UdpSocket {
     server_addr: SocketAddr,
     hop: Option<Mutex<HopState>>,
     obfs: Option<Salamander>,
+    recv_buffer: Mutex<Vec<u8>>,
 }
 
 impl Hy2UdpSocket {
@@ -52,6 +53,7 @@ impl Hy2UdpSocket {
             hop: HopState::new(hop_ports, hop_interval_min_secs, hop_interval_max_secs)?
                 .map(Mutex::new),
             obfs: (!obfs_password.is_empty()).then(|| Salamander::new(obfs_password.as_bytes())),
+            recv_buffer: Mutex::new(Vec::new()),
         }))
     }
 
@@ -151,48 +153,103 @@ impl AsyncUdpSocket for Hy2UdpSocket {
             )));
         }
 
+        let mut encrypted = self
+            .recv_buffer
+            .lock()
+            .expect("hysteria2 receive buffer mutex poisoned");
+        let buffer_count = bufs.len().min(meta.len()).min(quinn::udp::BATCH_SIZE);
+        let salt_overhead = SALAMANDER_SALT_LEN.saturating_mul(self.inner.max_receive_segments());
+        let slot_size = bufs
+            .iter()
+            .take(buffer_count)
+            .map(|buf| buf.len())
+            .max()
+            .unwrap_or_default()
+            .saturating_add(salt_overhead);
+        let Some(required) = slot_size.checked_mul(buffer_count) else {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "receive buffer size overflow",
+            )));
+        };
+        if encrypted.len() < required {
+            encrypted.resize(required, 0);
+        }
+
         loop {
-            let mut encrypted = vec![0u8; MAX_DATAGRAM_SIZE];
-            let mut encrypted_bufs = [IoSliceMut::new(&mut encrypted)];
-            let mut encrypted_meta = [RecvMeta::default()];
-            let n = match self
-                .inner
-                .poll_recv(cx, &mut encrypted_bufs, &mut encrypted_meta)
-            {
+            let mut encrypted_bufs: SmallVec<[IoSliceMut<'_>; 32]> = encrypted
+                .chunks_mut(slot_size)
+                .take(buffer_count)
+                .map(IoSliceMut::new)
+                .collect();
+            let mut encrypted_meta = [RecvMeta::default(); quinn::udp::BATCH_SIZE];
+            let n = match self.inner.poll_recv(
+                cx,
+                &mut encrypted_bufs,
+                &mut encrypted_meta[..buffer_count],
+            ) {
                 Poll::Ready(Ok(n)) => n,
                 other => return other,
             };
+            drop(encrypted_bufs);
             if n == 0 {
                 return Poll::Ready(Ok(0));
             }
 
-            let raw_len = encrypted_meta[0].len;
-            let stride = encrypted_meta[0].stride.max(raw_len);
-            let mut offset = 0usize;
-            while offset < raw_len {
-                let end = (offset + stride).min(raw_len);
-                let received = &encrypted[offset..end];
-                let Some(plain) = obfs.decode(received) else {
-                    offset = end;
+            let mut output_count = 0usize;
+            for (input_index, encrypted_meta) in encrypted_meta.iter().copied().take(n).enumerate()
+            {
+                let raw_len = encrypted_meta.len;
+                let stride = encrypted_meta.stride;
+                if stride <= SALAMANDER_SALT_LEN || stride > raw_len || raw_len > slot_size {
                     continue;
-                };
-
-                if plain.len() > bufs[0].len() {
-                    return Poll::Ready(Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "received UDP datagram exceeds buffer",
-                    )));
                 }
-                bufs[0][..plain.len()].copy_from_slice(&plain);
-                let source = self.incoming_source(encrypted_meta[0].addr);
-                meta[0] = RecvMeta {
-                    addr: source,
-                    len: plain.len(),
-                    stride: plain.len(),
-                    ecn: encrypted_meta[0].ecn,
-                    dst_ip: encrypted_meta[0].dst_ip,
+
+                let input_start = input_index * slot_size;
+                let input = &encrypted[input_start..input_start + raw_len];
+                let output = &mut bufs[output_count];
+                let mut input_offset = 0usize;
+                let mut written = 0usize;
+                while input_offset < raw_len {
+                    let input_end = (input_offset + stride).min(raw_len);
+                    let received = &input[input_offset..input_end];
+                    let plain_len = received.len().saturating_sub(SALAMANDER_SALT_LEN);
+                    if plain_len == 0 {
+                        input_offset = input_end;
+                        continue;
+                    }
+
+                    let Some(output_end) = written.checked_add(plain_len) else {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "received UDP datagram length overflow",
+                        )));
+                    };
+                    if output_end > output.len() {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "received UDP datagram exceeds buffer",
+                        )));
+                    }
+                    obfs.decode_into(received, &mut output[written..output_end]);
+                    written = output_end;
+                    input_offset = input_end;
+                }
+
+                if written == 0 {
+                    continue;
+                }
+                meta[output_count] = RecvMeta {
+                    addr: self.incoming_source(encrypted_meta.addr),
+                    len: written,
+                    stride: stride - SALAMANDER_SALT_LEN,
+                    ecn: encrypted_meta.ecn,
+                    dst_ip: encrypted_meta.dst_ip,
                 };
-                return Poll::Ready(Ok(1));
+                output_count += 1;
+            }
+            if output_count != 0 {
+                return Poll::Ready(Ok(output_count));
             }
         }
     }
@@ -210,11 +267,7 @@ impl AsyncUdpSocket for Hy2UdpSocket {
     }
 
     fn max_receive_segments(&self) -> usize {
-        if self.obfs.is_some() {
-            1
-        } else {
-            self.inner.max_receive_segments()
-        }
+        self.inner.max_receive_segments()
     }
 
     fn may_fragment(&self) -> bool {
@@ -248,19 +301,20 @@ impl Salamander {
         out
     }
 
-    fn decode(&self, payload: &[u8]) -> Option<Vec<u8>> {
-        if payload.len() <= SALAMANDER_SALT_LEN {
-            return None;
-        }
+    fn decode_into(&self, payload: &[u8], output: &mut [u8]) {
         let (salt, ciphertext) = payload.split_at(SALAMANDER_SALT_LEN);
+        debug_assert_eq!(ciphertext.len(), output.len());
         let key = self.key(salt);
-        Some(
-            ciphertext
-                .iter()
-                .enumerate()
-                .map(|(i, b)| b ^ key[i % key.len()])
-                .collect(),
-        )
+        for (index, (source, destination)) in ciphertext.iter().zip(output).enumerate() {
+            *destination = source ^ key[index % key.len()];
+        }
+    }
+
+    #[cfg(test)]
+    fn decode(&self, payload: &[u8]) -> Option<Vec<u8>> {
+        let mut output = vec![0; payload.len().checked_sub(SALAMANDER_SALT_LEN)?];
+        self.decode_into(payload, &mut output);
+        Some(output)
     }
 
     fn key(&self, salt: &[u8]) -> [u8; 32] {
@@ -418,6 +472,58 @@ fn parse_port(raw: &str) -> Result<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::task::noop_waker_ref;
+    use std::collections::VecDeque;
+
+    type MockBatch = VecDeque<(Vec<u8>, RecvMeta)>;
+
+    #[derive(Debug)]
+    struct MockUdpSocket {
+        batch: Mutex<MockBatch>,
+        max_receive_segments: usize,
+    }
+
+    impl AsyncUdpSocket for MockUdpSocket {
+        fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+            Box::pin(ReadyUdpPoller)
+        }
+
+        fn try_send(&self, _transmit: &Transmit<'_>) -> io::Result<()> {
+            unreachable!("send is not used by this receive-path test")
+        }
+
+        fn poll_recv(
+            &self,
+            _cx: &mut Context<'_>,
+            bufs: &mut [IoSliceMut<'_>],
+            meta: &mut [RecvMeta],
+        ) -> Poll<io::Result<usize>> {
+            let mut batch = self.batch.lock().unwrap();
+            let count = batch.len().min(bufs.len()).min(meta.len());
+            for (index, (payload, item_meta)) in batch.drain(..count).enumerate() {
+                bufs[index][..payload.len()].copy_from_slice(&payload);
+                meta[index] = item_meta;
+            }
+            Poll::Ready(Ok(count))
+        }
+
+        fn local_addr(&self) -> io::Result<SocketAddr> {
+            Ok("127.0.0.1:0".parse().unwrap())
+        }
+
+        fn max_receive_segments(&self) -> usize {
+            self.max_receive_segments
+        }
+    }
+
+    #[derive(Debug)]
+    struct ReadyUdpPoller;
+
+    impl UdpPoller for ReadyUdpPoller {
+        fn poll_writable(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
 
     #[test]
     fn salamander_round_trip() {
@@ -425,6 +531,79 @@ mod tests {
         let encoded = obfs.encode(b"payload");
         assert_ne!(&encoded[SALAMANDER_SALT_LEN..], b"payload");
         assert_eq!(obfs.decode(&encoded).unwrap(), b"payload");
+    }
+
+    #[test]
+    fn salamander_receive_preserves_gro_segments_and_batch_entries() {
+        let obfs = Salamander::new(b"secret");
+        let first = obfs.encode(b"first");
+        let second = obfs.encode(b"two");
+        let third = obfs.encode(b"third");
+        let stride = first.len();
+        let mut gro = first;
+        gro.extend_from_slice(&second);
+        let source: SocketAddr = "127.0.0.1:443".parse().unwrap();
+        let socket = Hy2UdpSocket {
+            inner: Arc::new(MockUdpSocket {
+                batch: Mutex::new(VecDeque::from([
+                    (
+                        gro.clone(),
+                        RecvMeta {
+                            addr: source,
+                            len: gro.len(),
+                            stride,
+                            ecn: None,
+                            dst_ip: None,
+                        },
+                    ),
+                    (
+                        third.clone(),
+                        RecvMeta {
+                            addr: source,
+                            len: third.len(),
+                            stride: third.len(),
+                            ecn: None,
+                            dst_ip: None,
+                        },
+                    ),
+                ])),
+                max_receive_segments: 2,
+            }),
+            server_addr: source,
+            hop: None,
+            obfs: Some(obfs),
+            recv_buffer: Mutex::new(Vec::new()),
+        };
+
+        let mut received = Vec::new();
+        while received.len() < 2 {
+            let mut first_output = [0u8; 64];
+            let mut second_output = [0u8; 64];
+            let mut meta = [RecvMeta::default(); 2];
+            let count = {
+                let mut bufs = [
+                    IoSliceMut::new(&mut first_output),
+                    IoSliceMut::new(&mut second_output),
+                ];
+                let mut cx = Context::from_waker(noop_waker_ref());
+                let Poll::Ready(Ok(count)) = socket.poll_recv(&mut cx, &mut bufs, &mut meta) else {
+                    panic!("mock receive must complete")
+                };
+                count
+            };
+            assert_ne!(count, 0);
+            let outputs = [&first_output[..], &second_output[..]];
+            for index in 0..count {
+                received.push((outputs[index][..meta[index].len].to_vec(), meta[index]));
+            }
+        }
+
+        assert_eq!(received[0].1.len, 8);
+        assert_eq!(received[0].1.stride, 5);
+        assert_eq!(received[0].0, b"firsttwo");
+        assert_eq!(received[1].1.len, 5);
+        assert_eq!(received[1].1.stride, 5);
+        assert_eq!(received[1].0, b"third");
     }
 
     #[test]

--- a/crates/meow-proxy/src/hysteria2/tcp.rs
+++ b/crates/meow-proxy/src/hysteria2/tcp.rs
@@ -7,57 +7,21 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 type ReadResponseFuture = Pin<Box<dyn Future<Output = (RecvStream, Result<()>)> + Send>>;
-type WriteOpenFuture = Pin<Box<dyn Future<Output = (SendStream, io::Result<()>)> + Send>>;
 
 pub struct DuplexStream {
-    target: String,
     read_state: ReadState,
-    write_state: WriteState,
+    send: SendStream,
 }
 
 impl DuplexStream {
-    pub(crate) fn new(
-        send: SendStream,
-        recv: RecvStream,
-        target: String,
-        request_written: bool,
-    ) -> Self {
+    pub(crate) fn new(send: SendStream, recv: RecvStream, response_read: bool) -> Self {
         Self {
-            target,
-            read_state: ReadState::NeedResponse(Some(recv)),
-            write_state: if request_written {
-                WriteState::Open(send)
+            read_state: if response_read {
+                ReadState::Open(recv)
             } else {
-                WriteState::NeedRequest(Some(send))
+                ReadState::NeedResponse(Some(recv))
             },
-        }
-    }
-
-    fn poll_open_write(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let this = self.get_mut();
-        loop {
-            match &mut this.write_state {
-                WriteState::Open(_) => return Poll::Ready(Ok(())),
-                WriteState::NeedRequest(_) => {
-                    return Poll::Ready(Ok(()));
-                }
-                WriteState::Opening { future, .. } => {
-                    let (send, result) = match future.as_mut().poll(cx) {
-                        Poll::Ready(result) => result,
-                        Poll::Pending => return Poll::Pending,
-                    };
-                    this.write_state = match result {
-                        Ok(()) => WriteState::Open(send),
-                        Err(e) => WriteState::Failed(e.kind()),
-                    };
-                }
-                WriteState::Failed(kind) => {
-                    return Poll::Ready(Err(io::Error::new(
-                        *kind,
-                        "hysteria2 TCP stream write failed",
-                    )));
-                }
-            }
+            send,
         }
     }
 }
@@ -105,96 +69,15 @@ impl AsyncWrite for DuplexStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        let this = self.get_mut();
-        loop {
-            match &mut this.write_state {
-                WriteState::NeedRequest(send) => {
-                    let send = send
-                        .take()
-                        .ok_or_else(|| io::Error::other("hysteria2 TCP send stream missing"))?;
-                    let frame =
-                        proto::encode_tcp_request(&this.target, buf).map_err(error_to_io)?;
-                    let payload_len = buf.len();
-                    this.write_state = WriteState::Opening {
-                        future: write_open(send, frame),
-                        payload_len,
-                    };
-                }
-                WriteState::Opening {
-                    future,
-                    payload_len,
-                } => {
-                    let (send, result) = match future.as_mut().poll(cx) {
-                        Poll::Ready(result) => result,
-                        Poll::Pending => return Poll::Pending,
-                    };
-                    match result {
-                        Ok(()) => {
-                            let n = *payload_len;
-                            this.write_state = WriteState::Open(send);
-                            return Poll::Ready(Ok(n));
-                        }
-                        Err(e) => {
-                            let kind = e.kind();
-                            this.write_state = WriteState::Failed(kind);
-                            return Poll::Ready(Err(e));
-                        }
-                    }
-                }
-                WriteState::Open(send) => {
-                    return tokio::io::AsyncWrite::poll_write(Pin::new(send), cx, buf);
-                }
-                WriteState::Failed(kind) => {
-                    return Poll::Ready(Err(io::Error::new(
-                        *kind,
-                        "hysteria2 TCP stream write failed",
-                    )));
-                }
-            }
-        }
+        tokio::io::AsyncWrite::poll_write(Pin::new(&mut self.get_mut().send), cx, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let mut this = self;
-        match this.as_mut().poll_open_write(cx) {
-            Poll::Ready(Ok(())) => {}
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-            Poll::Pending => return Poll::Pending,
-        }
-
-        match &mut this.get_mut().write_state {
-            WriteState::Open(send) => Pin::new(send).poll_flush(cx),
-            WriteState::NeedRequest(_) => Poll::Ready(Ok(())),
-            WriteState::Opening { .. } => Poll::Pending,
-            WriteState::Failed(kind) => Poll::Ready(Err(io::Error::new(
-                *kind,
-                "hysteria2 TCP stream write failed",
-            ))),
-        }
+        Pin::new(&mut self.get_mut().send).poll_flush(cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let mut this = self;
-        match this.as_mut().poll_open_write(cx) {
-            Poll::Ready(Ok(())) => {}
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-            Poll::Pending => return Poll::Pending,
-        }
-
-        match &mut this.get_mut().write_state {
-            WriteState::Open(send) => Pin::new(send).poll_shutdown(cx),
-            WriteState::NeedRequest(send) => {
-                let Some(mut send) = send.take() else {
-                    return Poll::Ready(Err(io::Error::other("hysteria2 TCP send stream missing")));
-                };
-                Poll::Ready(send.finish().map_err(io::Error::from))
-            }
-            WriteState::Opening { .. } => Poll::Pending,
-            WriteState::Failed(kind) => Poll::Ready(Err(io::Error::new(
-                *kind,
-                "hysteria2 TCP stream write failed",
-            ))),
-        }
+        Pin::new(&mut self.get_mut().send).poll_shutdown(cx)
     }
 }
 
@@ -207,28 +90,15 @@ enum ReadState {
     Failed,
 }
 
-enum WriteState {
-    NeedRequest(Option<SendStream>),
-    Opening {
-        future: WriteOpenFuture,
-        payload_len: usize,
-    },
-    Open(SendStream),
-    Failed(io::ErrorKind),
-}
-
 fn read_response(mut recv: RecvStream) -> ReadResponseFuture {
     Box::pin(async move {
-        let result = proto::read_tcp_response(&mut recv).await;
+        let result = read_initial_response(&mut recv).await;
         (recv, result)
     })
 }
 
-fn write_open(mut send: SendStream, frame: Vec<u8>) -> WriteOpenFuture {
-    Box::pin(async move {
-        let result = send.write_all(&frame).await.map_err(io::Error::from);
-        (send, result)
-    })
+pub(crate) async fn read_initial_response(recv: &mut RecvStream) -> Result<()> {
+    proto::read_tcp_response(recv).await
 }
 
 pub(crate) async fn write_initial_request(send: &mut SendStream, target: &str) -> Result<()> {

--- a/crates/meow-proxy/tests/hysteria2_integration.rs
+++ b/crates/meow-proxy/tests/hysteria2_integration.rs
@@ -245,6 +245,19 @@ async fn start_tcp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     (addr, handle)
 }
 
+async fn start_tcp_banner_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let _ = stream.write_all(b"server banner").await;
+            });
+        }
+    });
+    (addr, handle)
+}
+
 async fn start_udp_echo_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let addr = socket.local_addr().unwrap();
@@ -310,8 +323,24 @@ async fn hysteria2_docker_tcp_and_udp_round_trip() {
     };
     sleep(Duration::from_millis(500)).await;
     let (tcp_echo, _tcp_h) = start_tcp_echo_server().await;
+    let (tcp_banner, _tcp_banner_h) = start_tcp_banner_server().await;
     let (udp_echo, _udp_h) = start_udp_echo_server().await;
     let adapter = adapter(server_port);
+
+    // Fast Open must send the TCP request while dialing, even when the local
+    // client has no bytes to write. Otherwise server-speaks-first protocols
+    // deadlock before their banner reaches the client.
+    let banner_metadata = metadata_for(tcp_banner, Network::Tcp);
+    let mut banner_conn = timeout(T, dial_tcp_with_retry(&adapter, &banner_metadata))
+        .await
+        .expect("hysteria2 banner TCP dial timed out")
+        .unwrap_or_else(|e| panic!("hysteria2 banner TCP dial failed: {e}\n{}", server.logs()));
+    let mut banner = [0u8; 13];
+    timeout(T, banner_conn.read_exact(&mut banner))
+        .await
+        .expect("server-first banner read timed out")
+        .expect("server-first banner read failed");
+    assert_eq!(&banner, b"server banner");
 
     let tcp_metadata = metadata_for(tcp_echo, Network::Tcp);
     let mut conn = match timeout(T, dial_tcp_with_retry(&adapter, &tcp_metadata)).await {


### PR DESCRIPTION
## Summary

- send the Hysteria2 TCP request frame during dial even with Fast Open, while still deferring the response read
- preserve every Salamander receive batch entry and GRO segment, and reuse socket-level scratch storage
- bound HTTP/3 setup, authentication, stream opening, and TCP request/response setup; avoid detaching an H3 driver before authentication succeeds

Addresses Hysteria2 items 1-3 in #495.

## Validation

- `cargo fmt --check`
- `cargo test --lib`
- `cargo clippy --all-targets` (passes; the only warnings are five pre-existing lints in generated `meow-lwip` bindings)
- `cargo test -p meow-proxy --features hysteria2 --lib hysteria2` (17 passed)
- `cargo clippy -p meow-proxy --features hysteria2 --lib --tests -- -D warnings`
- `MEOW_REQUIRE_DOCKER=1 cargo test -p meow-proxy --features hysteria2 --test hysteria2_integration -- --nocapture` against Hysteria 2.9.2, covering TCP, UDP, and a server-first Fast Open banner
- private real-node smoke through config parsing, tunnel routing, listener, and the Hysteria2 adapter: HTTPS returned 204 over both negotiated HTTP/2 and forced HTTP/1.1
