### PR TITLE
fix(anytls): apply server-pushed padding schemes

### DIFF
--- a/crates/meow-anytls/src/client/client.rs
+++ b/crates/meow-anytls/src/client/client.rs
@@ -1,7 +1,7 @@
 //! AnyTLS Client implementation
 
 use crate::client::{SessionPool, SessionPoolConfig};
-use crate::padding::PaddingFactory;
+use crate::padding::{PaddingFactory, SharedPaddingFactory};
 use crate::session::{Session, SessionHeartbeatConfig};
 use crate::util::{AnyTlsError, Result, configure_tcp_stream, hash_password, send_authentication};
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -15,7 +15,10 @@ pub struct Client {
     server_addr: String,
     server_name: ServerName<'static>,
     tls_config: Arc<tokio_rustls::TlsConnector>,
-    padding: Arc<PaddingFactory>,
+    /// Padding factory in force for this server, shared with every session the
+    /// client opens so an `UpdatePaddingScheme` push outlives the session that
+    /// received it.
+    padding: SharedPaddingFactory,
     session_pool: Arc<SessionPool>,
     pool_config: SessionPoolConfig,
 }
@@ -58,7 +61,7 @@ impl Client {
             server_addr,
             server_name,
             tls_config,
-            padding,
+            padding: padding.into_shared(),
             session_pool,
             pool_config,
         }
@@ -295,7 +298,11 @@ impl Client {
         // Split TLS stream into reader and writer
         let (reader, mut writer) = tokio::io::split(tls_stream);
         tracing::trace!("[Client] Sending authentication");
-        send_authentication(&mut writer, &self.password_hash, &self.padding).await?;
+        let padding = {
+            let guard = self.padding.read().await;
+            Arc::clone(&guard)
+        };
+        send_authentication(&mut writer, &self.password_hash, &padding).await?;
         tracing::debug!("[Client] Authentication sent successfully");
 
         // Create session with reader and writer
@@ -306,7 +313,7 @@ impl Client {
         let session = Arc::new(Session::new_client(
             reader,
             writer,
-            self.padding.clone(),
+            Arc::clone(&self.padding),
             Some(heartbeat_config),
         ));
 

--- a/crates/meow-anytls/src/padding/factory.rs
+++ b/crates/meow-anytls/src/padding/factory.rs
@@ -1,6 +1,7 @@
 use crate::padding::CHECK_MARK;
 use crate::util::StringMap;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Default padding scheme
 pub const DEFAULT_PADDING_SCHEME: &str = r#"stop=8
@@ -22,8 +23,20 @@ pub struct PaddingFactory {
     md5: String,
 }
 
-/// Global padding factory
+/// The built-in default scheme, parsed once. Immutable: a scheme pushed by one
+/// server must not leak into sessions of another, so runtime updates go to the
+/// per-client `SharedPaddingFactory` cell instead.
 static DEFAULT_FACTORY: std::sync::OnceLock<Arc<PaddingFactory>> = std::sync::OnceLock::new();
+
+/// A padding factory that the peer can replace while a session is running.
+///
+/// An AnyTLS server answers any session whose advertised `padding-md5` differs
+/// from its own scheme with an `UpdatePaddingScheme` frame. One cell is shared
+/// by a client and every session it opens, so a pushed scheme applies to the
+/// live session and to sessions opened later — the same ownership anytls-go
+/// gets from handing its sessions the client's
+/// `atomic.TypedValue[*padding.PaddingFactory]`.
+pub type SharedPaddingFactory = Arc<RwLock<Arc<PaddingFactory>>>;
 
 impl PaddingFactory {
     /// Create a new PaddingFactory from raw scheme bytes
@@ -63,12 +76,9 @@ impl PaddingFactory {
             .clone()
     }
 
-    /// Update the default padding factory
-    pub fn update_default(raw_scheme: &[u8]) -> Result<(), String> {
-        let factory = Arc::new(Self::new(raw_scheme)?);
-        DEFAULT_FACTORY
-            .set(factory)
-            .map_err(|_| "failed to update default factory".to_string())
+    /// Wrap this factory in a cell that a client and its sessions share.
+    pub fn into_shared(self: Arc<Self>) -> SharedPaddingFactory {
+        Arc::new(RwLock::new(self))
     }
 
     /// Get the stop value

--- a/crates/meow-anytls/src/padding/factory.rs
+++ b/crates/meow-anytls/src/padding/factory.rs
@@ -1,5 +1,6 @@
 use crate::padding::CHECK_MARK;
 use crate::util::StringMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -17,10 +18,20 @@ pub const DEFAULT_PADDING_SCHEME: &str = r#"stop=8
 /// PaddingFactory generates padding sizes according to the scheme
 #[derive(Debug, Clone)]
 pub struct PaddingFactory {
-    scheme: StringMap,
+    sizes: HashMap<String, Vec<PaddingSize>>,
     raw_scheme: Vec<u8>,
     stop: u32,
     md5: String,
+}
+
+// Authentication and Waste frames encode lengths as u16. Bound the aggregate
+// too: a short peer-supplied scheme must not expand one write without limit.
+const MAX_PACKET_PADDING: usize = 1024 * 1024;
+
+#[derive(Debug, Clone)]
+enum PaddingSize {
+    Check,
+    Range(u16, u16),
 }
 
 /// The built-in default scheme, parsed once. Immutable: a scheme pushed by one
@@ -49,11 +60,46 @@ impl PaddingFactory {
             .parse::<u32>()
             .map_err(|_| "invalid 'stop' value".to_string())?;
 
+        let mut sizes = HashMap::new();
+        for (key, spec) in scheme.iter() {
+            if key.parse::<u32>().is_err() {
+                continue;
+            }
+            let mut packet_sizes = Vec::new();
+            let mut total = 0usize;
+            for part in spec.split(',').map(str::trim) {
+                if part == "c" {
+                    packet_sizes.push(PaddingSize::Check);
+                    continue;
+                }
+                let (min, max) = part
+                    .split_once('-')
+                    .ok_or_else(|| "invalid padding range".to_string())?;
+                let parse_size = |value: &str| {
+                    value
+                        .trim()
+                        .parse::<u16>()
+                        .ok()
+                        .filter(|n| *n > 0)
+                        .ok_or_else(|| "padding size must be between 1 and 65535".to_string())
+                };
+                let (min, max) = (parse_size(min)?, parse_size(max)?);
+                let (min, max) = (min.min(max), min.max(max));
+                // Each size can produce a Waste frame as well as its payload.
+                total += usize::from(max) + crate::protocol::HEADER_OVERHEAD_SIZE;
+                if total > MAX_PACKET_PADDING {
+                    return Err("padding for one packet exceeds 1 MiB".to_string());
+                }
+                packet_sizes.push(PaddingSize::Range(min, max));
+            }
+            sizes.insert(key.clone(), packet_sizes);
+        }
+
         let md5_hash = md5::compute(raw_scheme);
         let md5 = format!("{:x}", md5_hash);
 
         Ok(Self {
-            scheme,
+            sizes,
             raw_scheme: raw_scheme.to_vec(),
             stop,
             md5,
@@ -100,40 +146,16 @@ impl PaddingFactory {
     /// Returns a vector of sizes, where CHECK_MARK (-1) indicates a check point
     pub fn generate_record_payload_sizes(&self, pkt: u32) -> Vec<i32> {
         let key = pkt.to_string();
-        let Some(spec) = self.scheme.get(&key) else {
+        let Some(spec) = self.sizes.get(&key) else {
             return Vec::new();
         };
-
-        let mut sizes = Vec::new();
-        let parts: Vec<&str> = spec.split(',').collect();
-
-        for part in parts {
-            let part = part.trim();
-            if part == "c" {
-                sizes.push(CHECK_MARK);
-                continue;
-            }
-
-            if let Some((min_str, max_str)) = part.split_once('-') {
-                let min_val = min_str.trim().parse::<i64>().unwrap_or(0);
-                let max_val = max_str.trim().parse::<i64>().unwrap_or(0);
-
-                if min_val <= 0 || max_val <= 0 {
-                    continue;
-                }
-
-                let (min_val, max_val) = (min_val.min(max_val), min_val.max(max_val));
-
-                if min_val == max_val {
-                    sizes.push(min_val as i32);
-                } else {
-                    let size = rand::random_range(min_val..=max_val);
-                    sizes.push(size as i32);
-                }
-            }
-        }
-
-        sizes
+        spec.iter()
+            .map(|size| match *size {
+                PaddingSize::Check => CHECK_MARK,
+                PaddingSize::Range(min, max) if min == max => i32::from(min),
+                PaddingSize::Range(min, max) => i32::from(rand::random_range(min..=max)),
+            })
+            .collect()
     }
 }
 
@@ -173,6 +195,40 @@ mod tests {
         assert!(sizes[0] >= 400 && sizes[0] <= 500);
         assert_eq!(sizes[1], CHECK_MARK);
         assert!(sizes[2] >= 500 && sizes[2] <= 1000);
+    }
+
+    #[test]
+    fn rejects_unrepresentable_or_malformed_sizes() {
+        for range in [
+            "2147483648-2147483648",
+            "65536-65536",
+            "1-65536",
+            "-1-30",
+            "0-30",
+            "30",
+            "x-30",
+        ] {
+            for packet in [0, 1] {
+                let scheme = format!("stop=2\n{packet}={range}");
+                assert!(PaddingFactory::new(scheme.as_bytes()).is_err(), "{scheme}");
+            }
+        }
+    }
+
+    #[test]
+    fn accepts_wire_boundary_reversed_ranges_and_checkpoints() {
+        let factory = PaddingFactory::new(b"stop=2\n0=65535-65535\n1=2-1,c,9-9").unwrap();
+        assert_eq!(factory.generate_record_payload_sizes(0), vec![65535]);
+        let sizes = factory.generate_record_payload_sizes(1);
+        assert!((1..=2).contains(&sizes[0]));
+        assert_eq!(&sizes[1..], &[CHECK_MARK, 9]);
+    }
+
+    #[test]
+    fn bounds_total_padding_per_packet() {
+        let sizes = ["65535-65535"; 17].join(",");
+        let scheme = format!("stop=2\n1={sizes}");
+        assert!(PaddingFactory::new(scheme.as_bytes()).is_err());
     }
 
     #[test]

--- a/crates/meow-anytls/src/session/session.rs
+++ b/crates/meow-anytls/src/session/session.rs
@@ -1825,3 +1825,69 @@ mod tests {
         assert_eq!(session.padding.read().await.md5(), before);
     }
 }
+#[cfg(test)]
+mod padding_bounds_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn maximum_padding_keeps_the_next_frame_aligned() {
+        use tokio::io::AsyncReadExt;
+        let (writer, mut reader) = tokio::io::duplex(2 * u16::MAX as usize);
+        let padding =
+            Arc::new(PaddingFactory::new(b"stop=2\n1=65535-65535").unwrap()).into_shared();
+        let session = Session::new_client(tokio::io::empty(), writer, padding, None);
+        session
+            .pkt_counter
+            .store(1, std::sync::atomic::Ordering::SeqCst);
+        session.write_with_padding(BytesMut::new()).await.unwrap();
+        // The next unpadded frame must start after the declared Waste payload,
+        // even at the largest representable length.
+        let next = [Command::Waste as u8, 0, 0, 0, 0, 0, 0];
+        session
+            .write_with_padding(BytesMut::from(next.as_slice()))
+            .await
+            .unwrap();
+        let mut header = [0u8; 7];
+        reader.read_exact(&mut header).await.unwrap();
+        assert_eq!(header, [Command::Waste as u8, 0, 0, 0, 0, 255, 255]);
+        let mut payload = vec![1u8; u16::MAX as usize];
+        reader.read_exact(&mut payload).await.unwrap();
+        assert!(payload.iter().all(|b| *b == 0));
+        reader.read_exact(&mut header).await.unwrap();
+        assert_eq!(header, next);
+    }
+
+    #[tokio::test]
+    async fn oversized_pushed_scheme_is_rejected_before_the_next_write() {
+        let padding = PaddingFactory::default().into_shared();
+        let session = Arc::new(Session::new_client(
+            tokio::io::empty(),
+            tokio::io::sink(),
+            Arc::clone(&padding),
+            None,
+        ));
+        // A short, otherwise well-formed UpdatePaddingScheme received before
+        // packet 1. No large allocation is performed by this probe.
+        session
+            .pkt_counter
+            .store(1, std::sync::atomic::Ordering::SeqCst);
+        session
+            .handle_frame(Frame::with_data(
+                Command::UpdatePaddingScheme,
+                0,
+                Bytes::from_static(b"stop=2\n1=2147483648-2147483648"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(padding.read().await.md5(), PaddingFactory::default().md5());
+        let result = tokio::spawn(async move {
+            session
+                .write_with_padding(BytesMut::from(&b"payload"[..]))
+                .await
+        })
+        .await;
+        result
+            .expect("server-pushed padding must not panic")
+            .unwrap();
+    }
+}

--- a/crates/meow-anytls/src/session/session.rs
+++ b/crates/meow-anytls/src/session/session.rs
@@ -1,6 +1,6 @@
 //! Session implementation for AnyTLS protocol
 
-use crate::padding::PaddingFactory;
+use crate::padding::{PaddingFactory, SharedPaddingFactory};
 use crate::protocol::{Command, Frame, FrameCodec};
 use crate::session::Stream;
 use crate::session::writer::{StreamWriter, WriteRequest};
@@ -56,8 +56,9 @@ pub struct Session {
     // Session state
     is_closed: Arc<std::sync::atomic::AtomicBool>,
 
-    // Padding factory (wrapped in Arc for potential updates)
-    padding: Arc<RwLock<Arc<PaddingFactory>>>,
+    // Padding factory in force for this session. Client sessions share the
+    // client's cell, so a server-pushed scheme reaches sessions opened later.
+    padding: SharedPaddingFactory,
 
     // Client/Server specific
     is_client: bool,
@@ -109,7 +110,7 @@ impl Session {
     pub fn new_client<R, W>(
         reader: R,
         writer: W,
-        padding: Arc<PaddingFactory>,
+        padding: SharedPaddingFactory,
         heartbeat: Option<SessionHeartbeatConfig>,
     ) -> Self
     where
@@ -142,7 +143,7 @@ impl Session {
             stream_data_rx: Arc::new(tokio::sync::Mutex::new(Some(stream_data_rx))),
             stream_receive_tx: Arc::new(RwLock::new(HashMap::new())),
             is_closed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            padding: Arc::new(RwLock::new(padding)),
+            padding,
             is_client: true,
             send_padding: true,
             pkt_counter: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -182,7 +183,7 @@ impl Session {
             stream_data_rx: Arc::new(tokio::sync::Mutex::new(Some(stream_data_rx))),
             stream_receive_tx: Arc::new(RwLock::new(HashMap::new())),
             is_closed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            padding: Arc::new(RwLock::new(padding)),
+            padding: padding.into_shared(),
             is_client: false,
             send_padding: false,
             pkt_counter: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -700,22 +701,26 @@ impl Session {
                 }
             }
             Command::UpdatePaddingScheme => {
-                // Server updates padding scheme (client side)
+                // Server updates padding scheme (client side). The new factory
+                // goes into the shared cell, so this session switches scheme
+                // mid-flight and later sessions of the same client advertise
+                // the new md5 instead of provoking another update frame.
                 if self.is_client && !frame.data.is_empty() {
-                    let raw_scheme = frame.data.as_ref();
-                    match PaddingFactory::update_default(raw_scheme) {
-                        Ok(_) => {
-                            let md5_hash = md5::compute(raw_scheme);
-                            tracing::info!("[Session] Padding scheme updated: {:x}", md5_hash);
-                            // Update the session's padding factory
-                            let mut padding_guard = self.padding.write().await;
-                            *padding_guard = PaddingFactory::default();
+                    match PaddingFactory::new(&frame.data) {
+                        Ok(factory) => {
+                            let factory = Arc::new(factory);
+                            tracing::debug!(
+                                session_id = self.id,
+                                "[Session] Padding scheme updated: {}",
+                                factory.md5()
+                            );
+                            *self.padding.write().await = factory;
                         }
                         Err(e) => {
-                            let md5_hash = md5::compute(raw_scheme);
                             tracing::warn!(
+                                session_id = self.id,
                                 "[Session] Failed to update padding scheme {:x}: {}",
-                                md5_hash,
+                                md5::compute(&frame.data),
                                 e
                             );
                         }
@@ -1550,7 +1555,7 @@ mod tests {
         let client_session = Arc::new(Session::new_client(
             client_read,
             client_write,
-            padding.clone(),
+            Arc::clone(&padding).into_shared(),
             None,
         ));
 
@@ -1617,7 +1622,7 @@ mod tests {
         let client_session = Arc::new(Session::new_client(
             client_read,
             client_write,
-            padding.clone(),
+            Arc::clone(&padding).into_shared(),
             None,
         ));
 
@@ -1681,7 +1686,12 @@ mod tests {
 
         let padding = create_test_padding();
 
-        let session1 = Arc::new(Session::new_client(read1, write1, padding.clone(), None));
+        let session1 = Arc::new(Session::new_client(
+            read1,
+            write1,
+            Arc::clone(&padding).into_shared(),
+            None,
+        ));
 
         let session2 = Arc::new(Session::new_server(read2, write2, padding));
 
@@ -1724,5 +1734,94 @@ mod tests {
         assert!(!session2.is_closed());
 
         tracing::debug!("Bidirectional heartbeat test passed");
+    }
+
+    /// A pushed scheme must reach the live session *and* the client's shared
+    /// cell — the global `OnceLock` this used to write could only ever be set
+    /// once, so every push after the first session was silently dropped.
+    #[tokio::test]
+    async fn server_pushed_padding_scheme_replaces_the_shared_factory() {
+        const SCHEME: &str = "stop=2\n0=50-50\n1=100-200";
+
+        let padding = create_test_padding().into_shared();
+        let before = padding.read().await.md5().to_string();
+        let session = Arc::new(Session::new_client(
+            tokio::io::empty(),
+            tokio::io::sink(),
+            Arc::clone(&padding),
+            None,
+        ));
+
+        session
+            .handle_frame(Frame::with_data(
+                Command::UpdatePaddingScheme,
+                0,
+                Bytes::from_static(SCHEME.as_bytes()),
+            ))
+            .await
+            .unwrap();
+
+        let pushed = PaddingFactory::new(SCHEME.as_bytes()).unwrap();
+        assert_ne!(before, pushed.md5());
+        // The live session pads with the pushed scheme…
+        assert_eq!(session.padding.read().await.md5(), pushed.md5());
+        assert_eq!(
+            session
+                .padding
+                .read()
+                .await
+                .generate_record_payload_sizes(0),
+            vec![50]
+        );
+        // …and so does the cell, so the next session advertises the new md5
+        // instead of provoking another update frame.
+        assert_eq!(padding.read().await.md5(), pushed.md5());
+    }
+
+    /// An unparsable scheme leaves the previous one in force.
+    #[tokio::test]
+    async fn invalid_pushed_padding_scheme_keeps_the_previous_factory() {
+        let padding = create_test_padding().into_shared();
+        let before = padding.read().await.md5().to_string();
+        let session = Arc::new(Session::new_client(
+            tokio::io::empty(),
+            tokio::io::sink(),
+            Arc::clone(&padding),
+            None,
+        ));
+
+        session
+            .handle_frame(Frame::with_data(
+                Command::UpdatePaddingScheme,
+                0,
+                Bytes::from_static(b"0=30-30"),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(padding.read().await.md5(), before);
+        assert_eq!(session.padding.read().await.md5(), before);
+    }
+
+    /// Server sessions never apply a pushed scheme.
+    #[tokio::test]
+    async fn server_session_ignores_padding_scheme_updates() {
+        let session = Arc::new(Session::new_server(
+            tokio::io::empty(),
+            tokio::io::sink(),
+            create_test_padding(),
+        ));
+        let before = session.padding.read().await.md5().to_string();
+
+        session
+            .handle_frame(Frame::with_data(
+                Command::UpdatePaddingScheme,
+                0,
+                Bytes::from_static(b"stop=2\n0=50-50"),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(session.padding.read().await.md5(), before);
     }
 }


### PR DESCRIPTION
Server-pushed AnyTLS padding schemes previously failed to install because the process-wide `OnceLock` was already initialized. Each client now owns a shared factory cell: valid pushes update its live sessions and future sessions, while other clients retain their own schemes.

Before installation, parse packet ranges into bounded numeric values. Authentication and Waste-frame lengths must fit `u16`; the worst-case padding for one packet is capped at 1 MiB. Malformed or oversized schemes keep the previous factory. This prevents a pushed `1=2147483648-2147483648` range from overflowing the signed size conversion and aborting the release process on its next write. Checkpoints and reversed ranges remain supported, and ranges are parsed once rather than on every write.

Validation covers live-session updates, rejected updates, server-session isolation, length boundaries, aggregate limits, and the next write after an overflow attempt. AnyTLS unit tests and embedded-server integration/leak tests pass. Formatting, workspace regression tests, and rustdoc checks pass. Local workspace Clippy is blocked by the existing generated `meow-lwip` `unnecessary_transmute` errors; the remaining workspace is checked separately, and the full lint matrix runs in CI.
