### PR TITLE
fix(connections): cancel live TCP streams on deletion and reload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,8 @@ jobs:
             --test statistics_test \
             --test rules_test \
             --test api_test \
+            --test raii_guard_test \
+            --test http_connection_close \
             --test config_persistence_test \
             --test systemd_config_test \
             --test trojan_integration \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ cargo test --lib --bin meow \
   --test socks5_udp_user \
   --test common_test --test dns_cache_test --test config_test \
   --test statistics_test --test rules_test --test api_test \
+  --test raii_guard_test --test http_connection_close \
   --test config_persistence_test --test systemd_config_test \
   --test trojan_integration --test vless_config_test --test vless_integration \
   --test v2ray_plugin_integration --test pre_resolve_test \

--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -1933,12 +1933,12 @@ async fn put_configs(
 
     // Cold reload: close all connections with structured log (Class A divergence from upstream)
     let stats = state.tunnel.statistics();
-    let dropped = stats.active_connection_count();
-    stats.close_all_connections();
+    const RELOAD_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    let dropped = stats.drain_connections(RELOAD_DRAIN_TIMEOUT).await;
     if dropped > 0 {
         tracing::warn!(
             connections_dropped = dropped,
-            "connections force-closed after reload drain timeout"
+            "connection closure requested after reload drain timeout"
         );
     }
 

--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -1931,14 +1931,14 @@ async fn put_configs(
         }
     };
 
-    // Cold reload: close all connections with structured log (Class A divergence from upstream)
+    // Preserve immediate cold-reload closure. Graceful draining requires
+    // stopping admission first; listeners still accept connections here.
     let stats = state.tunnel.statistics();
-    const RELOAD_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-    let dropped = stats.drain_connections(RELOAD_DRAIN_TIMEOUT).await;
+    let dropped = stats.close_all_connections_counted();
     if dropped > 0 {
         tracing::warn!(
             connections_dropped = dropped,
-            "connection closure requested after reload drain timeout"
+            "connection closure requested for cold reload"
         );
     }
 

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -3120,18 +3120,18 @@ async fn delete_all_connections_terminates_both_stream_directions() {
 }
 
 #[tokio::test]
-async fn cold_reload_drains_then_terminates_live_stream() {
+async fn cold_reload_terminates_live_stream_without_drain_delay() {
     let state = test_state(RawConfig {
         rules: Some(vec!["MATCH,DIRECT".into()]),
         ..Default::default()
     });
     let (mut client, mut remote, task) = live_connection(&state).await;
-    let start = std::time::Instant::now();
     use base64::Engine as _;
     let payload =
         base64::engine::general_purpose::STANDARD.encode("mode: rule\nrules:\n  - MATCH,REJECT\n");
-    let response = create_router(Arc::clone(&state))
-        .oneshot(
+    let response = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        create_router(Arc::clone(&state)).oneshot(
             Request::builder()
                 .method("PUT")
                 .uri("/configs")
@@ -3140,11 +3140,12 @@ async fn cold_reload_drains_then_terminates_live_stream() {
                     serde_json::json!({"payload": payload}).to_string(),
                 ))
                 .unwrap(),
-        )
-        .await
-        .unwrap();
+        ),
+    )
+    .await
+    .expect("cold reload must not wait for live connections to finish")
+    .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
-    assert!(start.elapsed() >= std::time::Duration::from_secs(5));
     assert_socket_closed(&mut client).await;
     assert_socket_closed(&mut remote).await;
     task.await.unwrap();

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -2998,3 +2998,165 @@ async fn get_connections_entry_has_camel_case_shape() {
         "snake_case key must not appear"
     );
 }
+
+// Exercise actual sockets: an empty statistics map alone cannot prove closure.
+async fn live_connection(
+    state: &Arc<AppState>,
+) -> (
+    tokio::net::TcpStream,
+    tokio::net::TcpStream,
+    tokio::task::JoinHandle<()>,
+) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dst = upstream.local_addr().unwrap();
+    let inbound = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mut client = TcpStream::connect(inbound.local_addr().unwrap())
+        .await
+        .unwrap();
+    let (server, _) = inbound.accept().await.unwrap();
+    let inner = Arc::clone(state.tunnel.inner());
+    let task = tokio::spawn(async move {
+        meow_tunnel::tcp::handle_tcp(
+            &inner,
+            Box::new(server),
+            meow_common::Metadata {
+                dst_ip: Some(dst.ip()),
+                dst_port: dst.port(),
+                ..Default::default()
+            },
+        )
+        .await;
+    });
+    let (mut remote, _) = upstream.accept().await.unwrap();
+    client.write_all(b"before close").await.unwrap();
+    let mut buf = [0; 12];
+    remote.read_exact(&mut buf).await.unwrap();
+    remote.write_all(&buf).await.unwrap();
+    client.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"before close");
+    (client, remote, task)
+}
+
+async fn assert_socket_closed(stream: &mut tokio::net::TcpStream) {
+    use tokio::io::AsyncReadExt;
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), stream.read(&mut [0; 1]))
+        .await
+        .expect("connection still open after close request");
+    match result {
+        Ok(0) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+        other => panic!("expected EOF or RST, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn delete_connection_terminates_only_selected_stream() {
+    let state = test_state(RawConfig {
+        rules: Some(vec!["MATCH,DIRECT".into()]),
+        ..Default::default()
+    });
+    let (mut client, mut remote, task) = live_connection(&state).await;
+    let id = state.tunnel.statistics().active_connections()[0].id;
+    let (mut survivor, mut survivor_remote, survivor_task) = live_connection(&state).await;
+    let response = create_router(Arc::clone(&state))
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/connections/{id}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_socket_closed(&mut client).await;
+    assert_socket_closed(&mut remote).await;
+    task.await.unwrap();
+    assert_eq!(state.tunnel.statistics().active_connection_count(), 1);
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    survivor.write_all(b"ok").await.unwrap();
+    let mut buf = [0; 2];
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        survivor_remote.read_exact(&mut buf),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(&buf, b"ok");
+    state.tunnel.statistics().close_all_connections();
+    survivor_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_all_connections_terminates_both_stream_directions() {
+    let state = test_state(RawConfig {
+        rules: Some(vec!["MATCH,DIRECT".into()]),
+        ..Default::default()
+    });
+    let mut streams = Vec::new();
+    for _ in 0..2 {
+        streams.push(live_connection(&state).await);
+    }
+    let response = create_router(Arc::clone(&state))
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/connections")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    for (mut client, mut remote, task) in streams {
+        assert_socket_closed(&mut client).await;
+        assert_socket_closed(&mut remote).await;
+        task.await.unwrap();
+    }
+    assert_eq!(state.tunnel.statistics().active_connection_count(), 0);
+}
+
+#[tokio::test]
+async fn cold_reload_drains_then_terminates_live_stream() {
+    let state = test_state(RawConfig {
+        rules: Some(vec!["MATCH,DIRECT".into()]),
+        ..Default::default()
+    });
+    let (mut client, mut remote, task) = live_connection(&state).await;
+    let start = std::time::Instant::now();
+    use base64::Engine as _;
+    let payload =
+        base64::engine::general_purpose::STANDARD.encode("mode: rule\nrules:\n  - MATCH,REJECT\n");
+    let response = create_router(Arc::clone(&state))
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/configs")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    serde_json::json!({"payload": payload}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(start.elapsed() >= std::time::Duration::from_secs(5));
+    assert_socket_closed(&mut client).await;
+    assert_socket_closed(&mut remote).await;
+    task.await.unwrap();
+    let metadata = meow_common::Metadata {
+        dst_ip: Some("127.0.0.1".parse().unwrap()),
+        dst_port: 12345,
+        ..Default::default()
+    };
+    let (proxy, _, _) = state.tunnel.inner().resolve_proxy(&metadata).unwrap();
+    assert_eq!(
+        proxy.name(),
+        "REJECT",
+        "new connections must see the reloaded policy"
+    );
+}

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -263,87 +263,93 @@ async fn handle_http_inner(
             smallvec![Arc::from(proxy.name())],
         );
 
-        match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
-            Ok(mut remote) => {
-                // Rewrite the request line: remove the absolute URI scheme+host,
-                // keep the path. Rebuild headers without Proxy-* headers while
-                // preserving all other field bytes exactly.
-                let path = extract_path_from_url(url);
-                let rewritten = rewrite_plain_request(&request, path);
+        _guard
+            .run_until_closed(async {
+                match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
+                    Ok(mut remote) => {
+                        // Rewrite the request line: remove the absolute URI scheme+host,
+                        // keep the path. Rebuild headers without Proxy-* headers while
+                        // preserving all other field bytes exactly.
+                        let path = extract_path_from_url(url);
+                        let rewritten = rewrite_plain_request(&request, path);
 
-                // Force a one-request upstream exchange. The bounded client
-                // wrapper forwards exactly this request body, holds any
-                // pipelined request back, and marks the final response close.
-                remote.write_all(&rewritten).await?;
-                let up = Arc::clone(_guard.counters());
-                let dn = Arc::clone(_guard.counters());
-                // Relay scratch buffers live on this plain-HTTP path's stack —
-                // zero per-relay heap allocation (ADR-0008). Declared here
-                // (not at the top of handle_http_inner) so the dominant CONNECT
-                // path, which relays via the shared `route_inbound_tcp` helper
-                // and its own stack buffers, does not carry these 8 KiB.
-                let mut relay_buf_up = [0u8; RELAY_BUF_SIZE];
-                let mut relay_buf_dn = [0u8; RELAY_BUF_SIZE];
-                // Keep the response-head scratch out of `handle_http_inner`'s
-                // async frame. CONNECT is the dominant path and must not pay
-                // for storage used only by plain HTTP exchanges.
-                let pass_upstream_shutdown = AtomicBool::new(false);
-                let mut client = Box::new(SingleRequestClient::new(
-                    stream,
-                    &leftover,
-                    request.body_kind,
-                    request.upgrade_requested,
-                    &pass_upstream_shutdown,
-                ));
-                // Client EOF should finish the upload direction and arm the
-                // relay linger, but it must not half-close an encrypted proxy
-                // transport before the origin has produced its response. A
-                // validated 101 switches this gate to ordinary tunnel
-                // half-close semantics.
-                let mut remote = ShutdownGate::new(remote, &pass_upstream_shutdown);
+                        // Force a one-request upstream exchange. The bounded client
+                        // wrapper forwards exactly this request body, holds any
+                        // pipelined request back, and marks the final response close.
+                        remote.write_all(&rewritten).await?;
+                        let up = Arc::clone(_guard.counters());
+                        let dn = Arc::clone(_guard.counters());
+                        // Relay scratch buffers live on this plain-HTTP path's stack —
+                        // zero per-relay heap allocation (ADR-0008). Declared here
+                        // (not at the top of handle_http_inner) so the dominant CONNECT
+                        // path, which relays via the shared `route_inbound_tcp` helper
+                        // and its own stack buffers, does not carry these 8 KiB.
+                        let mut relay_buf_up = [0u8; RELAY_BUF_SIZE];
+                        let mut relay_buf_dn = [0u8; RELAY_BUF_SIZE];
+                        // Keep the response-head scratch out of `handle_http_inner`'s
+                        // async frame. CONNECT is the dominant path and must not pay
+                        // for storage used only by plain HTTP exchanges.
+                        let pass_upstream_shutdown = AtomicBool::new(false);
+                        let mut client = Box::new(SingleRequestClient::new(
+                            stream,
+                            &leftover,
+                            request.body_kind,
+                            request.upgrade_requested,
+                            &pass_upstream_shutdown,
+                        ));
+                        // Client EOF should finish the upload direction and arm the
+                        // relay linger, but it must not half-close an encrypted proxy
+                        // transport before the origin has produced its response. A
+                        // validated 101 switches this gate to ordinary tunnel
+                        // half-close semantics.
+                        let mut remote = ShutdownGate::new(remote, &pass_upstream_shutdown);
 
-                match copy_bidirectional_buf_tracked(
-                    &mut *client,
-                    &mut remote,
-                    &mut relay_buf_up,
-                    &mut relay_buf_dn,
-                    |n| {
-                        inner
-                            .stats
-                            .record_upload(&up, n as meow_common::atomic::Int);
-                    },
-                    |n| {
-                        inner
-                            .stats
-                            .record_download(&dn, n as meow_common::atomic::Int);
-                    },
-                )
-                .await
-                {
-                    Ok((up, down)) => {
-                        debug!("HTTP single-request relay closed: up={up} down={down}");
-                    }
-                    Err(e) => {
-                        debug!("HTTP single-request relay error: {}", e);
-                        // A response head the proxy rejects (oversized,
-                        // malformed, invalid status line) aborts the relay
-                        // before anything reached the client. Turn that into
-                        // an explicit 502 rather than a silent connection
-                        // close; once response bytes have flowed, appending
-                        // an error would corrupt the stream instead.
-                        let sent_response_bytes = client.sent_response_bytes;
-                        drop(client);
-                        if !sent_response_bytes {
-                            let _ = write_bad_gateway(stream).await;
+                        match copy_bidirectional_buf_tracked(
+                            &mut *client,
+                            &mut remote,
+                            &mut relay_buf_up,
+                            &mut relay_buf_dn,
+                            |n| {
+                                inner
+                                    .stats
+                                    .record_upload(&up, n as meow_common::atomic::Int);
+                            },
+                            |n| {
+                                inner
+                                    .stats
+                                    .record_download(&dn, n as meow_common::atomic::Int);
+                            },
+                        )
+                        .await
+                        {
+                            Ok((up, down)) => {
+                                debug!("HTTP single-request relay closed: up={up} down={down}");
+                            }
+                            Err(e) => {
+                                debug!("HTTP single-request relay error: {}", e);
+                                // A response head the proxy rejects (oversized,
+                                // malformed, invalid status line) aborts the relay
+                                // before anything reached the client. Turn that into
+                                // an explicit 502 rather than a silent connection
+                                // close; once response bytes have flowed, appending
+                                // an error would corrupt the stream instead.
+                                let sent_response_bytes = client.sent_response_bytes;
+                                drop(client);
+                                if !sent_response_bytes {
+                                    let _ = write_bad_gateway(stream).await;
+                                }
+                            }
                         }
                     }
+                    Err(e) => {
+                        warn!("{}:{} HTTP dial error: {}", host, port, e);
+                        write_bad_gateway(stream).await?;
+                    }
                 }
-            }
-            Err(e) => {
-                warn!("{}:{} HTTP dial error: {}", host, port, e);
-                write_bad_gateway(stream).await?;
-            }
-        }
+                Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+            })
+            .await
+            .unwrap_or(Ok(()))?;
         // _guard drops here, removing the entry from Statistics.
     }
 

--- a/crates/meow-listener/src/tproxy/mod.rs
+++ b/crates/meow-listener/src/tproxy/mod.rs
@@ -348,36 +348,40 @@ async fn handle_tproxy_conn(
     let mut relay_buf_up = [0u8; RELAY_BUF_SIZE];
     let mut relay_buf_dn = [0u8; RELAY_BUF_SIZE];
 
-    match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
-        Ok(mut remote) => {
-            let up = Arc::clone(_guard.counters());
-            let dn = Arc::clone(_guard.counters());
-            match copy_bidirectional_buf_tracked(
-                &mut stream,
-                &mut remote,
-                &mut relay_buf_up,
-                &mut relay_buf_dn,
-                |n| {
-                    inner
-                        .stats
-                        .record_upload(&up, n as meow_common::atomic::Int);
-                },
-                |n| {
-                    inner
-                        .stats
-                        .record_download(&dn, n as meow_common::atomic::Int);
-                },
-            )
-            .await
-            {
-                Ok((up, down)) => {
-                    debug!("TProxy relay closed: up={up} down={down}");
+    _guard
+        .run_until_closed(async {
+            match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
+                Ok(mut remote) => {
+                    let up = Arc::clone(_guard.counters());
+                    let dn = Arc::clone(_guard.counters());
+                    match copy_bidirectional_buf_tracked(
+                        &mut stream,
+                        &mut remote,
+                        &mut relay_buf_up,
+                        &mut relay_buf_dn,
+                        |n| {
+                            inner
+                                .stats
+                                .record_upload(&up, n as meow_common::atomic::Int);
+                        },
+                        |n| {
+                            inner
+                                .stats
+                                .record_download(&dn, n as meow_common::atomic::Int);
+                        },
+                    )
+                    .await
+                    {
+                        Ok((up, down)) => {
+                            debug!("TProxy relay closed: up={up} down={down}");
+                        }
+                        Err(e) => debug!("TProxy relay error: {e}"),
+                    }
                 }
-                Err(e) => debug!("TProxy relay error: {e}"),
+                Err(e) => warn!("TProxy dial error: {e}"),
             }
-        }
-        Err(e) => warn!("TProxy dial error: {e}"),
-    }
+        })
+        .await;
     // _guard drops here, removing the entry from Statistics.
     Ok(())
 }

--- a/crates/meow-listener/tests/http_connection_close.rs
+++ b/crates/meow-listener/tests/http_connection_close.rs
@@ -1,0 +1,53 @@
+//! Plain HTTP has its own dial/write/relay path and must honour closure too.
+#![cfg(feature = "listener-http")]
+mod common;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{timeout, Duration};
+
+#[tokio::test]
+async fn close_stalled_plain_http_response_terminates_sockets() {
+    timeout(Duration::from_secs(5), async {
+        let tunnel = common::direct_tunnel();
+        let stats = std::sync::Arc::clone(tunnel.statistics());
+        let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let destination = origin.local_addr().unwrap();
+        let inbound = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let inbound_addr = inbound.local_addr().unwrap();
+        let mut client = TcpStream::connect(inbound_addr).await.unwrap();
+        let (server, peer) = inbound.accept().await.unwrap();
+        let task = tokio::spawn(async move {
+            meow_listener::http_proxy::handle_http(
+                &tunnel,
+                server,
+                peer,
+                None,
+                None,
+                "http",
+                inbound_addr.port(),
+            )
+            .await;
+        });
+        client
+            .write_all(
+                format!("GET http://{destination}/ HTTP/1.1\r\nHost: {destination}\r\n\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let (mut remote, _) = origin.accept().await.unwrap();
+        let mut header = Vec::new();
+        while !header.ends_with(b"\r\n\r\n") {
+            header.push(remote.read_u8().await.unwrap());
+        }
+        assert!(header.starts_with(b"GET / HTTP/1.1\r\n"));
+        let id = stats.active_connections()[0].id;
+        stats.close_connection(id);
+        assert_eq!(client.read(&mut [0; 1]).await.unwrap(), 0);
+        assert_eq!(remote.read(&mut [0; 1]).await.unwrap(), 0);
+        task.await.unwrap();
+        assert_eq!(stats.active_connection_count(), 0);
+    })
+    .await
+    .expect("plain HTTP ignored the close request");
+}

--- a/crates/meow-tunnel/src/statistics.rs
+++ b/crates/meow-tunnel/src/statistics.rs
@@ -23,7 +23,7 @@ use parking_lot::Mutex;
 use serde::Serialize;
 use smallvec::SmallVec;
 use smol_str::SmolStr;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -67,9 +67,28 @@ impl Default for RuleMatchCounters {
 pub struct ConnCounters {
     pub upload: AtomicI,
     pub download: AtomicI,
+    // Stored in the existing Arc so cancellation adds no setup allocation.
+    closed: AtomicBool,
+    close_notify: tokio::sync::Notify,
 }
 
 impl ConnCounters {
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.close_notify.notify_waiters();
+    }
+
+    pub(crate) async fn closed(&self) {
+        // Register before checking the flag: closing before the first poll or
+        // between the check and await must not lose the wakeup.
+        let notified = self.close_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if !self.closed.load(Ordering::Acquire) {
+            notified.await;
+        }
+    }
+
     pub fn upload_bytes(&self) -> Int {
         self.upload.load(Ordering::Relaxed)
     }
@@ -230,22 +249,37 @@ impl Statistics {
         rule_payload: SmolStr,
         chains: SmallVec<[Arc<str>; 1]>,
     ) -> Uuid {
+        self.track_connection_with_counters(metadata, rule, rule_payload, chains)
+            .0
+    }
+
+    pub(crate) fn track_connection_with_counters(
+        &self,
+        metadata: Metadata,
+        rule: SmolStr,
+        rule_payload: SmolStr,
+        chains: SmallVec<[Arc<str>; 1]>,
+    ) -> (Uuid, Arc<ConnCounters>) {
         let uuid = Uuid::new_v4();
+        let counters = Arc::new(ConnCounters::default());
         let info = ConnectionInfo {
             id: uuid,
             metadata: Arc::new(metadata),
-            counters: Arc::new(ConnCounters::default()),
+            counters: Arc::clone(&counters),
             start: chrono_now(),
             chains,
             rule,
             rule_payload,
         };
         self.connections.insert(uuid, info);
-        uuid
+        (uuid, counters)
     }
 
+    /// Signal the owner to drop its dial/relay future and remove the entry.
     pub fn close_connection(&self, id: Uuid) {
-        self.connections.remove(&id);
+        if let Some((_, info)) = self.connections.remove(&id) {
+            info.counters.close();
+        }
     }
 
     /// Live cumulative `(upload, download)` totals, read straight from the
@@ -278,7 +312,36 @@ impl Statistics {
     }
 
     pub fn close_all_connections(&self) {
-        self.connections.clear();
+        self.close_all_connections_counted();
+    }
+
+    fn close_all_connections_counted(&self) -> usize {
+        let mut closed = 0;
+        // Signal and remove under the same shard lock. A separate iteration
+        // followed by clear could erase newly inserted, unsignalled entries.
+        self.connections.retain(|_, info| {
+            info.counters.close();
+            closed += 1;
+            false
+        });
+        closed
+    }
+
+    /// Allow active streams to finish, then cancel any remaining dials/relays.
+    /// Returns the number of connections for which closure was requested.
+    pub async fn drain_connections(&self, timeout: std::time::Duration) -> usize {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while self.active_connection_count() > 0 {
+            if tokio::time::Instant::now() >= deadline {
+                return self.close_all_connections_counted();
+            }
+            tokio::time::sleep_until(std::cmp::min(
+                deadline,
+                tokio::time::Instant::now() + std::time::Duration::from_millis(10),
+            ))
+            .await;
+        }
+        0
     }
 }
 

--- a/crates/meow-tunnel/src/statistics.rs
+++ b/crates/meow-tunnel/src/statistics.rs
@@ -315,7 +315,9 @@ impl Statistics {
         self.close_all_connections_counted();
     }
 
-    fn close_all_connections_counted(&self) -> usize {
+    /// Request closure of all tracked TCP connections and remove their entries.
+    /// Returns the number of closure requests, not completed socket teardowns.
+    pub fn close_all_connections_counted(&self) -> usize {
         let mut closed = 0;
         // Signal and remove under the same shard lock. A separate iteration
         // followed by clear could erase newly inserted, unsignalled entries.
@@ -325,23 +327,6 @@ impl Statistics {
             false
         });
         closed
-    }
-
-    /// Allow active streams to finish, then cancel any remaining dials/relays.
-    /// Returns the number of connections for which closure was requested.
-    pub async fn drain_connections(&self, timeout: std::time::Duration) -> usize {
-        let deadline = tokio::time::Instant::now() + timeout;
-        while self.active_connection_count() > 0 {
-            if tokio::time::Instant::now() >= deadline {
-                return self.close_all_connections_counted();
-            }
-            tokio::time::sleep_until(std::cmp::min(
-                deadline,
-                tokio::time::Instant::now() + std::time::Duration::from_millis(10),
-            ))
-            .await;
-        }
-        0
     }
 }
 

--- a/crates/meow-tunnel/src/tcp.rs
+++ b/crates/meow-tunnel/src/tcp.rs
@@ -301,35 +301,26 @@ mod tests {
         assert!(rx.await.is_err(), "cancelled future must release resources");
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn drain_allows_natural_completion_and_times_out_stalled_connections() {
+    #[tokio::test]
+    async fn close_all_counts_requests_and_cancels_each_connection() {
         let stats = Statistics::new();
-        let guard =
+        let first =
             ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
-        let start = tokio::time::Instant::now();
-        let complete = async {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            drop(guard);
-        };
-        let (closed, ()) = tokio::join!(
-            stats.drain_connections(std::time::Duration::from_secs(5)),
-            complete
-        );
-        assert_eq!(closed, 0);
-        assert!(start.elapsed() < std::time::Duration::from_secs(5));
+        let second =
+            ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
+        let completed =
+            ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
+        drop(completed);
 
-        let guard =
-            ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
-        let start = tokio::time::Instant::now();
-        assert_eq!(
-            stats
-                .drain_connections(std::time::Duration::from_secs(5))
-                .await,
-            1
-        );
-        assert_eq!(start.elapsed(), std::time::Duration::from_secs(5));
-        assert!(guard
-            .run_until_closed(std::future::pending::<()>())
+        assert_eq!(stats.close_all_connections_counted(), 2);
+        assert_eq!(stats.active_connection_count(), 0);
+        assert_eq!(stats.close_all_connections_counted(), 0);
+        assert!(first
+            .run_until_closed(async { panic!("first closed connection started dialing") })
+            .await
+            .is_none());
+        assert!(second
+            .run_until_closed(async { panic!("second closed connection started dialing") })
             .await
             .is_none());
     }

--- a/crates/meow-tunnel/src/tcp.rs
+++ b/crates/meow-tunnel/src/tcp.rs
@@ -36,14 +36,25 @@ impl<'a> ConnectionGuard<'a> {
         rule_payload: SmolStr,
         chains: SmallVec<[Arc<str>; 1]>,
     ) -> Self {
-        let id = stats.track_connection(metadata, rule, rule_payload, chains);
-        // Entry was just inserted; the fallback Arc only exists to keep this
-        // infallible if a concurrent close_all ever races connection setup.
-        let counters = stats.connection_counters(id).unwrap_or_default();
+        // Obtain the handle before publishing the entry. A concurrent DELETE
+        // must cancel this exact handle, even before its first poll.
+        let (id, counters) =
+            stats.track_connection_with_counters(metadata, rule, rule_payload, chains);
         Self {
             stats,
             id,
             counters,
+        }
+    }
+
+    /// Run the complete dial/write/relay lifetime until an API close request.
+    /// Dropping the future releases its remote stream; callers then return to
+    /// the listener so the owned inbound stream is dropped as well.
+    pub async fn run_until_closed<F: std::future::Future>(&self, future: F) -> Option<F::Output> {
+        tokio::select! {
+            biased;
+            () = self.counters.closed() => None,
+            output = future => Some(output),
         }
     }
 
@@ -167,77 +178,81 @@ pub async fn route_inbound_tcp<C>(
     // Dial the remote via proxy, bounded like mihomo's `C.DefaultTCPTimeout`:
     // a server that accepts and then stalls mid-handshake would otherwise pin
     // this task, its inbound socket and its stats entry forever.
-    match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
-        Ok(mut remote) => {
-            let up = Arc::clone(guard.counters());
-            let dn = Arc::clone(guard.counters());
-            // Re-emit any bytes the listener already read past the handshake
-            // (e.g. pipelined TLS ClientHello after a CONNECT 200). Counted
-            // as upload so the connection stats stay accurate. A failure
-            // here kills the connection (the remote half is unusable), so it
-            // must be visible at `warn` — the pre-refactor code propagated
-            // it to the caller instead of swallowing it at `debug`
-            // (review M9).
-            if !prefix.is_empty() {
-                if let Err(e) = remote.write_all(prefix).await {
-                    warn!(
-                        "{} {} prefix write error: {}",
-                        metadata.conn_type,
-                        metadata.remote_address(),
-                        e
-                    );
-                    return;
-                }
-                inner
-                    .stats
-                    .record_upload(&up, prefix.len() as meow_common::atomic::Int);
-            }
-            match copy_bidirectional_buf_tracked(
-                conn,
-                &mut remote,
-                &mut buf_up,
-                &mut buf_dn,
-                |n| {
-                    inner
-                        .stats
-                        .record_upload(&up, n as meow_common::atomic::Int);
-                },
-                |n| {
-                    inner
-                        .stats
-                        .record_download(&dn, n as meow_common::atomic::Int);
-                },
-            )
-            .await
-            {
-                Ok((up, down)) => {
-                    debug!(
-                        "{} {} relay closed: up={} down={}",
-                        metadata.conn_type,
-                        metadata.remote_address(),
-                        up,
-                        down
-                    );
+    guard
+        .run_until_closed(async {
+            match with_dial_timeout(proxy.name(), proxy.dial_tcp(&metadata)).await {
+                Ok(mut remote) => {
+                    let up = Arc::clone(guard.counters());
+                    let dn = Arc::clone(guard.counters());
+                    // Re-emit any bytes the listener already read past the handshake
+                    // (e.g. pipelined TLS ClientHello after a CONNECT 200). Counted
+                    // as upload so the connection stats stay accurate. A failure
+                    // here kills the connection (the remote half is unusable), so it
+                    // must be visible at `warn` — the pre-refactor code propagated
+                    // it to the caller instead of swallowing it at `debug`
+                    // (review M9).
+                    if !prefix.is_empty() {
+                        if let Err(e) = remote.write_all(prefix).await {
+                            warn!(
+                                "{} {} prefix write error: {}",
+                                metadata.conn_type,
+                                metadata.remote_address(),
+                                e
+                            );
+                            return;
+                        }
+                        inner
+                            .stats
+                            .record_upload(&up, prefix.len() as meow_common::atomic::Int);
+                    }
+                    match copy_bidirectional_buf_tracked(
+                        conn,
+                        &mut remote,
+                        &mut buf_up,
+                        &mut buf_dn,
+                        |n| {
+                            inner
+                                .stats
+                                .record_upload(&up, n as meow_common::atomic::Int);
+                        },
+                        |n| {
+                            inner
+                                .stats
+                                .record_download(&dn, n as meow_common::atomic::Int);
+                        },
+                    )
+                    .await
+                    {
+                        Ok((up, down)) => {
+                            debug!(
+                                "{} {} relay closed: up={} down={}",
+                                metadata.conn_type,
+                                metadata.remote_address(),
+                                up,
+                                down
+                            );
+                        }
+                        Err(e) => {
+                            debug!(
+                                "{} {} relay error: {}",
+                                metadata.conn_type,
+                                metadata.remote_address(),
+                                e
+                            );
+                        }
+                    }
                 }
                 Err(e) => {
-                    debug!(
-                        "{} {} relay error: {}",
+                    warn!(
+                        "{} {} dial error: {}",
                         metadata.conn_type,
                         metadata.remote_address(),
                         e
                     );
                 }
             }
-        }
-        Err(e) => {
-            warn!(
-                "{} {} dial error: {}",
-                metadata.conn_type,
-                metadata.remote_address(),
-                e
-            );
-        }
-    }
+        })
+        .await;
 }
 
 #[cfg(test)]
@@ -253,6 +268,70 @@ mod tests {
             dst_port: 443,
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn close_before_first_poll_does_not_start_dial() {
+        let stats = Statistics::new();
+        let guard =
+            ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
+        stats.close_connection(guard.id());
+        assert!(guard
+            .run_until_closed(async { panic!("closed connection started dialing") })
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn close_cancels_pending_future_and_drops_its_resources() {
+        let stats = Statistics::new();
+        let guard =
+            ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let pending = guard.run_until_closed(async move {
+            let _resource = tx;
+            std::future::pending::<()>().await;
+        });
+        let close = async {
+            tokio::task::yield_now().await;
+            stats.close_connection(guard.id());
+        };
+        let (result, ()) = tokio::join!(pending, close);
+        assert!(result.is_none());
+        assert!(rx.await.is_err(), "cancelled future must release resources");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_allows_natural_completion_and_times_out_stalled_connections() {
+        let stats = Statistics::new();
+        let guard =
+            ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
+        let start = tokio::time::Instant::now();
+        let complete = async {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            drop(guard);
+        };
+        let (closed, ()) = tokio::join!(
+            stats.drain_connections(std::time::Duration::from_secs(5)),
+            complete
+        );
+        assert_eq!(closed, 0);
+        assert!(start.elapsed() < std::time::Duration::from_secs(5));
+
+        let guard =
+            ConnectionGuard::track(&stats, metadata(), "MATCH".into(), "".into(), smallvec![]);
+        let start = tokio::time::Instant::now();
+        assert_eq!(
+            stats
+                .drain_connections(std::time::Duration::from_secs(5))
+                .await,
+            1
+        );
+        assert_eq!(start.elapsed(), std::time::Duration::from_secs(5));
+        assert!(guard
+            .run_until_closed(std::future::pending::<()>())
+            .await
+            .is_none());
     }
 
     #[test]

--- a/crates/meow-tunnel/tests/raii_guard_test.rs
+++ b/crates/meow-tunnel/tests/raii_guard_test.rs
@@ -157,3 +157,91 @@ async fn aborted_handle_tcp_does_not_leak_statistics_entry() {
     // Close the client side so the server task can clean up.
     let _ = _client_stream.shutdown().await;
 }
+
+#[tokio::test]
+async fn close_connection_cancels_pending_proxy_handshake() {
+    use tokio::io::AsyncReadExt;
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let tunnel = direct_tunnel();
+        let raw = meow_config::raw::RawConfig {
+            rules: Some(vec!["MATCH,REJECT-DROP".into()]),
+            ..Default::default()
+        };
+        let (proxies, rules) = meow_config::rebuild_from_raw(&raw).unwrap();
+        tunnel.update_proxies(proxies);
+        tunnel.update_rules(rules);
+        tunnel.set_mode(meow_common::TunnelMode::Rule);
+        let (server, mut client) = loopback_pair().await;
+        let inner = Arc::clone(tunnel.inner());
+        let task = tokio::spawn(async move {
+            handle_tcp(
+                &inner,
+                Box::new(server),
+                Metadata {
+                    network: Network::Tcp,
+                    dst_ip: Some("127.0.0.1".parse().unwrap()),
+                    dst_port: 12345,
+                    ..Default::default()
+                },
+            )
+            .await;
+        });
+        // REJECT-DROP's dial stalls for 60 s, keeping us in the dial phase.
+        while tunnel.statistics().active_connection_count() == 0 {
+            tokio::task::yield_now().await;
+        }
+        assert!(!task.is_finished());
+        let id = tunnel.statistics().active_connections()[0].id;
+        tunnel.statistics().close_connection(id);
+        assert_eq!(client.read(&mut [0; 1]).await.unwrap(), 0);
+        task.await.unwrap();
+    })
+    .await
+    .expect("close request failed to cancel pending dial");
+}
+
+#[tokio::test]
+async fn close_connection_cancels_blocked_prefix_write() {
+    use tokio::io::AsyncReadExt;
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        let tunnel = direct_tunnel();
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dst = upstream.local_addr().unwrap();
+        let (mut server, mut client) = loopback_pair().await;
+        let inner = Arc::clone(tunnel.inner());
+        let task = tokio::spawn(async move {
+            // Larger than the loopback TCP buffers: the peer reads one byte,
+            // leaving write_all pending before the relay can start.
+            let prefix = vec![b'x'; 16 * 1024 * 1024];
+            meow_tunnel::route_inbound_tcp(
+                &inner,
+                &mut server,
+                Metadata {
+                    dst_ip: Some(dst.ip()),
+                    dst_port: dst.port(),
+                    ..Default::default()
+                },
+                &prefix,
+            )
+            .await;
+        });
+        let (mut remote, _) = upstream.accept().await.unwrap();
+        assert_eq!(remote.read_u8().await.unwrap(), b'x');
+        let info = tunnel.statistics().active_connections().pop().unwrap();
+        assert_eq!(
+            info.counters.upload_bytes(),
+            0,
+            "prefix write must still be pending"
+        );
+        tunnel.statistics().close_connection(info.id);
+        assert_eq!(client.read(&mut [0; 1]).await.unwrap(), 0);
+        task.await.unwrap();
+        assert_eq!(
+            info.counters.upload_bytes(),
+            0,
+            "cancelled prefix must not complete"
+        );
+    })
+    .await
+    .expect("close request failed to cancel prefix write");
+}

--- a/docs/specs/api-config-reload-test-plan.md
+++ b/docs/specs/api-config-reload-test-plan.md
@@ -3,6 +3,12 @@
 Status: **draft** — owner: pm. Last updated: 2026-04-18.
 Tracks: task #23. Companion to `docs/specs/api-config-reload.md`.
 
+Implementation status (PR #509): the live-socket regression covers immediate
+TCP cancellation on cold reload and the new routing policy taking effect.
+It does not fulfill C3/C4: graceful draining depends on stopping listener
+admission and remains follow-up work with the listener lifecycle below in
+[#510](https://github.com/meow-rs/meow-rs/issues/510).
+
 This is the QA-owned acceptance test plan. The spec's `§Test plan` section
 is the PM's starting point; this document is the final shape engineer should
 implement against. If the spec and this document disagree, **this document

--- a/docs/specs/api-config-reload.md
+++ b/docs/specs/api-config-reload.md
@@ -9,6 +9,14 @@ See also: roadmap M3 "hot config reload without dropping connections" — this
 M1 spec is the cold-reload endpoint; M3 upgrades it to hot-reload.
 Upstream reference: `hub/server.go::patchConfig`, `component/profile/profile.go`.
 
+Implementation status (PR #509): cold reload requests immediate cancellation
+of tracked TCP connections before updating routing configuration. It does not
+stop listener admission or wait for graceful draining. The stop-listeners →
+drain (up to 5 seconds) → force-close → restart sequence below, including
+test-plan cases C3/C4, remains follow-up work in
+[#510](https://github.com/meow-rs/meow-rs/issues/510). UDP sessions are not tracked by
+the connection statistics table and are outside this TCP closure fix.
+
 ## Motivation
 
 The REST API has no way to reload configuration at runtime — operators must


### PR DESCRIPTION
`DELETE /connections/{id}`, `DELETE /connections`, and cold reload removed statistics while the underlying TCP streams continued forwarding. Give each tracked connection a cancellation signal and race it against the complete dial, prefix-write, and relay lifetime, including shared inbound routing, plain HTTP, and TProxy. Publish the signal with the entry so closure cannot be lost during registration.

Cold reload retains immediate execution: request TCP closure, log the actual number of requests, and install the new routing configuration. It adds no five-second drain delay. Full listener admission control and graceful draining, including spec cases C3/C4, are tracked in #510; the spec and test plan now state this implementation boundary explicitly.

Addresses finding 3 (P1, TCP scope) in #506. UDP session accounting/cancellation remains separate; this PR does not close the umbrella audit issue.

Validation on `aac5a50750fea8172681c702a9825d3c980c9a6d`, rebased onto main `e77f03e943016464b7dbd5ecdaec16fcc6cc9904` (includes #507/#508):
- Prescribed default suite: **1,666 passed, 4 ignored**. API suite: **81 passed in 1.09 seconds**. All-feature UDP routing regressions: **3 passed**.
- Live loopback sockets assert EOF/RST on both sides after single/all deletion and reload; deleting one preserves an unrelated stream. Reload must return within two seconds while a connection remains open, and subsequent routing selects the new REJECT policy.
- Pending dial, blocked prefix write, stalled plain HTTP response, close-before-first-poll, counted/idempotent cancellation, and existing abort/RAII cleanup are covered.
- Formatting and strict rustdoc passed. All three local strict clippy variants reproduce the pre-existing generated lwIP `unnecessary_transmutes` warnings; each supplementary run passes with only `-A unnecessary_transmutes`. CI retains the original strict commands. Toolchain: Rust 1.98.1.
- Release allocation gates: **3 exercised checks passed**; the provider-pressure case self-skips without local geodata.

Local W1 comparison, throughput in Gbps (median; IQR in parentheses):

| Workload | main | PR #509 | PR / main |
|---|---:|---:|---:|
| 4 KB x 10000 | 0.2191 (0.0208) | 0.2233 (0.0800) | 1.019x |
| 1 MB x 10 | 0.4034 (0.0102) | 0.4007 (0.0422) | 0.993x |
| 64 MB x 1 | 6.2168 (0.0587) | 6.3314 (0.5268) | 1.018x |

Method: Linux x86_64 KVM VM (Xeon Skylake), Rust 1.98.1, repository release profile/default features, loopback DIRECT config, CPU affinity 0–3, four Tokio workers. Five fresh-process samples per binary in AB/BA/AB/BA/AB order. The initial three samples exceeded the small-message spread criterion, so two further samples per binary were added, retaining all prior samples. The stock W1 branch ignores `--duration`, so a temporary driver repeats the unchanged W1 workloads after a discarded five-second warmup for at least 60 seconds per sample, then aggregates bytes / measured transfer time separately for each workload. This is a repeated mixed workload, not 60 seconds dedicated to each row. No local builds ran during measurement; no extra TIME_WAIT cooldown was inserted between targets.

All three median ratios exceed the 0.98x bar stated in CLAUDE.md, but this does **not** establish overall compliance: PR IQR/median is **35.8% for small messages** and **10.5% for medium transfers**, exceeding ADR-0006's 10% spread criterion. Those two results remain inconclusive even after the extra sampling. Bulk throughput has main/PR IQR/median of **0.94% / 8.32%** and shows no observed regression (1.018x median). This noisy VM comparison must not be presented as a performance gain or a canonical-reference-host M2 certification. A stable-host measurement is needed to establish the overall 2% non-regression target.

<details>
<summary>Raw W1 samples and temporary duration driver</summary>

Each list is all five measured samples in Gbps; no samples were discarded.

- 4 KB x 10000: main 0.234032, 0.248070, 0.219074, 0.210084, 0.213240; PR 0.295718, 0.299317, 0.215763, 0.223309, 0.209155.
- 1 MB x 10: main 0.403367, 0.425668, 0.406485, 0.396266, 0.392631; PR 0.425168, 0.418244, 0.375645, 0.400708, 0.376061.
- 64 MB x 1: main 6.268001, 6.434407, 6.216799, 6.209321, 6.151355; PR 6.512699, 6.794214, 5.985924, 6.331422, 5.894286.

The driver below was built in a temporary copy of `meow-bench`; it does not change the repository benchmark implementation. Both targets used the same driver with `--only throughput --duration 60` and `config-bench.yaml`.

```diff
--- a/crates/meow-bench/src/main.rs
+++ b/crates/meow-bench/src/main.rs
@@ -304,7 +304,25 @@
     // W1 — Throughput
     eprintln!("[{target_name}] benchmarking throughput...");
     let throughput = if run_all || only == "throughput" {
-        bench_throughput::bench_throughput(proxy_addr, echo_addr).await?
+        // Repeat the repository's unchanged W1 payloads after a discarded warmup.
+        let warmup_end = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < warmup_end {
+            bench_throughput::bench_throughput(proxy_addr, echo_addr).await?;
+        }
+        let deadline = std::time::Instant::now() + Duration::from_secs(args.duration);
+        let mut totals = bench_throughput::bench_throughput(proxy_addr, echo_addr).await?;
+        while std::time::Instant::now() < deadline {
+            let samples = bench_throughput::bench_throughput(proxy_addr, echo_addr).await?;
+            for (total, sample) in totals.iter_mut().zip(samples) {
+                assert_eq!(total.label, sample.label);
+                total.total_bytes += sample.total_bytes;
+                total.elapsed_secs += sample.elapsed_secs;
+            }
+        }
+        for total in &mut totals {
+            total.gbps = total.total_bytes as f64 * 8.0 / total.elapsed_secs / 1e9;
+        }
+        totals
     } else {
         vec![]
     };
```

</details>

Footprint previously measured with `rustc 1.97.1`, x86_64, `-Zprint-type-sizes`: `ConnectionInfo` 128 → 128 B; `ConnCounters` 16 → 56 B; `Metadata` 272 → 272 B; `UdpSession` 40 → 40 B. The follow-up commit changes none of these fields. The extra 40 B hold the closed flag and notification inside the existing Arc allocation. Relay buffers remain in the caller's async frame.

Library compatibility: `ConnCounters` gains private cancellation fields. External struct literals must migrate to `Default`; existing `Default` construction continues to work. The existing `close_all_connections()` return type is preserved; a counted variant is added for accurate reload logging.

Model attribution: OpenAI Codex, `gpt-6-astra`, reasoning effort `xhigh`.
