### PR TITLE
fix(config): choose primary outbound for GLOBAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ the canonical, in-repo source a release is cut from.
 
 ### Fixed
 
+- **Auto-created `GLOBAL` selectors now default to the config's primary
+  outbound.** Global mode always dispatches through `GLOBAL`, but the implicit
+  selector previously sorted every registry key and used the first one when no
+  choice was stored. That made global mode silently select `DIRECT` or route
+  through an alphabetically-first quota/expiry pseudo-node. The generated
+  selector still lists every proxy for mihomo-compatible dashboards, while its
+  first member is now the final valid `MATCH` target, falling back to the first
+  declared group or leaf proxy. Explicit user-defined `GLOBAL` groups remain
+  unchanged.
+
 - **`merge_family` no longer revives an expired sibling family.** When a new
   A answer merged into an entry whose AAAA had already expired, the old code
   unconditionally marked AAAA as `queried`, which `family_hit()` then read as a

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -707,6 +707,68 @@ fn apply_dialer_proxies(
     Ok(())
 }
 
+/// Policy names resolved internally rather than declared as usable outbounds.
+/// They must not become the default member of an auto-created `GLOBAL` group:
+/// choosing `DIRECT` would make global mode silently bypass every proxy.
+const BUILTIN_GLOBAL_POLICIES: [&str; 7] = [
+    "DIRECT",
+    "REJECT",
+    "REJECT-DROP",
+    "PASS",
+    "COMPATIBLE",
+    "GLOBAL",
+    "BLOCK",
+];
+
+fn is_usable_global_target(name: &str, proxies: &HashMap<SmolStr, Arc<dyn Proxy>>) -> bool {
+    !BUILTIN_GLOBAL_POLICIES
+        .iter()
+        .any(|policy| name.eq_ignore_ascii_case(policy))
+        && proxies.contains_key(name)
+}
+
+/// Find the outbound a config is built around, preserving declaration order.
+/// The final valid `MATCH` target is authoritative; otherwise prefer the first
+/// successfully-built group, then the first successfully-built leaf proxy.
+fn primary_global_target<'a>(
+    raw: &'a raw::RawConfig,
+    proxies: &HashMap<SmolStr, Arc<dyn Proxy>>,
+) -> Option<&'a str> {
+    let match_target = raw
+        .rules
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .rev()
+        .find_map(|rule| {
+            let mut parts = rule.split(',').map(str::trim);
+            if !parts.next()?.eq_ignore_ascii_case("MATCH") {
+                return None;
+            }
+            parts.next()
+        });
+    if let Some(target) = match_target.filter(|target| is_usable_global_target(target, proxies)) {
+        return Some(target);
+    }
+
+    if let Some(group) = raw
+        .proxy_groups
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .find(|group| is_usable_global_target(&group.name, proxies))
+    {
+        return Some(&group.name);
+    }
+
+    raw.proxies
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .filter_map(|proxy| proxy.get("name").and_then(serde_yaml::Value::as_str))
+        .find(|name| is_usable_global_target(name, proxies))
+}
+
 fn rebuild_from_raw_impl(
     raw: &raw::RawConfig,
     cache_dir: Option<&Path>,
@@ -815,12 +877,23 @@ fn rebuild_from_raw_impl(
 
     // Auto-create GLOBAL selector if not defined by user (mihomo compatibility).
     // clash-nyanpasu and other frontends depend on GLOBAL to build proxy tree.
+    // Keep the complete sorted list they expect, but put the config's primary
+    // outbound first: SelectorGroup uses its first member when no choice has
+    // been stored, and sorting every registry key previously made global mode
+    // default to DIRECT or an alphabetically-first quota/expiry pseudo-node.
     if !proxies.contains_key("GLOBAL") {
         let mut all_proxy_names: Vec<String> = proxies
             .keys()
             .map(std::string::ToString::to_string)
             .collect();
         all_proxy_names.sort();
+        let primary = primary_global_target(raw, &proxies).map(str::to_string);
+        if let Some(primary) = primary.as_deref() {
+            if let Some(position) = all_proxy_names.iter().position(|name| name == primary) {
+                all_proxy_names.remove(position);
+                all_proxy_names.insert(0, primary.to_string());
+            }
+        }
         let global_config = raw::RawProxyGroup {
             name: "GLOBAL".to_string(),
             group_type: "select".to_string(),
@@ -835,7 +908,10 @@ fn rebuild_from_raw_impl(
         ) {
             Ok(group) => {
                 proxies.insert(SmolStr::new_static("GLOBAL"), group);
-                info!("Auto-created GLOBAL selector with all proxies");
+                info!(
+                    primary = primary.as_deref().unwrap_or("DIRECT"),
+                    "Auto-created GLOBAL selector with all proxies"
+                );
             }
             Err(e) => warn!("Failed to create GLOBAL selector: {}", e),
         }

--- a/crates/meow-config/tests/config_persistence_test.rs
+++ b/crates/meow-config/tests/config_persistence_test.rs
@@ -203,6 +203,100 @@ fn rebuild_from_raw_with_groups() {
 }
 
 #[test]
+fn auto_global_defaults_to_final_match_group() {
+    let raw: RawConfig = serde_yaml::from_str(
+        r#"
+proxies:
+  - {name: "137.15 G | 500.00 G", type: socks5, server: 127.0.0.1, port: 1}
+  - {name: "HK 01", type: socks5, server: 127.0.0.1, port: 2}
+proxy-groups:
+  - {name: AutoSelect, type: url-test, proxies: ["HK 01"]}
+  - {name: Proxies, type: select, proxies: [AutoSelect, "HK 01"]}
+rules:
+  - DOMAIN,example.com,DIRECT
+  - MATCH,Proxies
+"#,
+    )
+    .unwrap();
+
+    let (proxies, _) = rebuild_from_raw(&raw).unwrap();
+    let global = proxies.get("GLOBAL").expect("auto-created GLOBAL");
+
+    assert_eq!(global.current().as_deref(), Some("Proxies"));
+    let members = global.members().expect("GLOBAL selector members");
+    assert_eq!(members.first().map(String::as_str), Some("Proxies"));
+    assert!(members.contains(&"137.15 G | 500.00 G".to_string()));
+    assert!(members.contains(&"AutoSelect".to_string()));
+    assert!(members.contains(&"HK 01".to_string()));
+    assert!(members.contains(&"DIRECT".to_string()));
+    assert!(members.contains(&"REJECT".to_string()));
+}
+
+#[test]
+fn auto_global_falls_back_to_first_declared_outbound() {
+    let group_first: RawConfig = serde_yaml::from_str(
+        r#"
+proxies:
+  - {name: "HK 01", type: socks5, server: 127.0.0.1, port: 2}
+proxy-groups:
+  - {name: Proxies, type: select, proxies: ["HK 01"]}
+rules:
+  - MATCH,DIRECT
+"#,
+    )
+    .unwrap();
+    let (proxies, _) = rebuild_from_raw(&group_first).unwrap();
+    assert_eq!(
+        proxies
+            .get("GLOBAL")
+            .and_then(|global| global.current())
+            .as_deref(),
+        Some("Proxies")
+    );
+
+    let proxy_only: RawConfig = serde_yaml::from_str(
+        r#"
+proxies:
+  - {name: "HK 01", type: socks5, server: 127.0.0.1, port: 2}
+rules:
+  - MATCH,DIRECT
+"#,
+    )
+    .unwrap();
+    let (proxies, _) = rebuild_from_raw(&proxy_only).unwrap();
+    assert_eq!(
+        proxies
+            .get("GLOBAL")
+            .and_then(|global| global.current())
+            .as_deref(),
+        Some("HK 01")
+    );
+}
+
+#[test]
+fn user_declared_global_keeps_its_own_default() {
+    let raw: RawConfig = serde_yaml::from_str(
+        r#"
+proxies:
+  - {name: "HK 01", type: socks5, server: 127.0.0.1, port: 2}
+proxy-groups:
+  - {name: Proxies, type: select, proxies: ["HK 01"]}
+  - {name: GLOBAL, type: select, proxies: [DIRECT, Proxies]}
+rules:
+  - MATCH,Proxies
+"#,
+    )
+    .unwrap();
+    let (proxies, _) = rebuild_from_raw(&raw).unwrap();
+    let global = proxies.get("GLOBAL").expect("user GLOBAL");
+    assert_eq!(global.current().as_deref(), Some("DIRECT"));
+    assert_eq!(
+        global.members().expect("GLOBAL members"),
+        vec!["DIRECT".to_string(), "Proxies".to_string()]
+    );
+}
+
+#[test]
 fn rebuild_from_raw_skips_invalid_proxy() {
     let mut raw = minimal_raw_config();
     let mut bad_proxy = HashMap::new();


### PR DESCRIPTION
## Summary

- head the implicit `GLOBAL` selector with the final valid `MATCH` target
- fall back to the first declared, successfully built group or leaf proxy
- preserve the complete sorted member list and explicit user-defined `GLOBAL` groups
- cover quota pseudo-nodes, fallback selection, and user-defined defaults

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `cargo test -p meow-config --test config_persistence_test`