### PR TITLE
fix(configs): prevent TCP setup from escaping cold reload

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -1057,8 +1057,7 @@ async fn apply_raw_to_tunnel(
             format!("proxy group '{missing}' failed validation"),
         ));
     }
-    state.tunnel.update_proxies(proxies);
-    state.tunnel.update_rules(rules);
+    state.tunnel.update_routing(proxies, rules);
     Ok(())
 }
 
@@ -1931,23 +1930,18 @@ async fn put_configs(
         }
     };
 
-    // Preserve immediate cold-reload closure. Graceful draining requires
-    // stopping admission first; listeners still accept connections here.
-    let stats = state.tunnel.statistics();
-    let dropped = stats.close_all_connections_counted();
+    // Prepare routing before the synchronous admission/cancellation boundary.
+    // No old-policy setup can register after this cold reload completes.
+    let mode = raw_config
+        .mode
+        .as_deref()
+        .and_then(|mode| mode.parse().ok());
+    let dropped = state.tunnel.reload_routing(proxies, rules, mode);
     if dropped > 0 {
         tracing::warn!(
             connections_dropped = dropped,
             "connection closure requested for cold reload"
         );
-    }
-
-    state.tunnel.update_proxies(proxies);
-    state.tunnel.update_rules(rules);
-    if let Some(mode_str) = &raw_config.mode {
-        if let Ok(mode) = mode_str.parse::<TunnelMode>() {
-            state.tunnel.set_mode(mode);
-        }
     }
 
     swap_config_and_reconcile_tun(&state, raw_config).await;

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -3161,3 +3161,139 @@ async fn cold_reload_terminates_live_stream_without_drain_delay() {
         "new connections must see the reloaded policy"
     );
 }
+
+/// Force the real routing/DNS await to straddle two completed PUT requests.
+/// Before #510, this flow registers only after close_all and dials DIRECT
+/// using the old IP-CIDR rule, even though the active policy is now REJECT.
+#[tokio::test]
+async fn cold_reload_rejects_tcp_setup_waiting_for_dns() {
+    use base64::Engine as _;
+    use hickory_proto::{
+        op::Message,
+        rr::{rdata::A, RData, Record, RecordType},
+    };
+    use meow_common::{Metadata, Network};
+    use tokio::net::{TcpListener, TcpStream, UdpSocket};
+    use tokio::time::{timeout, Duration};
+
+    timeout(Duration::from_secs(5), async {
+        let dns = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut state = test_state(RawConfig {
+            rules: Some(vec![
+                "IP-CIDR,127.0.0.0/8,DIRECT".into(),
+                "MATCH,REJECT".into(),
+            ]),
+            ..Default::default()
+        });
+        let raw = state.raw_config.read().clone();
+        let tunnel = Tunnel::new(Arc::new(Resolver::new(
+            vec![dns.local_addr().unwrap()],
+            vec![],
+            DnsMode::Normal,
+            DomainTrie::new(),
+            false,
+            false,
+        )));
+        let (proxies, rules) = meow_config::rebuild_from_raw(&raw).unwrap();
+        tunnel.update_proxies(proxies);
+        tunnel.update_rules(rules);
+        Arc::get_mut(&mut state).unwrap().tunnel = tunnel;
+
+        let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let destination = origin.local_addr().unwrap();
+        let inbound = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mut client = TcpStream::connect(inbound.local_addr().unwrap())
+            .await
+            .unwrap();
+        let (server, _) = inbound.accept().await.unwrap();
+        let inner = Arc::clone(state.tunnel.inner());
+        let task = tokio::spawn(async move {
+            meow_tunnel::tcp::handle_tcp(
+                &inner,
+                Box::new(server),
+                Metadata {
+                    host: "reload.test".into(),
+                    dst_port: destination.port(),
+                    network: Network::Tcp,
+                    ..Default::default()
+                },
+            )
+            .await;
+        });
+
+        let mut packet = [0; 512];
+        let (len, peer) = dns.recv_from(&mut packet).await.unwrap();
+        let query = Message::from_vec(&packet[..len]).unwrap();
+        assert_eq!(query.queries[0].query_type, RecordType::A);
+        assert_eq!(state.tunnel.statistics().active_connection_count(), 0);
+        let payload = base64::engine::general_purpose::STANDARD
+            .encode("mode: rule\nrules:\n  - MATCH,REJECT\n");
+        for _ in 0..2 {
+            let response = create_router(Arc::clone(&state))
+                .oneshot(
+                    Request::builder()
+                        .method("PUT")
+                        .uri("/configs")
+                        .header("content-type", "application/json")
+                        .body(axum::body::Body::from(
+                            serde_json::json!({"payload": payload}).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        }
+
+        let mut response = Message::response(query.metadata.id, query.metadata.op_code);
+        response.metadata.recursion_desired = true;
+        response.metadata.recursion_available = true;
+        response
+            .add_queries(query.queries.iter().cloned())
+            .add_answer(Record::from_rdata(
+                query.queries[0].name.clone(),
+                60,
+                RData::A(A(Ipv4Addr::LOCALHOST)),
+            ));
+        dns.send_to(&response.to_vec().unwrap(), peer)
+            .await
+            .unwrap();
+
+        tokio::select! {
+            biased;
+            _ = origin.accept() => panic!("old-policy TCP setup escaped reload and dialed DIRECT"),
+            result = task => result.unwrap(),
+        }
+        assert_socket_closed(&mut client).await;
+        assert_eq!(state.tunnel.statistics().active_connection_count(), 0);
+        // A new real connection observes REJECT, rather than being blocked
+        // by a forgotten admission flag or using the previous DIRECT rule.
+        let mut fresh_client = TcpStream::connect(inbound.local_addr().unwrap())
+            .await
+            .unwrap();
+        let (fresh_server, _) = inbound.accept().await.unwrap();
+        let metadata = Metadata {
+            dst_ip: Some(destination.ip()),
+            dst_port: destination.port(),
+            network: Network::Tcp,
+            ..Default::default()
+        };
+        let (proxy, _, _) = state.tunnel.inner().resolve_proxy(&metadata).unwrap();
+        assert_eq!(proxy.name(), "REJECT");
+        let inner = Arc::clone(state.tunnel.inner());
+        let fresh_task = tokio::spawn(async move {
+            meow_tunnel::tcp::handle_tcp(&inner, Box::new(fresh_server), metadata).await;
+        });
+        tokio::select! {
+            biased;
+            _ = origin.accept() => panic!("new TCP setup used the old DIRECT policy"),
+            () = assert_socket_closed(&mut fresh_client) => {},
+        }
+        // REJECT supplies a read EOF; close the upload half too before
+        // waiting for the bidirectional relay task to finish.
+        drop(fresh_client);
+        fresh_task.await.unwrap();
+    })
+    .await
+    .expect("DNS-delayed setup escaped cold reload or admission did not recover");
+}

--- a/crates/meow-app/src/main.rs
+++ b/crates/meow-app/src/main.rs
@@ -811,8 +811,7 @@ async fn run(
     // Create the tunnel (core routing engine)
     let tunnel = Tunnel::new(Arc::clone(&config.dns.resolver));
     tunnel.set_mode(config.general.mode);
-    tunnel.update_rules(config.rules);
-    tunnel.update_proxies(config.proxies);
+    tunnel.update_routing(config.proxies, config.rules);
     tunnel.spawn_background_tasks();
 
     // Spawn periodic health checks for fallback / url-test proxy groups.

--- a/crates/meow-app/src/subscription_refresh.rs
+++ b/crates/meow-app/src/subscription_refresh.rs
@@ -86,8 +86,7 @@ pub async fn run_loop(raw_config: Arc<RwLock<RawConfig>>, tunnel: Tunnel, config
 
                     match rebuild {
                         Ok(Ok((new_proxies, new_rules))) => {
-                            tunnel.update_proxies(new_proxies);
-                            tunnel.update_rules(new_rules);
+                            tunnel.update_routing(new_proxies, new_rules);
                             info!("Subscription '{}' refreshed successfully", name);
                             let _ =
                                 meow_config::save_raw_config_async(&config_path, &snapshot).await;

--- a/crates/meow-listener/src/http_proxy.rs
+++ b/crates/meow-listener/src/http_proxy.rs
@@ -1,9 +1,7 @@
 use crate::sniffer::SnifferRuntime;
 use base64::Engine;
 use meow_common::{with_dial_timeout, AuthConfig, ConnType, Metadata, Network};
-use meow_tunnel::{
-    copy_bidirectional_buf_tracked, route_inbound_tcp, ConnectionGuard, Tunnel, RELAY_BUF_SIZE,
-};
+use meow_tunnel::{copy_bidirectional_buf_tracked, route_inbound_tcp, Tunnel, RELAY_BUF_SIZE};
 use smallvec::smallvec;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
@@ -240,6 +238,7 @@ async fn handle_http_inner(
 
         let inner = tunnel.inner();
         inner.pre_handle_metadata(&mut metadata);
+        let admission = inner.tcp_admission();
         let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy_lazy(&mut metadata).await
         else {
             write_bad_gateway(stream).await?;
@@ -255,13 +254,14 @@ async fn handle_http_inner(
             proxy.name()
         );
 
-        let _guard = ConnectionGuard::track(
-            &inner.stats,
+        let Some(_guard) = admission.track(
             metadata.pure(),
             rule_name,
             rule_payload,
             smallvec![Arc::from(proxy.name())],
-        );
+        ) else {
+            return Ok(());
+        };
 
         _guard
             .run_until_closed(async {

--- a/crates/meow-listener/src/tproxy/mod.rs
+++ b/crates/meow-listener/src/tproxy/mod.rs
@@ -4,7 +4,7 @@ mod orig_dest;
 use crate::sniffer::SnifferRuntime;
 use firewall::FirewallGuard;
 use meow_common::{with_dial_timeout, ConnType, Metadata, Network};
-use meow_tunnel::{copy_bidirectional_buf_tracked, ConnectionGuard, Tunnel, RELAY_BUF_SIZE};
+use meow_tunnel::{copy_bidirectional_buf_tracked, Tunnel, RELAY_BUF_SIZE};
 use smallvec::smallvec;
 use std::collections::HashSet;
 use std::future::Future;
@@ -323,6 +323,7 @@ async fn handle_tproxy_conn(
     );
 
     let inner = tunnel.inner();
+    let admission = inner.tcp_admission();
     let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy(&metadata) else {
         return Err("no matching rule".into());
     };
@@ -336,13 +337,14 @@ async fn handle_tproxy_conn(
         proxy.name()
     );
 
-    let _guard = ConnectionGuard::track(
-        &inner.stats,
+    let Some(_guard) = admission.track(
         metadata.pure(),
         rule_name,
         rule_payload,
         smallvec![Arc::from(proxy.name())],
-    );
+    ) else {
+        return Ok(());
+    };
 
     // Relay buffers on the future's stack — zero per-relay heap allocation (ADR-0011 T6).
     let mut relay_buf_up = [0u8; RELAY_BUF_SIZE];

--- a/crates/meow-listener/tests/http_connection_close.rs
+++ b/crates/meow-listener/tests/http_connection_close.rs
@@ -51,3 +51,94 @@ async fn close_stalled_plain_http_response_terminates_sockets() {
     .await
     .expect("plain HTTP ignored the close request");
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cold_reload_rejects_plain_http_setup_before_registration() {
+    use meow_common::{Metadata, Rule, RuleMatchHelper, RuleType, TunnelMode};
+    use std::sync::Mutex;
+    use tokio::sync::oneshot;
+
+    // Pause the eager match callback to exercise the gap between route
+    // selection and registration independently of the DNS-based API test.
+    struct PausedMatch {
+        started: Mutex<Option<oneshot::Sender<()>>>,
+        resume: Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+    impl Rule for PausedMatch {
+        fn rule_type(&self) -> RuleType {
+            RuleType::GeoIp
+        }
+        fn adapter(&self) -> &str {
+            "DIRECT"
+        }
+        fn payload(&self) -> &str {
+            "test"
+        }
+        fn match_metadata(&self, _: &Metadata, _: &RuleMatchHelper) -> bool {
+            if let Some(started) = self.started.lock().unwrap().take() {
+                started.send(()).unwrap();
+                self.resume
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(Duration::from_secs(5))
+                    .unwrap();
+            }
+            true
+        }
+    }
+
+    timeout(Duration::from_secs(5), async {
+        let tunnel = common::direct_tunnel();
+        tunnel.set_mode(TunnelMode::Rule);
+        let (started_tx, started_rx) = oneshot::channel();
+        let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+        tunnel.update_rules(vec![Box::new(PausedMatch {
+            started: Mutex::new(Some(started_tx)),
+            resume: Mutex::new(resume_rx),
+        })]);
+        let origin = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let destination = origin.local_addr().unwrap();
+        let inbound = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let inbound_addr = inbound.local_addr().unwrap();
+        let mut client = TcpStream::connect(inbound_addr).await.unwrap();
+        let (server, peer) = inbound.accept().await.unwrap();
+        let handler_tunnel = tunnel.clone();
+        let task = tokio::spawn(async move {
+            meow_listener::http_proxy::handle_http(
+                &handler_tunnel,
+                server,
+                peer,
+                None,
+                None,
+                "http",
+                inbound_addr.port(),
+            )
+            .await;
+        });
+        client
+            .write_all(
+                format!("GET http://{destination}/ HTTP/1.1\r\nHost: {destination}\r\n\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+        started_rx.await.unwrap();
+        assert_eq!(tunnel.statistics().active_connection_count(), 0);
+        let raw = meow_config::raw::RawConfig {
+            rules: Some(vec!["MATCH,REJECT".into()]),
+            ..Default::default()
+        };
+        let (proxies, rules) = meow_config::rebuild_from_raw(&raw).unwrap();
+        assert_eq!(tunnel.reload_routing(proxies, rules, None), 0);
+        resume_tx.send(()).unwrap();
+        tokio::select! {
+            biased;
+            _ = origin.accept() => panic!("old-policy HTTP request dialed after reload"),
+            result = task => result.unwrap(),
+        }
+        assert_eq!(client.read(&mut [0; 1]).await.unwrap(), 0);
+        assert_eq!(tunnel.statistics().active_connection_count(), 0);
+    })
+    .await
+    .expect("plain HTTP setup escaped reload");
+}

--- a/crates/meow-tunnel/src/tcp.rs
+++ b/crates/meow-tunnel/src/tcp.rs
@@ -75,6 +75,47 @@ impl Drop for ConnectionGuard<'_> {
     }
 }
 
+/// A TCP setup's cold-reload generation, captured before reading routing state.
+/// This is a value, not a held lock, so DNS enrichment may safely await.
+#[must_use]
+pub struct TcpAdmission<'a> {
+    inner: &'a TunnelInner,
+    generation: u64,
+}
+
+impl TunnelInner {
+    /// Start TCP routing setup. Call before resolving the proxy, then register
+    /// through the returned token so cold reload cannot miss the connection.
+    pub fn tcp_admission(&self) -> TcpAdmission<'_> {
+        TcpAdmission {
+            inner: self,
+            generation: *self.tcp_generation.read(),
+        }
+    }
+}
+
+impl<'a> TcpAdmission<'a> {
+    /// Register only if no cold reload has crossed this routing decision.
+    /// The read lock covers both validation and insertion: a reload cannot
+    /// close the table between these operations and leave an old flow alive.
+    pub fn track(
+        self,
+        metadata: Metadata,
+        rule: SmolStr,
+        rule_payload: SmolStr,
+        chains: SmallVec<[Arc<str>; 1]>,
+    ) -> Option<ConnectionGuard<'a>> {
+        let generation = self.inner.tcp_generation.read();
+        if *generation != self.generation {
+            debug!("TCP routing setup invalidated by cold reload");
+            return None;
+        }
+        let guard = ConnectionGuard::track(&self.inner.stats, metadata, rule, rule_payload, chains);
+        drop(generation);
+        Some(guard)
+    }
+}
+
 pub async fn handle_tcp(tunnel: &TunnelInner, mut conn: Box<dyn ProxyConn>, metadata: Metadata) {
     route_inbound_tcp(tunnel, &mut conn, metadata, &[]).await;
 }
@@ -137,6 +178,8 @@ pub async fn route_inbound_tcp<C>(
     // snooping-cache hostname fill-in).
     inner.pre_handle_metadata(&mut metadata);
 
+    let admission = inner.tcp_admission();
+
     // Match rules with lazy enrichment: DNS pre-resolution and process
     // lookup run only if the scan reaches a rule that demands them.
     let Some((proxy, rule_name, rule_payload)) = inner.resolve_proxy_lazy(&mut metadata).await
@@ -162,13 +205,14 @@ pub async fn route_inbound_tcp<C>(
     // the abort case where the manual close call below would never run.
     // `rule_name` / `rule_payload` are moved in (already `SmolStr`); the
     // chains vec carries one `Arc<str>` for the proxy name.
-    let guard = ConnectionGuard::track(
-        &inner.stats,
+    let Some(guard) = admission.track(
         metadata.pure(),
         rule_name,
         rule_payload,
         smallvec![Arc::from(proxy.name())],
-    );
+    ) else {
+        return;
+    };
 
     // Declare relay buffers on the future's stack frame — zero per-relay heap
     // allocation (ADR-0011 T6). Paid once at task-spawn, not at relay-call time.
@@ -267,6 +311,71 @@ mod tests {
             host: "example.com".into(),
             dst_port: 443,
             ..Default::default()
+        }
+    }
+
+    fn test_tunnel() -> crate::Tunnel {
+        crate::Tunnel::new(Arc::new(meow_dns::Resolver::new(
+            vec![],
+            vec![],
+            meow_common::DnsMode::Normal,
+            meow_trie::DomainTrie::new(),
+            false,
+            false,
+        )))
+    }
+
+    #[tokio::test]
+    async fn cold_reload_rejects_late_registration_and_cancels_earlier_registration() {
+        let tunnel = test_tunnel();
+        let inner = tunnel.inner();
+        let late = inner.tcp_admission();
+        let registered = inner
+            .tcp_admission()
+            .track(metadata(), "MATCH".into(), "".into(), smallvec![])
+            .unwrap();
+
+        assert_eq!(tunnel.reload_routing(Default::default(), vec![], None), 1);
+        // Same configuration and mode across multiple reloads: a boolean
+        // running flag (or config equality) must not admit the old decision.
+        assert_eq!(tunnel.reload_routing(Default::default(), vec![], None), 0);
+        assert!(late
+            .track(metadata(), "MATCH".into(), "".into(), smallvec![])
+            .is_none());
+        assert!(registered
+            .run_until_closed(async { "dial" })
+            .await
+            .is_none());
+
+        let fresh = inner
+            .tcp_admission()
+            .track(metadata(), "MATCH".into(), "".into(), smallvec![])
+            .unwrap();
+        assert_eq!(fresh.run_until_closed(async { "dial" }).await, Some("dial"));
+        assert_eq!(inner.stats.active_connection_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_registration_cannot_escape_cold_reload() {
+        let tunnel = test_tunnel();
+        for _ in 0..64 {
+            let start = std::sync::Barrier::new(2);
+            let admission = tunnel.inner().tcp_admission();
+            // Race the final registration against closure on actual threads.
+            // Either it is rejected, or its exact cancellation handle is set.
+            let guard = std::thread::scope(|scope| {
+                let registration = scope.spawn(|| {
+                    start.wait();
+                    admission.track(metadata(), "MATCH".into(), "".into(), smallvec![])
+                });
+                start.wait();
+                tunnel.reload_routing(Default::default(), vec![], None);
+                registration.join().unwrap()
+            });
+            if let Some(guard) = guard {
+                assert!(guard.run_until_closed(async { "dial" }).await.is_none());
+            }
+            assert_eq!(tunnel.statistics().active_connection_count(), 0);
         }
     }
 

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -38,6 +38,17 @@ pub struct RouteTable {
 }
 
 impl RouteTable {
+    fn new(proxies: HashMap<SmolStr, Arc<dyn Proxy>>, rules: Vec<Box<dyn Rule>>) -> Self {
+        let domain_index = DomainIndex::build(&rules);
+        let compiled_rules = CompiledRuleSet::build(&rules);
+        Self {
+            rules: Arc::new(rules),
+            domain_index: Arc::new(domain_index),
+            compiled_rules: Arc::new(compiled_rules),
+            proxies,
+        }
+    }
+
     fn empty() -> Self {
         Self {
             rules: Arc::new(Vec::new()),
@@ -61,6 +72,11 @@ pub struct TunnelInner {
     pub direct: Arc<DirectAdapter>,
     pub nat_table: NatTable,
     pub stats: Arc<Statistics>,
+    /// Cold-reload admission boundary. TCP setup captures this generation
+    /// before routing, then checks it under a read lock through registration.
+    /// Reload holds the write lock through cancellation and route publication.
+    /// Neither side holds this lock across an await or during relay.
+    pub(crate) tcp_generation: RwLock<u64>,
     /// Cached: true if any rule needs the dst_ip resolved (GeoIP / IP-CIDR).
     /// Recomputed by `Tunnel::update_rules`.
     pub needs_ip_resolution: AtomicBool,
@@ -174,7 +190,7 @@ impl TunnelInner {
                 // One route-table snapshot — rules + index + proxies all read
                 // from a consistent table. Replaces three RwLock acquisitions.
                 let route = self.route();
-                let needs_proc = self.needs_process_lookup.load(Ordering::Relaxed);
+                let needs_proc = route.compiled_rules.needs_process_lookup();
                 let enriched = if needs_proc {
                     match_engine::maybe_enrich_with_process(metadata)
                 } else {
@@ -310,6 +326,7 @@ impl Tunnel {
                 direct,
                 nat_table: udp::new_nat_table(),
                 stats: Arc::new(Statistics::new()),
+                tcp_generation: RwLock::new(0),
                 needs_ip_resolution: AtomicBool::new(false),
                 needs_process_lookup: AtomicBool::new(false),
                 tun_handle: RwLock::new(None),
@@ -381,6 +398,59 @@ impl Tunnel {
             *route = Arc::new(new_route);
         }
         info!("Proxies updated");
+    }
+
+    /// Publish a complete rules/proxies snapshot, preserving active TCP flows.
+    /// Use this instead of successive partial updates for a config rebuild.
+    pub fn update_routing(
+        &self,
+        proxies: HashMap<SmolStr, Arc<dyn Proxy>>,
+        rules: Vec<Box<dyn Rule>>,
+    ) {
+        drop(self.install_routing(Arc::new(RouteTable::new(proxies, rules))));
+        info!("Routing configuration updated");
+    }
+
+    /// Immediately cancel tracked TCP flows and publish new routing state.
+    ///
+    /// Compilation finishes before admission is locked. Registration either
+    /// precedes cancellation, or detects the changed generation and refuses
+    /// the old routing decision (including a decision delayed by DNS). New
+    /// setup can capture the new generation only after publication completes.
+    /// Returns closure requests for tracked TCP flows, not completed teardowns;
+    /// unregistered setups are rejected later and UDP sessions are unaffected.
+    pub fn reload_routing(
+        &self,
+        proxies: HashMap<SmolStr, Arc<dyn Proxy>>,
+        rules: Vec<Box<dyn Rule>>,
+        mode: Option<TunnelMode>,
+    ) -> usize {
+        let route = Arc::new(RouteTable::new(proxies, rules));
+        let mut generation = self.inner.tcp_generation.write();
+        *generation = generation.checked_add(1).expect("TCP generation exhausted");
+        let closed = self.inner.stats.close_all_connections_counted();
+        let old = self.install_routing(route);
+        if let Some(mode) = mode {
+            self.set_mode(mode);
+        }
+        drop(generation);
+        // Releasing a large old rule set must not hold up TCP admission.
+        drop(old);
+        info!("Routing configuration reloaded");
+        closed
+    }
+
+    fn install_routing(&self, route: Arc<RouteTable>) -> Arc<RouteTable> {
+        let needs_ip = route.compiled_rules.needs_ip_resolution();
+        let needs_process = route.compiled_rules.needs_process_lookup();
+        let mut current = self.inner.route.write();
+        self.inner
+            .needs_ip_resolution
+            .store(needs_ip, Ordering::Relaxed);
+        self.inner
+            .needs_process_lookup
+            .store(needs_process, Ordering::Relaxed);
+        std::mem::replace(&mut *current, route)
     }
 
     pub fn statistics(&self) -> &Arc<Statistics> {
@@ -466,7 +536,7 @@ impl Clone for Tunnel {
 }
 
 #[cfg(test)]
-mod tun_handle_tests {
+mod tests {
     use super::*;
     use meow_common::DnsMode;
     use meow_dns::Resolver;
@@ -482,6 +552,88 @@ mod tun_handle_tests {
             true,
         ));
         Tunnel::new(resolver)
+    }
+
+    #[test]
+    fn routing_rebuild_keeps_old_snapshot_until_candidate_is_ready() {
+        use meow_common::{RuleMatchHelper, RuleType};
+        use std::sync::mpsc::{self, Receiver, SyncSender};
+        use std::time::Duration;
+
+        // Pause real rule compilation, after the caller has supplied both
+        // the replacement proxies and rules. A split publication exposes
+        // new proxies with old rules during precisely this interval.
+        struct PausedRule(parking_lot::Mutex<Option<(SyncSender<()>, Receiver<()>)>>);
+        impl Rule for PausedRule {
+            fn rule_type(&self) -> RuleType {
+                RuleType::Match
+            }
+            fn match_metadata(&self, _: &Metadata, _: &RuleMatchHelper) -> bool {
+                true
+            }
+            fn adapter(&self) -> &str {
+                "NEW"
+            }
+            fn payload(&self) -> &str {
+                if let Some((entered, resume)) = self.0.lock().take() {
+                    entered.send(()).unwrap();
+                    resume.recv_timeout(Duration::from_secs(5)).unwrap();
+                }
+                ""
+            }
+        }
+
+        for cold in [false, true] {
+            let tunnel = test_tunnel();
+            let proxy = meow_config::rebuild_from_raw(&Default::default())
+                .unwrap()
+                .0
+                .remove("DIRECT")
+                .unwrap();
+            tunnel.update_routing(
+                HashMap::from([("OLD".into(), Arc::clone(&proxy))]),
+                vec![Box::new(meow_rules::final_rule::FinalRule::new("OLD"))],
+            );
+            let stats = tunnel.statistics();
+            let id = stats.track_connection(
+                Metadata::default(),
+                "MATCH".into(),
+                "".into(),
+                smallvec::smallvec![],
+            );
+            let old = tunnel.route_snapshot();
+            let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+            let (resume_tx, resume_rx) = mpsc::sync_channel(1);
+            let candidate: Vec<Box<dyn Rule>> = vec![Box::new(PausedRule(
+                parking_lot::Mutex::new(Some((entered_tx, resume_rx))),
+            ))];
+            std::thread::scope(|scope| {
+                let writer = scope.spawn(|| {
+                    let proxies = HashMap::from([("NEW".into(), proxy)]);
+                    if cold {
+                        assert_eq!(tunnel.reload_routing(proxies, candidate, None), 1);
+                    } else {
+                        tunnel.update_routing(proxies, candidate);
+                    }
+                });
+                entered_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                let during_build = tunnel.route_snapshot();
+                let still_tracked = stats.active_connection_count();
+                // Release the compiler before asserting, including failure paths.
+                resume_tx.send(()).unwrap();
+                writer.join().unwrap();
+                assert!(Arc::ptr_eq(&old, &during_build));
+                assert_eq!(still_tracked, 1, "compilation must precede cancellation");
+            });
+            let new = tunnel.route_snapshot();
+            assert_eq!(new.rules[0].adapter(), "NEW");
+            assert!(new.proxies.contains_key("NEW"));
+            assert!(!new.proxies.contains_key("OLD"));
+            assert_eq!(old.rules[0].adapter(), "OLD");
+            assert!(old.proxies.contains_key("OLD"));
+            assert_eq!(stats.active_connection_count(), usize::from(!cold));
+            stats.close_connection(id);
+        }
     }
 
     /// Sends on drop, so a test can observe that an aborted listener task

--- a/docs/specs/api-config-reload-test-plan.md
+++ b/docs/specs/api-config-reload-test-plan.md
@@ -3,11 +3,28 @@
 Status: **draft** — owner: pm. Last updated: 2026-04-18.
 Tracks: task #23. Companion to `docs/specs/api-config-reload.md`.
 
-Implementation status (PR #509): the live-socket regression covers immediate
-TCP cancellation on cold reload and the new routing policy taking effect.
-It does not fulfill C3/C4: graceful draining depends on stopping listener
-admission and remains follow-up work with the listener lifecycle below in
-[#510](https://github.com/meow-rs/meow-rs/issues/510).
+Scope amendment (2026-09-05, [#510](https://github.com/meow-rs/meow-rs/issues/510)):
+the current acceptance scope is immediate TCP cancellation plus a synchronized
+routing/registration boundary, not listener teardown or five-second draining.
+**C3/C4 are superseded, not fulfilled.** C1/C2 and F1 remain deferred to listener
+reconciliation/M3; the ArcSwap-specific cases were superseded by #327. The
+historical case list below does not override these amendments.
+
+Current regressions run in the existing `meow-tunnel --lib`, `api_test`, and
+`http_connection_close` suites, which are already included in CI:
+
+| Case | Evidence |
+|------|----------|
+| DNS-delayed setup crosses two completed PUT requests | Release a real loopback DNS answer afterward; the old DIRECT destination must never be dialed, inbound must receive EOF/RST, and a fresh connection must obey REJECT. |
+| Plain HTTP setup crosses publication | Pause rule matching before registration, reload, and resume; the old DIRECT origin must never be contacted and the client receives EOF. |
+| Registration races closure | A setup either registers before cancellation and observes its close signal, or is rejected without an entry. Repeated reloads of the same config cannot admit an old setup. |
+| Candidate preparation and snapshot publication | Pause rule compilation; readers still see the entire old snapshot and old flows remain registered. After publication, new rules and proxies agree; non-cold updates preserve flows. |
+| Immediate cancellation | Existing #509 live-stream regression observes EOF/RST in both directions without a five-second wait. |
+
+Admission begins at TCP routing, after handshake/sniffing. A pending DNS query
+need not be cancelled immediately, but cannot register or dial with its old
+decision after returning. UDP flow cancellation and listener/DNS configuration
+reconciliation are outside this PR's acceptance scope.
 
 This is the QA-owned acceptance test plan. The spec's `§Test plan` section
 is the PM's starting point; this document is the final shape engineer should
@@ -100,7 +117,7 @@ calls. No real listeners spawned. Use `#[tokio::test]`.
 | B5 | `get_configs_mode_field_reflects_current_mode` | Config with `mode: rule`. Assert `"mode": "rule"` in response. Regression guard that mode is serialised from active config, not a hardcoded default. |
 | B6 | `get_configs_after_reload_reflects_new_config` **[guard-rail]** | Start with `mixed-port: 7890`. Reload to `mixed-port: 7891`. `GET /configs`. Assert `"mixed-port": 7891`. Guards that GET reflects post-reload state, not stale pre-reload config. |
 
-### C. `AppState::reload()` unit tests
+### C. Original `AppState::reload()` unit tests (see amendment above)
 
 These test the reload lifecycle in isolation with mock listeners and a
 controlled connection count.

--- a/docs/specs/api-config-reload.md
+++ b/docs/specs/api-config-reload.md
@@ -9,13 +9,27 @@ See also: roadmap M3 "hot config reload without dropping connections" — this
 M1 spec is the cold-reload endpoint; M3 upgrades it to hot-reload.
 Upstream reference: `hub/server.go::patchConfig`, `component/profile/profile.go`.
 
-Implementation status (PR #509): cold reload requests immediate cancellation
-of tracked TCP connections before updating routing configuration. It does not
-stop listener admission or wait for graceful draining. The stop-listeners →
-drain (up to 5 seconds) → force-close → restart sequence below, including
-test-plan cases C3/C4, remains follow-up work in
-[#510](https://github.com/meow-rs/meow-rs/issues/510). UDP sessions are not tracked by
-the connection statistics table and are outside this TCP closure fix.
+Scope amendment (2026-09-05, [#510](https://github.com/meow-rs/meow-rs/issues/510)):
+retain immediate cold-reload cancellation from #509 and fix the TCP admission
+boundary and routing snapshot publication. The original five-second drain
+design and test-plan C3/C4 are **superseded**, not completed. Listener lifecycle
+reconciliation and connection-preserving hot reload remain separate M3 work.
+
+The current boundary is the start of TCP routing, after inbound handshake and
+sniffing. Setup captures a generation before reading mode/rules/proxies. It
+registers under a read lock only if that generation is still current. Reload
+builds and compiles the candidate first, then holds the matching write lock to
+advance the generation, cancel tracked TCP flows, and publish rules/proxies
+as one `Arc<RouteTable>` plus the requested mode. No lock spans DNS awaits or
+relay. A DNS-delayed setup is rejected when it returns; cancellation of DNS
+itself and inbound handshakes is not promised. A handshake that reaches routing
+after the boundary uses the new configuration.
+
+`connections_dropped` counts closure requests for registered TCP flows, not
+completed socket teardowns or rejected unregistered setups. UDP sessions are
+outside this boundary. Ordinary listener bindings/authentication and DNS
+runtime are not rebuilt by PUT; TUN reconciliation currently compares only
+`tun.enable`. These configuration-application gaps remain separate work.
 
 ## Motivation
 
@@ -25,9 +39,9 @@ standard part of the Clash/mihomo API surface that dashboard tools (Yacd,
 MetaCubeXD) call after a user edits configuration. Without it, dashboard
 config editors are broken.
 
-M1 scope is a **cold reload**: the running tunnel and all listeners are torn
-down and re-initialized from the new config. Connections in flight are dropped.
-This is an intentional simplification — hot-reload (no connection drop) is M3.
+The implemented **cold reload** cancels tracked TCP flows and replaces routing
+configuration. Connection-preserving hot reload is M3. Full listener teardown
+from the original M1 design was never implemented.
 
 ## Scope
 
@@ -39,8 +53,8 @@ In scope:
    restart even if the config has parse errors. If unset and config is invalid,
    return 400 and leave current config unchanged.
 3. Config validation (parse + schema check) before teardown of current config.
-4. Graceful teardown: close all listeners, wait for in-flight connections to
-   drain (up to a configurable timeout), then start fresh with new config.
+4. Immediately cancel registered TCP flows and reject older routing setups
+   across one synchronized configuration-publication boundary.
 5. Response: `204 No Content` on success; `400 Bad Request` with error
    message body on parse failure (when `?force=false`).
 6. Auth: `require_auth` middleware — same as all other mutating REST endpoints.
@@ -189,7 +203,7 @@ pub async fn put_configs(
 }
 ```
 
-### AppState::reload
+### Original AppState::reload design (superseded by the scope amendment)
 
 ```rust
 impl AppState {
@@ -204,7 +218,7 @@ impl AppState {
 }
 ```
 
-**Drain timeout**: 5 seconds, not configurable in M1. After 5s, force-close
+**Historical drain timeout**: 5 seconds, not configurable in M1. After 5s, force-close
 remaining connections with a structured log:
 
 ```rust
@@ -264,8 +278,8 @@ line breaks. This matches what dashboard tools encode (MetaCubeXD, Yacd).
 
 ## Acceptance criteria
 
-1. `PUT /configs` with valid `path` → 204; new config active; old listeners
-   stopped and new listeners started on new ports.
+1. `PUT /configs` with valid `path` → 204; new routing config active.
+   Rebinding listeners to changed ports remains a separate M3 requirement.
 2. `PUT /configs` with valid `payload` (base64 YAML) → 204; same effect.
 3. `PUT /configs` with invalid YAML → 400 with error message body;
    current config unchanged.
@@ -310,7 +324,7 @@ line breaks. This matches what dashboard tools encode (MetaCubeXD, Yacd).
   config with `mixed-port: 7891`; assert old port closed, new port listening.
   NOT old port still accepting. NOT new port unopened.
 
-## Implementation checklist (engineer handoff)
+## Original implementation checklist (historical; see scope amendment)
 
 - [ ] Add `arc-swap = "1"` and `base64 = "0.22"` to `crates/meow-api/Cargo.toml`.
 - [ ] Wrap `tunnel` in `Arc<ArcSwap<Tunnel>>` in `AppState`; update all handlers


### PR DESCRIPTION
A TCP setup waiting for DNS can miss cold reload's connection cancellation, then register and dial using the old policy. The loopback regression reproduces this on main at `d5952ca`: two successful reloads to REJECT are followed by a DIRECT connection when the delayed DNS answer arrives.

Capture a TCP generation before routing and validate it under a short read lock through statistics registration. Cold reload advances that generation, cancels registered flows, and installs the compiled routing snapshot and requested mode under the matching write lock. This covers the shared TCP handler, plain HTTP, and TProxy without holding a lock across DNS or relay. Full config rebuilds now publish proxies and rules together; non-cold updates preserve connections.

Retains #509's immediate cancellation. The spec amendment supersedes five-second draining and C3/C4. Listener reconciliation/M3, UDP cancellation, and DNS runtime rebuilds remain separate; pending DNS setups are rejected when resolution returns, and admission starts after handshake/sniffing.

Closes #510 under its revised scope.

Validation on Rust 1.98.1:

- Copied the DNS regression into otherwise-unmodified main: fails with `old-policy TCP setup escaped reload and dialed DIRECT`; passes with this change.
- Required unit/integration bar: **1,671 passed, 4 ignored** across 34 test binaries. Includes DNS-delay, plain HTTP, concurrent registration and snapshot publication regressions.
- All-feature UDP/53 suite: **3 passed**. Release allocation suite: **4 passed**; provider-backed pressure subcase self-skipped because its optional MMDB fixture is absent.
- Formatting and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` pass.
- Strict Clippy on all three feature matrices encounters only the pre-existing five `unnecessary_transmutes` diagnostics in generated lwIP bindings. All three pass with `-D warnings -A unnecessary_transmutes`; no source lint suppression added.

Size comparison (`-Zprint-type-sizes`, x86_64): `ConnectionInfo` 128 → 128 B, `ConnCounters` 56 → 56 B, `ConnectionGuard` 32 → 32 B, `TunnelInner` 88 → 104 B; new `TcpAdmission` is a 16 B borrowed value. No new setup allocation or relay-buffer changes.

All eight [PR CI jobs](https://github.com/meow-rs/meow-rs/actions/runs/33966396574) passed on `f1c86d0d4356c1490d8619053062ac2d476f7109`, including strict lint, tests, feature matrices, MSRV, macOS, Windows, OpenWrt and TProxy. Remote strict lint needs no exception.

Release performance comparison against `d5952ca740e1849b81256ea6d26dd346ff93129c`: loopback, default features, Rust 1.98.1, `taskset -c 0-3`, four Tokio workers, no competing local builds. Three fresh-process samples per binary, order main / PR / PR / main / main / PR. W1 repeats unchanged payloads after a discarded 5 s workload warmup, aggregating bytes/time over 60 s; W3 uses the stock 30 s, concurrency-64 driver, each preceded by at least 60 s of W1.

| Workload | Main median (IQR) | PR median (IQR) | Median delta |
| --- | ---: | ---: | ---: |
| 4 KB x 10000 | 0.2156 (0.0020) Gbps | 0.2130 (0.0052) Gbps | -1.24% |
| 1 MB x 10 | 0.4026 (0.0064) Gbps | 0.4005 (0.0030) Gbps | -0.52% |
| 64 MB x 1 | 6.0949 (0.2808) Gbps | 5.8761 (0.2275) Gbps | -3.59% |
| connections/sec | 8267.0 (396.7) conn/s | 8330.0 (252.1) conn/s | +0.76% |

The initial 64 MB median was -3.59%, with only about 3 s of actual large-transfer time inside each mixed-workload sample. To investigate, repeated only the unchanged 64 MB workload for a full 60 s after 5 s warmup, again three samples per binary in the same alternating order: **main 5.9368 Gbps (IQR 0.0231), PR 5.9356 Gbps (IQR 0.0260), -0.02%**. These shared-host comparisons are not a formal M2 performance-gate claim.

All six W3 runs had zero echo timeouts. Release binary size: 14,925,240 → 14,931,096 B (+5,856 B, +0.039%). Candidate and baseline binaries were independently verified against their source revision and have distinct SHA-256 hashes.
