### PR TITLE
fix(tunnel): bound every outbound dial with a global timeout

### DIFF
--- a/crates/meow-common/src/dial.rs
+++ b/crates/meow-common/src/dial.rs
@@ -1,0 +1,111 @@
+//! Global ceiling on a single outbound dial.
+//!
+//! Every inbound path (tunnel TCP/UDP, HTTP CONNECT, TProxy, SOCKS5-UDP, TUN,
+//! the shadowsocks listener) hands its connection to a proxy adapter and awaits
+//! [`ProxyAdapter::dial_tcp`]/[`dial_udp`]. Those futures are unbounded: a
+//! server that completes the TCP handshake and then stalls mid-protocol —
+//! blackholed VLESS/Trojan, a QUIC path that never validates, a relay chain
+//! stuck on hop 2 — parks the caller forever, pinning the inbound socket, its
+//! NAT/session slot, and (for group members) the health state that would
+//! otherwise mark the node dead.
+//!
+//! mihomo bounds the same calls with `C.DefaultTCPTimeout` /
+//! `C.DefaultUDPTimeout` (5 s each) around `proxy.DialContext` and
+//! `proxy.ListenPacketContext` in `tunnel.handleTCPConn`. [`DIAL_TIMEOUT`] is
+//! the meow-rs equivalent.
+//!
+//! [`ProxyAdapter::dial_tcp`]: crate::adapter::ProxyAdapter::dial_tcp
+//! [`dial_udp`]: crate::adapter::ProxyAdapter::dial_udp
+
+use std::future::Future;
+use std::io;
+use std::time::Duration;
+
+use crate::error::{MeowError, Result};
+
+/// Ceiling on one outbound dial: the adapter's own name resolution, TCP
+/// connect, and whatever handshake its protocol performs before it yields a
+/// stream or packet conn. Matches mihomo's `C.DefaultTCPTimeout`.
+///
+/// This bounds a *dial*, not a connection — an established relay runs for as
+/// long as both peers keep it open.
+pub const DIAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Run a `dial_tcp`/`dial_udp` future under [`DIAL_TIMEOUT`].
+///
+/// `via` names the proxy for the error message; it is only formatted on the
+/// timeout path.
+///
+/// Expiry surfaces as [`io::ErrorKind::TimedOut`] rather than a new
+/// [`MeowError`] variant, so every existing dial-failure classifier — group
+/// health, failure escalation, the listener error arms — treats a stalled
+/// server exactly like a refused connection without having to learn about it.
+pub async fn with_dial_timeout<F, T>(via: &str, fut: F) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    match tokio::time::timeout(DIAL_TIMEOUT, fut).await {
+        Ok(result) => result,
+        Err(_) => Err(MeowError::Io(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("dial via {via} timed out after {}s", DIAL_TIMEOUT.as_secs()),
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::pending;
+
+    #[tokio::test]
+    async fn a_completed_dial_passes_through_untouched() {
+        let ok = with_dial_timeout("mock", async { Ok(7u8) }).await.unwrap();
+        assert_eq!(ok, 7);
+    }
+
+    #[tokio::test]
+    async fn a_failed_dial_keeps_its_own_error() {
+        let err = with_dial_timeout::<_, ()>("mock", async {
+            Err(MeowError::Proxy("connection refused".into()))
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(err, MeowError::Proxy(_)), "got {err:?}");
+    }
+
+    /// A server that accepts and then never speaks must not park the caller.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_dial_expires_as_timed_out() {
+        let start = tokio::time::Instant::now();
+        let err = with_dial_timeout::<_, ()>("🇭🇰 HK-01", pending())
+            .await
+            .unwrap_err();
+
+        let MeowError::Io(io_err) = err else {
+            panic!("expected an io error, got {err:?}");
+        };
+        assert_eq!(io_err.kind(), io::ErrorKind::TimedOut);
+        assert!(io_err.to_string().contains("🇭🇰 HK-01"));
+        assert_eq!(start.elapsed(), DIAL_TIMEOUT);
+    }
+
+    /// The bound is a ceiling, not a delay: a dial that finishes just under it
+    /// is not slowed down, and one that finishes just over it is cut.
+    #[tokio::test(start_paused = true)]
+    async fn the_bound_is_exclusive_to_slow_dials() {
+        let just_in_time = with_dial_timeout("mock", async {
+            tokio::time::sleep(DIAL_TIMEOUT - Duration::from_millis(1)).await;
+            Ok(())
+        })
+        .await;
+        assert!(just_in_time.is_ok());
+
+        let too_slow = with_dial_timeout("mock", async {
+            tokio::time::sleep(DIAL_TIMEOUT + Duration::from_millis(1)).await;
+            Ok(())
+        })
+        .await;
+        assert!(too_slow.is_err());
+    }
+}

--- a/crates/meow-common/src/dial.rs
+++ b/crates/meow-common/src/dial.rs
@@ -20,6 +20,7 @@
 use std::future::Future;
 use std::io;
 use std::time::Duration;
+use tokio::time::Instant;
 
 use crate::error::{MeowError, Result};
 
@@ -31,26 +32,47 @@ use crate::error::{MeowError, Result};
 /// long as both peers keep it open.
 pub const DIAL_TIMEOUT: Duration = Duration::from_secs(5);
 
+tokio::task_local! {
+    static DIAL_DEADLINE: Instant;
+}
+
+/// Deadline of the outbound dial currently being polled on this task.
+///
+/// Proxy groups capture it before awaiting a member so their cancellation
+/// guards can distinguish deadline expiry from an early caller cancellation.
+/// The scope follows the dial future; newly spawned tasks do not inherit it.
+pub fn dial_deadline() -> Option<Instant> {
+    DIAL_DEADLINE.try_with(|deadline| *deadline).ok()
+}
+
 /// Run a `dial_tcp`/`dial_udp` future under [`DIAL_TIMEOUT`].
 ///
 /// `via` names the proxy for the error message; it is only formatted on the
 /// timeout path.
 ///
-/// Expiry surfaces as [`io::ErrorKind::TimedOut`] rather than a new
-/// [`MeowError`] variant, so every existing dial-failure classifier — group
-/// health, failure escalation, the listener error arms — treats a stalled
-/// server exactly like a refused connection without having to learn about it.
+/// Nested calls reuse the original deadline, including time spent on earlier
+/// relay hops. Expiry surfaces as [`io::ErrorKind::TimedOut`]. Since timeout
+/// drops the pending future, group failure tracking must also handle expiry
+/// in a cancellation guard; an ordinary `Err` arm alone cannot observe it.
 pub async fn with_dial_timeout<F, T>(via: &str, fut: F) -> Result<T>
 where
     F: Future<Output = Result<T>>,
 {
-    match tokio::time::timeout(DIAL_TIMEOUT, fut).await {
-        Ok(result) => result,
-        Err(_) => Err(MeowError::Io(io::Error::new(
-            io::ErrorKind::TimedOut,
-            format!("dial via {via} timed out after {}s", DIAL_TIMEOUT.as_secs()),
-        ))),
-    }
+    let deadline = dial_deadline().unwrap_or_else(|| Instant::now() + DIAL_TIMEOUT);
+    DIAL_DEADLINE
+        .scope(deadline, async {
+            match tokio::time::timeout_at(deadline, fut).await {
+                Ok(result) => result,
+                Err(_) => Err(MeowError::Io(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!(
+                        "dial via {via} exceeded the {}s deadline",
+                        DIAL_TIMEOUT.as_secs()
+                    ),
+                ))),
+            }
+        })
+        .await
 }
 
 #[cfg(test)]
@@ -107,5 +129,24 @@ mod tests {
         })
         .await;
         assert!(too_slow.is_err());
+    }
+    #[tokio::test(start_paused = true)]
+    async fn nested_dials_share_the_original_budget() {
+        let start = Instant::now();
+        with_dial_timeout::<_, ()>("outer", async {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            with_dial_timeout("inner", async {
+                assert_eq!(dial_deadline(), Some(start + DIAL_TIMEOUT));
+                pending().await
+            })
+            .await
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(start.elapsed(), DIAL_TIMEOUT);
+        assert!(
+            dial_deadline().is_none(),
+            "deadline must not leak out of its scope"
+        );
     }
 }

--- a/crates/meow-common/src/lib.rs
+++ b/crates/meow-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod adapter_type;
 pub mod atomic;
 pub mod auth;
 pub mod conn;
+pub mod dial;
 pub mod dns_mode;
 pub mod error;
 pub mod home_dir;
@@ -27,6 +28,7 @@ pub use adapter::{
 pub use adapter_type::{AdapterType, ConnType};
 pub use auth::{AuthConfig, Credentials};
 pub use conn::{ProxyConn, ProxyPacketConn, UdpPacket};
+pub use dial::{with_dial_timeout, DIAL_TIMEOUT};
 pub use dns_mode::DnsMode;
 pub use error::{MeowError, Result};
 pub use home_dir::{meow_home_dir, set_home_dir};

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -1,6 +1,6 @@
 use crate::sniffer::SnifferRuntime;
 use base64::Engine;
-use meow_common::{AuthConfig, ConnType, Metadata, Network};
+use meow_common::{with_dial_timeout, AuthConfig, ConnType, Metadata, Network};
 use meow_tunnel::{
     copy_bidirectional_buf_tracked, route_inbound_tcp, ConnectionGuard, Tunnel, RELAY_BUF_SIZE,
 };
@@ -263,7 +263,7 @@ async fn handle_http_inner(
             smallvec![Arc::from(proxy.name())],
         );
 
-        match proxy.dial_tcp(&metadata).await {
+        match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
             Ok(mut remote) => {
                 // Rewrite the request line: remove the absolute URI scheme+host,
                 // keep the path. Rebuild headers without Proxy-* headers while

--- a/crates/meow-listener/src/shadowsocks.rs
+++ b/crates/meow-listener/src/shadowsocks.rs
@@ -342,7 +342,7 @@ fn build_metadata(peer: SocketAddr, target: &Address, in_name: &str, in_port: u1
 // dropped, aborting its reply task and freeing the outbound conn.
 
 use meow_common::atomic::{AtomicU, Uint};
-use meow_common::{ProxyAdapter, ProxyPacketConn};
+use meow_common::{with_dial_timeout, ProxyAdapter, ProxyPacketConn};
 use meow_tunnel::udp::DEFAULT_UDP_IDLE;
 use shadowsocks::relay::udprelay::{DatagramReceive, DatagramSend};
 use std::collections::HashMap;
@@ -537,8 +537,7 @@ where
     };
 
     let conn: Arc<dyn ProxyPacketConn> = Arc::from(
-        proxy
-            .dial_udp(&metadata)
+        with_dial_timeout(proxy.name(), proxy.dial_udp(&metadata))
             .await
             .map_err(|e| format!("dial_udp via {}: {e}", proxy.name()))?,
     );

--- a/crates/meow-listener/src/socks5_udp.rs
+++ b/crates/meow-listener/src/socks5_udp.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use meow_common::{ConnType, Metadata, Network, ProxyAdapter, ProxyPacketConn};
+use meow_common::{with_dial_timeout, ConnType, Metadata, Network, ProxyAdapter, ProxyPacketConn};
 use meow_tunnel::Tunnel;
 use smallvec::SmallVec;
 use tokio::io::AsyncReadExt;
@@ -226,8 +226,7 @@ async fn handle_client_datagram(
     };
 
     let conn: Arc<dyn ProxyPacketConn> = Arc::from(
-        proxy
-            .dial_udp(&metadata)
+        with_dial_timeout(proxy.name(), proxy.dial_udp(&metadata))
             .await
             .map_err(|e| format!("dial_udp via {}: {e}", proxy.name()))?,
     );

--- a/crates/meow-listener/src/tproxy/mod.rs
+++ b/crates/meow-listener/src/tproxy/mod.rs
@@ -3,7 +3,7 @@ mod orig_dest;
 
 use crate::sniffer::SnifferRuntime;
 use firewall::FirewallGuard;
-use meow_common::{ConnType, Metadata, Network};
+use meow_common::{with_dial_timeout, ConnType, Metadata, Network};
 use meow_tunnel::{copy_bidirectional_buf_tracked, ConnectionGuard, Tunnel, RELAY_BUF_SIZE};
 use smallvec::smallvec;
 use std::collections::HashSet;
@@ -348,7 +348,7 @@ async fn handle_tproxy_conn(
     let mut relay_buf_up = [0u8; RELAY_BUF_SIZE];
     let mut relay_buf_dn = [0u8; RELAY_BUF_SIZE];
 
-    match proxy.dial_tcp(&metadata).await {
+    match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
         Ok(mut remote) => {
             let up = Arc::clone(_guard.counters());
             let dn = Arc::clone(_guard.counters());

--- a/crates/meow-listener/src/tun/udp.rs
+++ b/crates/meow-listener/src/tun/udp.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use ipnet::Ipv4Net;
 use lwip::UdpSocket;
-use meow_common::{ConnType, Metadata, Network, ProxyAdapter};
+use meow_common::{with_dial_timeout, ConnType, Metadata, Network, ProxyAdapter};
 use meow_dns::server::{hex_prefix, DnsServer};
 use meow_tunnel::Tunnel;
 use tokio::sync::mpsc;
@@ -221,8 +221,7 @@ async fn relay_flow(
         }
     };
 
-    let conn = proxy
-        .dial_udp(&metadata)
+    let conn = with_dial_timeout(proxy.name(), proxy.dial_udp(&metadata))
         .await
         .map_err(|e| format!("dial_udp via {}: {e}", proxy.name()))?;
 

--- a/crates/meow-proxy/src/group/dial_timeout_tests.rs
+++ b/crates/meow-proxy/src/group/dial_timeout_tests.rs
@@ -1,0 +1,170 @@
+use super::fallback::FallbackGroup;
+use super::urltest::UrlTestGroup;
+use async_trait::async_trait;
+use meow_common::DIAL_TIMEOUT;
+use meow_common::{
+    with_dial_timeout, AdapterType, DelayHistory, MeowError, Metadata, Proxy, ProxyAdapter,
+    ProxyConn, ProxyHealth, ProxyPacketConn, Result,
+};
+use std::sync::Arc;
+use std::time::Duration;
+
+struct SlowProxy {
+    health: ProxyHealth,
+    kind: AdapterType,
+}
+#[async_trait]
+impl ProxyAdapter for SlowProxy {
+    fn name(&self) -> &str {
+        "slow-node"
+    }
+    fn adapter_type(&self) -> AdapterType {
+        self.kind
+    }
+    fn addr(&self) -> &str {
+        ""
+    }
+    fn support_udp(&self) -> bool {
+        true
+    }
+    fn health(&self) -> &ProxyHealth {
+        &self.health
+    }
+    async fn dial_tcp(&self, _: &Metadata) -> Result<Box<dyn ProxyConn>> {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        Err(MeowError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "native handshake timed out",
+        )))
+    }
+    async fn dial_udp(&self, _: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        Err(MeowError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "native handshake timed out",
+        )))
+    }
+}
+impl Proxy for SlowProxy {
+    fn alive(&self) -> bool {
+        self.health.alive()
+    }
+    fn alive_for_url(&self, _: &str) -> bool {
+        self.alive()
+    }
+    fn last_delay(&self) -> u16 {
+        1
+    }
+    fn last_delay_for_url(&self, _: &str) -> u16 {
+        1
+    }
+    fn delay_history(&self) -> Vec<DelayHistory> {
+        vec![]
+    }
+}
+
+fn group_with_member(kind: &str, member: Arc<dyn Proxy>) -> Arc<dyn Proxy> {
+    match kind {
+        "fallback" => Arc::new(FallbackGroup::new("fallback", vec![member])),
+        "urltest" => Arc::new(UrlTestGroup::new("urltest", vec![member], 0)),
+        "nested" => Arc::new(FallbackGroup::new(
+            "outer",
+            vec![Arc::new(UrlTestGroup::new("inner", vec![member], 0))],
+        )),
+        _ => unreachable!(),
+    }
+}
+
+async fn dial(group: &dyn Proxy, udp: bool) -> Result<()> {
+    let metadata = Metadata::default();
+    if udp {
+        group.dial_udp(&metadata).await.map(|_| ())
+    } else {
+        group.dial_tcp(&metadata).await.map(|_| ())
+    }
+}
+
+async fn time_out(group: &dyn Proxy, udp: bool) {
+    let started = tokio::time::Instant::now();
+    let err = with_dial_timeout(group.name(), dial(group, udp))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, MeowError::Io(ref err) if err.kind() == std::io::ErrorKind::TimedOut));
+    assert_eq!(started.elapsed(), DIAL_TIMEOUT);
+}
+
+#[tokio::test(start_paused = true)]
+async fn native_timeouts_still_mark_members_dead() {
+    for kind in ["fallback", "urltest"] {
+        for udp in [false, true] {
+            let slow = Arc::new(SlowProxy {
+                health: ProxyHealth::new(),
+                kind: AdapterType::Hysteria2,
+            });
+            let group = group_with_member(kind, Arc::clone(&slow) as Arc<dyn Proxy>);
+            let results =
+                futures::future::join_all((0..5).map(|_| dial(group.as_ref(), udp))).await;
+            assert!(results.iter().all(Result::is_err));
+            assert!(!slow.alive(), "{kind} udp={udp}");
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn global_timeouts_count_once_and_track_the_selected_member() {
+    for kind in ["fallback", "urltest", "nested"] {
+        for udp in [false, true] {
+            let slow = Arc::new(SlowProxy {
+                health: ProxyHealth::new(),
+                kind: AdapterType::Hysteria2,
+            });
+            let group = group_with_member(kind, Arc::clone(&slow) as Arc<dyn Proxy>);
+            // Four overlapping expired dials must stay below the threshold.
+            futures::future::join_all((0..4).map(|_| time_out(group.as_ref(), udp))).await;
+            assert!(
+                slow.alive(),
+                "counted an expired dial twice: {kind}, udp={udp}"
+            );
+            time_out(group.as_ref(), udp).await;
+            assert!(
+                !slow.alive(),
+                "expiry skipped failure tracking: {kind}, udp={udp}"
+            );
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn early_cancellation_does_not_count_as_a_node_failure() {
+    for kind in ["fallback", "urltest"] {
+        let slow = Arc::new(SlowProxy {
+            health: ProxyHealth::new(),
+            kind: AdapterType::Hysteria2,
+        });
+        let group = group_with_member(kind, Arc::clone(&slow) as Arc<dyn Proxy>);
+        for _ in 0..5 {
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                with_dial_timeout(group.name(), dial(group.as_ref(), false)),
+            )
+            .await
+            .unwrap_err();
+        }
+        futures::future::join_all((0..4).map(|_| time_out(group.as_ref(), false))).await;
+        assert!(
+            slow.alive(),
+            "early cancellation counted toward escalation: {kind}"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn expired_direct_dials_remain_exempt() {
+    let slow = Arc::new(SlowProxy {
+        health: ProxyHealth::new(),
+        kind: AdapterType::Direct,
+    });
+    let group = group_with_member("fallback", Arc::clone(&slow) as Arc<dyn Proxy>);
+    futures::future::join_all((0..5).map(|_| time_out(group.as_ref(), false))).await;
+    assert!(slow.alive());
+}

--- a/crates/meow-proxy/src/group/fallback.rs
+++ b/crates/meow-proxy/src/group/fallback.rs
@@ -169,16 +169,8 @@ impl ProxyAdapter for FallbackGroup {
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        match proxy.dial_tcp(metadata).await {
-            Ok(conn) => {
-                self.dial_failures.on_success();
-                Ok(conn)
-            }
-            Err(err) => {
-                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
-                Err(err)
-            }
-        }
+        let attempt = super::DialAttempt::new(&self.name, &self.dial_failures, &proxy);
+        attempt.finish(proxy.dial_tcp(metadata).await)
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
@@ -186,16 +178,8 @@ impl ProxyAdapter for FallbackGroup {
         let proxy = self
             .first_alive()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        match proxy.dial_udp(metadata).await {
-            Ok(conn) => {
-                self.dial_failures.on_success();
-                Ok(conn)
-            }
-            Err(err) => {
-                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
-                Err(err)
-            }
-        }
+        let attempt = super::DialAttempt::new(&self.name, &self.dial_failures, &proxy);
+        attempt.finish(proxy.dial_udp(metadata).await)
     }
 
     fn unwrap_proxy(&self, metadata: &Metadata) -> Option<Arc<dyn Proxy>> {

--- a/crates/meow-proxy/src/group/mod.rs
+++ b/crates/meow-proxy/src/group/mod.rs
@@ -152,6 +152,56 @@ pub(super) fn record_dial_failure(
     }
 }
 
+/// Tracks the selected member even when an outer dial deadline drops the
+/// group future before its error arm can run. Capturing the deadline avoids
+/// consulting task-local state during destruction. Ordinary cancellation
+/// before expiry is not a node failure, and completed dials are counted once.
+struct DialAttempt<'a> {
+    group_name: &'a str,
+    tracker: &'a DialFailureTracker,
+    member: &'a Arc<dyn Proxy>,
+    deadline: Option<tokio::time::Instant>,
+}
+
+impl<'a> DialAttempt<'a> {
+    fn new(
+        group_name: &'a str,
+        tracker: &'a DialFailureTracker,
+        member: &'a Arc<dyn Proxy>,
+    ) -> Self {
+        Self {
+            group_name,
+            tracker,
+            member,
+            deadline: meow_common::dial::dial_deadline(),
+        }
+    }
+
+    fn finish<T>(mut self, result: meow_common::Result<T>) -> meow_common::Result<T> {
+        self.deadline = None;
+        match &result {
+            Ok(_) => self.tracker.on_success(),
+            Err(err) => record_dial_failure(self.group_name, self.tracker, self.member, err),
+        }
+        result
+    }
+}
+
+impl Drop for DialAttempt<'_> {
+    fn drop(&mut self) {
+        if self
+            .deadline
+            .is_some_and(|deadline| tokio::time::Instant::now() >= deadline)
+        {
+            let err = MeowError::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "outbound dial deadline elapsed",
+            ));
+            record_dial_failure(self.group_name, self.tracker, self.member, &err);
+        }
+    }
+}
+
 pub mod dialer_proxy;
 pub mod fallback;
 pub mod load_balance;
@@ -260,3 +310,6 @@ mod tests {
         assert!(tracker.on_failure(&io_err("dial timed out")));
     }
 }
+
+#[cfg(test)]
+mod dial_timeout_tests;

--- a/crates/meow-proxy/src/group/urltest.rs
+++ b/crates/meow-proxy/src/group/urltest.rs
@@ -266,16 +266,8 @@ impl ProxyAdapter for UrlTestGroup {
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        match proxy.dial_tcp(metadata).await {
-            Ok(conn) => {
-                self.dial_failures.on_success();
-                Ok(conn)
-            }
-            Err(err) => {
-                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
-                Err(err)
-            }
-        }
+        let attempt = super::DialAttempt::new(&self.name, &self.dial_failures, &proxy);
+        attempt.finish(proxy.dial_tcp(metadata).await)
     }
 
     async fn dial_udp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
@@ -283,16 +275,8 @@ impl ProxyAdapter for UrlTestGroup {
         let proxy = self
             .pick_for_dial()
             .ok_or_else(|| MeowError::Proxy("no proxy available".into()))?;
-        match proxy.dial_udp(metadata).await {
-            Ok(conn) => {
-                self.dial_failures.on_success();
-                Ok(conn)
-            }
-            Err(err) => {
-                super::record_dial_failure(&self.name, &self.dial_failures, &proxy, &err);
-                Err(err)
-            }
-        }
+        let attempt = super::DialAttempt::new(&self.name, &self.dial_failures, &proxy);
+        attempt.finish(proxy.dial_udp(metadata).await)
     }
 
     fn unwrap_proxy(&self, metadata: &Metadata) -> Option<Arc<dyn Proxy>> {

--- a/crates/meow-tunnel/src/tcp.rs
+++ b/crates/meow-tunnel/src/tcp.rs
@@ -1,7 +1,7 @@
 use crate::relay::{copy_bidirectional_buf_tracked, RELAY_BUF_SIZE};
 use crate::statistics::Statistics;
 use crate::tunnel::TunnelInner;
-use meow_common::{Metadata, ProxyConn};
+use meow_common::{with_dial_timeout, Metadata, ProxyConn};
 use smallvec::{smallvec, SmallVec};
 use smol_str::SmolStr;
 use std::sync::Arc;
@@ -164,8 +164,10 @@ pub async fn route_inbound_tcp<C>(
     let mut buf_up = [0u8; RELAY_BUF_SIZE];
     let mut buf_dn = [0u8; RELAY_BUF_SIZE];
 
-    // Dial the remote via proxy
-    match proxy.dial_tcp(&metadata).await {
+    // Dial the remote via proxy, bounded like mihomo's `C.DefaultTCPTimeout`:
+    // a server that accepts and then stalls mid-handshake would otherwise pin
+    // this task, its inbound socket and its stats entry forever.
+    match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
         Ok(mut remote) => {
             let up = Arc::clone(guard.counters());
             let dn = Arc::clone(guard.counters());

--- a/crates/meow-tunnel/src/udp.rs
+++ b/crates/meow-tunnel/src/udp.rs
@@ -2,7 +2,7 @@ use crate::tunnel::TunnelInner;
 use dashmap::DashMap;
 use meow_common::adapter::ProxyAdapter;
 use meow_common::atomic::AtomicU;
-use meow_common::{Metadata, ProxyPacketConn};
+use meow_common::{with_dial_timeout, Metadata, ProxyPacketConn};
 use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -220,7 +220,10 @@ pub async fn handle_udp(
         proxy.name()
     );
 
-    match proxy.dial_udp(&metadata).await {
+    // Bounded like mihomo's `C.DefaultUDPTimeout`. An unbounded dial here is
+    // worse than on TCP: the key is still unclaimed (see below), so every
+    // datagram of the flow starts its own stalled dial.
+    match with_dial_timeout(proxy.name(), proxy.dial_udp(&metadata)).await {
         Ok(conn) => {
             let session = Arc::new(UdpSession::new(conn, Arc::from(proxy.name())));
             // Claim the key atomically before the first write. The dial above
@@ -652,6 +655,85 @@ mod tests {
         assert!(
             current.is_some_and(|s| Arc::ptr_eq(&s, &replacement)),
             "the fresh replacement session must survive the failed session's eviction"
+        );
+    }
+
+    /// A proxy whose dial never resolves — a server that completes the TCP/QUIC
+    /// handshake and then goes silent mid-protocol.
+    struct StalledDialProxy {
+        health: ProxyHealth,
+    }
+
+    #[async_trait]
+    impl ProxyAdapter for StalledDialProxy {
+        fn name(&self) -> &str {
+            "stalled-mock"
+        }
+        fn adapter_type(&self) -> AdapterType {
+            AdapterType::Direct
+        }
+        fn addr(&self) -> &str {
+            ""
+        }
+        fn support_udp(&self) -> bool {
+            true
+        }
+        async fn dial_tcp(&self, _metadata: &Metadata) -> MeowResult<Box<dyn ProxyConn>> {
+            std::future::pending().await
+        }
+        async fn dial_udp(&self, _metadata: &Metadata) -> MeowResult<Box<dyn ProxyPacketConn>> {
+            std::future::pending().await
+        }
+        fn health(&self) -> &ProxyHealth {
+            &self.health
+        }
+    }
+
+    impl Proxy for StalledDialProxy {
+        fn alive(&self) -> bool {
+            true
+        }
+        fn alive_for_url(&self, _url: &str) -> bool {
+            true
+        }
+        fn last_delay(&self) -> u16 {
+            0
+        }
+        fn last_delay_for_url(&self, _url: &str) -> u16 {
+            0
+        }
+        fn delay_history(&self) -> Vec<DelayHistory> {
+            Vec::new()
+        }
+    }
+
+    /// A dial that never completes must not park the caller forever. Without
+    /// the `DIAL_TIMEOUT` bound this test hangs: every datagram of the flow
+    /// spawns another immortal task, since the NAT key is only claimed after
+    /// the dial returns.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_dial_gives_up_instead_of_parking_the_flow() {
+        let tunnel = mk_tunnel();
+        tunnel.set_mode(TunnelMode::Global);
+        let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
+        proxies.insert(
+            SmolStr::new_static("GLOBAL"),
+            Arc::new(StalledDialProxy {
+                health: ProxyHealth::new(),
+            }) as Arc<dyn Proxy>,
+        );
+        tunnel.update_proxies(proxies);
+
+        let src = SocketAddr::from(([127, 0, 0, 1], 8888));
+        let dst = SocketAddr::from(([198, 51, 100, 10], 443));
+
+        let start = tokio::time::Instant::now();
+        handle_udp(tunnel.inner(), b"ping", src, mk_metadata(src, dst)).await;
+
+        assert_eq!(start.elapsed(), meow_common::DIAL_TIMEOUT);
+        assert!(
+            tunnel.inner().nat_table.is_empty(),
+            "a dial that never completed must not leave a session behind"
         );
     }
 }


### PR DESCRIPTION
Outbound TCP and UDP dials can stall indefinitely after the transport connects. Apply a five-second budget across the seven production tunnel/listener dial sites, covering name resolution and protocol setup. DNS and internal HTTP retain their existing deadlines. Established relays are unaffected.

Nested dial helpers reuse the original deadline. Fallback and URLTest capture that deadline and the selected member in a cancellation guard, so expiry still reaches their existing failure-escalation policy when the outer timer drops the group future. Completed dials are counted once; early caller cancellation and exempt Direct/Reject errors do not mark nodes dead. This adds no per-dial heap allocation for deadline propagation or tracking.

Regression coverage includes stalled TCP/UDP members, native protocol timeouts, nested groups, the five-failure threshold, early cancellation, Direct exemption, a shared deadline across nested calls, and a stalled tunnel UDP flow. Formatting, workspace regression tests, and rustdoc checks pass. Local workspace Clippy is blocked by the existing generated `meow-lwip` `unnecessary_transmute` errors; the remaining workspace is checked separately, and the full lint matrix runs in CI.
