### PR TITLE
fix(anytls): preserve destinations and make session writes cancellation-safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,12 @@ jobs:
             --test snell_server_docker_integration \
             -- --nocapture
 
+      - name: AnyTLS unit and integration tests (embedded server)
+        run: |
+          cargo test -p meow-anytls --lib
+          cargo test -p meow-proxy --features anytls --lib \
+            --test anytls_integration --test anytls_leak
+
       # One invocation/feature set for the feature-gated transport suites.
       # Per-feature-combination *compile* coverage (the old G1-G6 matrix)
       # lives in the feature-powerset job; the nightly coverage workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/meow-anytls/Cargo.toml
+++ b/crates/meow-anytls/Cargo.toml
@@ -53,7 +53,7 @@ rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 
 bytes = "1.10.1"
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec", "rt"] }
 
 sha2 = "0.10"
 md5 = "0.8"

--- a/crates/meow-anytls/src/client/client.rs
+++ b/crates/meow-anytls/src/client/client.rs
@@ -82,6 +82,7 @@ impl Client {
 
         // Open a new stream in the session
         let (stream, synack_rx) = session.open_stream().await?;
+        let mut guard = crate::session::stream::OpeningStreamGuard::new(Arc::clone(&stream));
         tracing::debug!(
             "[Client] Opened stream {} in session, waiting for SYNACK",
             stream.id()
@@ -160,6 +161,7 @@ impl Client {
 
         match tokio::time::timeout(DEFAULT_SYNACK_TIMEOUT, synack_rx).await {
             Ok(Ok(Ok(()))) => {
+                guard.disarm();
                 tracing::debug!(
                     "[Client] SYNACK received for stream {} - stream ready",
                     stream_id

--- a/crates/meow-anytls/src/client/udp_client.rs
+++ b/crates/meow-anytls/src/client/udp_client.rs
@@ -59,6 +59,7 @@ impl Client {
         // Send the initial request
         stream
             .send_data(initial_request)
+            .await
             .map_err(|e| AnyTlsError::Protocol(format!("Failed to send initial request: {}", e)))?;
 
         tracing::debug!(
@@ -192,7 +193,7 @@ async fn udp_to_stream(
         let packet = encode_udp_packet(&buf[..len])?;
 
         // Send to stream
-        stream.send_data(packet).map_err(|e| {
+        stream.send_data(packet).await.map_err(|e| {
             tracing::error!("[UDP Client] Failed to send to stream: {}", e);
             AnyTlsError::Protocol("Channel send failed".into())
         })?;

--- a/crates/meow-anytls/src/protocol/codec.rs
+++ b/crates/meow-anytls/src/protocol/codec.rs
@@ -26,13 +26,6 @@ impl Decoder for FrameCodec {
         // Save position before parsing header
         let before_header = src.len();
 
-        // Save first few bytes for debugging
-        let header_preview = if src.len() >= 20 {
-            format!("{:?}", &src[..20])
-        } else {
-            format!("{:?}", &src[..])
-        };
-
         // Parse header WITHOUT consuming bytes (use peek methods)
         // We'll only consume them if we have enough payload
         let mut header_reader = &src[..HEADER_OVERHEAD_SIZE];
@@ -41,10 +34,13 @@ impl Decoder for FrameCodec {
         let stream_id = header_reader.get_u32();
         let data_len = header_reader.get_u16() as usize;
 
-        tracing::debug!(
-            "[FrameCodec] decode: Parsing header (buffer had {} bytes, preview: {})",
+        // Keep the preview as a borrowed tracing field. Formatting it eagerly
+        // allocated a String for every decoded frame even when debug logs were
+        // disabled.
+        tracing::trace!(
+            preview = ?&src[..src.len().min(20)],
+            "[FrameCodec] decode: Parsing header (buffer had {} bytes)",
             before_header,
-            header_preview
         );
         tracing::debug!(
             "[FrameCodec] decode: Parsed header cmd={:?} (byte={}), stream_id={}, data_len={}",
@@ -97,6 +93,12 @@ impl Encoder<Frame> for FrameCodec {
 
     fn encode(&mut self, item: Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let data_len = item.data.len();
+        if data_len > u16::MAX as usize {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "AnyTLS frame payload exceeds u16 length",
+            ));
+        }
 
         // Reserve space: header + data
         dst.reserve(HEADER_OVERHEAD_SIZE + data_len);
@@ -118,6 +120,17 @@ impl Encoder<Frame> for FrameCodec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn oversized_frame_is_rejected_without_modifying_output() {
+        let mut output = BytesMut::from(&b"prefix"[..]);
+        let frame = Frame::data(1, Bytes::from(vec![0; u16::MAX as usize + 1]));
+        assert_eq!(
+            FrameCodec.encode(frame, &mut output).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert_eq!(&output[..], b"prefix");
+    }
 
     #[tokio::test]
     async fn test_encode_decode() {

--- a/crates/meow-anytls/src/server/handler.rs
+++ b/crates/meow-anytls/src/server/handler.rs
@@ -482,9 +482,12 @@ async fn proxy_tcp_connection_data_forwarding(
                 }
             };
 
-            // 写入 stream（使用 send_data，完全无锁！）
+            // Queue one complete frame with session-wide backpressure.
             use bytes::Bytes;
-            if let Err(e) = stream_for_write.send_data(Bytes::copy_from_slice(&buf[..n])) {
+            if let Err(e) = stream_for_write
+                .send_data(Bytes::copy_from_slice(&buf[..n]))
+                .await
+            {
                 tracing::error!(
                     "[Proxy-Task2] Stream write error (stream_id={}, iteration={}): {:?}",
                     stream_id,

--- a/crates/meow-anytls/src/server/udp_proxy.rs
+++ b/crates/meow-anytls/src/server/udp_proxy.rs
@@ -498,7 +498,7 @@ async fn udp_to_stream(
         };
 
         // Send to Stream using the send_data method
-        if let Err(e) = stream.send_data(packet) {
+        if let Err(e) = stream.send_data(packet).await {
             tracing::error!("[UDP] Failed to send to stream: {}", e);
             return Err(AnyTlsError::Protocol("Channel send failed".into()));
         }

--- a/crates/meow-anytls/src/session/mod.rs
+++ b/crates/meow-anytls/src/session/mod.rs
@@ -2,6 +2,7 @@
 pub mod session;
 pub mod stream;
 pub mod stream_reader;
+pub mod writer;
 
 pub use session::{Session, SessionHeartbeatConfig};
 pub use stream::Stream;

--- a/crates/meow-anytls/src/session/session.rs
+++ b/crates/meow-anytls/src/session/session.rs
@@ -3,6 +3,7 @@
 use crate::padding::PaddingFactory;
 use crate::protocol::{Command, Frame, FrameCodec};
 use crate::session::Stream;
+use crate::session::writer::{StreamWriter, WriteRequest};
 use crate::util::{AnyTlsError, Result, StringMap};
 use bytes::{Bytes, BytesMut};
 use md5;
@@ -33,7 +34,7 @@ struct HeartbeatState {
 }
 
 /// Session manages multiple streams over a single TLS connection
-type StreamDataReceiver = mpsc::UnboundedReceiver<(u32, Bytes)>;
+type StreamDataReceiver = mpsc::UnboundedReceiver<WriteRequest>;
 
 pub struct Session {
     id: u64,
@@ -46,7 +47,7 @@ pub struct Session {
     stream_id: Arc<std::sync::atomic::AtomicU32>,
 
     // Channel for receiving data from streams
-    stream_data_tx: mpsc::UnboundedSender<(u32, Bytes)>,
+    stream_data_tx: StreamWriter,
     stream_data_rx: Arc<tokio::sync::Mutex<Option<StreamDataReceiver>>>,
 
     // Channel for sending data to streams (stream_id -> sender)
@@ -115,7 +116,7 @@ impl Session {
         R: AsyncRead + Send + Unpin + 'static,
         W: AsyncWrite + Send + Unpin + 'static,
     {
-        let (stream_data_tx, stream_data_rx) = mpsc::unbounded_channel();
+        let (stream_data_tx, stream_data_rx) = StreamWriter::channel();
         #[allow(
             clippy::useless_conversion,
             reason = "identity on 64-bit; widens u32 on targets without 64-bit atomics"
@@ -162,7 +163,7 @@ impl Session {
         R: AsyncRead + Send + Unpin + 'static,
         W: AsyncWrite + Send + Unpin + 'static,
     {
-        let (stream_data_tx, stream_data_rx) = mpsc::unbounded_channel();
+        let (stream_data_tx, stream_data_rx) = StreamWriter::channel();
         #[allow(
             clippy::useless_conversion,
             reason = "identity on 64-bit; widens u32 on targets without 64-bit atomics"
@@ -239,6 +240,7 @@ impl Session {
         if already_closed {
             return Ok(());
         }
+        self.stream_data_tx.close();
         self.close_notify.notify_waiters();
 
         // Close stream data receiver so process_stream_data exits
@@ -728,20 +730,9 @@ impl Session {
                     "Unknown alert".to_string()
                 };
                 tracing::error!("[Session] Received Alert frame (fatal): {}", alert_msg);
-                // Close all streams
-                let mut streams = self.streams.write().await;
-                for (stream_id, stream) in streams.drain() {
-                    let error = AnyTlsError::Protocol(format!(
-                        "Session closed due to alert: {}",
-                        alert_msg
-                    ));
-                    stream.close_with_error(error).await;
-                    tracing::debug!("[Session] Closed stream {} due to alert", stream_id);
-                }
-                drop(streams);
-                // Mark session as closed
-                self.is_closed
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                // Close admission and wake the writer too, not just the flag:
+                // a blocked physical write must stop with the entire session.
+                self.close().await?;
                 return Err(AnyTlsError::Protocol(format!("Alert: {}", alert_msg)));
             }
             Command::HeartRequest => {
@@ -817,17 +808,17 @@ impl Session {
 
         let stream = Arc::new(stream);
 
-        // Store the receive_tx for sending data to this stream
-        {
-            let mut receive_map = self.stream_receive_tx.write().await;
-            receive_map.insert(stream_id, receive_tx);
-        }
-
-        // Store the stream
+        // Acquire both locks before mutating either map, in close()'s order.
         {
             let mut streams = self.streams.write().await;
+            let mut receive_map = self.stream_receive_tx.write().await;
+            if self.is_closed() {
+                return Err(AnyTlsError::SessionClosed);
+            }
+            receive_map.insert(stream_id, receive_tx);
             streams.insert(stream_id, stream.clone());
         }
+        let mut guard = crate::session::stream::OpeningStreamGuard::new(Arc::clone(&stream));
 
         tracing::trace!("[Session] Stream {} stored in session", stream_id);
 
@@ -837,6 +828,7 @@ impl Session {
         self.write_frame(frame).await?;
         tracing::debug!("[Session] SYN frame sent for stream {}", stream_id);
 
+        guard.disarm();
         Ok((stream, synack_rx))
     }
 
@@ -867,6 +859,12 @@ impl Session {
 
     /// Write a frame to the connection
     pub async fn write_frame(&self, frame: Frame) -> Result<()> {
+        self.stream_data_tx.write_frame(frame).await
+    }
+
+    // Only the session writer task performs wire I/O. start_client also calls
+    // this before spawning tasks, solely to buffer the initial Settings.
+    async fn write_frame_inner(&self, frame: Frame) -> Result<()> {
         use tokio_util::codec::Encoder;
         let frame_cmd = frame.cmd;
         let frame_stream_id = frame.stream_id;
@@ -927,9 +925,11 @@ impl Session {
             }
         }
 
-        // Log what we're about to send
+        // Per-frame wire details are intentionally trace-only: AnyTLS emits a
+        // frame for every relay chunk, so info-level logging is a hot-path
+        // throughput bottleneck under the application's default filter.
         if buffer.len() >= 7 {
-            tracing::info!(
+            tracing::trace!(
                 "[Session] About to send frame header: cmd={}, stream_id={:?}, data_len={:?}, total_buffer_len={}",
                 buffer[0],
                 u32::from_be_bytes([buffer[1], buffer[2], buffer[3], buffer[4]]),
@@ -956,12 +956,12 @@ impl Session {
             );
             let mut writer = self.writer.lock().await;
             if let Err(e) = writer.write_all(&buffer).await {
-                return Err(self.handle_io_error("write_without_padding", e).await);
+                return Err(AnyTlsError::Io(e));
             }
             if let Err(e) = writer.flush().await {
-                return Err(self.handle_io_error("flush_without_padding", e).await);
+                return Err(AnyTlsError::Io(e));
             }
-            tracing::info!(
+            tracing::trace!(
                 "[Session] write_with_padding: Successfully wrote {} bytes to connection",
                 buffer.len()
             );
@@ -984,10 +984,10 @@ impl Session {
             // For now, just write directly
             let mut writer = self.writer.lock().await;
             if let Err(e) = writer.write_all(&buffer).await {
-                return Err(self.handle_io_error("write_no_padding_stop", e).await);
+                return Err(AnyTlsError::Io(e));
             }
             if let Err(e) = writer.flush().await {
-                return Err(self.handle_io_error("flush_no_padding_stop", e).await);
+                return Err(AnyTlsError::Io(e));
             }
             return Ok(());
         }
@@ -999,10 +999,10 @@ impl Session {
         if pkt_sizes.is_empty() {
             let mut writer = self.writer.lock().await;
             if let Err(e) = writer.write_all(&buffer).await {
-                return Err(self.handle_io_error("write_no_padding_sizes", e).await);
+                return Err(AnyTlsError::Io(e));
             }
             if let Err(e) = writer.flush().await {
-                return Err(self.handle_io_error("flush_no_padding_sizes", e).await);
+                return Err(AnyTlsError::Io(e));
             }
             return Ok(());
         }
@@ -1045,7 +1045,7 @@ impl Session {
                     );
                 }
                 if let Err(e) = writer.write_all(&buffer[..size]).await {
-                    return Err(self.handle_io_error("write_padding_split_payload", e).await);
+                    return Err(AnyTlsError::Io(e));
                 }
                 buffer = buffer.split_off(size);
             } else if remain_payload_len > 0 {
@@ -1066,7 +1066,7 @@ impl Session {
                 }
 
                 if let Err(e) = writer.write_all(&buffer).await {
-                    return Err(self.handle_io_error("write_padding_payload_frame", e).await);
+                    return Err(AnyTlsError::Io(e));
                 }
                 buffer.clear();
             } else {
@@ -1078,7 +1078,7 @@ impl Session {
                 padding_frame.put_slice(&vec![0u8; size]); // padding data (zeros)
 
                 if let Err(e) = writer.write_all(&padding_frame).await {
-                    return Err(self.handle_io_error("write_padding_frame_only", e).await);
+                    return Err(AnyTlsError::Io(e));
                 }
             }
         }
@@ -1090,13 +1090,13 @@ impl Session {
                 buffer.len()
             );
             if let Err(e) = writer.write_all(&buffer).await {
-                return Err(self.handle_io_error("write_remaining_payload", e).await);
+                return Err(AnyTlsError::Io(e));
             }
         }
 
         tracing::trace!("[Session] write_with_padding: Flushing writer");
         if let Err(e) = writer.flush().await {
-            return Err(self.handle_io_error("flush_with_padding", e).await);
+            return Err(AnyTlsError::Io(e));
         }
         tracing::debug!("[Session] write_with_padding: Successfully wrote and flushed data");
         Ok(())
@@ -1120,7 +1120,7 @@ impl Session {
 
         self.buffering
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        self.write_frame(frame).await?;
+        self.write_frame_inner(frame).await?;
 
         // Start receive loop in background
         let session = Arc::clone(&self);
@@ -1244,143 +1244,81 @@ impl Session {
         Ok(())
     }
 
-    /// Process stream data from channels (should be run in a task)
+    /// Run the sole wire writer. Cancelling a producer never cancels a frame.
     pub async fn process_stream_data(&self) -> Result<()> {
-        let session_id = self.id();
-        let role = if self.is_client { "client" } else { "server" };
-        let process_span = info_span!(
-            "anytls.session.process_stream_data",
-            session_id,
-            role = %role,
-            bytes_out = field::Empty,
-            iterations = field::Empty
-        );
-        let _process_guard = process_span.enter();
-        tracing::debug!(
-            session_id = session_id,
-            is_client = self.is_client,
-            "[Session] process_stream_data started"
-        );
-        let mut iteration = 0u64;
-        let mut total_bytes_out: usize = 0;
-        let close_notify = Arc::clone(&self.close_notify);
-        let receiver = {
-            let mut guard = self.stream_data_rx.lock().await;
-            guard.take()
-        };
-
-        let Some(mut receiver) = receiver else {
-            tracing::debug!(
-                session_id = session_id,
-                "[Session] process_stream_data: Receiver already taken, nothing to process"
-            );
+        let Some(mut receiver) = self.stream_data_rx.lock().await.take() else {
             return Ok(());
         };
-        // Process data from streams and send as frames
         loop {
-            iteration += 1;
-            tracing::trace!(
-                session_id = session_id,
-                "[Session] process_stream_data: Waiting for data from streams (iteration {})",
-                iteration
-            );
-            let result = tokio::select! {
+            let closed = self.close_notify.notified();
+            tokio::pin!(closed);
+            closed.as_mut().enable();
+            if self.is_closed() {
+                break;
+            }
+            let request = tokio::select! {
                 biased;
-                _ = close_notify.notified() => {
-                    tracing::debug!(
-                        session_id = session_id,
-                        "[Session] process_stream_data: Received close notification (iteration {})",
-                        iteration
-                    );
-                    break;
-                }
-                result = receiver.recv() => result,
+                _ = &mut closed => break,
+                request = receiver.recv() => match request {
+                    Some(request) => request,
+                    None => break,
+                },
             };
-
-            match result {
-                Some((stream_id, data)) => {
-                    if self.is_closed() {
-                        tracing::debug!(
-                            session_id = session_id,
-                            "[Session] process_stream_data: Session closed, breaking (iteration {})",
-                            iteration
-                        );
-                        break;
-                    }
-                    if data.is_empty() {
-                        // Stream-close sentinel (see `Stream::close`): emit a
-                        // FIN for this stream so the peer evicts its slot, then
-                        // drop our own stream maps. This keeps `streams` /
-                        // `stream_receive_tx` bounded over a long-lived session
-                        // instead of growing one entry per opened stream.
-                        tracing::debug!(
-                            session_id = session_id,
-                            "[Session] process_stream_data: closing stream {} (FIN)",
-                            stream_id
-                        );
-                        let _ = self
-                            .write_control_frame(Frame::control(Command::Fin, stream_id))
-                            .await;
-                        self.streams.write().await.remove(&stream_id);
-                        self.stream_receive_tx.write().await.remove(&stream_id);
-                        continue;
-                    }
-                    let data_len = data.len();
-                    tracing::debug!(
-                        session_id = session_id,
-                        "[Session] process_stream_data: Received {} bytes from stream {} (iteration {})",
-                        data_len,
-                        stream_id,
-                        iteration
-                    );
-                    // Send data frame
-                    let write_result = self.write_data_frame(stream_id, data).await;
-                    match write_result {
-                        Ok(_) => {
-                            total_bytes_out += data_len;
-                            tracing::debug!(
-                                session_id = session_id,
-                                "[Session] process_stream_data: Successfully wrote data frame for stream {} (iteration {})",
-                                stream_id,
-                                iteration
-                            );
+            let (completion, result) = tokio::select! {
+                biased;
+                // Partial frames may only be abandoned when this entire
+                // session is already closed and will never be pooled again.
+                _ = &mut closed => break,
+                result = async {
+                    match request {
+                        WriteRequest::Frame { frame, _permit, completion } => {
+                            let fin = frame.cmd == Command::Fin;
+                            let stream_id = frame.stream_id;
+                            if fin {
+                                // A cancelled initial dial must not leave its
+                                // Settings/SYN/FIN buffered until another dial.
+                                self.disable_buffering();
+                            }
+                            let result = self.write_frame_inner(frame).await;
+                            if fin {
+                                self.streams.write().await.remove(&stream_id);
+                                self.stream_receive_tx.write().await.remove(&stream_id);
+                            }
+                            // Hold capacity through the physical write/flush.
+                            drop(_permit);
+                            (completion, result)
                         }
-                        Err(e) => {
-                            tracing::error!(
-                                session_id = session_id,
-                                "[Session] process_stream_data: Failed to write data frame for stream {}: {} (iteration {})",
-                                stream_id,
-                                e,
-                                iteration
-                            );
-                            return Err(e);
+                        WriteRequest::Flush(completion) => {
+                            let result = self.flush_inner().await;
+                            (Some(completion), result)
                         }
                     }
-                }
-                None => {
-                    tracing::debug!(
-                        session_id = session_id,
-                        "[Session] process_stream_data: Channel closed, exiting after {} iterations",
-                        iteration
-                    );
-                    break;
-                }
+                } => result,
+            };
+            let failed = result.is_err();
+            if let Err(error) = &result {
+                tracing::debug!(session_id = self.id(), %error, "AnyTLS session writer failed");
+            }
+            if let Some(completion) = completion {
+                let _ = completion.send(result);
+            }
+            if failed {
+                // No writer lock is held here; close() can safely shut it down.
+                self.close().await?;
+                return Err(AnyTlsError::SessionClosed);
             }
         }
+        Ok(())
+    }
 
-        tracing::debug!(
-            session_id = session_id,
-            "[Session] process_stream_data: Exiting after {} iterations",
-            iteration
-        );
-        tracing::info!(
-            session_id = session_id,
-            bytes_out = total_bytes_out as u64,
-            iterations = iteration,
-            "[Session] process_stream_data completed"
-        );
-        process_span.record("bytes_out", total_bytes_out as u64);
-        process_span.record("iterations", iteration);
+    async fn flush_inner(&self) -> Result<()> {
+        self.disable_buffering();
+        let buffered = std::mem::take(&mut *self.buffer.lock().await);
+        if !buffered.is_empty() {
+            self.write_with_padding(BytesMut::from(buffered.as_slice()))
+                .await?;
+        }
+        self.writer.lock().await.flush().await?;
         Ok(())
     }
 
@@ -1424,6 +1362,176 @@ mod tests {
     fn create_test_padding() -> Arc<PaddingFactory> {
         use crate::padding::DEFAULT_PADDING_SCHEME;
         Arc::new(PaddingFactory::new(DEFAULT_PADDING_SCHEME.as_bytes()).unwrap())
+    }
+
+    async fn read_frame(peer: &mut DuplexStream) -> Frame {
+        time::timeout(Duration::from_secs(2), async {
+            let mut header = [0; 7];
+            peer.read_exact(&mut header).await.unwrap();
+            let mut data = vec![0; u16::from_be_bytes([header[5], header[6]]) as usize];
+            peer.read_exact(&mut data).await.unwrap();
+            Frame::with_data(
+                Command::from(header[0]),
+                u32::from_be_bytes(header[1..5].try_into().unwrap()),
+                Bytes::from(data),
+            )
+        })
+        .await
+        .expect("frame writer stalled")
+    }
+
+    #[tokio::test]
+    async fn cancelled_open_finishes_syn_and_retires_stream() {
+        use std::future::Future;
+        use std::task::{Context, Waker};
+        let (io, mut peer) = duplex(4);
+        let (reader, writer) = tokio::io::split(io);
+        let session = Arc::new(Session::new_server(reader, writer, create_test_padding()));
+        let worker = Arc::clone(&session);
+        let task = tokio::spawn(async move { worker.process_stream_data().await });
+        let mut open = Box::pin(session.open_stream());
+        assert!(
+            open.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        // SYN is seven bytes but the wire only holds four. Cancel after the
+        // first byte was observed, while write_all still has work to do.
+        assert_eq!(peer.read_u8().await.unwrap(), u8::from(Command::Syn));
+        drop(open);
+        let mut tail = [0; 6];
+        peer.read_exact(&mut tail).await.unwrap();
+        assert_eq!(tail, [0, 0, 0, 1, 0, 0]);
+        assert_eq!(read_frame(&mut peer).await, Frame::control(Command::Fin, 1));
+        assert!(!session.has_active_streams().await);
+        assert!(session.stream_receive_tx.read().await.is_empty());
+
+        let next_session = Arc::clone(&session);
+        let next = tokio::spawn(async move { next_session.open_stream().await.unwrap().0 });
+        assert_eq!(read_frame(&mut peer).await, Frame::control(Command::Syn, 2));
+        next.await.unwrap().close();
+        assert_eq!(read_frame(&mut peer).await, Frame::control(Command::Fin, 2));
+        session.close().await.unwrap();
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_error_closes_session_without_relocking_itself() {
+        let (io, peer) = duplex(4);
+        drop(peer);
+        let (reader, writer) = tokio::io::split(io);
+        let session = Arc::new(Session::new_server(reader, writer, create_test_padding()));
+        let worker = Arc::clone(&session);
+        let task = tokio::spawn(async move { worker.process_stream_data().await });
+        assert!(
+            time::timeout(
+                Duration::from_secs(2),
+                session.write_data_frame(1, Bytes::from_static(b"failure"))
+            )
+            .await
+            .unwrap()
+            .is_err()
+        );
+        assert!(
+            time::timeout(Duration::from_secs(2), task)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_err()
+        );
+        assert!(session.is_closed());
+        assert!(
+            session
+                .write_data_frame(2, Bytes::from_static(b"closed"))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_alert_stops_writer_and_notifies_opening_streams() {
+        let (io, _peer) = duplex(64);
+        let (reader, writer) = tokio::io::split(io);
+        let session = Arc::new(Session::new_server(reader, writer, create_test_padding()));
+        let worker = Arc::clone(&session);
+        let task = tokio::spawn(async move { worker.process_stream_data().await });
+        let (stream, synack) = session.open_stream().await.unwrap();
+        assert!(
+            session
+                .handle_frame(Frame::with_data(
+                    Command::Alert,
+                    0,
+                    Bytes::from_static(b"stop")
+                ))
+                .await
+                .is_err()
+        );
+        assert!(stream.is_closed());
+        assert!(synack.await.unwrap().is_err());
+        time::timeout(Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(session.stream_data_tx.budget.is_closed());
+        assert!(session.stream_receive_tx.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn close_interrupts_blocked_writer_and_releases_budget() {
+        let (io, _peer) = duplex(4);
+        let (reader, writer) = tokio::io::split(io);
+        let session = Arc::new(Session::new_server(reader, writer, create_test_padding()));
+        let worker = Arc::clone(&session);
+        let task = tokio::spawn(async move { worker.process_stream_data().await });
+        let pending_session = Arc::clone(&session);
+        let pending = tokio::spawn(async move {
+            pending_session
+                .write_data_frame(1, Bytes::from(vec![0; 512]))
+                .await
+        });
+        tokio::task::yield_now().await;
+        time::timeout(Duration::from_secs(2), session.close())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(pending.await.unwrap().is_err());
+        task.await.unwrap().unwrap();
+        assert!(session.stream_data_tx.budget.is_closed());
+    }
+
+    #[tokio::test]
+    async fn frame_hot_path_emits_no_info_events() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tracing::instrument::WithSubscriber;
+        use tracing_subscriber::{Layer, layer::SubscriberExt};
+        struct CountInfo(Arc<AtomicUsize>);
+        impl<S: tracing::Subscriber> Layer<S> for CountInfo {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if *event.metadata().level() == tracing::Level::INFO {
+                    self.0.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        let count = Arc::new(AtomicUsize::new(0));
+        let subscriber = tracing_subscriber::registry().with(CountInfo(Arc::clone(&count)));
+        async {
+            let session =
+                Session::new_server(tokio::io::empty(), tokio::io::sink(), create_test_padding());
+            for _ in 0..100 {
+                session
+                    .write_frame_inner(Frame::data(1, Bytes::from_static(b"data")))
+                    .await
+                    .unwrap();
+            }
+        }
+        .with_subscriber(subscriber)
+        .await;
+        assert_eq!(count.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]

--- a/crates/meow-anytls/src/session/stream.rs
+++ b/crates/meow-anytls/src/session/stream.rs
@@ -1,165 +1,234 @@
-//! Stream implementation for AnyTLS protocol
-//!
-//! Stream provides a duplex communication channel that implements AsyncRead and AsyncWrite
+//! A multiplexed AnyTLS stream with bounded, cancellation-safe writes.
 
+use crate::protocol::{Command, Frame};
 use crate::session::StreamReader;
+use crate::session::writer::{MAX_FRAME_PAYLOAD, StreamWriter};
 use crate::util::{AnyTlsError, Result};
 use bytes::Bytes;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::{Context, Poll};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, oneshot};
+use tokio_util::sync::PollSemaphore;
 
-/// Stream represents a single data stream within a Session
-/// It implements AsyncRead and AsyncWrite to be used as a connection
+struct WriteState {
+    closed: bool,
+    fin_sent: bool,
+    permits: PollSemaphore,
+    flush: Option<oneshot::Receiver<Result<()>>>,
+    waker: Option<Waker>,
+}
+
+/// Retire a registered stream if opening it fails or its dial is cancelled.
+pub(crate) struct OpeningStreamGuard(Option<Arc<Stream>>);
+
+impl OpeningStreamGuard {
+    pub(crate) fn new(stream: Arc<Stream>) -> Self {
+        Self(Some(stream))
+    }
+    pub(crate) fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for OpeningStreamGuard {
+    fn drop(&mut self) {
+        if let Some(stream) = &self.0 {
+            stream.close();
+        }
+    }
+}
+
+/// Stream represents a single data stream within a Session.
 pub struct Stream {
     id: u32,
-
-    // ===== 读取部分：使用独立的 StreamReader =====
-    // Arc<Mutex<>> 是为了在 poll_read 中获取 &mut
     reader: Arc<tokio::sync::Mutex<StreamReader>>,
-
-    // ===== 写入部分：直接使用 channel，无需锁 =====
-    writer_tx: mpsc::UnboundedSender<(u32, Bytes)>,
-
-    // ===== SYNACK 通知 (用于超时检测) =====
-    synack_tx: Arc<tokio::sync::Mutex<Option<oneshot::Sender<Result<()>>>>>,
-
-    // ===== 状态管理 =====
-    is_closed: Arc<AtomicBool>,
-    close_error: Arc<tokio::sync::Mutex<Option<AnyTlsError>>>,
-
-    // Guards the one-shot stream-close sentinel so a FIN is emitted at most
-    // once regardless of how many times `close()`/`poll_shutdown` fire.
-    fin_sent: Arc<AtomicBool>,
+    writer: StreamWriter,
+    // Only synchronous admission and close operations run under this lock.
+    // In particular, no network I/O or await occurs while it is held.
+    write_state: Mutex<WriteState>,
+    close_notify: Notify,
+    synack_tx: tokio::sync::Mutex<Option<oneshot::Sender<Result<()>>>>,
+    close_error: tokio::sync::Mutex<Option<AnyTlsError>>,
 }
 
 impl Stream {
-    /// Create a new stream
-    ///
-    /// # Arguments
-    /// * `id` - Stream ID
-    /// * `reader` - StreamReader 用于读取数据
-    /// * `writer_tx` - 发送数据到 Session 的 channel
-    ///
-    /// # Returns
-    /// (Stream, Receiver) - The receiver can be used to wait for SYNACK
     pub fn new(
         id: u32,
         reader: StreamReader,
-        writer_tx: mpsc::UnboundedSender<(u32, Bytes)>,
+        writer: StreamWriter,
     ) -> (Self, oneshot::Receiver<Result<()>>) {
         let (synack_tx, synack_rx) = oneshot::channel();
-
-        let stream = Self {
-            id,
-            reader: Arc::new(tokio::sync::Mutex::new(reader)),
-            writer_tx,
-            synack_tx: Arc::new(tokio::sync::Mutex::new(Some(synack_tx))),
-            is_closed: Arc::new(AtomicBool::new(false)),
-            close_error: Arc::new(tokio::sync::Mutex::new(None)),
-            fin_sent: Arc::new(AtomicBool::new(false)),
-        };
-
-        (stream, synack_rx)
+        let permits = PollSemaphore::new(Arc::clone(&writer.budget));
+        (
+            Self {
+                id,
+                reader: Arc::new(tokio::sync::Mutex::new(reader)),
+                writer,
+                write_state: Mutex::new(WriteState {
+                    closed: false,
+                    fin_sent: false,
+                    permits,
+                    flush: None,
+                    waker: None,
+                }),
+                close_notify: Notify::new(),
+                synack_tx: tokio::sync::Mutex::new(Some(synack_tx)),
+                close_error: tokio::sync::Mutex::new(None),
+            },
+            synack_rx,
+        )
     }
 
-    /// Notify that SYNACK has been received
-    ///
-    /// # Arguments
-    /// * `result` - Ok(()) for success, Err for error
     pub async fn notify_synack(&self, result: Result<()>) {
-        let mut tx_guard = self.synack_tx.lock().await;
-        match tx_guard.take() {
-            Some(tx) => {
-                let result_clone = match &result {
-                    Ok(()) => Ok(()),
-                    Err(e) => Err(AnyTlsError::Protocol(e.to_string())),
-                };
-                let _ = tx.send(result_clone);
-                tracing::debug!(
-                    "[Stream] SYNACK notified for stream {}: {:?}",
-                    self.id,
-                    result.is_ok()
-                );
-            }
-            _ => {
-                tracing::warn!("[Stream] SYNACK already notified for stream {}", self.id);
-            }
+        if let Some(tx) = self.synack_tx.lock().await.take() {
+            let _ = tx.send(result);
         }
     }
 
-    /// Get stream ID
     pub fn id(&self) -> u32 {
         self.id
     }
 
-    /// Close the stream with error (can be called with `Arc<Stream>`)
     pub async fn close_with_error(&self, err: AnyTlsError) {
-        if self
-            .is_closed
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
-        {
-            tracing::warn!(
-                stream_id = self.id,
-                cause = %err,
-                "[Stream] Closing stream with error"
-            );
-            *self.close_error.lock().await = Some(err);
-        }
+        self.mark_closed(false);
+        *self.close_error.lock().await = Some(err);
     }
 
-    /// Check if stream is closed
     pub fn is_closed(&self) -> bool {
-        self.is_closed.load(Ordering::Relaxed)
+        self.write_state.lock().unwrap().closed
     }
 
-    /// Gracefully close this client stream.
-    ///
-    /// Signals the owning session (via the writer channel's empty-`Bytes`
-    /// sentinel — see `Session::process_stream_data`) to emit a `Fin` frame
-    /// for this stream id and evict it from the session's stream maps. Without
-    /// this, client streams were never removed from `Session::streams` /
-    /// `Session::stream_receive_tx` and never FIN-acked to the peer, so both
-    /// maps grew unbounded for the life of the (long-lived, pooled) session.
-    ///
-    /// Lock-free and idempotent, so it is safe to call from `poll_shutdown`
-    /// or a `Drop` impl on a wrapper type.
-    pub fn close(&self) {
-        self.is_closed.store(true, Ordering::Relaxed);
-        if self
-            .fin_sent
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            // Best-effort: if the session writer task is already gone the
-            // stream is being torn down anyway, so a send error is harmless.
-            let _ = self.writer_tx.send((self.id, Bytes::new()));
+    fn mark_closed(&self, send_fin: bool) {
+        let mut state = self.write_state.lock().unwrap();
+        state.closed = true;
+        // Drop a pending semaphore acquisition, releasing its reserved permits.
+        state.permits = PollSemaphore::new(Arc::clone(&self.writer.budget));
+        if send_fin && !state.fin_sent {
+            state.fin_sent = true;
+            // A pending flush may precede FIN. Shutdown must acknowledge a
+            // fresh barrier after it, even if an earlier flush was cancelled.
+            state.flush = None;
+            let _ = self
+                .writer
+                .enqueue(Frame::control(Command::Fin, self.id), None, None);
         }
+        let waker = state.waker.take();
+        drop(state);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+        self.close_notify.notify_waiters();
     }
 
-    /// Get a reference to the reader (for direct access in handlers)
+    /// Queue exactly one FIN after all accepted writes, including from Drop.
+    pub fn close(&self) {
+        self.mark_closed(true);
+    }
+
     pub fn reader(&self) -> &Arc<tokio::sync::Mutex<StreamReader>> {
         &self.reader
     }
 
-    /// Send data through the writer channel (无锁方式)
-    ///
-    /// 这个方法可以被多个任务并发调用，无需任何锁
-    pub fn send_data(
+    /// Accept one frame with session-wide backpressure. Cancellation either
+    /// enqueues the entire frame or none of it; the session owns physical I/O.
+    pub async fn send_data(&self, data: Bytes) -> Result<()> {
+        if data.len() > MAX_FRAME_PAYLOAD {
+            return Err(AnyTlsError::Protocol(
+                "frame payload exceeds u16 length".into(),
+            ));
+        }
+        let closed = self.close_notify.notified();
+        tokio::pin!(closed);
+        closed.as_mut().enable();
+        if self.is_closed() {
+            return Err(AnyTlsError::StreamClosed);
+        }
+        if data.is_empty() {
+            return Ok(());
+        }
+        let permit = tokio::select! {
+            biased;
+            _ = &mut closed => return Err(AnyTlsError::StreamClosed),
+            permit = Arc::clone(&self.writer.budget).acquire_owned() =>
+                permit.map_err(|_| AnyTlsError::SessionClosed)?,
+        };
+        let state = self.write_state.lock().unwrap();
+        if state.closed {
+            return Err(AnyTlsError::StreamClosed);
+        }
+        self.writer
+            .enqueue(Frame::data(self.id, data), Some(permit), None)
+    }
+
+    fn poll_pending_flush(
+        state: &mut WriteState,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if let Some(flush) = state.flush.as_mut() {
+            let result = std::task::ready!(Pin::new(flush).poll(cx));
+            state.flush = None;
+            return Poll::Ready(match result {
+                Ok(result) => result.map_err(std::io::Error::other),
+                Err(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "session writer closed",
+                )),
+            });
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    pub fn poll_write_data(
         &self,
-        data: Bytes,
-    ) -> std::result::Result<(), mpsc::error::SendError<(u32, Bytes)>> {
-        self.writer_tx.send((self.id, data))
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let mut state = self.write_state.lock().unwrap();
+        if state.closed {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "stream closed",
+            )));
+        }
+        // Do not let a cancelled flush become a stale barrier for later writes.
+        std::task::ready!(Self::poll_pending_flush(&mut state, cx))?;
+        state.waker = Some(cx.waker().clone());
+        let permit = std::task::ready!(state.permits.poll_acquire(cx)).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "session writer closed")
+        })?;
+        let len = buf.len().min(MAX_FRAME_PAYLOAD);
+        self.writer
+            .enqueue(
+                Frame::data(self.id, Bytes::copy_from_slice(&buf[..len])),
+                Some(permit),
+                None,
+            )
+            .map_err(std::io::Error::other)?;
+        Poll::Ready(Ok(len))
+    }
+
+    pub fn poll_flush_data(&self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let mut state = self.write_state.lock().unwrap();
+        // A caller may cancel a backpressured write and then flush instead.
+        // Release any capacity reserved by that abandoned acquisition.
+        state.permits = PollSemaphore::new(Arc::clone(&self.writer.budget));
+        if state.flush.is_none() {
+            state.flush = Some(self.writer.flush().map_err(std::io::Error::other)?);
+        }
+        Self::poll_pending_flush(&mut state, cx)
+    }
+
+    pub fn poll_shutdown_data(&self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.close();
+        self.poll_flush_data(cx)
     }
 }
-
-// Stream is not meant to be cloned - use Arc<Stream> instead
-// This implementation is only for compatibility with HashMap storage
 
 impl AsyncRead for Stream {
     fn poll_read(
@@ -211,130 +280,164 @@ impl AsyncRead for Stream {
 impl AsyncWrite for Stream {
     fn poll_write(
         self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
+        cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        let stream_id = self.id;
-        let buf_len = buf.len();
-        tracing::trace!(
-            "[Stream] poll_write: stream_id={}, buf_len={}",
-            stream_id,
-            buf_len
-        );
-
-        if self.is_closed.load(Ordering::Relaxed) {
-            tracing::warn!("[Stream] poll_write: Stream {} is closed", stream_id);
-            return Poll::Ready(Err(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "stream closed",
-            )));
-        }
-
-        // Send data to session via channel
-        let data = Bytes::copy_from_slice(buf);
-        tracing::trace!(
-            "[Stream] poll_write: Sending {} bytes to channel for stream {}",
-            buf_len,
-            stream_id
-        );
-        match self.writer_tx.send((self.id, data)) {
-            Ok(_) => {
-                tracing::debug!(
-                    "[Stream] poll_write: Successfully sent {} bytes to channel for stream {}",
-                    buf_len,
-                    stream_id
-                );
-                Poll::Ready(Ok(buf.len()))
-            }
-            Err(e) => {
-                tracing::error!(
-                    "[Stream] poll_write: Failed to send {} bytes to channel for stream {}: {:?}",
-                    buf_len,
-                    stream_id,
-                    e
-                );
-                Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "session channel closed",
-                )))
-            }
-        }
+        self.poll_write_data(cx, buf)
     }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Ok(()))
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.poll_flush_data(cx)
     }
-
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        // Emit a FIN and evict this stream from the session maps.
-        self.close();
-        Poll::Ready(Ok(()))
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.poll_shutdown_data(cx)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::StreamReader;
+    use crate::session::writer::WriteRequest;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::sync::mpsc;
+
+    fn stream() -> (Stream, mpsc::UnboundedReceiver<WriteRequest>) {
+        let (writer, rx) = StreamWriter::channel();
+        let (_, reader_rx) = mpsc::unbounded_channel();
+        (
+            Stream::new(1, StreamReader::new(1, reader_rx), writer).0,
+            rx,
+        )
+    }
+
+    fn frame(request: WriteRequest) -> Frame {
+        match request {
+            WriteRequest::Frame { frame, .. } => frame,
+            WriteRequest::Flush(_) => panic!("expected frame"),
+        }
+    }
 
     #[tokio::test]
-    async fn test_stream_write() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let (_reader_tx, reader_rx) = mpsc::unbounded_channel();
+    async fn writes_are_bounded_and_fin_follows_accepted_data() {
+        let (mut stream, mut rx) = stream();
+        assert_eq!(stream.write(&[]).await.unwrap(), 0);
+        assert!(rx.try_recv().is_err());
+        for _ in 0..64 {
+            stream.write_all(b"data").await.unwrap();
+        }
+        let mut write = Box::pin(stream.write(b"blocked"));
+        assert!(
+            write
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        drop(write);
+        stream.close();
+        assert!(
+            stream
+                .send_data(Bytes::from_static(b"after-fin"))
+                .await
+                .is_err()
+        );
+        for _ in 0..64 {
+            assert_eq!(frame(rx.recv().await.unwrap()).data, b"data"[..]);
+        }
+        assert_eq!(frame(rx.recv().await.unwrap()).cmd, Command::Fin);
+        stream.close();
+        assert!(rx.try_recv().is_err());
+    }
 
-        let reader = StreamReader::new(1, reader_rx);
-        let (mut stream, _synack_rx) = Stream::new(1, reader, tx);
+    #[tokio::test]
+    async fn oversized_tcp_write_is_chunked() {
+        let (mut stream, mut rx) = stream();
+        let data = vec![42; MAX_FRAME_PAYLOAD + 5];
+        stream.write_all(&data).await.unwrap();
+        assert_eq!(
+            frame(rx.recv().await.unwrap()).data.len(),
+            MAX_FRAME_PAYLOAD
+        );
+        assert_eq!(frame(rx.recv().await.unwrap()).data.len(), 5);
+        assert!(stream.send_data(Bytes::from(data)).await.is_err());
+    }
 
-        // 写入数据
-        stream.write_all(b"hello").await.unwrap();
+    #[tokio::test]
+    async fn flush_waits_for_writer_acknowledgement() {
+        let (mut stream, mut rx) = stream();
+        let mut flush = Box::pin(stream.flush());
+        assert!(
+            flush
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        match rx.recv().await.unwrap() {
+            WriteRequest::Flush(tx) => tx.send(Ok(())).unwrap(),
+            _ => panic!("expected flush"),
+        }
+        flush.await.unwrap();
+    }
 
-        // 验证数据发送到 channel
-        let (stream_id, data) = rx.recv().await.unwrap();
-        assert_eq!(stream_id, 1);
-        assert_eq!(data.as_ref(), b"hello");
+    #[tokio::test]
+    async fn close_wakes_a_blocked_async_send() {
+        let (mut stream, _rx) = stream();
+        for _ in 0..64 {
+            stream.write_all(b"data").await.unwrap();
+        }
+        let mut send = Box::pin(stream.send_data(Bytes::from_static(b"blocked")));
+        assert!(
+            send.as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        stream.close();
+        assert!(send.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_does_not_acknowledge_a_flush_before_fin() {
+        let (mut stream, mut rx) = stream();
+        let mut flush = Box::pin(stream.flush());
+        assert!(
+            flush
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        drop(flush);
+        let WriteRequest::Flush(old_flush) = rx.recv().await.unwrap() else {
+            panic!("expected flush")
+        };
+        let mut shutdown = Box::pin(stream.shutdown());
+        assert!(
+            shutdown
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        let _ = old_flush.send(Ok(()));
+        assert!(
+            shutdown
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+        assert_eq!(frame(rx.recv().await.unwrap()).cmd, Command::Fin);
+        let WriteRequest::Flush(new_flush) = rx.recv().await.unwrap() else {
+            panic!("expected flush")
+        };
+        new_flush.send(Ok(())).unwrap();
+        shutdown.await.unwrap();
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]
     async fn test_stream_read() {
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let (writer, _rx) = StreamWriter::channel();
         let (reader_tx, reader_rx) = mpsc::unbounded_channel();
-
-        let reader = StreamReader::new(1, reader_rx);
-        let (mut stream, _synack_rx) = Stream::new(1, reader, tx);
-
-        // 发送数据到 reader
-        reader_tx.send(Bytes::from("world")).unwrap();
-
-        // 读取数据
-        let mut buf = vec![0u8; 10];
-        let n = stream.read(&mut buf).await.unwrap();
-
-        assert_eq!(n, 5);
-        assert_eq!(&buf[..n], b"world");
-    }
-
-    #[tokio::test]
-    async fn test_stream_read_write() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let (reader_tx, reader_rx) = mpsc::unbounded_channel();
-
-        let reader = StreamReader::new(1, reader_rx);
-        let (mut stream, _synack_rx) = Stream::new(1, reader, tx);
-
-        // 同时读写
-        reader_tx.send(Bytes::from("input")).unwrap();
-        stream.write_all(b"output").await.unwrap();
-
-        // 验证读取
-        let mut buf = vec![0u8; 10];
-        let n = stream.read(&mut buf).await.unwrap();
-        assert_eq!(n, 5);
-        assert_eq!(&buf[..n], b"input");
-
-        // 验证写入
-        let (stream_id, data) = rx.recv().await.unwrap();
-        assert_eq!(stream_id, 1);
-        assert_eq!(data.as_ref(), b"output");
+        let (mut stream, _) = Stream::new(1, StreamReader::new(1, reader_rx), writer);
+        reader_tx.send(Bytes::from_static(b"world")).unwrap();
+        let mut buf = [0; 10];
+        assert_eq!(stream.read(&mut buf).await.unwrap(), 5);
+        assert_eq!(&buf[..5], b"world");
     }
 }

--- a/crates/meow-anytls/src/session/writer.rs
+++ b/crates/meow-anytls/src/session/writer.rs
@@ -1,0 +1,89 @@
+//! Cancellation-safe admission to the session's single wire writer.
+
+use crate::protocol::Frame;
+use crate::util::{AnyTlsError, Result};
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
+
+pub const MAX_FRAME_PAYLOAD: usize = u16::MAX as usize;
+// At most 64 data/control frames (about 4 MiB of payload) per session.
+// FIN and flush markers bypass the budget so Drop never needs to spawn a task.
+const QUEUED_FRAMES: usize = 64;
+
+pub(crate) enum WriteRequest {
+    Frame {
+        frame: Frame,
+        _permit: Option<OwnedSemaphorePermit>,
+        completion: Option<oneshot::Sender<Result<()>>>,
+    },
+    Flush(oneshot::Sender<Result<()>>),
+}
+
+/// Shared handle to a session writer. Created by `Session`, cloned into streams.
+#[derive(Clone)]
+pub struct StreamWriter {
+    tx: mpsc::UnboundedSender<WriteRequest>,
+    pub(crate) budget: Arc<Semaphore>,
+}
+
+impl StreamWriter {
+    pub(crate) fn channel() -> (Self, mpsc::UnboundedReceiver<WriteRequest>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                tx,
+                budget: Arc::new(Semaphore::new(QUEUED_FRAMES)),
+            },
+            rx,
+        )
+    }
+
+    pub(crate) fn close(&self) {
+        self.budget.close();
+    }
+
+    pub(crate) fn enqueue(
+        &self,
+        frame: Frame,
+        permit: Option<OwnedSemaphorePermit>,
+        completion: Option<oneshot::Sender<Result<()>>>,
+    ) -> Result<()> {
+        if self.budget.is_closed() {
+            return Err(AnyTlsError::SessionClosed);
+        }
+        self.tx
+            .send(WriteRequest::Frame {
+                frame,
+                _permit: permit,
+                completion,
+            })
+            .map_err(|_| AnyTlsError::SessionClosed)
+    }
+
+    pub(crate) async fn write_frame(&self, frame: Frame) -> Result<()> {
+        if frame.data.len() > MAX_FRAME_PAYLOAD {
+            return Err(AnyTlsError::Protocol(
+                "frame payload exceeds u16 length".into(),
+            ));
+        }
+        let permit = Arc::clone(&self.budget)
+            .acquire_owned()
+            .await
+            .map_err(|_| AnyTlsError::SessionClosed)?;
+        let (tx, rx) = oneshot::channel();
+        self.enqueue(frame, Some(permit), Some(tx))?;
+        // Dropping this receiver cannot cancel the physical frame write.
+        rx.await.map_err(|_| AnyTlsError::SessionClosed)?
+    }
+
+    pub(crate) fn flush(&self) -> Result<oneshot::Receiver<Result<()>>> {
+        let (tx, rx) = oneshot::channel();
+        if self.budget.is_closed() {
+            return Err(AnyTlsError::SessionClosed);
+        }
+        self.tx
+            .send(WriteRequest::Flush(tx))
+            .map_err(|_| AnyTlsError::SessionClosed)?;
+        Ok(rx)
+    }
+}

--- a/crates/meow-anytls/src/util/error.rs
+++ b/crates/meow-anytls/src/util/error.rs
@@ -27,6 +27,10 @@ pub enum AnyTlsError {
     #[error("Session closed")]
     SessionClosed,
 
+    /// Stream has been closed
+    #[error("Stream closed")]
+    StreamClosed,
+
     /// Invalid or malformed frame
     #[error("Invalid frame: {0}")]
     InvalidFrame(String),

--- a/crates/meow-proxy/src/anytls_adapter.rs
+++ b/crates/meow-proxy/src/anytls_adapter.rs
@@ -13,14 +13,12 @@
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use anytls_rs::client::Client as AnytlsClient;
 use anytls_rs::client::UDP_OVER_TCP_MAGIC_ADDR;
 use anytls_rs::padding::PaddingFactory;
-use anytls_rs::protocol::{Command, Frame};
 use anytls_rs::session::{Session, Stream as AnytlsStream, StreamReader};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -116,7 +114,7 @@ impl ProxyAdapter for AnytlsAdapter {
     }
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
-        let host = metadata.rule_host().to_string();
+        let host = anytls_tcp_destination(metadata)?;
         let port = metadata.dst_port;
         let (stream, session) = self
             .client
@@ -155,41 +153,45 @@ impl ProxyAdapter for AnytlsAdapter {
     }
 }
 
+/// Select the actual TCP dial target without substituting a sniffed rule host.
+///
+/// IP-only inbounds leave `host` empty, so fall back to `dst_ip`.  A sniffed
+/// hostname is useful for rule matching but must not silently replace the
+/// address the client actually requested.
+fn anytls_tcp_destination(metadata: &Metadata) -> Result<String> {
+    if !metadata.host.is_empty() {
+        return Ok(metadata.host.to_string());
+    }
+    metadata
+        .dst_ip
+        .map(|ip| ip.to_string())
+        .ok_or_else(|| MeowError::Proxy("anytls dial: missing destination host and IP".to_string()))
+}
+
 /// Bridge `(Arc<Stream>, Arc<Session>)` into a `ProxyConn`-shaped value.
 ///
 /// The upstream `Stream` impls `AsyncRead`/`AsyncWrite` on `Pin<&mut Self>`,
 /// but `create_proxy_stream` only hands us an `Arc<Stream>` — we can never
-/// obtain `&mut Stream`. So we re-implement the trait against the public
-/// `Stream::reader()` and `Session::write_data_frame()` API surface that the
-/// crate's own SOCKS5 client uses (`src/client/socks5.rs`).
-// The pending futures are `Send` but not `Sync`; `ProxyConn` requires `Sync`,
-// so we wrap them in `parking_lot::Mutex` (which is `Sync` whenever its
-// payload is `Send`). The mutex is uncontended in practice because all
-// access happens through `Pin<&mut Self>` from the AsyncRead/AsyncWrite
-// trait, but the type-level `Sync` bound on `ProxyConn` is what forces the
-// wrapping.
+/// obtain `&mut Stream`. So we re-implement the traits against its public
+/// reader and cancellation-safe writer-channel APIs.
+// The pending read future is `Send` but not `Sync`; `ProxyConn` requires
+// `Sync`, so it is wrapped in `parking_lot::Mutex`.
 type PendingRead = Pin<Box<dyn std::future::Future<Output = io::Result<Vec<u8>>> + Send>>;
-type PendingWrite = Pin<Box<dyn std::future::Future<Output = io::Result<()>> + Send>>;
 
 struct AnytlsConn {
     stream: Arc<AnytlsStream>,
-    session: Arc<Session>,
-    stream_id: u32,
+    // Keep the owning pooled session alive even if the adapter is dropped
+    // while this connection is still in use.
+    _session: Arc<Session>,
     pending_read: Mutex<Option<PendingRead>>,
-    pending_write: Mutex<Option<PendingWrite>>,
-    fin_sent: AtomicBool,
 }
 
 impl AnytlsConn {
     fn new(stream: Arc<AnytlsStream>, session: Arc<Session>) -> Self {
-        let stream_id = stream.id();
         Self {
             stream,
-            session,
-            stream_id,
+            _session: session,
             pending_read: Mutex::new(None),
-            pending_write: Mutex::new(None),
-            fin_sent: AtomicBool::new(false),
         }
     }
 
@@ -198,26 +200,10 @@ impl AnytlsConn {
     /// proxied target connection and evicts the per-stream map entry (issue
     /// #201 item 4). The session is pooled and multiplexes other streams, so
     /// this must never close the session itself.
-    ///
-    /// The registry `anytls-rs` exposes only an async session writer (the
-    /// git fork's synchronous `Stream::close()` is not published), so the frame
-    /// is sent fire-and-forget on the current runtime. If no runtime is active
-    /// (e.g. dropped outside tokio), the FIN is skipped — the connection is
-    /// being torn down regardless.
     fn fin_stream(&self) {
-        if self.fin_sent.swap(true, Ordering::Relaxed) {
-            return;
-        }
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-        let session = Arc::clone(&self.session);
-        let stream_id = self.stream_id;
-        handle.spawn(async move {
-            let _ = session
-                .write_control_frame(Frame::control(Command::Fin, stream_id))
-                .await;
-        });
+        // `Stream::close` uses the same FIFO as `send_data`, so all accepted
+        // data is written before FIN. It is synchronous and idempotent.
+        self.stream.close();
     }
 }
 
@@ -269,50 +255,15 @@ impl AsyncWrite for AnytlsConn {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        let len = buf.len();
-        let mut guard = self.pending_write.lock();
-        if guard.is_none() {
-            let session = Arc::clone(&self.session);
-            let stream_id = self.stream_id;
-            let data = Bytes::copy_from_slice(buf);
-            let fut = async move {
-                session
-                    .write_data_frame(stream_id, data)
-                    .await
-                    .map_err(|e| io::Error::other(format!("anytls write: {e}")))
-            };
-            *guard = Some(Box::pin(fut));
-        }
-        let fut = guard.as_mut().expect("just set");
-        match fut.as_mut().poll(cx) {
-            Poll::Ready(Ok(())) => {
-                *guard = None;
-                Poll::Ready(Ok(len))
-            }
-            Poll::Ready(Err(e)) => {
-                *guard = None;
-                Poll::Ready(Err(e))
-            }
-            Poll::Pending => Poll::Pending,
-        }
+        self.stream.poll_write_data(cx, buf)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // The upstream session writer is unbuffered (each write_data_frame
-        // pushes onto a tokio mpsc that's drained on the wire side), so
-        // there's nothing to flush.
-        Poll::Ready(Ok(()))
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.stream.poll_flush_data(cx)
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // Tear down just this stream (not the whole session, which is pooled
-        // and multiplexes other streams): `Stream::close` emits a FIN frame so
-        // the server releases the proxied target connection and evicts the
-        // stream from the session maps. Without this the server-side proxied
-        // socket and the session's per-stream map entry leaked on every dial
-        // (issue #201 item 4). Idempotent.
-        self.fin_stream();
-        Poll::Ready(Ok(()))
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.stream.poll_shutdown_data(cx)
     }
 }
 
@@ -495,23 +446,19 @@ async fn read_uot_addr(reader: &mut StreamReader) -> Result<SocketAddr> {
 /// `pending_request` mutex, which doubles as the lazy-request slot.
 struct AnytlsPacketConn {
     stream: Arc<AnytlsStream>,
-    session: Arc<Session>,
-    stream_id: u32,
+    // See `AnytlsConn::_session`.
+    _session: Arc<Session>,
     /// uot request, sent coalesced with the first datagram (upstream
     /// `uot.NewLazyConn`); `None` once it has gone out.
     pending_request: tokio::sync::Mutex<Option<Vec<u8>>>,
-    fin_sent: AtomicBool,
 }
 
 impl AnytlsPacketConn {
     fn new(stream: Arc<AnytlsStream>, session: Arc<Session>, request: Vec<u8>) -> Self {
-        let stream_id = stream.id();
         Self {
             stream,
-            session,
-            stream_id,
+            _session: session,
             pending_request: tokio::sync::Mutex::new(Some(request)),
-            fin_sent: AtomicBool::new(false),
         }
     }
 
@@ -519,19 +466,7 @@ impl AnytlsPacketConn {
     /// release the server's UDP socket and the session's stream-map entry
     /// without tearing down the pooled session.
     fn fin_stream(&self) {
-        if self.fin_sent.swap(true, Ordering::Relaxed) {
-            return;
-        }
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-        let session = Arc::clone(&self.session);
-        let stream_id = self.stream_id;
-        handle.spawn(async move {
-            let _ = session
-                .write_control_frame(Frame::control(Command::Fin, stream_id))
-                .await;
-        });
+        self.stream.close();
     }
 }
 
@@ -584,8 +519,7 @@ impl ProxyPacketConn for AnytlsPacketConn {
         frame.extend_from_slice(&length.to_be_bytes());
         frame.extend_from_slice(buf);
 
-        // The anytls frame header is a `u16` too, and the codec truncates
-        // silently rather than erroring — reject instead of corrupting.
+        // The AnyTLS frame header is a u16 too; reject oversized datagrams.
         if frame.len() > MAX_UOT_FRAME {
             return Err(MeowError::Proxy(format!(
                 "anytls udp: framed packet too large ({} > {MAX_UOT_FRAME})",
@@ -593,10 +527,10 @@ impl ProxyPacketConn for AnytlsPacketConn {
             )));
         }
 
-        self.session
-            .write_data_frame(self.stream_id, Bytes::from(frame))
+        self.stream
+            .send_data(Bytes::from(frame))
             .await
-            .map_err(|e| MeowError::Proxy(format!("anytls udp write: {e}")))?;
+            .map_err(|_| MeowError::Proxy("anytls udp write: session writer closed".to_string()))?;
         *pending = None;
         Ok(buf.len())
     }
@@ -768,12 +702,47 @@ fn install_anytls_bridges() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anytls_rs::protocol::Command;
     use meow_common::Network;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 
     fn reader_over(bytes: &[u8]) -> StreamReader {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         tx.send(Bytes::copy_from_slice(bytes)).unwrap();
         StreamReader::new(0, rx)
+    }
+
+    async fn test_session() -> (Arc<Session>, DuplexStream) {
+        let (io, peer) = tokio::io::duplex(64);
+        let (reader, writer) = tokio::io::split(io);
+        // Server sessions skip padding, making the wire assertions exact.
+        let session = Arc::new(Session::new_server(
+            reader,
+            writer,
+            PaddingFactory::default(),
+        ));
+        let writer_session = Arc::clone(&session);
+        tokio::spawn(async move {
+            writer_session.process_stream_data().await.unwrap();
+        });
+        (session, peer)
+    }
+
+    async fn wire_frame(peer: &mut DuplexStream) -> (Command, u32, Vec<u8>) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            let mut header = [0; 7];
+            peer.read_exact(&mut header).await.unwrap();
+            let mut data = vec![0; u16::from_be_bytes([header[5], header[6]]) as usize];
+            peer.read_exact(&mut data).await.unwrap();
+            (
+                Command::from(header[0]),
+                u32::from_be_bytes(header[1..5].try_into().unwrap()),
+                data,
+            )
+        })
+        .await
+        .expect("writer stalled")
     }
 
     fn metadata_for(host: &str, ip: Option<IpAddr>, port: u16) -> Metadata {
@@ -784,6 +753,126 @@ mod tests {
             dst_port: port,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn tcp_destination_uses_original_host_then_ip() {
+        let mut metadata =
+            metadata_for("requested.example", Some("192.0.2.1".parse().unwrap()), 443);
+        metadata.network = Network::Tcp;
+        metadata.sniff_host = smol_str::SmolStr::from("sniffed.example");
+        assert_eq!(
+            anytls_tcp_destination(&metadata).unwrap(),
+            "requested.example",
+            "a sniffed rule host must not replace the requested dial target"
+        );
+
+        metadata.host = smol_str::SmolStr::default();
+        assert_eq!(anytls_tcp_destination(&metadata).unwrap(), "192.0.2.1");
+
+        metadata.dst_ip = Some("2001:db8::1".parse().unwrap());
+        assert_eq!(anytls_tcp_destination(&metadata).unwrap(), "2001:db8::1");
+
+        metadata.dst_ip = None;
+        assert!(anytls_tcp_destination(&metadata)
+            .unwrap_err()
+            .to_string()
+            .contains("missing destination host and IP"));
+    }
+
+    #[tokio::test]
+    async fn tcp_drop_during_partial_frame_preserves_other_streams() {
+        let (session, mut peer) = test_session().await;
+        let (first, _) = session.open_stream().await.unwrap();
+        let first_id = first.id();
+        let (second, _) = session.open_stream().await.unwrap();
+        let second_id = second.id();
+        assert_eq!(wire_frame(&mut peer).await.0, Command::Syn);
+        assert_eq!(wire_frame(&mut peer).await.0, Command::Syn);
+        let mut first = AnytlsConn::new(first, Arc::clone(&session));
+        let mut second = AnytlsConn::new(second, Arc::clone(&session));
+        first.write_all(&[42; 512]).await.unwrap();
+
+        // A 64-byte duplex cannot fit this frame. Seeing its prefix proves
+        // the writer has started, while the rest is still backpressured.
+        let mut prefix = [0; 4];
+        peer.read_exact(&mut prefix).await.unwrap();
+        drop(first);
+        second.write_all(b"still-aligned").await.unwrap();
+
+        let mut remainder = vec![0; 7 + 512 - prefix.len()];
+        peer.read_exact(&mut remainder).await.unwrap();
+        let mut full_frame = prefix.to_vec();
+        full_frame.extend_from_slice(&remainder);
+        assert_eq!(full_frame[0], u8::from(Command::Push));
+        assert_eq!(
+            u32::from_be_bytes(full_frame[1..5].try_into().unwrap()),
+            first_id
+        );
+        assert_eq!(&full_frame[7..], &[42; 512]);
+        assert_eq!(
+            wire_frame(&mut peer).await,
+            (Command::Fin, first_id, vec![])
+        );
+        assert_eq!(
+            wire_frame(&mut peer).await,
+            (Command::Push, second_id, b"still-aligned".to_vec())
+        );
+        drop(second);
+        assert_eq!(
+            wire_frame(&mut peer).await,
+            (Command::Fin, second_id, vec![])
+        );
+        session.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn udp_data_and_fin_use_the_stream_writer_fifo() {
+        let (session, mut peer) = test_session().await;
+        let (stream, _) = session.open_stream().await.unwrap();
+        let id = stream.id();
+        assert_eq!(wire_frame(&mut peer).await.0, Command::Syn);
+        let conn = AnytlsPacketConn::new(stream, Arc::clone(&session), vec![0xaa]);
+        let destination: SocketAddr = "192.0.2.2:53".parse().unwrap();
+
+        assert_eq!(conn.write_packet(b"udp", &destination).await.unwrap(), 3);
+        drop(conn);
+        let (cmd, stream_id, data) = wire_frame(&mut peer).await;
+        assert_eq!((cmd, stream_id), (Command::Push, id));
+        assert_eq!(data[0], 0xaa, "the lazy UoT request must be coalesced");
+        assert_eq!(wire_frame(&mut peer).await, (Command::Fin, id, vec![]));
+        session.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn udp_cancelled_admission_preserves_lazy_request_and_close_order() {
+        let (session, mut peer) = test_session().await;
+        let (stream, _) = session.open_stream().await.unwrap();
+        let id = stream.id();
+        assert_eq!(wire_frame(&mut peer).await.0, Command::Syn);
+        // Fill the session budget while the first frame blocks on the wire.
+        for _ in 0..64 {
+            stream.send_data(Bytes::from(vec![42; 512])).await.unwrap();
+        }
+        let conn = AnytlsPacketConn::new(stream, Arc::clone(&session), vec![0xaa]);
+        let destination: SocketAddr = "192.0.2.2:53".parse().unwrap();
+        let mut write = Box::pin(conn.write_packet(b"cancelled", &destination));
+        assert!(futures::poll!(&mut write).is_pending());
+        drop(write);
+        assert_eq!(*conn.pending_request.try_lock().unwrap(), Some(vec![0xaa]));
+
+        let mut write = Box::pin(conn.write_packet(b"closed", &destination));
+        assert!(futures::poll!(&mut write).is_pending());
+        conn.close().unwrap();
+        assert!(write.await.is_err(), "close must wake blocked admission");
+        for _ in 0..64 {
+            assert_eq!(
+                wire_frame(&mut peer).await,
+                (Command::Push, id, vec![42; 512])
+            );
+        }
+        assert_eq!(wire_frame(&mut peer).await, (Command::Fin, id, vec![]));
+        session.close().await.unwrap();
     }
 
     /// The request header uses SOCKS5 family bytes, *not* the uot ones.

--- a/crates/meow-proxy/tests/anytls_integration.rs
+++ b/crates/meow-proxy/tests/anytls_integration.rs
@@ -142,6 +142,50 @@ async fn anytls_round_trip_through_upstream_server() {
 }
 
 #[tokio::test]
+async fn anytls_ip_only_destination_round_trips() {
+    install_crypto_provider();
+
+    let (echo_addr, _echo_h) = start_echo_server().await;
+    let (cert, key) = self_signed_cert();
+    let (server_addr, _server_h) = start_anytls_server(cert, key).await;
+    let adapter = AnytlsAdapter::new(
+        "test-anytls-ip-only",
+        &server_addr.ip().to_string(),
+        server_addr.port(),
+        PASSWORD,
+        Some("localhost"),
+        true,
+        true,
+    )
+    .expect("adapter must build");
+
+    // SOCKS5 IP literals and transparent inbounds without a reverse-table hit
+    // carry no hostname. The adapter must encode dst_ip rather than an empty
+    // domain or a sniffed rule-only hostname.
+    let metadata = Metadata {
+        network: Network::Tcp,
+        host: smol_str::SmolStr::default(),
+        dst_ip: Some(echo_addr.ip()),
+        dst_port: echo_addr.port(),
+        sniff_host: smol_str::SmolStr::from("must-not-be-dialed.invalid"),
+        ..Default::default()
+    };
+
+    let mut conn = timeout(T, adapter.dial_tcp(&metadata))
+        .await
+        .expect("dial_tcp must not stall")
+        .expect("IP-only dial must succeed");
+    let payload = b"ip-only-anytls";
+    conn.write_all(payload).await.unwrap();
+    let mut echoed = vec![0; payload.len()];
+    timeout(T, conn.read_exact(&mut echoed))
+        .await
+        .expect("echo must not stall")
+        .expect("echo must succeed");
+    assert_eq!(echoed, payload);
+}
+
+#[tokio::test]
 async fn anytls_concurrent_dials_each_get_independent_streams() {
     install_crypto_provider();
     let (echo_addr, _echo_h) = start_echo_server().await;


### PR DESCRIPTION
## Summary

Addresses #495, **AnyTLS items 9, 10, and 13 only**. The issue also covers other protocols and should remain open.

- Preserve the requested hostname, falling back to the destination IPv4/IPv6 address for IP-only inbounds; never substitute the sniffed rule hostname.
- Route SYN, destination/control frames, TCP/UDP data, FIN and flush through one session-owned writer. Cancelling a producer cannot truncate a shared wire frame.
- Preserve backpressure with a 64-frame session budget, serialize stream admission against FIN, and acknowledge flush/shutdown after wire completion. Split large TCP writes and reject oversized protocol frames.
- Retire streams on failed/cancelled opens, and stop the writer on I/O errors or peer alerts without re-locking the writer during teardown.
- Move per-frame info events to trace and make decoder previews lazy. No measured throughput improvement is claimed.

## Regression coverage

- Cancel a SYN after its first byte is written, then verify cleanup and a successful subsequent open.
- Drop a TCP connection mid-frame under deterministic duplex backpressure; verify the remaining bytes, ordered FIN, and an intact second stream.
- Fill the writer budget, cancel a UDP send, and race another blocked send with close; verify lazy-request retention and data-before-FIN ordering.
- Verify bounded admission, real flush acknowledgement, shutdown after a cancelled flush, empty writes, frame size limits, session teardown and no info events in the frame hot path.
- Add AnyTLS library and embedded-server integration/leak suites to CI.

## Validation

- `cargo test -p meow-anytls --lib`: 63 passed.
- `cargo test -p meow-proxy --features anytls --lib --test anytls_integration --test anytls_leak`: 385 unit tests passed (3 existing ignored), 9 integration tests passed, 1 leak test passed.
- Clippy with `-D warnings`: AnyTLS crate; proxy crate with defaults + AnyTLS; proxy crate with no defaults + AnyTLS.
- `cargo fmt --all -- --check` and `git diff --check`.
- Only local synthetic/embedded-server tests; no private nodes or subscriptions used.
