### PR TITLE
fix: close five of the six audit findings in #513

### DIFF
--- a/crates/meow-api/src/routes.rs
+++ b/crates/meow-api/src/routes.rs
@@ -1047,7 +1047,14 @@ async fn apply_raw_to_tunnel(
         cache_dir,
     )
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    .map_err(|e| match e {
+        // The candidate is the caller's, so a parser rejection is a bad
+        // request — the same classification `PUT /configs` uses. This covers
+        // the proxies, groups, and rules that now fail the load instead of
+        // being warn-skipped (issue #513).
+        RebuildError::Config(msg) => (StatusCode::BAD_REQUEST, msg),
+        RebuildError::Task(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+    })?;
     if let Some(missing) = expected_groups
         .iter()
         .find(|name| !proxies.contains_key(name.as_str()))
@@ -1070,18 +1077,37 @@ async fn commit_raw_candidate(
     Ok(())
 }
 
+/// Why a candidate config did not turn into a route table. Callers classify
+/// the two cases differently: a rejected config is the caller's fault, a failed
+/// task is ours.
+enum RebuildError {
+    /// The parser refused the config — an unbuildable proxy, group, or rule
+    /// (issue #513), an escaping provider path, a bad rule-provider payload.
+    Config(String),
+    /// The blocking rebuild task panicked or was cancelled.
+    Task(String),
+}
+
+impl std::fmt::Display for RebuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Config(msg) | Self::Task(msg) => f.write_str(msg),
+        }
+    }
+}
+
 async fn rebuild_from_raw_with_resolver_async(
     raw: RawConfig,
     resolver: Arc<meow_dns::Resolver>,
     providers: HashMap<String, Arc<ProxyProvider>>,
     cache_dir: std::path::PathBuf,
-) -> Result<meow_config::RebuildResult, String> {
+) -> Result<meow_config::RebuildResult, RebuildError> {
     tokio::task::spawn_blocking(move || {
         meow_config::rebuild_from_raw_runtime(&raw, Some(resolver), &providers, Some(&cache_dir))
     })
     .await
-    .map_err(|e| format!("config rebuild task failed: {e}"))?
-    .map_err(|e| e.to_string())
+    .map_err(|e| RebuildError::Task(format!("config rebuild task failed: {e}")))?
+    .map_err(|e| RebuildError::Config(e.to_string()))
 }
 
 // ── Subscriptions ────────────────────────────────────────────────────

--- a/crates/meow-api/tests/api_test.rs
+++ b/crates/meow-api/tests/api_test.rs
@@ -1086,7 +1086,12 @@ async fn get_subscriptions_reports_counts() {
     // Subscription replaces proxies/groups/rules with remote data
     let mut proxy1 = std::collections::HashMap::new();
     proxy1.insert("name".to_string(), serde_yaml::Value::String("S1".into()));
-    proxy1.insert("type".to_string(), serde_yaml::Value::String("ss".into()));
+    // `direct` is the smallest node that builds from a name alone — an
+    // unparseable proxy now fails the load instead of being warn-skipped.
+    proxy1.insert(
+        "type".to_string(),
+        serde_yaml::Value::String("direct".into()),
+    );
     raw.proxies = Some(vec![proxy1]);
     raw.proxy_groups = Some(vec![RawProxyGroup {
         name: "G".into(),
@@ -1140,7 +1145,12 @@ async fn delete_subscription_clears_data() {
     }]);
     let mut proxy1 = std::collections::HashMap::new();
     proxy1.insert("name".to_string(), serde_yaml::Value::String("S1".into()));
-    proxy1.insert("type".to_string(), serde_yaml::Value::String("ss".into()));
+    // `direct` is the smallest node that builds from a name alone — an
+    // unparseable proxy now fails the load instead of being warn-skipped.
+    proxy1.insert(
+        "type".to_string(),
+        serde_yaml::Value::String("direct".into()),
+    );
     raw.proxies = Some(vec![proxy1]);
     raw.proxy_groups = Some(vec![RawProxyGroup {
         name: "G".into(),

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -788,6 +788,24 @@ fn rebuild_from_raw_impl(
     shared_ctx: Option<&meow_rules::ParserContext>,
     prefetched_payloads: Option<&rule_provider::PrefetchedPayloads>,
 ) -> Result<RebuildResult, anyhow::Error> {
+    // Fail hard on any rule- or proxy-provider path that would escape the
+    // provider cache directory — before any fetch or on-disk write happens,
+    // so a hostile `PUT /configs` is rejected without touching the
+    // filesystem (issue #429). Proxy-providers get the same loud failure as
+    // rule-providers (PR #444 review follow-up) instead of being warn-skipped
+    // with every group referencing them silently degrading.
+    //
+    // This runs first because an unbuildable group now fails the load too
+    // (issue #513): a group whose members all come from a provider slot it
+    // cannot resolve would otherwise report its own emptiness and bury the
+    // containment violation that caused it.
+    if let Some(map) = raw.rule_providers.as_ref() {
+        rule_provider::validate_paths(map, cache_dir)?;
+    }
+    if let Some(map) = raw.proxy_providers.as_ref() {
+        proxy_provider::validate_paths(map, cache_dir).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+
     let ipv6 = effective_ipv6(raw.ipv6);
     let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
     // `dialer-proxy` front hops are resolved by name against this registry on
@@ -836,7 +854,17 @@ fn rebuild_from_raw_impl(
                     .into();
                 proxies.insert(key, proxy);
             }
-            Err(e) => warn!("Failed to parse proxy: {}", e),
+            // Upstream mihomo warns and keeps loading, which leaves every
+            // group and rule naming that proxy resolving to nothing — the
+            // traffic then degrades to DIRECT rather than failing. Name the
+            // offending proxy so the load failure is actionable (issue #513).
+            Err(e) => {
+                let name = raw_proxy
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unnamed>");
+                return Err(anyhow::anyhow!("proxies: '{name}': {e}"));
+            }
         }
     }
 
@@ -894,7 +922,13 @@ fn rebuild_from_raw_impl(
                         let name = SmolStr::from(group.name());
                         proxies.insert(name, group);
                     }
-                    Err(e) => warn!("Failed to parse proxy group '{}': {}", raw_group.name, e),
+                    // The lenient pass already absorbs missing members; an
+                    // `Err` here means the group itself is unusable. Upstream
+                    // mihomo warns and continues, leaving every rule that
+                    // names it without a target (issue #513).
+                    Err(e) => {
+                        return Err(anyhow::anyhow!("proxy-groups: '{}': {e}", raw_group.name))
+                    }
                 }
             }
             break;
@@ -940,7 +974,11 @@ fn rebuild_from_raw_impl(
                     "Auto-created GLOBAL selector with all proxies"
                 );
             }
-            Err(e) => warn!("Failed to create GLOBAL selector: {}", e),
+            // GLOBAL is synthesized from the registry itself, so a failure
+            // here is not a bad member list but an unusable group — and
+            // rules or frontends naming it would silently lose their target
+            // (issue #513).
+            Err(e) => return Err(anyhow::anyhow!("proxy-groups: 'GLOBAL': {e}")),
         }
     }
 
@@ -948,19 +986,6 @@ fn rebuild_from_raw_impl(
     // Per-provider `proxy:` overrides resolve against the full registry —
     // groups and provider-sourced proxies included (issue #377).
     let registry_lookup = |name: &str| proxies.get(name).cloned();
-
-    // Fail hard on any rule- or proxy-provider path that would escape the
-    // provider cache directory — before any fetch or on-disk write happens,
-    // so a hostile `PUT /configs` is rejected without touching the
-    // filesystem (issue #429). Proxy-providers get the same loud failure as
-    // rule-providers (PR #444 review follow-up) instead of being warn-skipped
-    // with every group referencing them silently degrading.
-    if let Some(map) = raw.rule_providers.as_ref() {
-        rule_provider::validate_paths(map, cache_dir)?;
-    }
-    if let Some(map) = raw.proxy_providers.as_ref() {
-        proxy_provider::validate_paths(map, cache_dir).map_err(|e| anyhow::anyhow!("{e}"))?;
-    }
 
     // Fetch/read rule-provider payload bytes once — the parser-context build
     // scans them for geo keys (issue #277) and the provider load below parses
@@ -1016,22 +1041,8 @@ fn rebuild_from_raw_impl(
         &ruleset_map,
         ctx,
         &sub_rules,
-    );
-
-    // Validate: any `SUB-RULE,<name>` in top-level rules must reference a
-    // defined block. `parse_rules_full` warns on unknown blocks; promote
-    // undefined-block to a hard error here (Class A per ADR-0002).
-    if let Some(raw_rules) = raw.rules.as_deref() {
-        for line in raw_rules {
-            if let Some(name) = sub_rules_parser::parse_sub_rule_reference(line) {
-                if !sub_rules.contains_key(&name) {
-                    return Err(anyhow::anyhow!(
-                        "rules: SUB-RULE,{name} references undefined sub-rule block"
-                    ));
-                }
-            }
-        }
-    }
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     // Publish the finished registry: the `dialer-proxy` chains bound above
     // resolve their front hop by name against it, and only now does it hold the

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -547,9 +547,17 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// Apply per-outbound `dialer-proxy` in place (issue #210).
 ///
 /// For every proxy that declares `dialer-proxy: <name>`, its registry entry is
-/// re-parsed from the raw config with a [`meow_proxy::dialer::ProxyDialer`]
+/// re-parsed from the raw config with a [`meow_proxy::dialer::NamedProxyDialer`]
 /// injected, so the adapter dials its server through `<name>` transparently
 /// (mihomo `proxyDialer` model).
+///
+/// `<name>` is bound *late*: the injected dialer keeps the name plus a
+/// [`meow_proxy::dialer::ProxyRegistry`] handle and looks the front proxy up on
+/// every dial, which is what mihomo does (`component/proxydialer/byname.go`).
+/// Capturing the front `Arc` here instead freezes whatever the registry holds
+/// at build time — and since this pass runs *before* groups are built, so that
+/// grouped members inherit the chain (issue #513), a group-valued dialer does
+/// not exist yet at that point.
 ///
 /// Adapter types that do not establish their underlying connection through the
 /// pluggable dialer — `anytls`, `hysteria2` (QUIC), and `ss` with an external
@@ -564,21 +572,17 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// association rather than leaking the real source path; mux-based UDP rides
 /// the dialer over TCP and is unaffected.
 ///
-/// Nested dialer-proxies are resolved deepest-first so each layer sees its
-/// dialer's final (already-rebuilt) form. A self-referencing dialer, a
-/// reference to an unknown proxy, or a dialer cycle is a hard config error —
-/// silently falling back to a direct dial would let traffic egress from the
-/// real source path past a chain the user configured for policy/security
-/// reasons (Class A, ADR-0002).
-///
-/// Note: this rewrites the registry entry, so direct rule references
-/// (`…,<proxy>`) and dialers that are groups both work. A proxy that is also a
-/// static member of a group keeps the dialer for direct references but not when
-/// reached via that group, because group members are resolved eagerly before
-/// this pass.
+/// A self-referencing dialer, a reference to a name the config does not
+/// declare, or a dialer cycle is a hard config error — silently falling back to
+/// a direct dial would let traffic egress from the real source path past a
+/// chain the user configured for policy/security reasons (Class A, ADR-0002).
+/// A cycle has to be caught here in particular: late binding would turn it into
+/// unbounded recursion on the first dial.
 fn apply_dialer_proxies(
     proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
     raw_proxies: &[HashMap<String, serde_yaml::Value>],
+    raw_groups: &[raw::RawProxyGroup],
+    registry: &meow_proxy::dialer::ProxyRegistry,
     ipv6: bool,
 ) -> Result<(), anyhow::Error> {
     // Collect proxy -> dialer edges from the raw config.
@@ -588,7 +592,7 @@ fn apply_dialer_proxies(
     // duplicate `name:` entries the last block is the effective definition.
     // Collecting edges from superseded duplicates would apply a chain the
     // effective block never declared.
-    let mut pending: Vec<(SmolStr, SmolStr)> = Vec::new();
+    let mut edges: Vec<(SmolStr, SmolStr)> = Vec::new();
     let mut seen_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for raw_proxy in raw_proxies.iter().rev() {
         let Some(name) = raw_proxy.get("name").and_then(|v| v.as_str()) else {
@@ -607,102 +611,108 @@ fn apply_dialer_proxies(
         if dialer == name {
             anyhow::bail!("proxy '{name}': dialer-proxy points to itself");
         }
-        pending.push((SmolStr::from(name), SmolStr::from(dialer)));
+        edges.push((SmolStr::from(name), SmolStr::from(dialer)));
     }
-    if pending.is_empty() {
+    if edges.is_empty() {
         return Ok(());
     }
 
-    // Names that declared a dialer-proxy — used to defer an edge until its
-    // dialer has reached its final wrapped form (nested dialer-proxies).
-    let needs_wrap: std::collections::HashSet<SmolStr> =
-        pending.iter().map(|(n, _)| n.clone()).collect();
-    let mut resolved: std::collections::HashSet<SmolStr> = std::collections::HashSet::new();
-
-    loop {
-        let mut progressed = false;
-        let mut deferred = Vec::new();
-        for (name, dialer) in std::mem::take(&mut pending) {
-            // Defer until the dialer is in its final form (either it never
-            // needed wrapping, or it has already been resolved this pass).
-            if needs_wrap.contains(&dialer) && !resolved.contains(&dialer) {
-                deferred.push((name, dialer));
-                continue;
-            }
-            progressed = true;
-            let Some(dialer_proxy) = proxies.get(&dialer).cloned() else {
-                anyhow::bail!("proxy '{name}': dialer-proxy '{dialer}' not found");
-            };
-            // Re-parse the raw block with a `ProxyDialer` injected (mihomo
-            // model), so the adapter's own dial + handshake runs on the
-            // tunneled stream.
-            //
-            // `rev()` matters: the registry-building loop above uses `insert`,
-            // so for a config with duplicate `name:` entries the *last* block
-            // wins. A forward `find` here would resurrect the *first* block and
-            // silently swap the running definition out from under the user.
-            let raw_proxy = raw_proxies
-                .iter()
-                .rev()
-                .find(|rp| rp.get("name").and_then(|v| v.as_str()) == Some(&*name));
-            if let Some(raw) = raw_proxy {
-                let proxy_dialer: Arc<dyn meow_proxy::dialer::TcpDialer> = Arc::new(
-                    meow_proxy::dialer::ProxyDialer::new(Arc::clone(&dialer_proxy)),
-                );
-                match proxy_parser::parse_proxy_with_dialer(raw, &proxy_dialer, ipv6) {
-                    Ok(rebuilt) => {
-                        proxies.insert(name.clone(), rebuilt);
-                    }
-                    Err(e) => {
-                        // The adapter type cannot carry an injected dialer
-                        // (anytls, hysteria2, SS-with-external-SIP003-plugin) or
-                        // the block is otherwise unparseable. Fall back to the
-                        // relay-based `DialerProxyAdapter`, which preserves the
-                        // pre-dialer behaviour: it works for the protocols that
-                        // implement `connect_over` (HTTP/SOCKS5/Snell) and fails
-                        // loudly at dial time for the rest — never silently
-                        // dialing direct and leaking past the chain.
-                        //
-                        // The inner outbound may itself have failed to parse
-                        // earlier, in which case there is nothing to wrap.
-                        if let Some(inner) = proxies.get(&name).cloned() {
-                            warn!(
-                                "proxy '{name}': cannot inject dialer-proxy '{dialer}' \
-                                 ({e}); falling back to the relay-based wrapper"
-                            );
-                            let wrapped: Arc<dyn Proxy> =
-                                Arc::new(meow_proxy::DialerProxyAdapter::new(inner, dialer_proxy));
-                            proxies.insert(name.clone(), wrapped);
-                        } else {
-                            warn!(
-                                "proxy '{name}': dialer-proxy '{dialer}' not applied \
-                                 ({e}); the outbound itself failed to parse"
-                            );
-                        }
-                    }
-                }
-            } else {
-                // Unreachable in practice — edges are only collected from blocks
-                // in this same list — but refuse instead of silently dialing
-                // direct if the invariant ever breaks.
-                anyhow::bail!(
-                    "proxy '{name}': dialer-proxy '{dialer}' not applied; no raw \
-                     config block found for this name"
-                );
-            }
-            resolved.insert(name);
+    // Names a dialer may reference. Leaf proxies are in the registry already;
+    // groups are built after this pass, so only their *declared* names count
+    // here, plus `GLOBAL`, which is auto-created when the config omits it.
+    let dialable: std::collections::HashSet<&str> = proxies
+        .keys()
+        .map(SmolStr::as_str)
+        .chain(raw_groups.iter().map(|group| group.name.as_str()))
+        .chain(std::iter::once("GLOBAL"))
+        .collect();
+    for (name, dialer) in &edges {
+        if !dialable.contains(dialer.as_str()) {
+            anyhow::bail!("proxy '{name}': dialer-proxy '{dialer}' not found");
         }
-        pending = deferred;
-        if pending.is_empty() || !progressed {
+    }
+
+    // Peel every edge whose dialer declares no dialer of its own. What survives
+    // is on a cycle or feeds one, and late binding would recurse forever on it.
+    let mut live: std::collections::HashSet<&SmolStr> = edges.iter().map(|(n, _)| n).collect();
+    loop {
+        let before = live.len();
+        for (name, dialer) in &edges {
+            if live.contains(name) && !live.contains(dialer) {
+                live.remove(name);
+            }
+        }
+        if live.is_empty() || live.len() == before {
             break;
         }
     }
-    if !pending.is_empty() {
-        let edges: Vec<String> = pending
+    if !live.is_empty() {
+        let cycle: Vec<String> = edges
             .iter()
+            .filter(|(name, _)| live.contains(name))
             .map(|(name, dialer)| format!("{name} -> {dialer}"))
             .collect();
-        anyhow::bail!("dialer-proxy cycle detected: {}", edges.join(", "));
+        anyhow::bail!("dialer-proxy cycle detected: {}", cycle.join(", "));
+    }
+
+    // Apply the edges. Order no longer matters — the front hop is resolved at
+    // dial time — so nested chains need no deepest-first deferral pass.
+    for (name, dialer) in &edges {
+        let target = meow_proxy::dialer::DialerTarget::new(dialer.clone(), registry.clone());
+        // `rev()` matters: the registry-building loop above uses `insert`, so
+        // for a config with duplicate `name:` entries the *last* block wins. A
+        // forward `find` here would resurrect the *first* block and silently
+        // swap the running definition out from under the user.
+        let Some(raw) = raw_proxies
+            .iter()
+            .rev()
+            .find(|rp| rp.get("name").and_then(|v| v.as_str()) == Some(name.as_str()))
+        else {
+            // Unreachable in practice — edges are only collected from blocks in
+            // this same list — but refuse instead of silently dialing direct if
+            // the invariant ever breaks.
+            anyhow::bail!(
+                "proxy '{name}': dialer-proxy '{dialer}' not applied; no raw \
+                 config block found for this name"
+            );
+        };
+        // Re-parse the raw block with the by-name dialer injected (mihomo
+        // model), so the adapter's own dial + handshake runs on the tunneled
+        // stream.
+        let proxy_dialer: Arc<dyn meow_proxy::dialer::TcpDialer> =
+            Arc::new(meow_proxy::dialer::NamedProxyDialer::new(target.clone()));
+        match proxy_parser::parse_proxy_with_dialer(raw, &proxy_dialer, ipv6) {
+            Ok(rebuilt) => {
+                proxies.insert(name.clone(), rebuilt);
+            }
+            Err(e) => {
+                // The adapter type cannot carry an injected dialer (anytls,
+                // hysteria2, SS-with-external-SIP003-plugin) or the block is
+                // otherwise unparseable. Fall back to the relay-based
+                // `DialerProxyAdapter`, which preserves the pre-dialer
+                // behaviour: it works for the protocols that implement
+                // `connect_over` (HTTP/SOCKS5/Snell) and fails loudly at dial
+                // time for the rest — never silently dialing direct and leaking
+                // past the chain.
+                //
+                // The inner outbound may itself have failed to parse earlier,
+                // in which case there is nothing to wrap.
+                if let Some(inner) = proxies.get(name).cloned() {
+                    warn!(
+                        "proxy '{name}': cannot inject dialer-proxy '{dialer}' \
+                         ({e}); falling back to the relay-based wrapper"
+                    );
+                    let wrapped: Arc<dyn Proxy> =
+                        Arc::new(meow_proxy::DialerProxyAdapter::new(inner, target));
+                    proxies.insert(name.clone(), wrapped);
+                } else {
+                    warn!(
+                        "proxy '{name}': dialer-proxy '{dialer}' not applied \
+                         ({e}); the outbound itself failed to parse"
+                    );
+                }
+            }
+        }
     }
     Ok(())
 }
@@ -780,6 +790,9 @@ fn rebuild_from_raw_impl(
 ) -> Result<RebuildResult, anyhow::Error> {
     let ipv6 = effective_ipv6(raw.ipv6);
     let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
+    // `dialer-proxy` front hops are resolved by name against this registry on
+    // every dial; it is published once the build below has finished.
+    let registry = meow_proxy::dialer::ProxyRegistry::default();
     // Built-in proxies
     let mut direct = meow_proxy::DirectAdapter::new();
     if let Some(mark) = raw.routing_mark {
@@ -827,9 +840,23 @@ fn rebuild_from_raw_impl(
         }
     }
 
+    let raw_groups = raw.proxy_groups.as_deref().unwrap_or(&[]);
+
+    // Apply per-outbound `dialer-proxy` chains (issue #210) *before* groups are
+    // built: groups clone their members eagerly, so a chain applied afterwards
+    // would only cover direct rule references and a grouped node would silently
+    // bypass it (issue #513). The front hop is resolved by name at dial time,
+    // which is what lets a dialer name a group that does not exist yet here.
+    apply_dialer_proxies(
+        &mut proxies,
+        raw.proxies.as_deref().unwrap_or(&[]),
+        raw_groups,
+        &registry,
+        ipv6,
+    )?;
+
     // Multi-pass group resolution: groups can reference other groups.
     // Keep trying until no new groups are resolved.
-    let raw_groups = raw.proxy_groups.as_deref().unwrap_or(&[]);
     let mut remaining: Vec<&raw::RawProxyGroup> = raw_groups.iter().collect();
     let mut max_passes = remaining.len() + 1;
     while !remaining.is_empty() && max_passes > 0 {
@@ -916,10 +943,6 @@ fn rebuild_from_raw_impl(
             Err(e) => warn!("Failed to create GLOBAL selector: {}", e),
         }
     }
-
-    // Apply per-outbound `dialer-proxy` wrappers (issue #210). Runs after both
-    // leaf proxies and groups are built so a dialer may reference either.
-    apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]), ipv6)?;
 
     let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     // Per-provider `proxy:` overrides resolve against the full registry —
@@ -1009,6 +1032,13 @@ fn rebuild_from_raw_impl(
             }
         }
     }
+
+    // Publish the finished registry: the `dialer-proxy` chains bound above
+    // resolve their front hop by name against it, and only now does it hold the
+    // groups they may name (issue #513). A later rebuild publishes into its own
+    // registry, so adapters already handed to the tunnel keep resolving the
+    // snapshot they were built from.
+    registry.publish(Arc::new(proxies.clone()));
 
     Ok((proxies, rules))
 }
@@ -2203,12 +2233,24 @@ mod dialer_proxy_tests {
         !Arc::ptr_eq(b, a)
     }
 
+    /// Run the dialer pass against a fresh by-name registry and publish it on
+    /// success, the way `rebuild_from_raw_impl` does — without the publish the
+    /// chained adapters cannot resolve their front hop at dial time.
+    fn apply_chains(
+        proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
+        raw_proxies: &[HashMap<String, serde_yaml::Value>],
+    ) -> Result<(), anyhow::Error> {
+        let registry = meow_proxy::dialer::ProxyRegistry::default();
+        apply_dialer_proxies(proxies, raw_proxies, &[], &registry, true)?;
+        registry.publish(Arc::new(proxies.clone()));
+        Ok(())
+    }
+
     #[test]
     fn wraps_proxy_with_dialer() {
         let mut proxies = registry(&["A", "fast"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("fast"))], true)
-            .expect("valid chain applies");
+        apply_chains(&mut proxies, &[raw_proxy("A", Some("fast"))]).expect("valid chain applies");
         assert!(was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "fast"));
     }
@@ -2217,7 +2259,7 @@ mod dialer_proxy_tests {
     fn self_reference_is_a_config_error() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        let err = apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("A"))], true)
+        let err = apply_chains(&mut proxies, &[raw_proxy("A", Some("A"))])
             .expect_err("a self-referencing dialer must not silently dial direct");
         assert!(
             err.to_string().contains("points to itself"),
@@ -2230,7 +2272,7 @@ mod dialer_proxy_tests {
     fn missing_dialer_is_a_config_error() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        let err = apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("ghost"))], true)
+        let err = apply_chains(&mut proxies, &[raw_proxy("A", Some("ghost"))])
             .expect_err("an unknown dialer must not silently dial direct");
         assert!(err.to_string().contains("not found"), "unexpected: {err}");
         assert!(!was_wrapped(&before, &proxies, "A"));
@@ -2240,15 +2282,34 @@ mod dialer_proxy_tests {
     fn cycle_is_a_config_error() {
         let mut proxies = registry(&["A", "B"]);
         let before = proxies.clone();
-        let err = apply_dialer_proxies(
+        let err = apply_chains(
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("A"))],
-            true,
         )
         .expect_err("a dialer cycle must not silently dial direct");
         assert!(err.to_string().contains("cycle"), "unexpected: {err}");
         assert!(!was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "B"));
+    }
+
+    /// A cycle that only *some* of the edges sit on still has to be rejected:
+    /// late binding recurses through the whole chain, so `A` feeding `B <-> C`
+    /// never terminates either.
+    #[test]
+    fn chain_feeding_a_cycle_is_a_config_error() {
+        let mut proxies = registry(&["A", "B", "C"]);
+        let before = proxies.clone();
+        let err = apply_chains(
+            &mut proxies,
+            &[
+                raw_proxy("A", Some("B")),
+                raw_proxy("B", Some("C")),
+                raw_proxy("C", Some("B")),
+            ],
+        )
+        .expect_err("an edge feeding a cycle must not silently dial direct");
+        assert!(err.to_string().contains("cycle"), "unexpected: {err}");
+        assert!(!was_wrapped(&before, &proxies, "A"));
     }
 
     /// Duplicate `name:` blocks: only the *last* block is the effective
@@ -2270,8 +2331,7 @@ mod dialer_proxy_tests {
             serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
         );
 
-        apply_dialer_proxies(&mut proxies, &[first, last], true)
-            .expect("the effective block declares no dialer");
+        apply_chains(&mut proxies, &[first, last]).expect("the effective block declares no dialer");
 
         assert!(
             !was_wrapped(&before, &proxies, "A"),
@@ -2281,14 +2341,15 @@ mod dialer_proxy_tests {
     }
 
     #[test]
-    fn nested_chain_wraps_deepest_first() {
-        // A -> B -> C: A and B are wrapped, C (no dialer-proxy) is untouched.
+    fn nested_chain_wraps_every_layer() {
+        // A -> B -> C: A and B are chained, C (no dialer-proxy) is untouched.
+        // The front hop is resolved at dial time, so neither layer has to wait
+        // for the other to reach its final form.
         let mut proxies = registry(&["A", "B", "C"]);
         let before = proxies.clone();
-        apply_dialer_proxies(
+        apply_chains(
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("C"))],
-            true,
         )
         .expect("valid nested chain applies");
         assert!(was_wrapped(&before, &proxies, "A"));
@@ -2346,12 +2407,8 @@ mod dialer_proxy_tests {
         proxies.insert(SmolStr::from("A"), parsed_a);
         let before = proxies.clone();
 
-        apply_dialer_proxies(
-            &mut proxies,
-            &[raw_socks5_proxy("A", Some("front"), true)],
-            true,
-        )
-        .expect("valid chain applies");
+        apply_chains(&mut proxies, &[raw_socks5_proxy("A", Some("front"), true)])
+            .expect("valid chain applies");
 
         assert!(was_wrapped(&before, &proxies, "A"), "A should be re-parsed");
         assert!(
@@ -2391,12 +2448,8 @@ mod dialer_proxy_tests {
             let mut proxies = registry(&["A", "front"]);
             let before = proxies.clone();
 
-            apply_dialer_proxies(
-                &mut proxies,
-                &[raw_typed_proxy("A", ty, Some("front"))],
-                true,
-            )
-            .expect("valid chain applies via the wrapper fallback");
+            apply_chains(&mut proxies, &[raw_typed_proxy("A", ty, Some("front"))])
+                .expect("valid chain applies via the wrapper fallback");
 
             let after = proxies.get("A").expect("entry survives");
             assert!(
@@ -2434,8 +2487,7 @@ mod dialer_proxy_tests {
 
         // Must not panic and must not spawn: the parse is rejected before
         // `ShadowsocksAdapter::new` runs, so the fallback wrapper is used.
-        apply_dialer_proxies(&mut proxies, &[raw], true)
-            .expect("valid chain applies via the wrapper fallback");
+        apply_chains(&mut proxies, &[raw]).expect("valid chain applies via the wrapper fallback");
 
         assert!(
             proxies.contains_key("A"),
@@ -2461,7 +2513,7 @@ mod dialer_proxy_tests {
             serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
         );
 
-        apply_dialer_proxies(&mut proxies, &[first, last], true).expect("valid chain applies");
+        apply_chains(&mut proxies, &[first, last]).expect("valid chain applies");
 
         let rebuilt = proxies.get("A").expect("present after");
         assert_eq!(
@@ -2485,7 +2537,7 @@ mod dialer_proxy_tests {
         let before = proxies.clone();
 
         // raw_proxy has no `type` → parse_proxy_with_dialer fails → fallback.
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("front"))], true)
+        apply_chains(&mut proxies, &[raw_proxy("A", Some("front"))])
             .expect("valid chain applies via the wrapper fallback");
 
         assert!(
@@ -2619,8 +2671,7 @@ mod dialer_proxy_tests {
             proxy_parser::parse_proxy(&raw_inner, true).expect("parse inner"),
         );
 
-        apply_dialer_proxies(&mut proxies, &[raw_front, raw_inner], true)
-            .expect("valid chain applies");
+        apply_chains(&mut proxies, &[raw_front, raw_inner]).expect("valid chain applies");
 
         // Dial a final target through `inner`; `inner` must reach its own
         // server (127.0.0.1:inner_port) *via* `front`.

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -94,13 +94,47 @@ impl Proxy for WrappedProxy {
     }
 }
 
+/// Where a proxy definition came from, which decides how much of it may name
+/// local resources.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProxyOrigin {
+    /// The operator's own config document — naming a local executable there is
+    /// already a local decision.
+    Local,
+    /// A proxy-provider's fetched document. Remote input even when the vehicle
+    /// is a local file, so it needs the operator's explicit per-provider
+    /// opt-in before it may select a local executable (issue #513).
+    Provider { allow_external_plugin: bool },
+}
+
 pub fn parse_proxy(
     config: &HashMap<String, serde_yaml::Value>,
     ipv6: bool,
 ) -> std::result::Result<Arc<dyn Proxy>, String> {
     let dialer: std::sync::Arc<dyn meow_proxy::dialer::TcpDialer> =
         std::sync::Arc::new(meow_proxy::dialer::DirectDialer);
-    parse_proxy_with_dialer(config, &dialer, ipv6)
+    parse_proxy_scoped(config, &dialer, ProxyOrigin::Local, ipv6)
+}
+
+/// Parse a proxy node whose definition came from a proxy-provider.
+///
+/// Provider documents are remote input, so they are held to a stricter policy
+/// than the operator's own config: see [`ProxyOrigin::Provider`].
+pub fn parse_provider_proxy(
+    config: &HashMap<String, serde_yaml::Value>,
+    allow_external_plugin: bool,
+    ipv6: bool,
+) -> std::result::Result<Arc<dyn Proxy>, String> {
+    let dialer: std::sync::Arc<dyn meow_proxy::dialer::TcpDialer> =
+        std::sync::Arc::new(meow_proxy::dialer::DirectDialer);
+    parse_proxy_scoped(
+        config,
+        &dialer,
+        ProxyOrigin::Provider {
+            allow_external_plugin,
+        },
+        ipv6,
+    )
 }
 
 /// Like [parse_proxy] but injects a custom [meow_proxy::dialer::TcpDialer]
@@ -110,6 +144,15 @@ pub fn parse_proxy(
 pub fn parse_proxy_with_dialer(
     config: &HashMap<String, serde_yaml::Value>,
     dialer: &std::sync::Arc<dyn meow_proxy::dialer::TcpDialer>,
+    ipv6: bool,
+) -> std::result::Result<Arc<dyn Proxy>, String> {
+    parse_proxy_scoped(config, dialer, ProxyOrigin::Local, ipv6)
+}
+
+fn parse_proxy_scoped(
+    config: &HashMap<String, serde_yaml::Value>,
+    dialer: &std::sync::Arc<dyn meow_proxy::dialer::TcpDialer>,
+    origin: ProxyOrigin,
     ipv6: bool,
 ) -> std::result::Result<Arc<dyn Proxy>, String> {
     let name = config
@@ -143,6 +186,32 @@ pub fn parse_proxy_with_dialer(
                 .unwrap_or(false);
             let plugin = config.get("plugin").and_then(|v| v.as_str());
             let plugin_opts_str = config.get("plugin-opts").and_then(serialize_plugin_opts);
+
+            // An external SIP003 plugin becomes the executable handed to
+            // `Command::new` inside `ShadowsocksAdapter::new`, so it is a local
+            // process launch driven by whatever named the plugin — and for a
+            // provider-sourced node that is the remote document. The launch
+            // happens at construction, i.e. during the initial load and on every
+            // provider refresh, not only when traffic later dials the node, so
+            // reject it here rather than after the process boundary has been
+            // reached. Built-in plugins run in-process and are unaffected, as is
+            // the operator's own config (issue #513, Class A ADR-0002).
+            if matches!(
+                origin,
+                ProxyOrigin::Provider {
+                    allow_external_plugin: false
+                }
+            ) && is_external_sip003_plugin(plugin)
+            {
+                return Err(format!(
+                    "ss[{name}]: refusing the external SIP003 plugin '{}' from \
+                     provider content — upstream launches it as a local subprocess \
+                     while parsing, which would let a remote document choose the \
+                     executable. Add `allow-external-plugin: true` to the \
+                     proxy-provider to opt in",
+                    plugin.unwrap_or_default()
+                ));
+            }
 
             // A SIP003 *external* plugin is a local subprocess spawned by
             // `ShadowsocksAdapter::new`, and the adapter deliberately dials it
@@ -3282,6 +3351,7 @@ tls: true
             exclude_type: None,
             health_check: None,
             header: None,
+            allow_external_plugin: None,
         };
         let cache_dir = path.parent().expect("temp file has a parent dir");
         let provider =
@@ -3523,5 +3593,74 @@ tls: true
             "name: sn\ntype: snell\nserver: 1.2.3.4\nport: 8388\npsk: s\nobfs-opts:\n  mode: http\n",
         );
         assert!(parse_proxy(&cfg).is_ok());
+    }
+
+    // ─── provider trust boundary for external SIP003 plugins (issue #513) ────
+
+    #[cfg(feature = "ss")]
+    fn ss_node(extra: &str) -> HashMap<String, serde_yaml::Value> {
+        proxy_config(&format!(
+            "name: provider-node\ntype: ss\nserver: 127.0.0.1\nport: 443\npassword: p\n\
+             cipher: aes-128-gcm\n{extra}"
+        ))
+    }
+
+    /// A name no built-in plugin claims is handed to the external launcher.
+    #[cfg(feature = "ss")]
+    const EXTERNAL_PLUGIN: &str = "plugin: definitely-not-a-real-plugin\n";
+
+    #[cfg(feature = "ss")]
+    #[test]
+    fn provider_node_may_not_name_an_external_plugin_by_default() {
+        let cfg = ss_node(EXTERNAL_PLUGIN);
+        let Err(err) = super::parse_provider_proxy(&cfg, false, true) else {
+            panic!("provider content must not reach the plugin launcher by default");
+        };
+        assert!(
+            err.contains("allow-external-plugin"),
+            "must name the opt-in: {err}"
+        );
+    }
+
+    #[cfg(feature = "ss")]
+    #[test]
+    fn provider_opt_in_opens_the_gate_and_only_then_reaches_the_launcher() {
+        // Same node, operator opted in: what remains is the launch failure, so
+        // the decision is the flag and not the plugin name.
+        let cfg = ss_node(EXTERNAL_PLUGIN);
+        let Err(err) = super::parse_provider_proxy(&cfg, true, true) else {
+            panic!("a nonexistent plugin still cannot start");
+        };
+        assert!(
+            !err.contains("allow-external-plugin"),
+            "gate must be open: {err}"
+        );
+        assert!(err.contains("failed to start ss plugin"), "msg: {err}");
+    }
+
+    #[cfg(feature = "ss")]
+    #[test]
+    fn provider_gate_leaves_builtin_plugins_alone() {
+        // Built-in plugins run in-process, so they never cross the boundary the
+        // gate guards and must keep working for provider nodes.
+        let cfg = ss_node("plugin: obfs\nplugin-opts:\n  mode: http\n");
+        super::parse_provider_proxy(&cfg, false, true)
+            .expect("an in-process plugin is not an external executable");
+    }
+
+    #[cfg(feature = "ss")]
+    #[test]
+    fn local_config_keeps_naming_external_plugins() {
+        // The very node the provider path rejects: in the operator's own config
+        // it is a local decision, so it must still reach the launcher.
+        let cfg = ss_node(EXTERNAL_PLUGIN);
+        let Err(err) = parse_proxy(&cfg) else {
+            panic!("a nonexistent plugin still cannot start");
+        };
+        assert!(
+            !err.contains("allow-external-plugin"),
+            "local config is not provider-scoped: {err}"
+        );
+        assert!(err.contains("failed to start ss plugin"), "msg: {err}");
     }
 }

--- a/crates/meow-config/src/proxy_parser.rs
+++ b/crates/meow-config/src/proxy_parser.rs
@@ -155,6 +155,12 @@ fn parse_proxy_scoped(
     origin: ProxyOrigin,
     ipv6: bool,
 ) -> std::result::Result<Arc<dyn Proxy>, String> {
+    // `origin` gates the `ss` arm's external-plugin check. Without that
+    // feature there is no config-driven path to a local executable left to
+    // gate, so the parameter is deliberately unread.
+    #[cfg(not(feature = "ss"))]
+    let _ = origin;
+
     let name = config
         .get("name")
         .and_then(|v| v.as_str())

--- a/crates/meow-config/src/proxy_provider.rs
+++ b/crates/meow-config/src/proxy_provider.rs
@@ -30,6 +30,10 @@ pub struct ProxyProvider {
     updated_at: AtomicU,
     header: HashMap<String, String>,
     ipv6: bool,
+    /// The operator's explicit opt-in letting this provider's nodes select an
+    /// external SIP003 plugin, i.e. a local executable named by the fetched
+    /// document (issue #513). Off unless the config says otherwise.
+    allow_external_plugin: bool,
     /// Group-level filtered views of `slot` (issue #358), re-populated on
     /// every refresh. Weak: each view is kept alive by the group built from
     /// it, so views belonging to dropped or rebuilt groups get pruned here.
@@ -199,6 +203,7 @@ impl ProxyProvider {
             updated_at: AtomicU::new(0),
             header,
             ipv6,
+            allow_external_plugin: raw.allow_external_plugin.unwrap_or(false),
             derived: RwLock::new(Vec::new()),
         })
     }
@@ -326,7 +331,8 @@ impl ProxyProvider {
                 continue;
             }
 
-            match proxy_parser::parse_proxy(raw_map, self.ipv6) {
+            match proxy_parser::parse_provider_proxy(raw_map, self.allow_external_plugin, self.ipv6)
+            {
                 Ok(proxy) => result.push(proxy),
                 Err(e) => {
                     warn!(provider = %self.name, proxy = raw_name, error = %e, "failed to parse proxy");
@@ -496,6 +502,7 @@ mod tests {
             exclude_type: None,
             health_check: None,
             header: None,
+            allow_external_plugin: None,
         }
     }
 
@@ -543,6 +550,7 @@ mod tests {
             exclude_type: None,
             health_check: None,
             header: None,
+            allow_external_plugin: None,
         };
         let Err(err) = ProxyProvider::new("test", &raw, Some(dir.path()), true) else {
             panic!("escaping http cache path must be rejected");
@@ -583,6 +591,7 @@ mod tests {
                 exclude_type: None,
                 health_check: None,
                 header: None,
+                allow_external_plugin: None,
             },
         );
         validate_paths(&map, Some(dir.path())).expect("contained paths must validate");
@@ -604,6 +613,7 @@ mod tests {
             exclude_type: None,
             health_check: None,
             header: Some(headers),
+            allow_external_plugin: None,
         };
         let p = ProxyProvider::new("airport", &raw, None, true).unwrap();
         assert_eq!(p.vehicle_type, "HTTP");
@@ -636,6 +646,48 @@ header:
         assert!(raw.header.is_none());
         let p = ProxyProvider::new("p", &raw, Some(dir.path()), true).unwrap();
         assert!(p.header.is_empty());
+    }
+
+    // ─── external SIP003 plugin opt-in (issue #513) ──────────────────────────
+
+    /// A provider document with one clean node and one naming an executable no
+    /// built-in plugin claims.
+    #[cfg(feature = "ss")]
+    const PROVIDER_WITH_EXTERNAL_PLUGIN: &str = r#"proxies:
+  - {name: "clean", type: ss, server: 127.0.0.1, port: 443, cipher: aes-128-gcm, password: p}
+  - {name: "plugged", type: ss, server: 127.0.0.1, port: 443, cipher: aes-128-gcm, password: p, plugin: definitely-not-a-real-plugin}
+"#;
+
+    #[test]
+    fn raw_proxy_provider_deserializes_allow_external_plugin() {
+        // The kebab-case spelling is the operator-facing contract: a rename here
+        // would silently leave the opt-in unsettable.
+        let yaml = "type: file\npath: proxies.yaml\nallow-external-plugin: true\n";
+        let raw: RawProxyProvider = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.allow_external_plugin, Some(true));
+    }
+
+    #[test]
+    fn external_plugin_opt_in_is_denied_unless_the_config_says_otherwise() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut raw = raw_file_provider("proxies.yaml");
+        let p = ProxyProvider::new("p", &raw, Some(dir.path()), true).unwrap();
+        assert!(!p.allow_external_plugin);
+
+        raw.allow_external_plugin = Some(true);
+        let p = ProxyProvider::new("p", &raw, Some(dir.path()), true).unwrap();
+        assert!(p.allow_external_plugin);
+    }
+
+    #[cfg(feature = "ss")]
+    #[tokio::test]
+    async fn provider_content_cannot_select_an_external_plugin() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), PROVIDER_WITH_EXTERNAL_PLUGIN).unwrap();
+        let provider = file_provider(tmp.path()).await;
+        // The clean node still loads; the plugin node is rejected before
+        // `ShadowsocksAdapter::new` can hand the name to the launcher.
+        assert_eq!(slot_names(&provider.slot), ["clean"]);
     }
 
     fn group_filter(

--- a/crates/meow-config/src/raw.rs
+++ b/crates/meow-config/src/raw.rs
@@ -418,6 +418,12 @@ pub struct RawProxyProvider {
     pub health_check: Option<RawHealthCheck>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub header: Option<std::collections::HashMap<String, String>>,
+    /// Let nodes from this provider select an external SIP003 plugin — a local
+    /// executable named by provider content and spawned while the node is
+    /// parsed. Denied by default: the provider document is remote input even
+    /// when the vehicle is a local file (issue #513).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_external_plugin: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/meow-config/src/rule_parser.rs
+++ b/crates/meow-config/src/rule_parser.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 
 use meow_common::Rule;
 use meow_rules::{ParserContext, RuleSet, RuleSetRule};
-use tracing::warn;
 
 use crate::sub_rules_parser::{build_sub_rule_rule, parse_sub_rule_reference, SubRuleBlocks};
 
 /// Parse rules with no rule-providers or sub-rule blocks available.
-pub fn parse_rules(raw_rules: &[String], ctx: &ParserContext) -> Vec<Box<dyn Rule>> {
+pub fn parse_rules(
+    raw_rules: &[String],
+    ctx: &ParserContext,
+) -> Result<Vec<Box<dyn Rule>>, String> {
     parse_rules_with_providers(raw_rules, &HashMap::new(), ctx)
 }
 
@@ -19,18 +21,23 @@ pub fn parse_rules_with_providers(
     raw_rules: &[String],
     providers: &HashMap<String, Arc<dyn RuleSet>>,
     ctx: &ParserContext,
-) -> Vec<Box<dyn Rule>> {
+) -> Result<Vec<Box<dyn Rule>>, String> {
     parse_rules_full(raw_rules, providers, ctx, &HashMap::new())
 }
 
 /// Parse the `rules:` block with full resolver context — providers, ctx,
 /// and pre-resolved sub-rule blocks for `SUB-RULE,<name>` entries.
+///
+/// A single unparseable line fails the whole block: upstream mihomo drops it
+/// with a warning and keeps routing the rest, which turns a typo into a
+/// silent hole in the policy — traffic the operator wrote a rule for now
+/// falls through to whatever comes next, usually `MATCH,DIRECT` (issue #513).
 pub fn parse_rules_full(
     raw_rules: &[String],
     providers: &HashMap<String, Arc<dyn RuleSet>>,
     ctx: &ParserContext,
     sub_rules: &SubRuleBlocks,
-) -> Vec<Box<dyn Rule>> {
+) -> Result<Vec<Box<dyn Rule>>, String> {
     let mut rules: Vec<Box<dyn Rule>> = Vec::new();
     for line in raw_rules {
         let line = line.trim();
@@ -39,10 +46,10 @@ pub fn parse_rules_full(
         }
         match parse_one_rule_or_subrule(line, providers, ctx, sub_rules) {
             Ok(rule) => rules.push(rule),
-            Err(e) => warn!("Failed to parse rule '{}': {}", line, e),
+            Err(e) => return Err(format!("rules: cannot parse '{line}': {e}")),
         }
     }
-    rules
+    Ok(rules)
 }
 
 /// Parse a single rule line. Handles `RULE-SET,<name>,...`,

--- a/crates/meow-config/tests/config_persistence_test.rs
+++ b/crates/meow-config/tests/config_persistence_test.rs
@@ -297,7 +297,7 @@ rules:
 }
 
 #[test]
-fn rebuild_from_raw_skips_invalid_proxy() {
+fn rebuild_from_raw_rejects_invalid_proxy() {
     let mut raw = minimal_raw_config();
     let mut bad_proxy = HashMap::new();
     bad_proxy.insert("name".to_string(), serde_yaml::Value::String("bad".into()));
@@ -306,9 +306,14 @@ fn rebuild_from_raw_skips_invalid_proxy() {
         serde_yaml::Value::String("unknown_protocol".into()),
     );
     raw.proxies = Some(vec![bad_proxy]);
-    // Should not fail, just skip
-    let (proxies, _) = rebuild_from_raw(&raw).unwrap();
-    assert!(!proxies.contains_key("bad"));
+    // An entry the parser cannot build fails the load rather than being
+    // dropped with a warning (issue #513): every rule naming it would
+    // otherwise lose its target.
+    let err = match rebuild_from_raw(&raw) {
+        Ok(_) => panic!("an unbuildable proxy must fail the rebuild"),
+        Err(e) => e.to_string(),
+    };
+    assert!(err.contains("proxies: 'bad'"), "must name it: {err}");
 }
 
 // ── RawConfig serialization tests ────────────────────────────────

--- a/crates/meow-config/tests/config_test.rs
+++ b/crates/meow-config/tests/config_test.rs
@@ -3,6 +3,32 @@ use meow_config::{load_config_from_str, ListenerSpec};
 // Some tests use #[tokio::test] because ShadowsocksAdapter plugin startup
 // internally requires a tokio runtime (tokio::process::Command).
 
+/// Load `yaml` and return why it was refused.
+///
+/// A proxy, group, or rule the parser cannot build fails the whole load rather
+/// than being dropped with a warning (issue #513), so "this node is rejected"
+/// is asserted on the error text — the message names the entry — and not on a
+/// registry key that is merely absent.
+async fn load_rejection(yaml: &str) -> String {
+    match load_config_from_str(yaml).await {
+        Ok(config) => panic!(
+            "this config must not load; registry: {:?}",
+            config.proxies.keys().collect::<Vec<_>>()
+        ),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Assert `yaml` is refused and that the refusal names the proxy `name`.
+async fn assert_proxy_rejected(yaml: &str, name: &str) -> String {
+    let err = load_rejection(yaml).await;
+    assert!(
+        err.contains(&format!("proxies: '{name}'")),
+        "the load must fail on '{name}' and say why: {err}"
+    );
+    err
+}
+
 #[tokio::test]
 async fn test_minimal_config() {
     let yaml = r#"
@@ -483,8 +509,7 @@ proxies:
       enabled: "true"
 "#;
     // A string "true" must not be silently treated as disabled.
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(!config.proxies.contains_key("trojan-bad-mux"));
+    assert_proxy_rejected(yaml, "trojan-bad-mux").await;
 }
 
 #[tokio::test]
@@ -498,8 +523,7 @@ proxies:
     password: "password123"
     smux: true
 "#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(!config.proxies.contains_key("trojan-scalar-mux"));
+    assert_proxy_rejected(yaml, "trojan-scalar-mux").await;
 }
 
 #[cfg(feature = "mux")]
@@ -521,7 +545,7 @@ proxies:
 }
 
 #[tokio::test]
-async fn test_unsupported_proxy_type_skipped() {
+async fn test_unsupported_proxy_type_rejected() {
     let yaml = r#"
 proxies:
   - name: "wireguard-server"
@@ -529,8 +553,8 @@ proxies:
     server: "1.2.3.4"
     port: 443
 "#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(!config.proxies.contains_key("wireguard-server"));
+    let err = assert_proxy_rejected(yaml, "wireguard-server").await;
+    assert!(err.contains("wireguard"), "must name the type: {err}");
 }
 
 #[tokio::test]
@@ -559,11 +583,7 @@ proxies:
     uuid: "b831381d-6324-4d53-ad4f-8cda48b30811"
     cipher: zero
 "#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    assert!(
-        !config.proxies.contains_key("vmess-zero"),
-        "cipher:zero must be rejected"
-    );
+    assert_proxy_rejected(yaml, "vmess-zero").await;
 }
 
 #[tokio::test]
@@ -764,8 +784,9 @@ rules:
 
 #[tokio::test]
 async fn test_proxy_parsing_ss_with_plugin_missing_binary() {
-    // A non-existent plugin binary causes proxy creation to fail.
-    // The config loader logs a warning and skips the proxy (does not panic).
+    // A non-existent plugin binary makes the adapter constructor fail, and
+    // that failure now fails the load instead of dropping the node with a
+    // warning (issue #513).
     let yaml = r#"
 proxies:
   - name: "ss-missing-plugin"
@@ -779,15 +800,18 @@ proxies:
       mode: http
       host: example.com
 "#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    // The proxy is skipped because the plugin binary doesn't exist
-    assert!(!config.proxies.contains_key("ss-missing-plugin"));
+    let err = assert_proxy_rejected(yaml, "ss-missing-plugin").await;
+    assert!(
+        err.contains("nonexistent-plugin-binary-xyz"),
+        "must name the plugin that failed to launch: {err}"
+    );
 }
 
 #[tokio::test]
 async fn test_proxy_parsing_ss_with_plugin_opts_string() {
-    // Plugin opts can be passed as a pre-formatted string.
-    // Uses a non-existent plugin to verify config parsing succeeds.
+    // Plugin opts can be passed as a pre-formatted string; the node is still
+    // refused for its missing plugin binary, and that refusal now fails the
+    // load rather than dropping the node (issue #513).
     let yaml = r#"
 proxies:
   - name: "ss-plugin-str"
@@ -799,26 +823,29 @@ proxies:
     plugin: nonexistent-plugin-binary-xyz
     plugin-opts: "obfs=http;obfs-host=example.com"
 "#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    // Skipped because plugin binary doesn't exist, but config parsing succeeds
-    assert!(!config.proxies.contains_key("ss-plugin-str"));
+    let err = assert_proxy_rejected(yaml, "ss-plugin-str").await;
+    assert!(
+        err.contains("nonexistent-plugin-binary-xyz"),
+        "the string plugin-opts must have parsed far enough to launch the plugin: {err}"
+    );
 }
 
 #[tokio::test]
 async fn test_proxy_parsing_ss_with_builtin_obfs_table() {
     // Built-in simple-obfs (`plugin: obfs` / `plugin: simple-obfs`) needs no
     // external binary, so a well-formed node must register; a node whose obfs
-    // config cannot be resolved to a valid mode must be skipped (never
-    // silently falling back to the "external plugin" path).
+    // config cannot be resolved to a valid mode must be refused outright
+    // (never silently falling back to the "external plugin" path, and never
+    // dropped with a warning while the rest of the config loads — issue #513).
     //
     // Each case supplies the `plugin:`/`plugin-opts:` tail (and, where it
-    // matters, the `server:` value) plus the expected registration outcome.
+    // matters, the `server:` value) plus the expected outcome.
     struct Case {
         label: &'static str,
         name: &'static str,
         server: &'static str,
         plugin_block: &'static str,
-        expect_present: bool,
+        expect_registered: bool,
     }
 
     let cases = [
@@ -827,70 +854,70 @@ async fn test_proxy_parsing_ss_with_builtin_obfs_table() {
             name: "ss-obfs-http",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: http\n      host: bing.com\n",
-            expect_present: true,
+            expect_registered: true,
         },
         Case {
             label: "yaml map, mode=tls",
             name: "ss-obfs-tls",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: tls\n      host: gateway.icloud.com\n",
-            expect_present: true,
+            expect_registered: true,
         },
         Case {
             label: "SIP003 string form `obfs=tls;obfs-host=...`",
             name: "ss-obfs-str",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n    plugin-opts: \"obfs=tls;obfs-host=cloudflare.com\"\n",
-            expect_present: true,
+            expect_registered: true,
         },
         Case {
             label: "legacy `plugin: simple-obfs` alias",
             name: "ss-simple-obfs",
             server: "1.2.3.4",
             plugin_block: "    plugin: simple-obfs\n    plugin-opts:\n      mode: http\n      host: bing.com\n",
-            expect_present: true,
+            expect_registered: true,
         },
         Case {
             label: "yaml map with SIP003-native keys `obfs`/`obfs-host`",
             name: "ss-obfs-sip003-map",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n    plugin-opts:\n      obfs: tls\n      obfs-host: gateway.icloud.com\n",
-            expect_present: true,
+            expect_registered: true,
         },
         Case {
             label: "mode parsed case-insensitively (TLS)",
             name: "ss-obfs-upper",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: TLS\n      host: cloudflare.com\n",
-            expect_present: true,
+            expect_registered: true,
         },
         Case {
             label: "host omitted falls back to the ss server name",
             name: "ss-obfs-default-host",
             server: "ss.example.org",
             plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: http\n",
-            expect_present: true,
+            expect_registered: true,
         },
         Case {
-            label: "missing `mode` is invalid -> skipped",
+            label: "missing `mode` is invalid -> refused",
             name: "ss-obfs-bad",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n    plugin-opts:\n      host: example.com\n",
-            expect_present: false,
+            expect_registered: false,
         },
         Case {
-            label: "no plugin-opts at all -> skipped, no external fallback",
+            label: "no plugin-opts at all -> refused, no external fallback",
             name: "ss-obfs-no-opts",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n",
-            expect_present: false,
+            expect_registered: false,
         },
         Case {
-            label: "unknown mode `quic` -> skipped",
+            label: "unknown mode `quic` -> refused",
             name: "ss-obfs-bad-mode",
             server: "1.2.3.4",
             plugin_block: "    plugin: obfs\n    plugin-opts:\n      mode: quic\n      host: foo\n",
-            expect_present: false,
+            expect_registered: false,
         },
     ];
 
@@ -900,13 +927,33 @@ async fn test_proxy_parsing_ss_with_builtin_obfs_table() {
             "proxies:\n  - name: \"{}\"\n    type: ss\n    server: \"{}\"\n    port: 8388\n    cipher: \"aes-256-gcm\"\n    password: \"password123\"\n{}",
             case.name, case.server, case.plugin_block
         );
-        let config = load_config_from_str(&yaml).await.unwrap();
-        let present = config.proxies.contains_key(case.name);
-        if present != case.expect_present {
-            failures.push(format!(
-                "[{}] proxy `{}`: expected present={}, got present={}",
-                case.label, case.name, case.expect_present, present
-            ));
+        if case.expect_registered {
+            match load_config_from_str(&yaml).await {
+                Ok(config) if config.proxies.contains_key(case.name) => {}
+                Ok(_) => failures.push(format!(
+                    "[{}] proxy `{}`: expected to register",
+                    case.label, case.name
+                )),
+                Err(e) => failures.push(format!(
+                    "[{}] proxy `{}`: expected to register, load failed: {e}",
+                    case.label, case.name
+                )),
+            }
+        } else {
+            // A node the parser cannot build fails the whole load and names
+            // itself (issue #513) — it is no longer dropped with a warning
+            // while the rest of the config keeps routing.
+            match load_config_from_str(&yaml).await {
+                Err(e) if e.to_string().contains(&format!("proxies: '{}'", case.name)) => {}
+                Err(e) => failures.push(format!(
+                    "[{}] proxy `{}`: load failed without naming it: {e}",
+                    case.label, case.name
+                )),
+                Ok(_) => failures.push(format!(
+                    "[{}] proxy `{}`: expected the load to fail",
+                    case.label, case.name
+                )),
+            }
         }
     }
     assert!(
@@ -978,18 +1025,21 @@ rules:
 }
 
 #[tokio::test]
-async fn test_missing_rule_provider_is_skipped() {
-    // Referencing an undefined rule-set should warn and skip, not panic.
+async fn test_missing_rule_provider_fails_the_load() {
+    // Referencing an undefined rule-set used to warn and skip, which quietly
+    // deleted the operator's REJECT rule while the config still loaded; it now
+    // fails the load and quotes the offending line (issue #513).
     let yaml = r#"
 mixed-port: 7890
 rules:
   - RULE-SET,nonexistent,REJECT
   - MATCH,DIRECT
 "#;
-    let config = load_config_from_str(yaml).await.unwrap();
-    // Only the MATCH rule survives.
-    assert_eq!(config.rules.len(), 1);
-    assert_eq!(config.rules[0].rule_type().to_string(), "MATCH");
+    let err = load_rejection(yaml).await;
+    assert!(
+        err.contains("RULE-SET,nonexistent,REJECT") && err.contains("nonexistent"),
+        "the load must fail quoting the rule: {err}"
+    );
 }
 
 // ─── SUB-RULE (M1.D-7) ─────────────────────────────────────────────

--- a/crates/meow-config/tests/dialer_proxy_group.rs
+++ b/crates/meow-config/tests/dialer_proxy_group.rs
@@ -1,0 +1,170 @@
+//! A node's `dialer-proxy` must survive being reached through a proxy group,
+//! and a dialer must be able to name a group (issue #513).
+//!
+//! Proxy groups clone their members eagerly, so applying the chain after the
+//! group build left every group holding the pre-dialer adapter: selecting the
+//! node through the group dialled its own server directly and silently bypassed
+//! the chain the user configured for policy reasons. The dialer pass now runs
+//! before groups are built and binds the front hop *by name* (mihomo
+//! `component/proxydialer/byname.go`), so both paths chain identically and a
+//! group that does not exist yet at build time is still a valid dialer.
+//!
+//! The observable is which mock server each dial physically contacts. Every TLS
+//! handshake fails fast against the plain listeners — the accept counts, not the
+//! dial result, are what these tests assert on.
+
+use meow_common::{Metadata, Network};
+use meow_config::raw::RawConfig;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+/// TCP listener that counts accepts and drops each connection immediately, so
+/// the client-side TLS handshake errors out instead of hanging on a ServerHello
+/// that never arrives.
+async fn counting_listener() -> (SocketAddr, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let count = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&count);
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            counter.fetch_add(1, Ordering::SeqCst);
+            drop(stream);
+        }
+    });
+    (addr, count)
+}
+
+/// `A` chains through the leaf proxy `B`; `C` chains through the group `G2`
+/// (which holds `B`); `G` is a select group over `A`.
+fn config(port_a: u16, port_b: u16, port_c: u16) -> RawConfig {
+    serde_yaml::from_str(&format!(
+        r#"
+mixed-port: 17890
+mode: rule
+proxies:
+  - name: A
+    type: trojan
+    server: 127.0.0.1
+    port: {port_a}
+    password: issue-513
+    dialer-proxy: B
+  - name: B
+    type: trojan
+    server: 127.0.0.1
+    port: {port_b}
+    password: issue-513
+  - name: C
+    type: trojan
+    server: 127.0.0.1
+    port: {port_c}
+    password: issue-513
+    dialer-proxy: G2
+proxy-groups:
+  - name: G
+    type: select
+    proxies: [A]
+  - name: G2
+    type: select
+    proxies: [B]
+rules:
+  - MATCH,DIRECT
+"#
+    ))
+    .unwrap()
+}
+
+/// Registry plus the three mock servers, with per-server accept counters.
+struct Harness {
+    proxies: HashMap<smol_str::SmolStr, Arc<dyn meow_common::Proxy>>,
+    accepts: HashMap<&'static str, Arc<AtomicUsize>>,
+}
+
+impl Harness {
+    fn accepts(&self, server: &str) -> usize {
+        self.accepts[server].load(Ordering::SeqCst)
+    }
+
+    /// Dial `name` and discard the outcome — the handshakes are expected to
+    /// fail, only the physical contact matters.
+    async fn dial(&self, name: &str) {
+        let metadata = Metadata {
+            network: Network::Tcp,
+            host: "127.0.0.1".into(),
+            dst_ip: Some("127.0.0.1".parse().unwrap()),
+            dst_port: 9,
+            ..Default::default()
+        };
+        let proxy = self
+            .proxies
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} must be in the registry"));
+        let _ = proxy.dial_tcp(&metadata).await;
+    }
+}
+
+async fn harness() -> Harness {
+    let (server_a, a_accepts) = counting_listener().await;
+    let (server_b, b_accepts) = counting_listener().await;
+    let (server_c, c_accepts) = counting_listener().await;
+
+    let raw = config(server_a.port(), server_b.port(), server_c.port());
+    let (proxies, _rules) = meow_config::rebuild_from_raw(&raw).expect("rebuild ok");
+
+    Harness {
+        proxies,
+        accepts: HashMap::from([("A", a_accepts), ("B", b_accepts), ("C", c_accepts)]),
+    }
+}
+
+/// The regression: `G` selects `A`, and `A` declares `dialer-proxy: B`. Both
+/// the direct registry dial and the dial through the group must contact B's
+/// server first. Before the fix the group held the pre-dialer `A` and contacted
+/// A's server directly, bypassing the chain.
+#[tokio::test]
+async fn group_member_honours_its_dialer_proxy() {
+    let h = harness().await;
+
+    h.dial("A").await;
+    assert_eq!(h.accepts("B"), 1, "registry A must chain through dialer B");
+    assert_eq!(
+        h.accepts("A"),
+        0,
+        "registry A must not contact its own server directly"
+    );
+
+    h.dial("G").await;
+    assert_eq!(
+        h.accepts("B"),
+        2,
+        "the group must reach the chained A, not a stale pre-dialer copy"
+    );
+    assert_eq!(
+        h.accepts("A"),
+        0,
+        "dialer-proxy bypassed when the node is reached via a group"
+    );
+}
+
+/// A `dialer-proxy` may name a group. The group is built *after* the dialer
+/// pass, so only by-name resolution can find it; capturing an `Arc` at build
+/// time would have nothing to capture.
+#[tokio::test]
+async fn dialer_may_name_a_group_built_later() {
+    let h = harness().await;
+
+    h.dial("C").await;
+    assert_eq!(
+        h.accepts("B"),
+        1,
+        "C must chain through group G2, whose only member is B"
+    );
+    assert_eq!(
+        h.accepts("C"),
+        0,
+        "C must not contact its own server directly"
+    );
+}

--- a/crates/meow-config/tests/ech_dns_test.rs
+++ b/crates/meow-config/tests/ech_dns_test.rs
@@ -204,16 +204,17 @@ proxies:
       enable: true
       config: "!!!definitely_not_base64!!!"
 "#;
-    let cfg = load_config_from_str(yaml)
-        .await
-        .expect("config must still load (parse_vless logs and skips bad proxy)");
-    // Top-level parse must not register the proxy with malformed ECH config —
-    // parse_vless returns Err and the loader logs+skips, leaving only the
-    // built-in proxies (DIRECT, REJECT, REJECT-DROP).
+    // parse_vless's rejection of malformed ECH base64 now reaches the caller:
+    // an entry the parser cannot build fails the load instead of being logged
+    // and skipped, which is what kept the rejection from being silently
+    // downgraded to "no ECH" (issue #513).
+    let err = match load_config_from_str(yaml).await {
+        Ok(_) => panic!("malformed ECH base64 must fail the config load"),
+        Err(e) => e.to_string(),
+    };
     assert!(
-        !cfg.proxies.contains_key("bad-ech"),
-        "proxy with invalid ECH base64 must NOT register; got: {:?}",
-        cfg.proxies.keys().collect::<Vec<_>>()
+        err.contains("proxies: 'bad-ech'"),
+        "the failure must name the rejected proxy: {err}"
     );
 }
 

--- a/crates/meow-config/tests/strict_config_load.rs
+++ b/crates/meow-config/tests/strict_config_load.rs
@@ -1,0 +1,173 @@
+//! A config load must fail on an entry it cannot build, not warn and keep
+//! going (issue #513).
+//!
+//! Upstream mihomo drops the offending proxy, group, or rule with a warning and
+//! loads everything else, so the rebuild reports success while the policy in
+//! memory is not the policy on disk: every rule naming the dropped entry now
+//! has no target, and a dropped rule hands its traffic to whatever comes next —
+//! usually `MATCH,DIRECT`. These tests pin the rust-port behaviour: fail the
+//! load and name the entry that caused it.
+
+use meow_config::raw::RawConfig;
+
+fn load(yaml: &str) -> Result<(usize, Vec<String>), String> {
+    let raw: RawConfig = serde_yaml::from_str(yaml).expect("test yaml must deserialize");
+    meow_config::rebuild_from_raw(&raw)
+        .map(|(proxies, rules)| {
+            let mut names: Vec<String> = proxies
+                .keys()
+                .map(std::string::ToString::to_string)
+                .collect();
+            names.sort();
+            (rules.len(), names)
+        })
+        .map_err(|e| e.to_string())
+}
+
+fn load_error(yaml: &str) -> String {
+    match load(yaml) {
+        Ok((rules, names)) => {
+            panic!("this config must not load — got {rules} rules and registry {names:?}")
+        }
+        Err(e) => e,
+    }
+}
+
+#[test]
+fn an_unbuildable_proxy_fails_the_load_and_names_itself() {
+    let err = load_error(
+        r#"
+mode: rule
+proxies:
+  - name: good
+    type: trojan
+    server: 127.0.0.1
+    port: 443
+    password: x
+  - name: broken
+    type: trojan
+    server: 127.0.0.1
+    port: not-a-number
+    password: x
+rules:
+  - MATCH,DIRECT
+"#,
+    );
+    assert!(err.contains("broken"), "must name the proxy: {err}");
+}
+
+#[test]
+fn an_unbuildable_group_fails_the_load_and_names_itself() {
+    let err = load_error(
+        r#"
+mode: rule
+proxies:
+  - name: node
+    type: trojan
+    server: 127.0.0.1
+    port: 443
+    password: x
+proxy-groups:
+  - name: broken-group
+    type: not-a-group-type
+    proxies:
+      - node
+rules:
+  - MATCH,DIRECT
+"#,
+    );
+    assert!(err.contains("broken-group"), "must name the group: {err}");
+}
+
+#[test]
+fn an_unparseable_rule_fails_the_load_and_quotes_the_line() {
+    let err = load_error(
+        r#"
+mode: rule
+rules:
+  - THIS-IS-NOT-A-RULE,DIRECT
+  - MATCH,DIRECT
+"#,
+    );
+    assert!(
+        err.contains("THIS-IS-NOT-A-RULE,DIRECT"),
+        "must quote the offending line: {err}"
+    );
+}
+
+#[test]
+fn a_rule_naming_an_undefined_sub_rule_block_fails_the_load() {
+    // `parse_rules_full` now hard-fails on any line it cannot parse, which
+    // covers the undefined-block case a separate promotion pass used to.
+    let err = load_error(
+        r#"
+mode: rule
+rules:
+  - SUB-RULE,never-defined
+  - MATCH,DIRECT
+"#,
+    );
+    assert!(
+        err.contains("never-defined"),
+        "must name the missing sub-rule block: {err}"
+    );
+}
+
+#[test]
+fn a_config_where_every_entry_builds_still_loads() {
+    let (rules, names) = load(
+        r#"
+mode: rule
+proxies:
+  - name: node
+    type: trojan
+    server: 127.0.0.1
+    port: 443
+    password: x
+proxy-groups:
+  - name: select-group
+    type: select
+    proxies:
+      - node
+      - DIRECT
+rules:
+  - DOMAIN,example.com,select-group
+  - MATCH,DIRECT
+"#,
+    )
+    .expect("a fully valid config must load");
+    assert_eq!(rules, 2, "both rule lines must survive");
+    assert!(names.iter().any(|n| n == "node"), "registry: {names:?}");
+    assert!(
+        names.iter().any(|n| n == "select-group"),
+        "registry: {names:?}"
+    );
+}
+
+#[test]
+fn a_group_missing_one_member_still_builds() {
+    // The leniency that stays: a group naming a proxy this config does not
+    // have is upstream behaviour, not an unbuildable entry. Dropping the whole
+    // group over one absent member would take the rest of the policy with it.
+    let (_rules, names) = load(
+        r#"
+mode: rule
+proxies:
+  - name: node
+    type: trojan
+    server: 127.0.0.1
+    port: 443
+    password: x
+proxy-groups:
+  - name: partial
+    type: select
+    proxies:
+      - node
+      - gone-with-the-wind
+rules:
+  - MATCH,partial
+"#,
+    )
+    .expect("a group with one absent member must still build");
+    assert!(names.iter().any(|n| n == "partial"), "registry: {names:?}");
+}

--- a/crates/meow-config/tests/vless_config_test.rs
+++ b/crates/meow-config/tests/vless_config_test.rs
@@ -103,6 +103,34 @@ where
     (result, cap_clone.captured())
 }
 
+// ─── Rejection helpers ───────────────────────────────────────────────────────
+
+/// Load `yaml` and return why it was refused.
+///
+/// A proxy the parser cannot build fails the whole load rather than being
+/// dropped with a warning (issue #513), so "this node is rejected" is asserted
+/// on the error text — which names the entry — and not on a registry key that
+/// is merely absent.
+async fn load_rejection(yaml: &str) -> String {
+    match load_config_from_str(yaml).await {
+        Ok(config) => panic!(
+            "this config must not load; registry: {:?}",
+            config.proxies.keys().collect::<Vec<_>>()
+        ),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Assert `yaml` is refused and that the refusal names the proxy `name`.
+async fn assert_proxy_rejected(yaml: &str, name: &str) -> String {
+    let err = load_rejection(yaml).await;
+    assert!(
+        err.contains(&format!("proxies: '{name}'")),
+        "the load must fail on '{name}' and say why: {err}"
+    );
+    err
+}
+
 // ─── Base YAML helpers ───────────────────────────────────────────────────────
 
 const MINIMAL_VLESS: &str = r#"
@@ -222,12 +250,11 @@ proxies:
         .expect("flow: xtls-rprx-vision with tls: true must parse OK");
 }
 
-// ─── D6: unknown flow → hard error (proxy skipped) ───────────────────────────
+// ─── D6: unknown flow → load refused ─────────────────────────────────────────
 
 /// D6: `parse_vless_flow_unknown_hard_errors`
 ///
-/// Unknown flow string → proxy parse error; proxy is absent from config.
-/// The config loader warns-and-skips (does not crash the full config load).
+/// Unknown flow string → proxy parse error, which fails the whole load.
 /// upstream: `adapter/outbound/vless.go` ignores unknown flows.
 /// NOT accepted — Class A per ADR-0002: unknown flow may skip security processing.
 #[tokio::test]
@@ -241,20 +268,18 @@ proxies:
     uuid: b831381d-6324-4d53-ad4f-8cda48b30811
     flow: "xtls-rprx-unknown"
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with unknown flow must be skipped (not registered)"
+        err.contains("xtls-rprx-unknown"),
+        "the refusal must name the unknown flow: {err}"
     );
 }
 
-// ─── D7: flow: xtls-rprx-direct → proxy skipped ──────────────────────────────
+// ─── D7: flow: xtls-rprx-direct → load refused ───────────────────────────────
 
 /// D7: `parse_vless_flow_deprecated_direct_hard_errors`
 ///
-/// `flow: "xtls-rprx-direct"` → proxy parse error; proxy absent from config.
+/// `flow: "xtls-rprx-direct"` → proxy parse error, which fails the whole load.
 /// upstream: `adapter/outbound/vless.go` accepts this as a deprecated alias.
 /// NOT accepted — Class A per ADR-0002: security regression vs Vision.
 #[tokio::test]
@@ -268,20 +293,18 @@ proxies:
     uuid: b831381d-6324-4d53-ad4f-8cda48b30811
     flow: "xtls-rprx-direct"
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with xtls-rprx-direct flow must be skipped (deprecated — Class A)"
+        err.contains("xtls-rprx-direct"),
+        "the refusal must name the deprecated flow: {err}"
     );
 }
 
-// ─── D8: flow: xtls-rprx-splice → proxy skipped ──────────────────────────────
+// ─── D8: flow: xtls-rprx-splice → load refused ───────────────────────────────
 
 /// D8: `parse_vless_flow_deprecated_splice_hard_errors`
 ///
-/// `flow: "xtls-rprx-splice"` → proxy parse error; proxy absent from config.
+/// `flow: "xtls-rprx-splice"` → proxy parse error, which fails the whole load.
 /// upstream: `adapter/outbound/vless.go` accepts as deprecated.
 /// NOT accepted — Class A per ADR-0002.
 #[tokio::test]
@@ -295,12 +318,10 @@ proxies:
     uuid: b831381d-6324-4d53-ad4f-8cda48b30811
     flow: "xtls-rprx-splice"
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with xtls-rprx-splice flow must be skipped (deprecated — Class A)"
+        err.contains("xtls-rprx-splice"),
+        "the refusal must name the deprecated flow: {err}"
     );
 }
 
@@ -323,12 +344,10 @@ proxies:
     reality-opts:
       public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with reality-opts but no client-fingerprint must be skipped"
+        err.contains("client-fingerprint"),
+        "the refusal must name the missing field: {err}"
     );
 }
 
@@ -345,17 +364,15 @@ proxies:
     reality-opts:
       public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with reality-opts but tls=false must be skipped"
+        err.contains("reality-opts requires `tls: true`"),
+        "the refusal must demand tls: true: {err}"
     );
 }
 
 #[tokio::test]
-async fn parse_vless_reality_opts_invalid_public_key_skipped() {
+async fn parse_vless_reality_opts_invalid_public_key_rejected() {
     let yaml = r#"
 proxies:
   - name: v
@@ -368,17 +385,15 @@ proxies:
     reality-opts:
       public-key: abc123
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with invalid REALITY public key must be skipped"
+        err.contains("invalid REALITY public key"),
+        "the refusal must name the bad public key: {err}"
     );
 }
 
 #[tokio::test]
-async fn parse_vless_reality_opts_invalid_short_id_skipped() {
+async fn parse_vless_reality_opts_invalid_short_id_rejected() {
     let yaml = r#"
 proxies:
   - name: v
@@ -392,12 +407,10 @@ proxies:
       public-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE
       short-id: 001122334455667788
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with >8-byte REALITY short-id must be skipped"
+        err.contains("invalid REALITY short ID"),
+        "the refusal must name the bad short-id: {err}"
     );
 }
 
@@ -663,12 +676,12 @@ proxies:
     );
 }
 
-// ─── D12: vision + no TLS → proxy skipped ────────────────────────────────────
+// ─── D12: vision + no TLS → load refused ─────────────────────────────────────
 
 /// D12: `parse_vless_vision_without_tls_hard_errors`
 ///
 /// `flow: "xtls-rprx-vision"` with `tls: false` and no TLS-enforcing transport →
-/// proxy parse error; proxy absent from config.
+/// proxy parse error, which fails the whole load.
 /// Class A per ADR-0002: Vision without outer TLS is a no-op the user did not intend.
 #[tokio::test]
 async fn parse_vless_vision_without_tls_hard_errors() {
@@ -682,12 +695,10 @@ proxies:
     tls: false
     flow: "xtls-rprx-vision"
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with vision + no TLS must be skipped (Vision without TLS is a no-op — Class A)"
+        err.contains("xtls-rprx-vision requires an encrypting transport"),
+        "the refusal must explain that Vision needs TLS: {err}"
     );
 }
 
@@ -717,11 +728,11 @@ proxies:
         .expect("vision + grpc (TLS-enforcing) must parse OK without tls: true");
 }
 
-// ─── D14: encryption: non-none → proxy skipped ───────────────────────────────
+// ─── D14: encryption: non-none → load refused ────────────────────────────────
 
 /// D14: `parse_vless_encryption_non_none_hard_errors`
 ///
-/// `encryption: "aes-128-gcm"` → proxy parse error; proxy absent from config.
+/// `encryption: "aes-128-gcm"` → proxy parse error, which fails the whole load.
 /// upstream: also errors on non-"none" values — this is a match, not a divergence.
 #[tokio::test]
 async fn parse_vless_encryption_non_none_hard_errors() {
@@ -734,12 +745,10 @@ proxies:
     uuid: b831381d-6324-4d53-ad4f-8cda48b30811
     encryption: "aes-128-gcm"
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with non-none encryption must be skipped"
+        err.contains("aes-128-gcm"),
+        "the refusal must name the rejected encryption value: {err}"
     );
 }
 
@@ -769,8 +778,9 @@ proxies:
 /// The post-quantum `encryption: mlkem768x25519plus…` line from the issue #301
 /// 3x-ui config — using the reporter's exact key, whose base64 has non-canonical
 /// trailing bits (Go decodes it; strict decoders would not). The proxy builds
-/// with the `vless-encryption` feature and is skipped (with a feature-pointing
-/// error) without it.
+/// with the `vless-encryption` feature; without it the field cannot be honoured,
+/// so the load is refused with an error pointing at the missing feature
+/// (issue #513).
 ///
 /// (REALITY is exercised separately — `reality-opts` additionally needs the
 /// `boring-tls` feature, which the shipping app build enables.)
@@ -790,20 +800,25 @@ proxies:
     encryption: mlkem768x25519plus.native.0rtt.DA7B2WRj7X2zGFwMelbIbcaoUrpLjzoPpmydYW8NvQW
     client-fingerprint: chrome
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip if feature absent)");
 
     #[cfg(feature = "vless-encryption")]
-    assert!(
-        config.proxies.contains_key("vpn26"),
-        "issue #301 encryption config must build a proxy with the vless-encryption feature"
-    );
+    {
+        let config = load_config_from_str(yaml)
+            .await
+            .expect("issue #301 encryption config must build with the vless-encryption feature");
+        assert!(
+            config.proxies.contains_key("vpn26"),
+            "issue #301 encryption config must build a proxy with the vless-encryption feature"
+        );
+    }
     #[cfg(not(feature = "vless-encryption"))]
-    assert!(
-        !config.proxies.contains_key("vpn26"),
-        "mlkem768x25519plus encryption must be skipped without the vless-encryption feature"
-    );
+    {
+        let err = assert_proxy_rejected(yaml, "vpn26").await;
+        assert!(
+            err.contains("vless-encryption"),
+            "the refusal must point at the missing feature: {err}"
+        );
+    }
 }
 
 // ─── D16: mux enabled → sing-mux attached ────────────────────────────────────
@@ -867,8 +882,9 @@ proxies:
     );
 }
 
-/// D16e: unknown mux protocol → proxy rejected with a loud warn (meow's
-/// warn+skip parse semantics; mihomo hard-errors on the same input).
+/// D16e: unknown mux protocol → the load is refused, naming the proxy. mihomo
+/// hard-errors on the same input; meow used to warn and drop the node, which
+/// left every rule naming it without a target (issue #513).
 #[cfg(feature = "mux")]
 #[tokio::test]
 async fn parse_vless_mux_unknown_protocol_rejects_proxy() {
@@ -883,19 +899,10 @@ proxies:
       enabled: true
       protocol: not-a-protocol
 "#;
-    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    let config = result.expect("unknown mux protocol must not fail the whole config");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with unknown mux protocol must be skipped"
-    );
-    let warns = lines
-        .iter()
-        .filter(|l| l.contains("unknown mux protocol"))
-        .count();
-    assert!(
-        warns >= 1,
-        "expected an unknown-mux-protocol warn; {lines:?}"
+        err.contains("unknown mux protocol"),
+        "the refusal must name the bad protocol: {err}"
     );
 }
 
@@ -983,17 +990,10 @@ proxies:
     mux:
       enabled: true
 "#;
-    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    let config = result.expect("invalid proxy must not fail the whole config");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "vision + sing-mux (h2mux default) node must be skipped"
-    );
-    assert!(
-        lines
-            .iter()
-            .any(|l| l.contains("incompatible with sing-mux")),
-        "expected a sing-mux incompatibility warn; {lines:?}"
+        err.contains("incompatible with sing-mux"),
+        "the refusal must explain the sing-mux incompatibility: {err}"
     );
 }
 
@@ -1013,17 +1013,10 @@ proxies:
       enabled: true
       protocol: muxcool
 "#;
-    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    let config = result.expect("invalid proxy must not fail the whole config");
+    let err = assert_proxy_rejected(yaml, "t").await;
     assert!(
-        !config.proxies.contains_key("t"),
-        "trojan node with muxcool must be skipped"
-    );
-    assert!(
-        lines
-            .iter()
-            .any(|l| l.contains("muxcool") && l.contains("VLESS")),
-        "expected a VLESS/VMess-only warn; {lines:?}"
+        err.contains("muxcool") && err.contains("VLESS/VMess-only"),
+        "the refusal must say muxcool is VLESS/VMess-only: {err}"
     );
 }
 
@@ -1094,17 +1087,10 @@ proxies:
       enabled: true
       protocol: muxcool
 "#;
-    let (result, lines) = with_warn_capture_async(load_config_from_str(yaml)).await;
-    let config = result.expect("invalid proxy must not fail the whole config");
+    let err = assert_proxy_rejected(yaml, "s").await;
     assert!(
-        !config.proxies.contains_key("s"),
-        "ss node with muxcool must be skipped"
-    );
-    assert!(
-        lines
-            .iter()
-            .any(|l| l.contains("muxcool") && l.contains("VLESS")),
-        "expected a VLESS/VMess-only warn; {lines:?}"
+        err.contains("muxcool") && err.contains("VLESS/VMess-only"),
+        "the refusal must say muxcool is VLESS/VMess-only: {err}"
     );
 }
 
@@ -1379,11 +1365,11 @@ proxies:
         .expect("hex-only UUID must be accepted");
 }
 
-// ─── D19: invalid UUID → proxy skipped ───────────────────────────────────────
+// ─── D19: invalid UUID → load refused ────────────────────────────────────────
 
 /// D19: `parse_vless_uuid_invalid_hard_errors`
 ///
-/// `uuid: "not-a-uuid"` → proxy parse error; proxy absent from config.
+/// `uuid: "not-a-uuid"` → proxy parse error, which fails the whole load.
 /// guard-rail: an invalid UUID would produce a zeroed or garbage auth ID with no diagnostic.
 #[tokio::test]
 async fn parse_vless_uuid_invalid_hard_errors() {
@@ -1395,20 +1381,18 @@ proxies:
     port: 443
     uuid: "not-a-uuid"
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with invalid uuid must be skipped"
+        err.contains("invalid uuid 'not-a-uuid'"),
+        "the refusal must name the bad uuid: {err}"
     );
 }
 
-// ─── D20: server > 255 bytes → proxy skipped ─────────────────────────────────
+// ─── D20: server > 255 bytes → load refused ──────────────────────────────────
 
 /// D20: `parse_vless_server_domain_over_255_errors`
 ///
-/// `server:` is a 256-char hostname → proxy parse error; proxy absent from config.
+/// `server:` is a 256-char hostname → proxy parse error, which fails the whole load.
 /// Class A per ADR-0002: wrong destination, no diagnostic on silent truncate.
 /// upstream: `transport/vless/encoding.go` does not enforce this limit.
 /// NOT silent truncation — 256-byte domain in ATYP 0x02 wraps to 0 bytes, wrong destination.
@@ -1425,12 +1409,10 @@ proxies:
     uuid: b831381d-6324-4d53-ad4f-8cda48b30811
 "#
     );
-    let config = load_config_from_str(&yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(&yaml, "v").await;
     assert!(
-        !config.proxies.contains_key("v"),
-        "proxy with server > 255 bytes must be skipped (Class A)"
+        err.contains("256 bytes") && err.contains("max 255"),
+        "the refusal must report the length limit: {err}"
     );
 }
 
@@ -1476,7 +1458,7 @@ proxies:
     assert!(config.proxies.contains_key("vless-xhttp-full"));
 }
 #[tokio::test]
-async fn parse_vless_xhttp_unsupported_mode_skipped() {
+async fn parse_vless_xhttp_unsupported_mode_rejected() {
     let yaml = r#"
 proxies:
   - name: vless-xhttp-bad-mode
@@ -1489,17 +1471,15 @@ proxies:
     xhttp-opts:
       mode: auto
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "vless-xhttp-bad-mode").await;
     assert!(
-        !config.proxies.contains_key("vless-xhttp-bad-mode"),
-        "proxy with unsupported xhttp mode must be skipped"
+        err.contains("unsupported xhttp mode 'auto'"),
+        "the refusal must name the unsupported mode: {err}"
     );
 }
 
 #[tokio::test]
-async fn parse_vless_xhttp_invalid_padding_range_skipped() {
+async fn parse_vless_xhttp_invalid_padding_range_rejected() {
     let yaml = r#"
 proxies:
   - name: vless-xhttp-bad-pad
@@ -1512,17 +1492,15 @@ proxies:
     xhttp-opts:
       x-padding-bytes: 900-100
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "vless-xhttp-bad-pad").await;
     assert!(
-        !config.proxies.contains_key("vless-xhttp-bad-pad"),
-        "proxy with inverted padding range must be skipped"
+        err.contains("min (900) exceeds max (100)"),
+        "the refusal must report the inverted range: {err}"
     );
 }
 
 #[tokio::test]
-async fn parse_vless_xhttp_invalid_padding_shape_skipped() {
+async fn parse_vless_xhttp_invalid_padding_shape_rejected() {
     let yaml = r#"
 proxies:
   - name: vless-xhttp-bad-pad-shape
@@ -1535,11 +1513,9 @@ proxies:
     xhttp-opts:
       x-padding-bytes: 100
 "#;
-    let config = load_config_from_str(yaml)
-        .await
-        .expect("config load must succeed (warn-and-skip)");
+    let err = assert_proxy_rejected(yaml, "vless-xhttp-bad-pad-shape").await;
     assert!(
-        !config.proxies.contains_key("vless-xhttp-bad-pad-shape"),
-        "proxy with invalid padding shape must be skipped"
+        err.contains("'min-max' string or 2-element integer array"),
+        "the refusal must describe the accepted shapes: {err}"
     );
 }

--- a/crates/meow-proxy/src/dialer.rs
+++ b/crates/meow-proxy/src/dialer.rs
@@ -9,13 +9,15 @@
 //!
 //! upstream: mihomo `component/proxydialer` + `BasicOption.NewDialer`.
 
+use std::collections::HashMap;
 use std::io;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use meow_common::{ConnType, Metadata, Network, Proxy, ProxyConn};
 use meow_transport::Stream;
+use smol_str::SmolStr;
 
 /// A pluggable dialer for the underlying connection to a proxy server.
 ///
@@ -162,6 +164,105 @@ impl TcpDialer for ProxyDialer {
             ..Default::default()
         };
         self.dial_metadata(meta).await
+    }
+
+    fn is_proxy(&self) -> bool {
+        true
+    }
+}
+
+/// An immutable snapshot of a finished config build, shared with every
+/// `dialer-proxy` bound from it.
+pub type ProxySnapshot = Arc<HashMap<SmolStr, Arc<dyn Proxy>>>;
+
+/// The proxies built from one config, published when the build completes and
+/// consulted by name on every chained dial.
+///
+/// mihomo resolves `dialer-proxy` the same way (`component/proxydialer/byname.go`).
+/// Capturing the front proxy as an `Arc` while the config is still being built
+/// freezes a stale entry instead: proxy groups clone their members before the
+/// dialer pass replaces them, and a group-valued dialer does not exist yet when
+/// the outbound chaining through it is built (issue #513).
+#[derive(Clone, Default)]
+pub struct ProxyRegistry {
+    proxies: Arc<RwLock<Option<ProxySnapshot>>>,
+}
+
+impl ProxyRegistry {
+    /// Publish the finished registry. Called once per config build, after every
+    /// leaf proxy and group exists; a rebuild publishes into its own registry,
+    /// so adapters from a previous config keep resolving their own snapshot.
+    pub fn publish(&self, proxies: ProxySnapshot) {
+        *self.proxies.write().unwrap() = Some(proxies);
+    }
+
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Proxy>> {
+        self.proxies.read().unwrap().as_ref()?.get(name).cloned()
+    }
+}
+
+/// The front hop of a `dialer-proxy` chain, addressed by name.
+#[derive(Clone)]
+pub struct DialerTarget {
+    name: SmolStr,
+    registry: ProxyRegistry,
+}
+
+impl DialerTarget {
+    pub fn new(name: impl Into<SmolStr>, registry: ProxyRegistry) -> Self {
+        Self {
+            name: name.into(),
+            registry,
+        }
+    }
+
+    /// Registry key of the front proxy, as written in the config.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// `None` when the registry has not been published yet or no longer holds
+    /// the name. Callers must fail loudly — falling back to a direct dial would
+    /// leak past a chain the user configured for policy reasons.
+    pub fn resolve(&self) -> Option<Arc<dyn Proxy>> {
+        self.registry.resolve(&self.name)
+    }
+
+    /// Error for an unresolvable target, worded for the two error types the
+    /// chained dial paths report through.
+    pub fn missing_error(&self) -> String {
+        format!("dialer-proxy '{}' is not in the proxy registry", self.name)
+    }
+}
+
+/// [`TcpDialer`] for a `dialer-proxy` front hop that is resolved by name at
+/// dial time. Equivalent to mihomo's `proxydialer.NewByNameDialer`.
+pub struct NamedProxyDialer {
+    target: DialerTarget,
+}
+
+impl NamedProxyDialer {
+    pub fn new(target: DialerTarget) -> Self {
+        Self { target }
+    }
+}
+
+#[async_trait]
+impl TcpDialer for NamedProxyDialer {
+    async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>> {
+        let front = self
+            .target
+            .resolve()
+            .ok_or_else(|| io::Error::other(self.target.missing_error()))?;
+        ProxyDialer::new(front).dial(host, port).await
+    }
+
+    async fn dial_addr(&self, addr: SocketAddr) -> io::Result<Box<dyn Stream>> {
+        let front = self
+            .target
+            .resolve()
+            .ok_or_else(|| io::Error::other(self.target.missing_error()))?;
+        ProxyDialer::new(front).dial_addr(addr).await
     }
 
     fn is_proxy(&self) -> bool {

--- a/crates/meow-proxy/src/group/dialer_proxy.rs
+++ b/crates/meow-proxy/src/group/dialer_proxy.rs
@@ -18,6 +18,13 @@
 //! presents itself as the inner outbound — same name, type, address, and health
 //! — so dashboards and rules see no difference.
 //!
+//! The front hop is held as a [`DialerTarget`] — a *name* plus a registry
+//! handle — and resolved on every dial, matching mihomo's
+//! `component/proxydialer/byname.go`.  Capturing the front proxy as an `Arc`
+//! while the config is still being built freezes a stale entry instead: proxy
+//! groups clone their members before the `dialer-proxy` pass replaces them, so
+//! a grouped node would silently bypass its chain (issue #513).
+//!
 //! ## Limitations (first implementation)
 //!
 //! - **UDP**: routing a UDP association through an arbitrary dialer requires
@@ -38,26 +45,21 @@ use meow_common::{
 use std::sync::Arc;
 
 use super::relay::relay_tcp;
+use crate::dialer::DialerTarget;
 
 /// Wraps an outbound so its underlying connection is dialled through `dialer`.
 pub struct DialerProxyAdapter {
     /// The actual outbound (SS/Trojan/VLESS/Snell/…); identity is borrowed from
     /// it so the wrapper is transparent to the API and rule engine.
     inner: Arc<dyn Proxy>,
-    /// Front proxy/group the inner outbound dials through.
-    dialer: Arc<dyn Proxy>,
-    /// Pre-built `[dialer, inner]` chain handed to `relay_tcp`.
-    chain: Vec<Arc<dyn Proxy>>,
+    /// Front proxy/group the inner outbound dials through, resolved by name on
+    /// every dial.
+    dialer: DialerTarget,
 }
 
 impl DialerProxyAdapter {
-    pub fn new(inner: Arc<dyn Proxy>, dialer: Arc<dyn Proxy>) -> Self {
-        let chain = vec![Arc::clone(&dialer), Arc::clone(&inner)];
-        Self {
-            inner,
-            dialer,
-            chain,
-        }
+    pub fn new(inner: Arc<dyn Proxy>, dialer: DialerTarget) -> Self {
+        Self { inner, dialer }
     }
 
     /// Name of the front dialer proxy/group (for diagnostics/tests).
@@ -87,8 +89,14 @@ impl ProxyAdapter for DialerProxyAdapter {
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
         // `[dialer, inner]`: dialer dials inner's server, inner connects to the
-        // real target via `connect_over`.
-        relay_tcp(&self.chain, metadata).await
+        // real target via `connect_over`. An unresolvable front hop must fail —
+        // dialling direct would leak past a chain configured for policy reasons.
+        let front = self
+            .dialer
+            .resolve()
+            .ok_or_else(|| MeowError::Proxy(self.dialer.missing_error()))?;
+        let chain = [front, Arc::clone(&self.inner)];
+        relay_tcp(&chain, metadata).await
     }
 
     async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
@@ -147,8 +155,11 @@ impl Proxy for DialerProxyAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dialer::ProxyRegistry;
     use crate::group::test_support::MockProxy;
     use meow_common::MeowError;
+    use smol_str::SmolStr;
+    use std::collections::HashMap;
 
     fn meta(host: &str, port: u16) -> Metadata {
         Metadata {
@@ -158,11 +169,22 @@ mod tests {
         }
     }
 
+    /// Publish `dialer` in a registry of its own and hand back the target that
+    /// resolves it — the late-binding shape `meow-config` builds at load time.
+    fn front(dialer: Arc<MockProxy>) -> DialerTarget {
+        let name = SmolStr::from(dialer.name());
+        let registry = ProxyRegistry::default();
+        let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
+        proxies.insert(name.clone(), dialer);
+        registry.publish(Arc::new(proxies));
+        DialerTarget::new(name, registry)
+    }
+
     #[tokio::test]
     async fn dial_tcp_routes_through_dialer_first() {
         let dialer = MockProxy::new("fast");
         let inner = MockProxy::new("daniel");
-        let adapter = DialerProxyAdapter::new(Arc::clone(&inner) as _, Arc::clone(&dialer) as _);
+        let adapter = DialerProxyAdapter::new(Arc::clone(&inner) as _, front(Arc::clone(&dialer)));
 
         // dialer.dial_tcp errors at relay hop 0 → confirms the chain dials the
         // front proxy first. The inner adapter is only reached via connect_over,
@@ -179,9 +201,31 @@ mod tests {
         );
     }
 
+    /// A front hop that never resolves (registry not published, or the name
+    /// gone after a rebuild) must fail the dial. Falling back to a direct dial
+    /// would leak past a chain the user configured for policy reasons.
+    #[tokio::test]
+    async fn unresolved_front_hop_fails_loudly() {
+        let inner = MockProxy::new("daniel");
+        let adapter = DialerProxyAdapter::new(
+            Arc::clone(&inner) as _,
+            DialerTarget::new("ghost", ProxyRegistry::default()),
+        );
+
+        match adapter.dial_tcp(&meta("example.com", 443)).await {
+            Err(MeowError::Proxy(msg)) => assert!(
+                msg.contains("ghost"),
+                "the error must name the missing dialer: {msg}"
+            ),
+            other => panic!("expected a Proxy error, got {:?}", other.err()),
+        }
+        assert_eq!(inner.dials(), 0, "the inner outbound must not be dialled");
+    }
+
     #[tokio::test]
     async fn udp_is_unsupported() {
-        let adapter = DialerProxyAdapter::new(MockProxy::new("inner"), MockProxy::new_udp("fast"));
+        let adapter =
+            DialerProxyAdapter::new(MockProxy::new("inner"), front(MockProxy::new_udp("fast")));
         assert!(!adapter.support_udp());
         match adapter.dial_udp(&meta("example.com", 53)).await {
             Err(MeowError::UdpNotSupported) => {}
@@ -192,7 +236,7 @@ mod tests {
     #[test]
     fn identity_delegates_to_inner() {
         let inner = MockProxy::new("daniel");
-        let adapter = DialerProxyAdapter::new(inner, MockProxy::new("fast"));
+        let adapter = DialerProxyAdapter::new(inner, front(MockProxy::new("fast")));
         assert_eq!(adapter.name(), "daniel");
         assert_eq!(adapter.dialer_name(), "fast");
         assert_eq!(adapter.adapter_type(), AdapterType::Direct); // MockProxy's type

--- a/crates/meow-proxy/src/vmess/body.rs
+++ b/crates/meow-proxy/src/vmess/body.rs
@@ -9,6 +9,16 @@ use super::header::{response_body_keys, Security};
 /// Maximum plaintext per body record (matching upstream 16 KiB - 16 tag).
 const MAX_PLAINTEXT: usize = 16384 - 16;
 
+/// Records one AEAD key/nonce pair may carry.
+///
+/// The body key and IV are derived once per connection and the record counter
+/// occupies the first two nonce bytes, so the budget is exactly that counter's
+/// range — VMess has no rekey to extend it. It is a *physical* connection
+/// budget: mux multiplexes many logical streams over one body cipher, so they
+/// all draw from the same counter and the session dies with it (the mux client
+/// re-dials on a dead session).
+const MAX_RECORDS: u32 = u16::MAX as u32 + 1;
+
 /// Body keys/IVs derived from the per-connection req_key and req_iv. The IVs
 /// are the full 16-byte seeds; each record nonce is `count(2 BE) || iv[2..12]`.
 struct DerivedKeys {
@@ -122,8 +132,31 @@ pub struct BodyCipher {
     write_iv: [u8; 16],
     read: RecordCipher,
     read_iv: [u8; 16],
-    write_counter: u16,
-    read_counter: u16,
+    /// Wider than the wire counter so exhaustion is detected before the value
+    /// that goes into the nonce wraps.
+    write_counter: u32,
+    read_counter: u32,
+}
+
+/// Next record nonce for one direction, or an error once [`MAX_RECORDS`] is
+/// spent.
+///
+/// Sealing two records under one key/nonce pair destroys AEAD confidentiality
+/// outright — the XOR of the ciphertexts is the XOR of the plaintexts, and the
+/// auth key leaks with it — so the counter must stop rather than wrap. The
+/// caller surfaces this as a failed record, which retires the physical
+/// connection (issue #513). The nonce *format* is untouched: this is a budget
+/// check, not a rekey, and the peer still sees `count(2 BE) || iv[2..12]`.
+fn next_nonce(iv: &[u8; 16], counter: &mut u32) -> std::io::Result<[u8; 12]> {
+    if *counter >= MAX_RECORDS {
+        return Err(std::io::Error::other(format!(
+            "vmess: AEAD nonce budget of {MAX_RECORDS} records exhausted"
+        )));
+    }
+    // The bound above makes the narrowing exact.
+    let nonce = record_nonce(iv, *counter as u16);
+    *counter += 1;
+    Ok(nonce)
 }
 
 impl BodyCipher {
@@ -152,16 +185,12 @@ impl BodyCipher {
         self.read_counter = self.write_counter;
     }
 
-    fn write_nonce(&mut self) -> [u8; 12] {
-        let nonce = record_nonce(&self.write_iv, self.write_counter);
-        self.write_counter = self.write_counter.wrapping_add(1);
-        nonce
+    fn write_nonce(&mut self) -> std::io::Result<[u8; 12]> {
+        next_nonce(&self.write_iv, &mut self.write_counter)
     }
 
-    fn read_nonce(&mut self) -> [u8; 12] {
-        let nonce = record_nonce(&self.read_iv, self.read_counter);
-        self.read_counter = self.read_counter.wrapping_add(1);
-        nonce
+    fn read_nonce(&mut self) -> std::io::Result<[u8; 12]> {
+        next_nonce(&self.read_iv, &mut self.read_counter)
     }
 
     /// Encrypt and write one body record: [len(2 BE)][ciphertext + tag(16)].
@@ -181,7 +210,7 @@ impl BodyCipher {
             return writer.flush().await;
         }
 
-        let nonce = self.write_nonce();
+        let nonce = self.write_nonce()?;
         let ct = self.write.seal(&nonce, plaintext)?;
         let len = ct.len() as u16;
         writer.write_all(&len.to_be_bytes()).await?;
@@ -214,7 +243,7 @@ impl BodyCipher {
         }
         let mut ct = vec![0u8; ct_len];
         reader.read_exact(&mut ct).await?;
-        let nonce = self.read_nonce();
+        let nonce = self.read_nonce()?;
         self.read.open(&nonce, &ct)
     }
 
@@ -293,8 +322,66 @@ mod tests {
 
         let (req_key, _) = test_keys();
         let mut cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &iv, 0x42);
-        assert_eq!(cipher.write_nonce()[..2], [0, 0]);
-        assert_eq!(cipher.write_nonce()[..2], [0, 1]);
+        assert_eq!(cipher.write_nonce().unwrap()[..2], [0, 0]);
+        assert_eq!(cipher.write_nonce().unwrap()[..2], [0, 1]);
+    }
+
+    /// The record counter feeds the nonce directly and VMess has no rekey, so
+    /// it must stop at the end of its range. Wrapping would seal record 65537
+    /// under record 1's key/nonce pair, which leaks the XOR of the two
+    /// plaintexts and the auth key. Both AEAD suites share this path.
+    fn nonce_budget_is_enforced_before_the_counter_wraps() {
+        for security in [Security::Aes128Gcm, Security::ChaCha20Poly1305] {
+            let (req_key, req_iv) = test_keys();
+            let mut cipher = BodyCipher::new(security, &req_key, &req_iv, 0x42);
+
+            for expected in 0..MAX_RECORDS {
+                let nonce = cipher.write_nonce().expect("still within budget");
+                assert_eq!(
+                    nonce[..2],
+                    u16::try_from(expected).unwrap().to_be_bytes(),
+                    "the wire counter must advance in order and stay 2 bytes"
+                );
+            }
+            let err = cipher
+                .write_nonce()
+                .expect_err("the budget must be enforced before the counter wraps");
+            assert!(
+                err.to_string().contains("nonce budget"),
+                "unexpected: {err}"
+            );
+
+            // The read direction is enforced independently: a peer that keeps
+            // sending past its own budget must not be decrypted under a reused
+            // nonce either.
+            for _ in 0..MAX_RECORDS {
+                cipher.read_nonce().expect("still within budget");
+            }
+            assert!(
+                cipher.read_nonce().is_err(),
+                "read direction must enforce the same budget"
+            );
+        }
+    }
+
+    /// Exhaustion has to stop the record before anything reaches the wire — a
+    /// sealed-and-sent record cannot be un-sent, and the failed write is what
+    /// retires the physical connection.
+    async fn write_record_puts_nothing_on_the_wire_once_the_budget_is_spent() {
+        let (req_key, req_iv) = test_keys();
+        let mut cipher = BodyCipher::new(Security::Aes128Gcm, &req_key, &req_iv, 0x42);
+        cipher.write_counter = MAX_RECORDS;
+
+        let mut wire = Vec::new();
+        let err = cipher
+            .write_record(&mut wire, b"one record too many")
+            .await
+            .expect_err("the record must not be sealed under a reused nonce");
+        assert!(wire.is_empty(), "no bytes may reach the wire, got {wire:?}");
+        assert!(
+            err.to_string().contains("nonce budget"),
+            "unexpected: {err}"
+        );
     }
 
     /// End-to-end read-direction interop: a hand-rolled "server" encrypts a
@@ -334,5 +421,11 @@ mod tests {
         body_key_derivation_matches_protocol();
         record_nonce_overwrites_iv_prefix_and_increments();
         read_record_decrypts_independently_encoded_response().await;
+    }
+
+    #[tokio::test]
+    async fn nonce_budget_stops_the_counter_instead_of_wrapping() {
+        nonce_budget_is_enforced_before_the_counter_wraps();
+        write_record_puts_nothing_on_the_wire_once_the_budget_is_spent().await;
     }
 }

--- a/crates/meow-proxy/src/vmess/conn.rs
+++ b/crates/meow-proxy/src/vmess/conn.rs
@@ -38,15 +38,31 @@ pub fn spawn_vmess_relay(
                 return;
             }
 
-            while let Ok(plaintext) = read_cipher.read_record(&mut rd).await {
-                if proxy_wr.write_all(&plaintext).await.is_err() {
-                    break;
+            loop {
+                match read_cipher.read_record(&mut rd).await {
+                    Ok(plaintext) => {
+                        if proxy_wr.write_all(&plaintext).await.is_err() {
+                            break;
+                        }
+                    }
+                    // A peer closing mid-stream is ordinary. Anything else — a
+                    // failed record authentication, an exhausted AEAD nonce
+                    // budget — is the reason this connection is being retired.
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                    Err(e) => {
+                        tracing::warn!(
+                            "vmess: dropping connection after a failed body record: {e}"
+                        );
+                        break;
+                    }
                 }
             }
             let _ = proxy_wr.shutdown().await;
         });
 
-        // Downstream: proxy_rd → encrypt → stream
+        // Downstream: proxy_rd → encrypt → stream. A failed record ends the
+        // relay and the shutdown below closes the physical stream — that is how
+        // an exhausted AEAD nonce budget retires the connection (issue #513).
         let write_task = tokio::spawn(async move {
             let mut buf = vec![0u8; BodyCipher::max_plaintext()];
             loop {
@@ -54,7 +70,8 @@ pub fn spawn_vmess_relay(
                     Ok(0) | Err(_) => break,
                     Ok(n) => n,
                 };
-                if write_cipher.write_record(&mut wr, &buf[..n]).await.is_err() {
+                if let Err(e) = write_cipher.write_record(&mut wr, &buf[..n]).await {
+                    tracing::warn!("vmess: dropping connection after a failed body record: {e}");
                     break;
                 }
             }

--- a/crates/meow-proxy/tests/vmess_nonce_budget.rs
+++ b/crates/meow-proxy/tests/vmess_nonce_budget.rs
@@ -1,0 +1,320 @@
+//! End-to-end regression for the VMess body AEAD nonce budget (issue #513).
+//!
+//! The body key and IV are derived once per connection and the record counter
+//! occupies the first two nonce bytes, so a physical connection may seal at most
+//! 65,536 records. Past that the u16 counter wraps and record 65,537 reuses
+//! record 1's (key, nonce) — two seals under one AEAD pair leak the XOR of the
+//! plaintexts and the authentication key with it. VMess negotiates no rekey, so
+//! the connection has to be retired instead.
+//!
+//! This drives a real [`VmessAdapter`] against a mock server that decrypts every
+//! body record under its own sequential counter and asserts the server sees
+//! exactly 65,536 records before EOF: the budget is enforced, the wire nonce
+//! format is untouched, and the physical connection is closed rather than
+//! reused. Mux needs no separate case — it multiplexes logical streams over one
+//! body cipher, so they all draw from this same counter and the session dies
+//! with it.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes128Gcm, KeyInit, Nonce};
+use meow_common::{Metadata, ProxyAdapter};
+use meow_proxy::dialer::DirectDialer;
+use meow_proxy::vmess::header::cmd_key;
+use meow_proxy::vmess::Security;
+use meow_proxy::{TransportChain, VmessAdapter};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Records one AEAD key/nonce pair may carry — the range of the two-byte record
+/// counter that forms the nonce prefix.
+const MAX_RECORDS: usize = 65_536;
+
+// ─── VMess AEAD KDF — verbatim port of crates/meow-proxy/src/vmess/kdf.rs ────
+
+fn sha256(data: &[u8]) -> [u8; 32] {
+    Sha256::digest(data).into()
+}
+
+fn nested_hmac(keys: &[&[u8]], msg: &[u8]) -> [u8; 32] {
+    let Some((k, inner_keys)) = keys.split_last() else {
+        return sha256(msg);
+    };
+    let mut key_block = [0u8; 64];
+    if k.len() > 64 {
+        key_block[..32].copy_from_slice(&nested_hmac(inner_keys, k));
+    } else {
+        key_block[..k.len()].copy_from_slice(k);
+    }
+    let mut ipad = [0x36u8; 64];
+    let mut opad = [0x5cu8; 64];
+    for i in 0..64 {
+        ipad[i] ^= key_block[i];
+        opad[i] ^= key_block[i];
+    }
+    let mut inner_msg = Vec::with_capacity(64 + msg.len());
+    inner_msg.extend_from_slice(&ipad);
+    inner_msg.extend_from_slice(msg);
+    let inner_digest = nested_hmac(inner_keys, &inner_msg);
+    let mut outer_msg = Vec::with_capacity(64 + 32);
+    outer_msg.extend_from_slice(&opad);
+    outer_msg.extend_from_slice(&inner_digest);
+    nested_hmac(inner_keys, &outer_msg)
+}
+
+fn kdf(key: &[u8], path: &[&[u8]]) -> [u8; 32] {
+    let mut keys: Vec<&[u8]> = Vec::with_capacity(1 + path.len());
+    keys.push(b"VMess AEAD KDF");
+    keys.extend_from_slice(path);
+    nested_hmac(&keys, key)
+}
+
+fn kdf16(key: &[u8], path: &[&[u8]]) -> [u8; 16] {
+    kdf(key, path)[..16].try_into().unwrap()
+}
+
+fn kdf12(key: &[u8], path: &[&[u8]]) -> [u8; 12] {
+    kdf(key, path)[..12].try_into().unwrap()
+}
+
+// ─── Mock VMess server helpers ───────────────────────────────────────────────
+
+/// The wire nonce: `count(2 BE) || iv[2..12]`.
+fn record_nonce(iv: &[u8; 16], counter: u16) -> [u8; 12] {
+    let mut nonce = [0u8; 12];
+    nonce[..2].copy_from_slice(&counter.to_be_bytes());
+    nonce[2..].copy_from_slice(&iv[2..12]);
+    nonce
+}
+
+/// The response body key/iv: SHA-256 of the request key/iv, truncated to 16.
+fn response_body_keys(req_key: &[u8; 16], req_iv: &[u8; 16]) -> ([u8; 16], [u8; 16]) {
+    let k: [u8; 32] = Sha256::digest(req_key).into();
+    let i: [u8; 32] = Sha256::digest(req_iv).into();
+    (k[..16].try_into().unwrap(), i[..16].try_into().unwrap())
+}
+
+/// Seal the AEAD response header the relay's read side expects.
+fn seal_response_header(req_key: &[u8; 16], req_iv: &[u8; 16], resp_v: u8) -> Vec<u8> {
+    let (resp_key, resp_iv) = response_body_keys(req_key, req_iv);
+    let header = [resp_v, 0, 0, 0];
+
+    let len_key = kdf16(&resp_key, &[b"AEAD Resp Header Len Key"]);
+    let len_iv = kdf12(&resp_iv, &[b"AEAD Resp Header Len IV"]);
+    let len_ct = Aes128Gcm::new_from_slice(&len_key)
+        .unwrap()
+        .encrypt(
+            Nonce::from_slice(&len_iv),
+            (header.len() as u16).to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+    let header_key = kdf16(&resp_key, &[b"AEAD Resp Header Key"]);
+    let header_iv = kdf12(&resp_iv, &[b"AEAD Resp Header IV"]);
+    let header_ct = Aes128Gcm::new_from_slice(&header_key)
+        .unwrap()
+        .encrypt(Nonce::from_slice(&header_iv), header.as_ref())
+        .unwrap();
+
+    [len_ct, header_ct].concat()
+}
+
+struct RequestHeader {
+    req_key: [u8; 16],
+    req_iv: [u8; 16],
+    resp_v: u8,
+}
+
+/// Parse the AEAD-sealed request header off the wire:
+/// `auth_id(16) || enc_len(18) || conn_nonce(8) || enc_header(N+16)`.
+async fn read_vmess_request_header(stream: &mut TcpStream, cmd_key: &[u8; 16]) -> RequestHeader {
+    let mut auth_id = [0u8; 16];
+    stream.read_exact(&mut auth_id).await.expect("read auth_id");
+    let mut enc_len = [0u8; 18];
+    stream.read_exact(&mut enc_len).await.expect("read enc_len");
+    let mut conn_nonce = [0u8; 8];
+    stream
+        .read_exact(&mut conn_nonce)
+        .await
+        .expect("read conn_nonce");
+
+    let length_key = kdf16(
+        cmd_key,
+        &[b"VMess Header AEAD Key_Length", &auth_id, &conn_nonce],
+    );
+    let length_iv = kdf12(
+        cmd_key,
+        &[b"VMess Header AEAD Nonce_Length", &auth_id, &conn_nonce],
+    );
+    let len_pt = Aes128Gcm::new_from_slice(&length_key)
+        .unwrap()
+        .decrypt(
+            Nonce::from_slice(&length_iv),
+            Payload {
+                msg: &enc_len,
+                aad: &auth_id,
+            },
+        )
+        .expect("decrypt header length block");
+    let header_len = u16::from_be_bytes([len_pt[0], len_pt[1]]) as usize;
+
+    let mut enc_header = vec![0u8; header_len + 16];
+    stream
+        .read_exact(&mut enc_header)
+        .await
+        .expect("read enc_header");
+    let header_key = kdf16(cmd_key, &[b"VMess Header AEAD Key", &auth_id, &conn_nonce]);
+    let header_iv = kdf12(
+        cmd_key,
+        &[b"VMess Header AEAD Nonce", &auth_id, &conn_nonce],
+    );
+    let header = Aes128Gcm::new_from_slice(&header_key)
+        .unwrap()
+        .decrypt(
+            Nonce::from_slice(&header_iv),
+            Payload {
+                msg: &enc_header,
+                aad: &auth_id,
+            },
+        )
+        .expect("decrypt request header");
+
+    let mut req_iv = [0u8; 16];
+    req_iv.copy_from_slice(&header[1..17]);
+    let mut req_key = [0u8; 16];
+    req_key.copy_from_slice(&header[17..33]);
+    RequestHeader {
+        req_key,
+        req_iv,
+        resp_v: header[33],
+    }
+}
+
+fn test_uuid() -> [u8; 16] {
+    std::array::from_fn(|i| (i + 1) as u8)
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+// The relay emits one wire record per read off the duplex, so record sizes are
+// not controlled from the app side. Small chunks plus a yield after each write
+// keep reads tracking writes ~1:1, which is what makes the record count a usable
+// proxy for the counter value.
+const CHUNK: usize = 32;
+const MAX_WRITES: usize = 2_000_000;
+
+#[tokio::test]
+async fn body_records_stop_at_the_nonce_budget_and_retire_the_connection() {
+    let uuid = test_uuid();
+    let cmd_key = cmd_key(&uuid);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    // Released once the server hits EOF, so the write pump below stops as soon
+    // as the relay has retired the connection.
+    let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let hdr = tokio::time::timeout(
+            Duration::from_secs(10),
+            read_vmess_request_header(&mut stream, &cmd_key),
+        )
+        .await
+        .expect("request header did not arrive in time");
+
+        stream
+            .write_all(&seal_response_header(&hdr.req_key, &hdr.req_iv, hdr.resp_v))
+            .await
+            .unwrap();
+
+        let cipher = Aes128Gcm::new_from_slice(&hdr.req_key).unwrap();
+        let mut count = 0usize;
+
+        loop {
+            let mut len_buf = [0u8; 2];
+            if stream.read_exact(&mut len_buf).await.is_err() {
+                break; // EOF between records
+            }
+            let ct_len = u16::from_be_bytes(len_buf) as usize;
+            let mut ct = vec![0u8; ct_len];
+            if stream.read_exact(&mut ct).await.is_err() {
+                break; // EOF mid-record
+            }
+            count += 1;
+
+            // A record past the budget can only have been sealed with a counter
+            // that already wrapped — and it would still decrypt, which is exactly
+            // why the count and not the decryption is the assertion here.
+            assert!(
+                count <= MAX_RECORDS,
+                "record {count} was sent under a reused AEAD (key, nonce): the \
+                 body counter wrapped instead of retiring the connection"
+            );
+
+            // Every record must still authenticate under its own sequential
+            // counter, so the budget is enforced without touching the wire format.
+            let counter = u16::try_from(count - 1).unwrap();
+            cipher
+                .decrypt(
+                    Nonce::from_slice(&record_nonce(&hdr.req_iv, counter)),
+                    ct.as_slice(),
+                )
+                .unwrap_or_else(|_| panic!("record {count} must decrypt under counter {counter}"));
+        }
+
+        // Let the writer stop before asserting, so a failure here is reported
+        // rather than racing a blocked write pump.
+        let _ = stop_tx.send(());
+
+        assert_eq!(
+            count, MAX_RECORDS,
+            "server saw {count} body records before EOF; the connection must be \
+             retired after exactly {MAX_RECORDS}"
+        );
+    });
+
+    let adapter = VmessAdapter::new(
+        "vmess-nonce-budget",
+        "127.0.0.1",
+        port,
+        uuid,
+        Security::Aes128Gcm,
+        false,
+        TransportChain::empty(),
+        Arc::new(DirectDialer),
+    );
+    let metadata = Metadata {
+        host: "example.com".into(),
+        dst_port: 443,
+        ..Default::default()
+    };
+    let mut conn = adapter.dial_tcp(&metadata).await.expect("dial_tcp");
+
+    let chunk = vec![0u8; CHUNK];
+    tokio::time::timeout(Duration::from_secs(180), async {
+        for _ in 0..MAX_WRITES {
+            tokio::select! {
+                biased;
+                _ = &mut stop_rx => break,
+                r = conn.write_all(&chunk) => {
+                    // The relay closes the stream once the budget is spent, so a
+                    // write error here is the retirement, not a failure.
+                    if r.is_err() {
+                        break;
+                    }
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("record pump timed out");
+    drop(conn);
+
+    server.await.unwrap();
+}

--- a/crates/meow-proxy/tests/vmess_nonce_budget.rs
+++ b/crates/meow-proxy/tests/vmess_nonce_budget.rs
@@ -15,6 +15,8 @@
 //! body cipher, so they all draw from this same counter and the session dies
 //! with it.
 
+#![cfg(feature = "vmess")]
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/meow-rules/src/mrs_parser.rs
+++ b/crates/meow-rules/src/mrs_parser.rs
@@ -218,11 +218,19 @@ fn parse_upstream_domain_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
 }
 
 fn read_u64_vec(r: &mut ByteReader<'_>, what: &'static str) -> Result<Vec<u64>, MrsError> {
-    let len = r.read_i64_be(what)?;
-    if len < 1 {
-        return Err(MrsError::InvalidLength(what, len));
+    let declared = r.read_i64_be(what)?;
+    if declared < 1 {
+        return Err(MrsError::InvalidLength(what, declared));
     }
-    let mut out = Vec::with_capacity(len as usize);
+    // The word count comes from a remote rule-provider, so prove the bytes are
+    // actually present before reserving: `with_capacity` on a bogus count trips
+    // the capacity-overflow check and aborts the process (issue #513).
+    let len = usize::try_from(declared).map_err(|_| MrsError::InvalidLength(what, declared))?;
+    let bytes = len
+        .checked_mul(std::mem::size_of::<u64>())
+        .ok_or(MrsError::InvalidLength(what, declared))?;
+    r.need(what, bytes)?;
+    let mut out = Vec::with_capacity(len);
     for _ in 0..len {
         out.push(r.read_u64_be(what)?);
     }
@@ -423,15 +431,20 @@ pub fn parse_geosite_payload(
     allowed: Option<&std::collections::HashSet<String>>,
 ) -> Result<GeositePayload, MrsError> {
     let mut r = ByteReader::new(decompressed);
-    let cat_count = r.read_u32_be("category_count")?;
-    let mut categories = Vec::with_capacity(cat_count as usize);
+    let cat_count = r.read_u32_be("category_count")? as usize;
+    // Both counts come from a remote geodata file. Reserving them verbatim asks
+    // for hundreds of gigabytes on a bogus count, which aborts under the
+    // workspace's `panic = "abort"`; cap at what the input can actually hold —
+    // an empty category still costs a u16 name length plus a u32 domain count,
+    // and an empty domain still costs a u16 length.
+    let mut categories = Vec::with_capacity(bounded_capacity(cat_count, r.remaining(), 6));
     for _ in 0..cat_count {
         let name_len = r.read_u16_be("category_name_len")? as usize;
         let name_bytes = r.read_slice("category_name", name_len)?;
         let name = String::from_utf8(name_bytes.to_vec())
             .map_err(|e| MrsError::Utf8("category_name", e))?
             .to_ascii_lowercase();
-        let dom_count = r.read_u32_be("domain_count")?;
+        let dom_count = r.read_u32_be("domain_count")? as usize;
 
         // If an allow-set is active and this category is not in it, skip its
         // domains at the byte level — read lengths and advance the cursor
@@ -446,7 +459,7 @@ pub fn parse_geosite_payload(
             }
         }
 
-        let mut domains = Vec::with_capacity(dom_count as usize);
+        let mut domains = Vec::with_capacity(bounded_capacity(dom_count, r.remaining(), 2));
         for _ in 0..dom_count {
             let dom_len = r.read_u16_be("domain_len")? as usize;
             let dom_bytes = r.read_slice("domain", dom_len)?;
@@ -458,6 +471,14 @@ pub fn parse_geosite_payload(
         categories.push((name, domains));
     }
     Ok(GeositePayload { categories })
+}
+
+/// Cap a reservation derived from a declared element count at what the
+/// remaining input can actually hold, given the smallest encoded size of one
+/// element. The declared counts are remote-controlled; without the cap a bogus
+/// count becomes an allocation failure rather than a `Truncated` error.
+fn bounded_capacity(declared: usize, remaining: usize, min_element_bytes: usize) -> usize {
+    declared.min(remaining / min_element_bytes)
 }
 
 /// Encode a `GeositePayload` into the uncompressed inner payload bytes.
@@ -526,13 +547,22 @@ impl<'a> ByteReader<'a> {
         &self.data[self.pos..]
     }
 
+    /// Unread byte count. Saturating because a hostile declared length can push
+    /// `pos` arithmetic that would otherwise wrap.
+    fn remaining(&self) -> usize {
+        self.data.len().saturating_sub(self.pos)
+    }
+
     fn need(&self, what: &'static str, n: usize) -> Result<(), MrsError> {
-        if self.pos + n > self.data.len() {
+        // Compare against the remaining length rather than `pos + n`: a declared
+        // length near `usize::MAX` would wrap the sum and pass the check.
+        let have = self.remaining();
+        if n > have {
             return Err(MrsError::Truncated {
                 what,
                 offset: self.pos,
                 need: n,
-                have: self.data.len() - self.pos,
+                have,
             });
         }
         Ok(())
@@ -797,5 +827,48 @@ mod tests {
         let parsed = parse_upstream_ruleset_mrs(&bytes).unwrap();
         assert_eq!(parsed.behavior, TYPE_IPCIDR);
         assert_eq!(parsed.entries, vec!["192.168.0.0/24"]);
+    }
+
+    /// A remote rule-provider can declare an enormous word count in a payload
+    /// only a few dozen bytes long. Both `read_u64_vec` call sites must reject
+    /// it with an error: reserving from the declared count trips the
+    /// capacity-overflow check, which terminates the process under the
+    /// workspace's `panic = "abort"` release profile (issue #513).
+    #[test]
+    fn upstream_ruleset_mrs_oversized_word_counts_are_rejected() {
+        // `i64::MAX` overflows the byte-count multiplication; `i64::MAX / 8 + 1`
+        // does not and must instead be caught by the remaining-input check.
+        for declared in [i64::MAX, i64::MAX / 8 + 1, 100] {
+            let mut leaves = vec![1u8];
+            write_i64(&mut leaves, declared);
+            assert!(
+                parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, 1, &leaves)).is_err(),
+                "leaves_len={declared} must not reserve from the declared count"
+            );
+
+            let mut bitmap = vec![1u8];
+            write_i64(&mut bitmap, 1);
+            write_u64(&mut bitmap, 0);
+            write_i64(&mut bitmap, declared);
+            assert!(
+                parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, 1, &bitmap)).is_err(),
+                "label_bitmap_len={declared} must not reserve from the declared count"
+            );
+        }
+    }
+
+    /// Same class on the geodata path: `category_count` and `domain_count` are
+    /// u32 values from a remote geodata file, so the reservation has to be
+    /// capped by the input rather than asking for hundreds of gigabytes.
+    #[test]
+    fn geosite_payload_declared_counts_are_bounded_by_input() {
+        assert!(parse_geosite_payload(&u32::MAX.to_be_bytes(), None).is_err());
+
+        let mut category_without_domains = Vec::new();
+        category_without_domains.extend_from_slice(&1u32.to_be_bytes());
+        category_without_domains.extend_from_slice(&2u16.to_be_bytes());
+        category_without_domains.extend_from_slice(b"cn");
+        category_without_domains.extend_from_slice(&u32::MAX.to_be_bytes());
+        assert!(parse_geosite_payload(&category_without_domains, None).is_err());
     }
 }

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -4,13 +4,13 @@ use crate::statistics::Statistics;
 use crate::udp::{self, NatTable};
 use meow_common::{Metadata, Proxy, ProxyAdapter, Rule, TunnelMode};
 use meow_dns::Resolver;
-use meow_proxy::DirectAdapter;
+use meow_proxy::{DirectAdapter, RejectAdapter};
 use parking_lot::RwLock;
 use smol_str::SmolStr;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Bundled rules + domain index + proxies map, swapped as one `Arc` on
 /// config reload. Reads on the connection-setup hot path take a single
@@ -70,6 +70,12 @@ pub struct TunnelInner {
     /// when Direct/Global mode bypasses the proxies map. Pre-built with the
     /// internal resolver so hostname dials avoid the OS resolver.
     pub direct: Arc<DirectAdapter>,
+    /// Refusal adapter for a matched rule whose target is not in the
+    /// registry. Such a rule is a broken policy, and answering it with
+    /// `direct` would send traffic the operator routed through a proxy
+    /// straight out instead (issue #513). Non-drop, so the connection fails
+    /// immediately rather than black-holing for a minute.
+    pub reject: Arc<RejectAdapter>,
     pub nat_table: NatTable,
     pub stats: Arc<Statistics>,
     /// Cold-reload admission boundary. TCP setup captures this generation
@@ -266,7 +272,9 @@ impl TunnelInner {
     }
 
     /// Map a rule-match result to the public `(proxy, rule name, payload)`
-    /// tuple, recording match statistics; `None` falls through to DIRECT.
+    /// tuple, recording match statistics. No rule matching falls through to
+    /// DIRECT; a *matched* rule whose target the registry does not hold is
+    /// refused instead, never dialled out directly.
     fn materialize_rule_match(
         &self,
         route: &RouteTable,
@@ -274,23 +282,44 @@ impl TunnelInner {
     ) -> (Arc<dyn ProxyAdapter>, SmolStr, SmolStr) {
         match result {
             Some(m) => {
-                let action = if m.adapter_name == "DIRECT" {
-                    "DIRECT"
-                } else if m.adapter_name.starts_with("REJECT") {
-                    "REJECT"
-                } else {
-                    "PROXY"
+                let target = m.adapter_name;
+                // A matched rule naming something the registry does not hold is
+                // a broken policy. Upstream mihomo routes it to DIRECT, which
+                // quietly sends traffic the operator routed through a proxy
+                // straight out, so refuse it instead — and report the refusal
+                // as the REJECT it now is rather than as a proxy hop that
+                // never happened (issue #513). DIRECT needs no registry entry:
+                // the tunnel owns a direct adapter for exactly this.
+                let (proxy, action): (Arc<dyn ProxyAdapter>, &str) = match route
+                    .proxies
+                    .get(target)
+                    .map(Arc::clone)
+                {
+                    Some(p) => {
+                        let action = if target == "DIRECT" {
+                            "DIRECT"
+                        } else if target.starts_with("REJECT") {
+                            "REJECT"
+                        } else {
+                            "PROXY"
+                        };
+                        (p, action)
+                    }
+                    None if target == "DIRECT" => {
+                        (Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>, "DIRECT")
+                    }
+                    None => {
+                        warn!(
+                            target,
+                            rule = %m.rule_type.as_str(),
+                            "matched rule names a target that is not in the registry; refusing the connection instead of dialling DIRECT"
+                        );
+                        (Arc::clone(&self.reject) as Arc<dyn ProxyAdapter>, "REJECT")
+                    }
                 };
                 self.stats
                     .rule_match
                     .increment(m.rule_type.as_str(), action);
-                let proxy = route.proxies.get(m.adapter_name).cloned().map_or_else(
-                    || {
-                        debug!("proxy '{}' not found, using DIRECT", m.adapter_name);
-                        Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>
-                    },
-                    |p| p as Arc<dyn ProxyAdapter>,
-                );
                 // `rule_type.as_str()` is a `&'static str` — wrap it
                 // inline without heap.
                 (
@@ -324,6 +353,7 @@ impl Tunnel {
                 route: RwLock::new(Arc::new(RouteTable::empty())),
                 resolver,
                 direct,
+                reject: Arc::new(RejectAdapter::new(false)),
                 nat_table: udp::new_nat_table(),
                 stats: Arc::new(Statistics::new()),
                 tcp_generation: RwLock::new(0),

--- a/crates/meow-tunnel/tests/rule_target_missing_refuses.rs
+++ b/crates/meow-tunnel/tests/rule_target_missing_refuses.rs
@@ -1,0 +1,143 @@
+//! A matched rule whose target the registry does not hold must refuse the
+//! connection, never dial it out over DIRECT (issue #513).
+//!
+//! Upstream mihomo falls back to DIRECT here, which turns one misspelt proxy or
+//! group name into a silent policy bypass: traffic the operator meant to route
+//! through a proxy leaves the machine directly, and nothing in the connection
+//! record says so. meow-rs substitutes its own REJECT adapter and reports the
+//! match to the statistics as the refusal it now is.
+
+use meow_common::{AdapterType, DnsMode, Metadata, Network, Rule, TunnelMode};
+use meow_dns::Resolver;
+use meow_rules::final_rule::FinalRule;
+use meow_trie::DomainTrie;
+use meow_tunnel::Tunnel;
+use std::sync::Arc;
+
+fn resolver() -> Arc<Resolver> {
+    Arc::new(Resolver::new(
+        vec![],
+        vec![],
+        DnsMode::Normal,
+        DomainTrie::new(),
+        true,
+        true,
+    ))
+}
+
+/// A tunnel in rule mode whose registry is the one every real load publishes:
+/// the built-in DIRECT / REJECT / REJECT-DROP entries and nothing else.
+fn tunnel_with_builtin_registry() -> Tunnel {
+    let tunnel = Tunnel::new(resolver());
+    let (proxies, _) = meow_config::rebuild_from_raw(&meow_config::raw::RawConfig::default())
+        .expect("an empty config must build its built-in registry");
+    tunnel.update_proxies(proxies);
+    tunnel.set_mode(TunnelMode::Rule);
+    tunnel
+}
+
+fn metadata() -> Metadata {
+    Metadata {
+        host: "example.test".into(),
+        dst_port: 443,
+        network: Network::Tcp,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn a_matched_rule_with_a_missing_target_is_refused_not_dialled_direct() {
+    let tunnel = tunnel_with_builtin_registry();
+    let rules: Vec<Box<dyn Rule>> = vec![Box::new(FinalRule::new("ghost-group"))];
+    tunnel.update_rules(rules);
+
+    let (proxy, rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(rule, "MATCH");
+    assert_eq!(
+        proxy.adapter_type(),
+        AdapterType::Reject,
+        "the connection must be refused, not sent out directly"
+    );
+    assert_eq!(
+        tunnel.statistics().rule_match.snapshot(),
+        vec![(("MATCH", "REJECT"), 1)],
+        "the stats must report the refusal rather than a proxy hop that never happened"
+    );
+}
+
+#[tokio::test]
+async fn the_lazy_resolve_path_refuses_a_missing_target_too() {
+    let tunnel = tunnel_with_builtin_registry();
+    let rules: Vec<Box<dyn Rule>> = vec![Box::new(FinalRule::new("ghost-group"))];
+    tunnel.update_rules(rules);
+
+    let mut md = metadata();
+    let (proxy, _rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy_lazy(&mut md)
+        .await
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(proxy.adapter_type(), AdapterType::Reject);
+}
+
+#[test]
+fn a_target_the_registry_holds_is_used_as_is() {
+    let tunnel = tunnel_with_builtin_registry();
+    let rules: Vec<Box<dyn Rule>> = vec![Box::new(FinalRule::new("REJECT-DROP"))];
+    tunnel.update_rules(rules);
+
+    let (proxy, _rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(
+        proxy.adapter_type(),
+        AdapterType::RejectDrop,
+        "the registry's own REJECT-DROP must win over the substituted REJECT"
+    );
+}
+
+#[test]
+fn a_rule_naming_direct_needs_no_registry_entry() {
+    // DIRECT is a built-in the tunnel owns an adapter for, so a rule naming it
+    // must resolve even before any registry snapshot has been published —
+    // otherwise the refusal above would swallow the common case.
+    let tunnel = Tunnel::new(resolver());
+    tunnel.set_mode(TunnelMode::Rule);
+    let rules: Vec<Box<dyn Rule>> = vec![Box::new(FinalRule::new("DIRECT"))];
+    tunnel.update_rules(rules);
+
+    let (proxy, _rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(proxy.adapter_type(), AdapterType::Direct);
+    assert_eq!(
+        tunnel.statistics().rule_match.snapshot(),
+        vec![(("MATCH", "DIRECT"), 1)]
+    );
+}
+
+#[test]
+fn no_rule_matching_still_falls_through_to_direct() {
+    // Only a *matched* rule with an unresolvable target is refused. Nothing
+    // matching at all is the ordinary end of the rule list.
+    let tunnel = tunnel_with_builtin_registry();
+    let rules: Vec<Box<dyn Rule>> = vec![];
+    tunnel.update_rules(rules);
+
+    let (proxy, rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("the no-match path still yields DIRECT");
+
+    assert_eq!(rule, "Final");
+    assert_eq!(proxy.adapter_type(), AdapterType::Direct);
+}

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -131,6 +131,18 @@ to upstream mihomo, the following are hard load-time errors instead of warnings:
 - Duplicate listener ports or names.
 - Deprecated VLESS flows (`xtls-rprx-direct` / `-splice`) and VMess `cipher: zero`.
 - Unsupported Hysteria2 options (`certificate`, `private-key`, server-side ECH, …).
+- Any `proxies`, `proxy-groups`, or `rules` entry that cannot be built. Upstream drops the
+  entry with a warning and keeps loading; meow-rs fails the load and names the entry,
+  because a dropped entry leaves every rule pointing at it without a target.
+
+A rule that matches but names a target the registry does not hold is refused at connection
+time rather than sent out directly — upstream falls back to DIRECT, which quietly leaks
+traffic the operator routed through a proxy. A rule naming `DIRECT`, and a connection no
+rule matches, still use the built-in DIRECT adapter.
+
+Nodes fetched by a [proxy-provider](./providers) are held to the opposite rule: a
+provider document is remote input, so one unparseable node is dropped with a warning and
+the rest of the subscription still loads.
 
 Forward-compatibility fields that meow-rs does not implement (e.g. some `geodata`
 sub-keys) are accepted and ignored with a one-time warning so upstream configs still load.

--- a/website/guide/providers.md
+++ b/website/guide/providers.md
@@ -38,6 +38,23 @@ proxy-groups:
 | `exclude-type` | string \| list | `[]` | Drop proxy types, e.g. `[ss]` |
 | `health-check` | block | — | Periodic probing (below) |
 | `header` | map | `{}` | Extra HTTP request headers (`http` only) |
+| `allow-external-plugin` | bool | `false` | Let this provider's nodes select an external SIP003 plugin (below) |
+
+#### External SIP003 plugins
+
+A Shadowsocks node whose `plugin:` is not one of the built-in in-process plugins
+(`obfs`, `simple-obfs`, `v2ray-plugin`, `ech-tls-tunnel`) runs that plugin as a
+local subprocess. The process is launched as soon as the node is parsed — on
+first load and again on every refresh — not when traffic later dials the node.
+
+A provider document is remote input even when its vehicle is a local file, so by
+default its nodes may not name an executable: such a node is dropped with a
+warning and the rest of the provider still loads. Set
+`allow-external-plugin: true` on a provider you trust to lift that restriction
+for its nodes only.
+
+Nodes written directly in your own `proxies:` block are unaffected — naming a
+plugin there is already a local decision.
 
 ### `type: http`
 


### PR DESCRIPTION
Fixes findings **1, 2, 3, 5 and 6** of #513, one commit each, in the issue's suggested repair order.

Finding **4** (the `from_utf8_unchecked` binary KDF contexts in VLESS encryption) is deliberately **not** in this PR — it needs a byte-oriented BLAKE3 derive-key that preserves the exact two-phase domain separation, which is a separate change. #513 should stay open for it.

## What changed

| # | Finding | Commit |
|---|---------|--------|
| 1 | **[P0]** mrs `read_u64_vec` allocates from the declared length before proving the input exists — a 30-byte remote payload aborts the release process | `a3b3dc0` |
| 2 | **[P1]** groups clone their members before `apply_dialer_proxies` rewrites the registry, so any grouped node bypasses its `dialer-proxy` chain | `593c5c7` |
| 3 | **[P1]** the VMess body `u16` record counter wraps and reuses an AEAD key/nonce pair | `ba0c805` |
| 5 | **[P1]** a remote proxy-provider's SIP003 `plugin:` reaches `Command::new` while the node is parsed | `e53648e` |
| 6 | **[P1]** unparseable proxies/groups/rules are warn-skipped while the rebuild succeeds, and a matched rule with a missing target resolves to DIRECT | `434347b` |

Two small follow-ups fix feature-gate regressions the CI clippy matrix caught in commits 3 and 5: `0b2d750` (`parse_proxy_scoped` built with an unused `origin` parameter when `ss` is off) and `e835c9e` (the new VMess nonce-budget test was not gated on `vmess`).

### Notes on the individual fixes

**1** — `read_u64_vec` now does a checked `len * size_of::<u64>()`, compares against the remaining input, and only then allocates. Covers both confirmed call sites (`leaves_len`, `label_bitmap_len`); the fields the audit showed already failing with `Truncated` are untouched.

**2** — the build order is now leaves → `apply_dialer_proxies` → groups → auto-GLOBAL, so groups clone the chained adapters.

**3** — the nonce format is unchanged and no rekey is negotiated, per the issue's constraint. The budget is enforced before seal/open and the physical connection is retired on exhaustion. Mux needs no separate case: logical streams share one body cipher and therefore one counter, so the session dies with it.

**5** — not string filtering. `parse_proxy_scoped` takes a `ProxyOrigin`, and a node whose origin is `Provider` may not name an external SIP003 plugin unless that provider sets `allow-external-plugin: true`. Default-deny, per provider, opt-in by the operator only. Built-in in-process plugins (`obfs`, `simple-obfs`, `v2ray-plugin`, `ech-tls-tunnel`) and the operator's own `proxies:` block are unaffected.

**6** — Class A per ADR-0002, following #490's precedent of turning warn into hard-fail:

- A proxy, group, or rule the parser cannot build now fails the load, and the message names the entry. ADR-0002 defers any `--strict` leniency flag to M3, so there is no flag here.
- A *matched* rule whose target the registry does not hold is refused through a non-drop `RejectAdapter`, never dialled out directly. `DIRECT` needs no registry entry — the tunnel owns a direct adapter for exactly that — and a connection no rule matches still falls through to DIRECT. The refusal is reported to the match statistics as the REJECT it now is rather than as a proxy hop that never happened (no new metric label, per ADR-0004).
- Provider documents keep the lenient behaviour: a subscription is remote input, so one unparseable node is still warn-dropped and the rest loads. Only a group left with no members at all fails.
- The provider path-containment checks (#429 / #444) move to the top of the rebuild, so a group that cannot resolve its provider slot reports the containment violation instead of its own emptiness.
- A parser rejection is the caller's fault, so the subscription and reload routes now return 400 rather than 500.

## Verification

- New: `crates/meow-config/tests/strict_config_load.rs` (6 tests), `crates/meow-tunnel/tests/rule_target_missing_refuses.rs` (5 tests), `crates/meow-proxy/tests/vmess_nonce_budget.rs`, plus per-finding regression tests in the earlier commits.
- Migrated the existing tests that pinned the old warn-skip contract (30 across `config_test`, `vless_config_test`, `config_persistence_test`, `ech_dns_test`, `api_test`) to assert on the refusal text, which names the offending entry.
- `cargo test --workspace --no-fail-fast`: 99 test binaries pass. The one failure, `meow-tunnel::raii_guard_test::close_connection_cancels_blocked_prefix_write`, is pre-existing on `a663364` and unrelated — it asserts a 16 MiB loopback prefix write stays pending, which does not hold on this host's socket buffers.
- CI gates run locally and clean: `cargo clippy --all-targets` with default features, `--all-features`, and `--no-default-features` (all `-D warnings`), `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, and `cargo fmt --all -- --check`.
- Docs: `website/guide/configuration.md` compatibility notes now list the hard-fail behaviour and the connection-time refusal; `website/guide/providers.md` documents `allow-external-plugin`.