### PR TITLE
fix(hysteria2): let a configured fingerprint actually pin the certificate

### DIFF
--- a/crates/meow-proxy/src/hysteria2/tls.rs
+++ b/crates/meow-proxy/src/hysteria2/tls.rs
@@ -19,27 +19,14 @@ pub fn build_client_config(config: &Config) -> Result<ClientConfig> {
     let pin = parse_sha256_pin(&config.pin_sha256)?;
 
     let builder = rustls::ClientConfig::builder();
-    let mut tls_config = if config.insecure {
-        builder
+    let mut tls_config = match server_cert_verifier(config.insecure, pin) {
+        Some(verifier) => builder
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoVerify))
-            .with_no_client_auth()
-    } else if let Some(expected) = pin {
-        let roots = root_store();
-        let inner = rustls::client::WebPkiServerVerifier::builder_with_provider(
-            Arc::new(roots),
-            Arc::new(rustls::crypto::ring::default_provider()),
-        )
-        .build()
-        .map_err(|e| Error::tls(format!("webpki verifier setup: {e}")))?;
-        builder
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(PinVerifier { inner, expected }))
-            .with_no_client_auth()
-    } else {
-        builder
+            .with_custom_certificate_verifier(verifier)
+            .with_no_client_auth(),
+        None => builder
             .with_root_certificates(root_store())
-            .with_no_client_auth()
+            .with_no_client_auth(),
     };
 
     tls_config.alpn_protocols = vec![ALPN_H3.to_vec()];
@@ -64,6 +51,31 @@ pub fn build_client_config(config: &Config) -> Result<ClientConfig> {
     client.transport_config(Arc::new(transport));
 
     Ok(client)
+}
+
+/// Pick the certificate verifier for a client config. `None` means "no custom
+/// verifier" — validate against the bundled WebPKI roots as usual.
+///
+/// Precedence matches mihomo's `ca.GetTLSConfig`, which applies
+/// `GetSpecifiedFingerprintTLSConfig` *after* `skip-cert-verify` and thereby
+/// lets a configured `fingerprint` override it: pinning is a stricter promise
+/// than "trust anything", so a config carrying both must not silently degrade
+/// to no verification at all.
+///
+/// A pin also *replaces* chain and hostname validation rather than adding to
+/// it (mihomo and hysteria both set `InsecureSkipVerify` alongside the pin
+/// callback). Requiring a WebPKI chain on top would reject exactly the setup
+/// pinning exists for: the self-signed certificate that a typical hysteria2
+/// server generates.
+fn server_cert_verifier(
+    insecure: bool,
+    pin: Option<[u8; 32]>,
+) -> Option<Arc<dyn ServerCertVerifier>> {
+    match (pin, insecure) {
+        (Some(expected), _) => Some(Arc::new(PinVerifier::new(expected))),
+        (None, true) => Some(Arc::new(NoVerify)),
+        (None, false) => None,
+    }
 }
 
 fn root_store() -> RootCertStore {
@@ -138,28 +150,45 @@ impl ServerCertVerifier for NoVerify {
     }
 }
 
+/// Trust exactly one certificate, identified by the SHA-256 digest of its DER
+/// encoding (`fingerprint` / `pin-sha256`).
+///
+/// Only the *end-entity* certificate is compared. mihomo and hysteria both
+/// accept a match against any certificate the server sent, which a MITM
+/// defeats by appending the pinned certificate to a chain fronted by its own
+/// leaf — the handshake signature is then checked against the attacker's key.
+/// Pinning the leaf is what users actually configure, and it is the only form
+/// that holds.
 #[derive(Debug)]
 struct PinVerifier {
-    inner: Arc<rustls::client::WebPkiServerVerifier>,
     expected: [u8; 32],
+    /// Signature verification is still real: `ServerCertVerifier` owns it in
+    /// rustls (unlike Go, where the TLS stack checks it before the
+    /// `VerifyPeerCertificate` hook runs). Asserting it blindly here would
+    /// make the pin worthless — certificates are public, so anyone could
+    /// replay the pinned one without holding its private key.
+    supported_algs: rustls::crypto::WebPkiSupportedAlgorithms,
+}
+
+impl PinVerifier {
+    fn new(expected: [u8; 32]) -> Self {
+        Self {
+            expected,
+            supported_algs: rustls::crypto::ring::default_provider()
+                .signature_verification_algorithms,
+        }
+    }
 }
 
 impl ServerCertVerifier for PinVerifier {
     fn verify_server_cert(
         &self,
         end_entity: &CertificateDer<'_>,
-        intermediates: &[CertificateDer<'_>],
-        server_name: &ServerName<'_>,
-        ocsp_response: &[u8],
-        now: UnixTime,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
     ) -> std::result::Result<ServerCertVerified, rustls::Error> {
-        self.inner.verify_server_cert(
-            end_entity,
-            intermediates,
-            server_name,
-            ocsp_response,
-            now,
-        )?;
         let actual = Sha256::digest(end_entity.as_ref());
         if actual.as_slice() == self.expected {
             Ok(ServerCertVerified::assertion())
@@ -176,7 +205,7 @@ impl ServerCertVerifier for PinVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
-        self.inner.verify_tls12_signature(message, cert, dss)
+        rustls::crypto::verify_tls12_signature(message, cert, dss, &self.supported_algs)
     }
 
     fn verify_tls13_signature(
@@ -185,11 +214,11 @@ impl ServerCertVerifier for PinVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
-        self.inner.verify_tls13_signature(message, cert, dss)
+        rustls::crypto::verify_tls13_signature(message, cert, dss, &self.supported_algs)
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.inner.supported_verify_schemes()
+        self.supported_algs.supported_schemes()
     }
 }
 
@@ -228,5 +257,244 @@ mod tests {
     #[test]
     fn rejects_invalid_sha256_pin() {
         assert!(parse_sha256_pin("abc").is_err());
+    }
+
+    /// A self-signed certificate and its `fingerprint`, as a hysteria2 server
+    /// set up by the upstream install script would present.
+    struct SelfSigned {
+        cert: CertificateDer<'static>,
+        key: rustls::pki_types::PrivatePkcs8KeyDer<'static>,
+        pin: [u8; 32],
+    }
+
+    fn self_signed() -> SelfSigned {
+        let ck = rcgen::generate_simple_self_signed(vec!["hy2.example".into()]).unwrap();
+        let cert = CertificateDer::from(ck.cert.der().to_vec());
+        let mut pin = [0u8; 32];
+        pin.copy_from_slice(Sha256::digest(cert.as_ref()).as_slice());
+        SelfSigned {
+            cert,
+            key: rustls::pki_types::PrivatePkcs8KeyDer::from(ck.key_pair.serialize_der()),
+            pin,
+        }
+    }
+
+    fn verify(
+        verifier: &dyn ServerCertVerifier,
+        cert: &CertificateDer<'_>,
+    ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+        verifier.verify_server_cert(
+            cert,
+            &[],
+            &ServerName::try_from("hy2.example").unwrap(),
+            &[],
+            UnixTime::now(),
+        )
+    }
+
+    /// The point of pinning: a server certificate that chains to nothing is
+    /// trusted because its digest matches. The previous verifier ran WebPKI
+    /// chain validation first, so every self-signed hysteria2 server — the
+    /// overwhelmingly common deployment — failed the handshake even with a
+    /// correct `fingerprint`.
+    #[test]
+    fn a_matching_pin_trusts_a_self_signed_cert() {
+        let server = self_signed();
+        let verifier =
+            server_cert_verifier(false, Some(server.pin)).expect("pin needs a custom verifier");
+        verify(verifier.as_ref(), &server.cert).expect("pinned cert must verify");
+    }
+
+    #[test]
+    fn a_mismatched_pin_is_rejected() {
+        let server = self_signed();
+        let verifier = server_cert_verifier(false, Some([0x11; 32])).unwrap();
+        assert!(verify(verifier.as_ref(), &server.cert).is_err());
+    }
+
+    /// `skip-cert-verify: true` alongside a `fingerprint` used to win, quietly
+    /// turning a pinned config into an unauthenticated one. The stricter
+    /// setting must survive (mihomo applies the pin last, for the same reason).
+    #[test]
+    fn a_pin_overrides_skip_cert_verify() {
+        let server = self_signed();
+        let verifier = server_cert_verifier(true, Some(server.pin)).unwrap();
+        verify(verifier.as_ref(), &server.cert).expect("the pinned cert still verifies");
+
+        let other = server_cert_verifier(true, Some([0x22; 32])).unwrap();
+        assert!(
+            verify(other.as_ref(), &server.cert).is_err(),
+            "skip-cert-verify must not disable a configured pin"
+        );
+    }
+
+    #[test]
+    fn skip_cert_verify_without_a_pin_accepts_anything() {
+        let server = self_signed();
+        let verifier = server_cert_verifier(true, None).unwrap();
+        verify(verifier.as_ref(), &server.cert).expect("insecure accepts any cert");
+    }
+
+    #[test]
+    fn plain_config_keeps_the_webpki_roots() {
+        assert!(
+            server_cert_verifier(false, None).is_none(),
+            "no pin and no skip-cert-verify must fall through to the root store"
+        );
+    }
+
+    /// Drive a real TLS 1.3 handshake against a local server presenting
+    /// `server`'s certificate, with `verifier` on the client side. Returns the
+    /// client's handshake result — the whole rustls path (certificate *and*
+    /// `CertificateVerify` signature), not just the digest comparison.
+    async fn handshake(
+        verifier: Arc<dyn ServerCertVerifier>,
+        server: &SelfSigned,
+    ) -> std::result::Result<(), String> {
+        // Both provider features are reachable through the dev-dependency
+        // graph, so the process default has to be chosen explicitly — same
+        // call `build_client_config` makes.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(
+                vec![server.cert.clone()],
+                rustls::pki_types::PrivateKeyDer::Pkcs8(server.key.clone_key()),
+            )
+            .map_err(|e| format!("server config: {e}"))?;
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let _ = acceptor.accept(stream).await;
+            }
+        });
+
+        let client_config = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(verifier)
+            .with_no_client_auth();
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        connector
+            .connect(ServerName::try_from("hy2.example").unwrap(), stream)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    /// End-to-end shape of the bug: a self-signed server plus the matching
+    /// `fingerprint` must complete a handshake, and a wrong fingerprint must
+    /// abort it.
+    #[tokio::test]
+    async fn a_pinned_self_signed_server_completes_a_handshake() {
+        let server = self_signed();
+
+        handshake(
+            server_cert_verifier(false, Some(server.pin)).unwrap(),
+            &server,
+        )
+        .await
+        .expect("a correctly pinned self-signed server must be reachable");
+
+        let wrong = handshake(
+            server_cert_verifier(false, Some([0x33; 32])).unwrap(),
+            &server,
+        )
+        .await;
+        assert!(wrong.is_err(), "a wrong pin must abort the handshake");
+    }
+
+    /// Records the `CertificateVerify` inputs rustls passes to the wrapped
+    /// verifier during a real handshake.
+    #[derive(Debug)]
+    struct CaptureSignature {
+        inner: Arc<dyn ServerCertVerifier>,
+        seen: std::sync::Mutex<Vec<(Vec<u8>, CertificateDer<'static>, DigitallySignedStruct)>>,
+    }
+
+    impl ServerCertVerifier for CaptureSignature {
+        fn verify_server_cert(
+            &self,
+            end_entity: &CertificateDer<'_>,
+            intermediates: &[CertificateDer<'_>],
+            server_name: &ServerName<'_>,
+            ocsp_response: &[u8],
+            now: UnixTime,
+        ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+            self.inner.verify_server_cert(
+                end_entity,
+                intermediates,
+                server_name,
+                ocsp_response,
+                now,
+            )
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+            self.inner.verify_tls12_signature(message, cert, dss)
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+            self.seen.lock().unwrap().push((
+                message.to_vec(),
+                cert.clone().into_owned(),
+                dss.clone(),
+            ));
+            self.inner.verify_tls13_signature(message, cert, dss)
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            self.inner.supported_verify_schemes()
+        }
+    }
+
+    /// Pinning must not weaken the handshake itself. Certificates are public,
+    /// so if the verifier asserted signatures instead of checking them anyone
+    /// could replay the pinned certificate without holding its private key —
+    /// the pin would authenticate nothing.
+    ///
+    /// Capture the real `CertificateVerify` from a successful handshake, then
+    /// replay it over a tampered transcript: the pin verifier must reject it.
+    #[tokio::test]
+    async fn pinning_still_verifies_the_handshake_signature() {
+        let server = self_signed();
+        let capture = Arc::new(CaptureSignature {
+            inner: server_cert_verifier(false, Some(server.pin)).unwrap(),
+            seen: std::sync::Mutex::new(Vec::new()),
+        });
+
+        handshake(Arc::clone(&capture) as Arc<dyn ServerCertVerifier>, &server)
+            .await
+            .expect("pinned handshake succeeds");
+
+        let seen = capture.seen.lock().unwrap();
+        let (message, cert, dss) = seen.first().expect("TLS 1.3 CertificateVerify was checked");
+
+        let verifier = server_cert_verifier(false, Some(server.pin)).unwrap();
+        verifier
+            .verify_tls13_signature(message, cert, dss)
+            .expect("the genuine signature verifies");
+
+        let mut tampered = message.clone();
+        tampered[0] ^= 0xff;
+        assert!(
+            verifier
+                .verify_tls13_signature(&tampered, cert, dss)
+                .is_err(),
+            "a signature that does not cover the transcript must be rejected"
+        );
     }
 }

--- a/crates/meow-proxy/src/hysteria2/tls.rs
+++ b/crates/meow-proxy/src/hysteria2/tls.rs
@@ -56,17 +56,12 @@ pub fn build_client_config(config: &Config) -> Result<ClientConfig> {
 /// Pick the certificate verifier for a client config. `None` means "no custom
 /// verifier" — validate against the bundled WebPKI roots as usual.
 ///
-/// Precedence matches mihomo's `ca.GetTLSConfig`, which applies
-/// `GetSpecifiedFingerprintTLSConfig` *after* `skip-cert-verify` and thereby
-/// lets a configured `fingerprint` override it: pinning is a stricter promise
-/// than "trust anything", so a config carrying both must not silently degrade
-/// to no verification at all.
+/// A configured fingerprint remains mandatory even when `insecure` is set.
 ///
-/// A pin also *replaces* chain and hostname validation rather than adding to
-/// it (mihomo and hysteria both set `InsecureSkipVerify` alongside the pin
-/// callback). Requiring a WebPKI chain on top would reject exactly the setup
-/// pinning exists for: the self-signed certificate that a typical hysteria2
-/// server generates.
+/// A leaf pin replaces chain and hostname validation in meow-rs, matching
+/// mihomo's leaf-fingerprint path and allowing self-signed certificates.
+/// Hysteria's CLI differs: its pin is an additional leaf check, while its
+/// `insecure` setting independently controls chain and hostname validation.
 fn server_cert_verifier(
     insecure: bool,
     pin: Option<[u8; 32]>,
@@ -153,20 +148,16 @@ impl ServerCertVerifier for NoVerify {
 /// Trust exactly one certificate, identified by the SHA-256 digest of its DER
 /// encoding (`fingerprint` / `pin-sha256`).
 ///
-/// Only the *end-entity* certificate is compared. mihomo and hysteria both
-/// accept a match against any certificate the server sent, which a MITM
-/// defeats by appending the pinned certificate to a chain fronted by its own
-/// leaf — the handshake signature is then checked against the attacker's key.
-/// Pinning the leaf is what users actually configure, and it is the only form
-/// that holds.
+/// Only the end-entity certificate is compared. This is a leaf-certificate
+/// pin, not a trust-anchor pin: unrelated appended certificates cannot satisfy
+/// it. Hysteria also compares the leaf; mihomo additionally supports a pinned
+/// CA by verifying the leaf's chain against that anchor.
 #[derive(Debug)]
 struct PinVerifier {
     expected: [u8; 32],
-    /// Signature verification is still real: `ServerCertVerifier` owns it in
-    /// rustls (unlike Go, where the TLS stack checks it before the
-    /// `VerifyPeerCertificate` hook runs). Asserting it blindly here would
-    /// make the pin worthless — certificates are public, so anyone could
-    /// replay the pinned one without holding its private key.
+    /// rustls exposes handshake-signature verification through this same
+    /// verifier trait. The certificate digest alone does not prove possession
+    /// of the private key: certificates are public and can be replayed.
     supported_algs: rustls::crypto::WebPkiSupportedAlgorithms,
 }
 
@@ -496,5 +487,85 @@ mod tests {
                 .is_err(),
             "a signature that does not cover the transcript must be rejected"
         );
+    }
+}
+#[cfg(test)]
+mod quic_pin_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn production_quic_config_pin_matrix() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let ck = rcgen::generate_simple_self_signed(vec!["hy2.example".into()]).unwrap();
+        let cert = CertificateDer::from(ck.cert.der().to_vec());
+        let pin = hex::encode(Sha256::digest(cert.as_ref()));
+        for (insecure, fingerprint, expected) in [
+            (false, pin.clone(), true),
+            (true, pin.clone(), true),
+            (false, "11".repeat(32), false),
+            (true, "11".repeat(32), false),
+            (false, String::new(), false),
+            (true, String::new(), true),
+        ] {
+            let key = rustls::pki_types::PrivatePkcs8KeyDer::from(ck.key_pair.serialize_der());
+            let mut server_tls = rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(vec![cert.clone()], key.into())
+                .unwrap();
+            server_tls.alpn_protocols = vec![b"h3".to_vec()];
+            let server_crypto =
+                quinn::crypto::rustls::QuicServerConfig::try_from(server_tls).unwrap();
+            let server = quinn::Endpoint::server(
+                quinn::ServerConfig::with_crypto(Arc::new(server_crypto)),
+                "127.0.0.1:0".parse().unwrap(),
+            )
+            .unwrap();
+            let mut client = quinn::Endpoint::client("127.0.0.1:0".parse().unwrap()).unwrap();
+            client.set_default_client_config(
+                build_client_config(&Config {
+                    insecure,
+                    pin_sha256: fingerprint.clone(),
+                    ..Default::default()
+                })
+                .unwrap(),
+            );
+            let addr = server.local_addr().unwrap();
+            let task = tokio::spawn(async move {
+                let incoming = server.accept().await.unwrap();
+                let result = incoming.await;
+                (server, result)
+            });
+            let result = tokio::time::timeout(
+                Duration::from_secs(5),
+                client.connect(addr, "hy2.example").unwrap(),
+            )
+            .await
+            .expect("local QUIC handshake must finish");
+            assert_eq!(
+                result.is_ok(),
+                expected,
+                "insecure={insecure}, pin={}, result={result:?}",
+                !fingerprint.is_empty()
+            );
+            client.close(0u32.into(), b"test complete");
+            task.abort();
+            let _ = task.await;
+        }
+    }
+
+    #[test]
+    fn appending_pinned_certificate_does_not_authenticate_another_leaf() {
+        let pinned = rcgen::generate_simple_self_signed(vec!["hy2.example".into()]).unwrap();
+        let other = rcgen::generate_simple_self_signed(vec!["hy2.example".into()]).unwrap();
+        let hash: [u8; 32] = Sha256::digest(pinned.cert.der().as_ref()).into();
+        let verifier = server_cert_verifier(true, Some(hash)).unwrap();
+        let result = verifier.verify_server_cert(
+            other.cert.der(),
+            &[pinned.cert.der().clone()],
+            &ServerName::try_from("hy2.example").unwrap(),
+            &[],
+            UnixTime::now(),
+        );
+        assert!(result.is_err());
     }
 }

--- a/crates/meow-proxy/src/hysteria2_adapter.rs
+++ b/crates/meow-proxy/src/hysteria2_adapter.rs
@@ -65,6 +65,17 @@ impl Hy2Options {
             return Err(format!("hysteria2[{}]: port must be non-zero", self.name));
         }
 
+        // Both set: the pin wins (see `hysteria2::tls::server_cert_verifier`).
+        // Say so once at load rather than let a user believe verification is
+        // off when it is not.
+        if self.skip_cert_verify && self.fingerprint.is_some() {
+            tracing::warn!(
+                "hysteria2[{}]: skip-cert-verify is ignored because fingerprint is set; \
+                 the certificate is still pinned",
+                self.name
+            );
+        }
+
         let obfs_password = match self.obfs {
             Some(Hy2Obfs::Salamander) => self.obfs_password.unwrap_or_default(),
             None => String::new(),


### PR DESCRIPTION
A configured Hysteria2 `fingerprint` could be bypassed by `skip-cert-verify`, while pinning alone still rejected self-signed certificates through WebPKI validation. Give the leaf SHA-256 pin precedence over `skip-cert-verify` and use it as the trust decision. Without a pin, existing insecure/WebPKI behavior is unchanged. TLS handshake signatures remain cryptographically verified on the pin path.

This follows [mihomo's leaf-fingerprint behavior](https://github.com/MetaCubeX/mihomo/blob/Meta/component/ca/fingerprint.go). Meow supports leaf pins only; mihomo also supports a pinned CA with chain verification. [Hysteria's CLI](https://github.com/apernet/hysteria/blob/master/app/cmd/client.go) checks the leaf pin as an additional condition and independently controls chain validation with `insecure`. These upstream implementations do not accept an arbitrary unrelated certificate appended to a chain.

Validation includes a real local QUIC handshake using the production `build_client_config`: correct, wrong, and absent pins crossed with both insecure settings. Further tests cover rejection of an unrelated leaf with the pinned certificate appended, real TLS 1.3 handshakes, and a tampered handshake-signature transcript. Formatting, workspace regression tests, and rustdoc checks pass. Local workspace Clippy is blocked by the existing generated `meow-lwip` `unnecessary_transmute` errors; the remaining workspace is checked separately, and the full lint matrix runs in CI.

PR #500 rewrites this TLS backend and will need to preserve these verifier semantics and regression cases when rebased.
