### PR TITLE
fix: bound mrs allocation and bind dialer-proxy by name (#513)

### DIFF
--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -577,13 +577,14 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// a direct dial would let traffic egress from the real source path past a
 /// chain the user configured for policy/security reasons (Class A, ADR-0002).
 /// A cycle has to be caught here in particular: late binding would turn it into
-/// unbounded recursion on the first dial. The check covers cycles through group
-/// membership too — a group-valued dialer can select the chained proxy itself —
-/// not just proxy→proxy edges, which is all upstream mihomo validates.
+/// unbounded recursion on the first dial. Cycles *through group membership* are
+/// checked separately by [`reject_group_membership_cycles`], which runs after
+/// the group build where the real membership is known.
 ///
 /// Returns the applied `(proxy, dialer)` edges so the caller can re-validate
 /// dialer targets once groups have been built (a *declared* group that failed
-/// to build satisfies `dialable` but never enters the registry).
+/// to build satisfies `dialable` but never enters the registry) and run
+/// [`reject_group_membership_cycles`] against the finished registry.
 fn apply_dialer_proxies(
     proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
     raw_proxies: &[HashMap<String, serde_yaml::Value>],
@@ -664,77 +665,6 @@ fn apply_dialer_proxies(
         anyhow::bail!("dialer-proxy cycle detected: {}", cycle.join(", "));
     }
 
-    // A dialer may name a *group*, whose front-hop dial then selects any member
-    // — including, transitively, the proxy that declared the chain. That loop
-    // never reaches I/O: it is synchronous nested polls and exhausts the
-    // native stack on the first dial (mihomo's `validateDialerProxies` has the
-    // same blind spot — it only sees proxy→proxy edges). Reject any edge whose
-    // dialer can reach back to its source over the combined graph of dialer
-    // edges and group-membership edges.
-    //
-    // Group membership is expanded from the *declared* config: `proxies:` may
-    // name leaves or other groups (nested), `include-all-proxies` and an
-    // auto-created `GLOBAL` contain every registry name. Provider-slot members
-    // (`use:` / `include-all`) can never carry a `dialer-proxy` themselves, so
-    // they are dead ends for reachability and are ignored.
-    let all_names: std::collections::HashSet<&str> = proxies
-        .keys()
-        .map(SmolStr::as_str)
-        .chain(raw_groups.iter().map(|group| group.name.as_str()))
-        .collect();
-    let mut members_of: HashMap<&str, Vec<&str>> = HashMap::new();
-    for group in raw_groups {
-        let mut members: Vec<&str> = group
-            .proxies
-            .as_deref()
-            .unwrap_or(&[])
-            .iter()
-            .map(String::as_str)
-            .collect();
-        if group.include_all_proxies.unwrap_or(false) {
-            members.extend(all_names.iter().copied());
-        }
-        members_of.insert(group.name.as_str(), members);
-    }
-    if !raw_groups.iter().any(|group| group.name == "GLOBAL") {
-        // Auto-created GLOBAL selects over the entire registry.
-        members_of.insert("GLOBAL", all_names.iter().copied().collect());
-    }
-    let edge_map: HashMap<&str, &str> = edges
-        .iter()
-        .map(|(name, dialer)| (name.as_str(), dialer.as_str()))
-        .collect();
-    // DFS from each dialer over dialer edges and membership edges; reaching the
-    // edge's source means the first dial recurses without bound.
-    for (name, dialer) in &edges {
-        // A source that never parsed has no entry to wrap, so no chain is
-        // applied and it cannot re-enter itself — skip it rather than rejecting
-        // a config that is otherwise only missing one node.
-        if !proxies.contains_key(name) {
-            continue;
-        }
-        let mut stack: Vec<&str> = vec![dialer.as_str()];
-        let mut visited: std::collections::HashSet<&str> = std::collections::HashSet::new();
-        while let Some(node) = stack.pop() {
-            if node == name.as_str() {
-                anyhow::bail!(
-                    "proxy '{name}': dialer-proxy '{dialer}' can route back to \
-                     '{name}' through group membership, which would recurse \
-                     forever on the first dial"
-                );
-            }
-            if !visited.insert(node) {
-                continue;
-            }
-            if let Some(next) = edge_map.get(node) {
-                stack.push(next);
-            }
-            if let Some(members) = members_of.get(node) {
-                stack.extend(members.iter().copied());
-            }
-        }
-    }
-
     // Apply the edges. Order no longer matters — the front hop is resolved at
     // dial time — so nested chains need no deepest-first deferral pass.
     for (name, dialer) in &edges {
@@ -795,6 +725,101 @@ fn apply_dialer_proxies(
         }
     }
     Ok(edges)
+}
+
+/// Reject any `dialer-proxy` edge whose target can route the front-hop dial
+/// back to the chained proxy through group membership — a loop that never
+/// reaches I/O: it is synchronous nested polls and exhausts the native stack
+/// on the first dial (mihomo's `validateDialerProxies` only sees proxy→proxy
+/// edges and has the same blind spot).
+///
+/// Runs after the group build so the model matches the *built* registry:
+/// groups that failed to build contribute no membership edges, and a declared
+/// `GLOBAL` that failed to build is backstopped by the auto-created one
+/// holding every registry entry — modelling declared membership before the
+/// build would miss both.
+///
+/// Conservative over-approximations, all fail-closed: `include-all-proxies`
+/// expands to the final registry (the build itself saw a mid-pass subset);
+/// duplicate group declarations are unioned (the registry keeps the last
+/// *successful* build, not the last declaration); relay members are all
+/// treated as reachable heads (only the first member's dialer can actually
+/// fire); provider-slot members (`use:` / `include-all`) are dead ends —
+/// provider nodes never carry a `dialer-proxy`.
+fn reject_group_membership_cycles(
+    edges: &[(SmolStr, SmolStr)],
+    raw_groups: &[raw::RawProxyGroup],
+    proxies: &HashMap<SmolStr, Arc<dyn Proxy>>,
+    global_auto_created: bool,
+) -> Result<(), anyhow::Error> {
+    if edges.is_empty() {
+        return Ok(());
+    }
+    let mut members_of: HashMap<&str, Vec<&str>> = HashMap::new();
+    for group in raw_groups {
+        if !proxies.contains_key(group.name.as_str()) {
+            // Never built — its entry is absent, so it contributes no
+            // membership edges at runtime.
+            continue;
+        }
+        let mut members: Vec<&str> = group
+            .proxies
+            .as_deref()
+            .unwrap_or(&[])
+            .iter()
+            .map(String::as_str)
+            .filter(|m| proxies.contains_key(*m))
+            .collect();
+        if group.include_all_proxies.unwrap_or(false) {
+            members.extend(proxies.keys().map(SmolStr::as_str));
+        }
+        members_of
+            .entry(group.name.as_str())
+            .or_default()
+            .extend(members);
+    }
+    if global_auto_created {
+        members_of
+            .entry("GLOBAL")
+            .or_default()
+            .extend(proxies.keys().map(SmolStr::as_str));
+    }
+    // Only edges whose source actually entered the registry produce a wrapped
+    // adapter; an unparseable source can never fire its chain, so following
+    // its edge would be a phantom.
+    let edge_map: HashMap<&str, &str> = edges
+        .iter()
+        .filter(|(name, _)| proxies.contains_key(name))
+        .map(|(name, dialer)| (name.as_str(), dialer.as_str()))
+        .collect();
+    // DFS from each dialer over dialer edges and membership edges; reaching the
+    // edge's source means the first dial recurses without bound.
+    for (name, dialer) in edges {
+        if !proxies.contains_key(name) {
+            continue;
+        }
+        let mut stack: Vec<&str> = vec![dialer.as_str()];
+        let mut visited: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        while let Some(node) = stack.pop() {
+            if node == name.as_str() {
+                anyhow::bail!(
+                    "proxy '{name}': dialer-proxy '{dialer}' can route back to \
+                     '{name}' through group membership, which would recurse \
+                     forever on the first dial"
+                );
+            }
+            if !visited.insert(node) {
+                continue;
+            }
+            if let Some(next) = edge_map.get(node) {
+                stack.push(next);
+            }
+            if let Some(members) = members_of.get(node) {
+                stack.extend(members.iter().copied());
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Policy names resolved internally rather than declared as usable outbounds.
@@ -988,7 +1013,8 @@ fn rebuild_from_raw_impl(
     // outbound first: SelectorGroup uses its first member when no choice has
     // been stored, and sorting every registry key previously made global mode
     // default to DIRECT or an alphabetically-first quota/expiry pseudo-node.
-    if !proxies.contains_key("GLOBAL") {
+    let had_global = proxies.contains_key("GLOBAL");
+    if !had_global {
         let mut all_proxy_names: Vec<String> = proxies
             .keys()
             .map(std::string::ToString::to_string)
@@ -1023,6 +1049,9 @@ fn rebuild_from_raw_impl(
             Err(e) => warn!("Failed to create GLOBAL selector: {}", e),
         }
     }
+    // Whether `GLOBAL` is the auto-created all-registry selector or a declared
+    // group changes what a `dialer-proxy: GLOBAL` edge can reach.
+    let global_auto_created = !had_global && proxies.contains_key("GLOBAL");
 
     // `dialable` admitted *declared* group names before the group build ran;
     // a group that failed to build never entered the registry, so re-check
@@ -1036,6 +1065,11 @@ fn rebuild_from_raw_impl(
             );
         }
     }
+
+    // Cycles that run through group membership — including a declared-but-
+    // failed GLOBAL that the auto-create just backstopped — are only decidable
+    // now that the registry is finished.
+    reject_group_membership_cycles(&dialer_edges, raw_groups, &proxies, global_auto_created)?;
 
     // Publish the finished registry: the `dialer-proxy` chains bound above
     // resolve their front hop by name against it, and only now does it hold the
@@ -2340,14 +2374,24 @@ mod dialer_proxy_tests {
     }
 
     /// Same as [`apply_chains`] but with declared `proxy-groups`, so tests can
-    /// exercise group-valued dialers and the membership cycle check.
+    /// exercise group-valued dialers and the membership cycle check. Stands in
+    /// for the group build by giving every declared group a registry entry —
+    /// the cycle check models declared membership, so what the entry *is*
+    /// does not matter, only that it exists.
     fn apply_chains_with_groups(
         proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
         raw_proxies: &[HashMap<String, serde_yaml::Value>],
         raw_groups: &[raw::RawProxyGroup],
     ) -> Result<(), anyhow::Error> {
         let registry = meow_proxy::dialer::ProxyRegistry::default();
-        apply_dialer_proxies(proxies, raw_proxies, raw_groups, &registry, true)?;
+        let edges = apply_dialer_proxies(proxies, raw_proxies, raw_groups, &registry, true)?;
+        for group in raw_groups {
+            proxies
+                .entry(SmolStr::from(group.name.as_str()))
+                .or_insert_with(|| simple_proxy(&group.name));
+        }
+        let global_auto_created = !proxies.contains_key("GLOBAL");
+        reject_group_membership_cycles(&edges, raw_groups, proxies, global_auto_created)?;
         registry.publish(Arc::new(proxies.clone()));
         Ok(())
     }

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -547,9 +547,17 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// Apply per-outbound `dialer-proxy` in place (issue #210).
 ///
 /// For every proxy that declares `dialer-proxy: <name>`, its registry entry is
-/// re-parsed from the raw config with a [`meow_proxy::dialer::ProxyDialer`]
+/// re-parsed from the raw config with a [`meow_proxy::dialer::NamedProxyDialer`]
 /// injected, so the adapter dials its server through `<name>` transparently
 /// (mihomo `proxyDialer` model).
+///
+/// `<name>` is bound *late*: the injected dialer keeps the name plus a
+/// [`meow_proxy::dialer::ProxyRegistry`] handle and looks the front proxy up on
+/// every dial, which is what mihomo does (`component/proxydialer/byname.go`).
+/// Capturing the front `Arc` here instead freezes whatever the registry holds
+/// at build time — and since this pass runs *before* groups are built, so that
+/// grouped members inherit the chain (issue #513), a group-valued dialer does
+/// not exist yet at that point.
 ///
 /// Adapter types that do not establish their underlying connection through the
 /// pluggable dialer — `anytls`, `hysteria2` (QUIC), and `ss` with an external
@@ -564,21 +572,17 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// association rather than leaking the real source path; mux-based UDP rides
 /// the dialer over TCP and is unaffected.
 ///
-/// Nested dialer-proxies are resolved deepest-first so each layer sees its
-/// dialer's final (already-rebuilt) form. A self-referencing dialer, a
-/// reference to an unknown proxy, or a dialer cycle is a hard config error —
-/// silently falling back to a direct dial would let traffic egress from the
-/// real source path past a chain the user configured for policy/security
-/// reasons (Class A, ADR-0002).
-///
-/// Note: this rewrites the registry entry, so direct rule references
-/// (`…,<proxy>`) and dialers that are groups both work. A proxy that is also a
-/// static member of a group keeps the dialer for direct references but not when
-/// reached via that group, because group members are resolved eagerly before
-/// this pass.
+/// A self-referencing dialer, a reference to a name the config does not
+/// declare, or a dialer cycle is a hard config error — silently falling back to
+/// a direct dial would let traffic egress from the real source path past a
+/// chain the user configured for policy/security reasons (Class A, ADR-0002).
+/// A cycle has to be caught here in particular: late binding would turn it into
+/// unbounded recursion on the first dial.
 fn apply_dialer_proxies(
     proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
     raw_proxies: &[HashMap<String, serde_yaml::Value>],
+    raw_groups: &[raw::RawProxyGroup],
+    registry: &meow_proxy::dialer::ProxyRegistry,
     ipv6: bool,
 ) -> Result<(), anyhow::Error> {
     // Collect proxy -> dialer edges from the raw config.
@@ -588,7 +592,7 @@ fn apply_dialer_proxies(
     // duplicate `name:` entries the last block is the effective definition.
     // Collecting edges from superseded duplicates would apply a chain the
     // effective block never declared.
-    let mut pending: Vec<(SmolStr, SmolStr)> = Vec::new();
+    let mut edges: Vec<(SmolStr, SmolStr)> = Vec::new();
     let mut seen_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for raw_proxy in raw_proxies.iter().rev() {
         let Some(name) = raw_proxy.get("name").and_then(|v| v.as_str()) else {
@@ -607,102 +611,108 @@ fn apply_dialer_proxies(
         if dialer == name {
             anyhow::bail!("proxy '{name}': dialer-proxy points to itself");
         }
-        pending.push((SmolStr::from(name), SmolStr::from(dialer)));
+        edges.push((SmolStr::from(name), SmolStr::from(dialer)));
     }
-    if pending.is_empty() {
+    if edges.is_empty() {
         return Ok(());
     }
 
-    // Names that declared a dialer-proxy — used to defer an edge until its
-    // dialer has reached its final wrapped form (nested dialer-proxies).
-    let needs_wrap: std::collections::HashSet<SmolStr> =
-        pending.iter().map(|(n, _)| n.clone()).collect();
-    let mut resolved: std::collections::HashSet<SmolStr> = std::collections::HashSet::new();
-
-    loop {
-        let mut progressed = false;
-        let mut deferred = Vec::new();
-        for (name, dialer) in std::mem::take(&mut pending) {
-            // Defer until the dialer is in its final form (either it never
-            // needed wrapping, or it has already been resolved this pass).
-            if needs_wrap.contains(&dialer) && !resolved.contains(&dialer) {
-                deferred.push((name, dialer));
-                continue;
-            }
-            progressed = true;
-            let Some(dialer_proxy) = proxies.get(&dialer).cloned() else {
-                anyhow::bail!("proxy '{name}': dialer-proxy '{dialer}' not found");
-            };
-            // Re-parse the raw block with a `ProxyDialer` injected (mihomo
-            // model), so the adapter's own dial + handshake runs on the
-            // tunneled stream.
-            //
-            // `rev()` matters: the registry-building loop above uses `insert`,
-            // so for a config with duplicate `name:` entries the *last* block
-            // wins. A forward `find` here would resurrect the *first* block and
-            // silently swap the running definition out from under the user.
-            let raw_proxy = raw_proxies
-                .iter()
-                .rev()
-                .find(|rp| rp.get("name").and_then(|v| v.as_str()) == Some(&*name));
-            if let Some(raw) = raw_proxy {
-                let proxy_dialer: Arc<dyn meow_proxy::dialer::TcpDialer> = Arc::new(
-                    meow_proxy::dialer::ProxyDialer::new(Arc::clone(&dialer_proxy)),
-                );
-                match proxy_parser::parse_proxy_with_dialer(raw, &proxy_dialer, ipv6) {
-                    Ok(rebuilt) => {
-                        proxies.insert(name.clone(), rebuilt);
-                    }
-                    Err(e) => {
-                        // The adapter type cannot carry an injected dialer
-                        // (anytls, hysteria2, SS-with-external-SIP003-plugin) or
-                        // the block is otherwise unparseable. Fall back to the
-                        // relay-based `DialerProxyAdapter`, which preserves the
-                        // pre-dialer behaviour: it works for the protocols that
-                        // implement `connect_over` (HTTP/SOCKS5/Snell) and fails
-                        // loudly at dial time for the rest — never silently
-                        // dialing direct and leaking past the chain.
-                        //
-                        // The inner outbound may itself have failed to parse
-                        // earlier, in which case there is nothing to wrap.
-                        if let Some(inner) = proxies.get(&name).cloned() {
-                            warn!(
-                                "proxy '{name}': cannot inject dialer-proxy '{dialer}' \
-                                 ({e}); falling back to the relay-based wrapper"
-                            );
-                            let wrapped: Arc<dyn Proxy> =
-                                Arc::new(meow_proxy::DialerProxyAdapter::new(inner, dialer_proxy));
-                            proxies.insert(name.clone(), wrapped);
-                        } else {
-                            warn!(
-                                "proxy '{name}': dialer-proxy '{dialer}' not applied \
-                                 ({e}); the outbound itself failed to parse"
-                            );
-                        }
-                    }
-                }
-            } else {
-                // Unreachable in practice — edges are only collected from blocks
-                // in this same list — but refuse instead of silently dialing
-                // direct if the invariant ever breaks.
-                anyhow::bail!(
-                    "proxy '{name}': dialer-proxy '{dialer}' not applied; no raw \
-                     config block found for this name"
-                );
-            }
-            resolved.insert(name);
+    // Names a dialer may reference. Leaf proxies are in the registry already;
+    // groups are built after this pass, so only their *declared* names count
+    // here, plus `GLOBAL`, which is auto-created when the config omits it.
+    let dialable: std::collections::HashSet<&str> = proxies
+        .keys()
+        .map(SmolStr::as_str)
+        .chain(raw_groups.iter().map(|group| group.name.as_str()))
+        .chain(std::iter::once("GLOBAL"))
+        .collect();
+    for (name, dialer) in &edges {
+        if !dialable.contains(dialer.as_str()) {
+            anyhow::bail!("proxy '{name}': dialer-proxy '{dialer}' not found");
         }
-        pending = deferred;
-        if pending.is_empty() || !progressed {
+    }
+
+    // Peel every edge whose dialer declares no dialer of its own. What survives
+    // is on a cycle or feeds one, and late binding would recurse forever on it.
+    let mut live: std::collections::HashSet<&SmolStr> = edges.iter().map(|(n, _)| n).collect();
+    loop {
+        let before = live.len();
+        for (name, dialer) in &edges {
+            if live.contains(name) && !live.contains(dialer) {
+                live.remove(name);
+            }
+        }
+        if live.is_empty() || live.len() == before {
             break;
         }
     }
-    if !pending.is_empty() {
-        let edges: Vec<String> = pending
+    if !live.is_empty() {
+        let cycle: Vec<String> = edges
             .iter()
+            .filter(|(name, _)| live.contains(name))
             .map(|(name, dialer)| format!("{name} -> {dialer}"))
             .collect();
-        anyhow::bail!("dialer-proxy cycle detected: {}", edges.join(", "));
+        anyhow::bail!("dialer-proxy cycle detected: {}", cycle.join(", "));
+    }
+
+    // Apply the edges. Order no longer matters — the front hop is resolved at
+    // dial time — so nested chains need no deepest-first deferral pass.
+    for (name, dialer) in &edges {
+        let target = meow_proxy::dialer::DialerTarget::new(dialer.clone(), registry.clone());
+        // `rev()` matters: the registry-building loop above uses `insert`, so
+        // for a config with duplicate `name:` entries the *last* block wins. A
+        // forward `find` here would resurrect the *first* block and silently
+        // swap the running definition out from under the user.
+        let Some(raw) = raw_proxies
+            .iter()
+            .rev()
+            .find(|rp| rp.get("name").and_then(|v| v.as_str()) == Some(name.as_str()))
+        else {
+            // Unreachable in practice — edges are only collected from blocks in
+            // this same list — but refuse instead of silently dialing direct if
+            // the invariant ever breaks.
+            anyhow::bail!(
+                "proxy '{name}': dialer-proxy '{dialer}' not applied; no raw \
+                 config block found for this name"
+            );
+        };
+        // Re-parse the raw block with the by-name dialer injected (mihomo
+        // model), so the adapter's own dial + handshake runs on the tunneled
+        // stream.
+        let proxy_dialer: Arc<dyn meow_proxy::dialer::TcpDialer> =
+            Arc::new(meow_proxy::dialer::NamedProxyDialer::new(target.clone()));
+        match proxy_parser::parse_proxy_with_dialer(raw, &proxy_dialer, ipv6) {
+            Ok(rebuilt) => {
+                proxies.insert(name.clone(), rebuilt);
+            }
+            Err(e) => {
+                // The adapter type cannot carry an injected dialer (anytls,
+                // hysteria2, SS-with-external-SIP003-plugin) or the block is
+                // otherwise unparseable. Fall back to the relay-based
+                // `DialerProxyAdapter`, which preserves the pre-dialer
+                // behaviour: it works for the protocols that implement
+                // `connect_over` (HTTP/SOCKS5/Snell) and fails loudly at dial
+                // time for the rest — never silently dialing direct and leaking
+                // past the chain.
+                //
+                // The inner outbound may itself have failed to parse earlier,
+                // in which case there is nothing to wrap.
+                if let Some(inner) = proxies.get(name).cloned() {
+                    warn!(
+                        "proxy '{name}': cannot inject dialer-proxy '{dialer}' \
+                         ({e}); falling back to the relay-based wrapper"
+                    );
+                    let wrapped: Arc<dyn Proxy> =
+                        Arc::new(meow_proxy::DialerProxyAdapter::new(inner, target));
+                    proxies.insert(name.clone(), wrapped);
+                } else {
+                    warn!(
+                        "proxy '{name}': dialer-proxy '{dialer}' not applied \
+                         ({e}); the outbound itself failed to parse"
+                    );
+                }
+            }
+        }
     }
     Ok(())
 }
@@ -780,6 +790,9 @@ fn rebuild_from_raw_impl(
 ) -> Result<RebuildResult, anyhow::Error> {
     let ipv6 = effective_ipv6(raw.ipv6);
     let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
+    // `dialer-proxy` front hops are resolved by name against this registry on
+    // every dial; it is published once the build below has finished.
+    let registry = meow_proxy::dialer::ProxyRegistry::default();
     // Built-in proxies
     let mut direct = meow_proxy::DirectAdapter::new();
     if let Some(mark) = raw.routing_mark {
@@ -827,9 +840,23 @@ fn rebuild_from_raw_impl(
         }
     }
 
+    let raw_groups = raw.proxy_groups.as_deref().unwrap_or(&[]);
+
+    // Apply per-outbound `dialer-proxy` chains (issue #210) *before* groups are
+    // built: groups clone their members eagerly, so a chain applied afterwards
+    // would only cover direct rule references and a grouped node would silently
+    // bypass it (issue #513). The front hop is resolved by name at dial time,
+    // which is what lets a dialer name a group that does not exist yet here.
+    apply_dialer_proxies(
+        &mut proxies,
+        raw.proxies.as_deref().unwrap_or(&[]),
+        raw_groups,
+        &registry,
+        ipv6,
+    )?;
+
     // Multi-pass group resolution: groups can reference other groups.
     // Keep trying until no new groups are resolved.
-    let raw_groups = raw.proxy_groups.as_deref().unwrap_or(&[]);
     let mut remaining: Vec<&raw::RawProxyGroup> = raw_groups.iter().collect();
     let mut max_passes = remaining.len() + 1;
     while !remaining.is_empty() && max_passes > 0 {
@@ -916,10 +943,6 @@ fn rebuild_from_raw_impl(
             Err(e) => warn!("Failed to create GLOBAL selector: {}", e),
         }
     }
-
-    // Apply per-outbound `dialer-proxy` wrappers (issue #210). Runs after both
-    // leaf proxies and groups are built so a dialer may reference either.
-    apply_dialer_proxies(&mut proxies, raw.proxies.as_deref().unwrap_or(&[]), ipv6)?;
 
     let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     // Per-provider `proxy:` overrides resolve against the full registry —
@@ -1009,6 +1032,13 @@ fn rebuild_from_raw_impl(
             }
         }
     }
+
+    // Publish the finished registry: the `dialer-proxy` chains bound above
+    // resolve their front hop by name against it, and only now does it hold the
+    // groups they may name (issue #513). A later rebuild publishes into its own
+    // registry, so adapters already handed to the tunnel keep resolving the
+    // snapshot they were built from.
+    registry.publish(Arc::new(proxies.clone()));
 
     Ok((proxies, rules))
 }
@@ -2203,12 +2233,24 @@ mod dialer_proxy_tests {
         !Arc::ptr_eq(b, a)
     }
 
+    /// Run the dialer pass against a fresh by-name registry and publish it on
+    /// success, the way `rebuild_from_raw_impl` does — without the publish the
+    /// chained adapters cannot resolve their front hop at dial time.
+    fn apply_chains(
+        proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
+        raw_proxies: &[HashMap<String, serde_yaml::Value>],
+    ) -> Result<(), anyhow::Error> {
+        let registry = meow_proxy::dialer::ProxyRegistry::default();
+        apply_dialer_proxies(proxies, raw_proxies, &[], &registry, true)?;
+        registry.publish(Arc::new(proxies.clone()));
+        Ok(())
+    }
+
     #[test]
     fn wraps_proxy_with_dialer() {
         let mut proxies = registry(&["A", "fast"]);
         let before = proxies.clone();
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("fast"))], true)
-            .expect("valid chain applies");
+        apply_chains(&mut proxies, &[raw_proxy("A", Some("fast"))]).expect("valid chain applies");
         assert!(was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "fast"));
     }
@@ -2217,7 +2259,7 @@ mod dialer_proxy_tests {
     fn self_reference_is_a_config_error() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        let err = apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("A"))], true)
+        let err = apply_chains(&mut proxies, &[raw_proxy("A", Some("A"))])
             .expect_err("a self-referencing dialer must not silently dial direct");
         assert!(
             err.to_string().contains("points to itself"),
@@ -2230,7 +2272,7 @@ mod dialer_proxy_tests {
     fn missing_dialer_is_a_config_error() {
         let mut proxies = registry(&["A"]);
         let before = proxies.clone();
-        let err = apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("ghost"))], true)
+        let err = apply_chains(&mut proxies, &[raw_proxy("A", Some("ghost"))])
             .expect_err("an unknown dialer must not silently dial direct");
         assert!(err.to_string().contains("not found"), "unexpected: {err}");
         assert!(!was_wrapped(&before, &proxies, "A"));
@@ -2240,15 +2282,34 @@ mod dialer_proxy_tests {
     fn cycle_is_a_config_error() {
         let mut proxies = registry(&["A", "B"]);
         let before = proxies.clone();
-        let err = apply_dialer_proxies(
+        let err = apply_chains(
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("A"))],
-            true,
         )
         .expect_err("a dialer cycle must not silently dial direct");
         assert!(err.to_string().contains("cycle"), "unexpected: {err}");
         assert!(!was_wrapped(&before, &proxies, "A"));
         assert!(!was_wrapped(&before, &proxies, "B"));
+    }
+
+    /// A cycle that only *some* of the edges sit on still has to be rejected:
+    /// late binding recurses through the whole chain, so `A` feeding `B <-> C`
+    /// never terminates either.
+    #[test]
+    fn chain_feeding_a_cycle_is_a_config_error() {
+        let mut proxies = registry(&["A", "B", "C"]);
+        let before = proxies.clone();
+        let err = apply_chains(
+            &mut proxies,
+            &[
+                raw_proxy("A", Some("B")),
+                raw_proxy("B", Some("C")),
+                raw_proxy("C", Some("B")),
+            ],
+        )
+        .expect_err("an edge feeding a cycle must not silently dial direct");
+        assert!(err.to_string().contains("cycle"), "unexpected: {err}");
+        assert!(!was_wrapped(&before, &proxies, "A"));
     }
 
     /// Duplicate `name:` blocks: only the *last* block is the effective
@@ -2270,8 +2331,7 @@ mod dialer_proxy_tests {
             serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
         );
 
-        apply_dialer_proxies(&mut proxies, &[first, last], true)
-            .expect("the effective block declares no dialer");
+        apply_chains(&mut proxies, &[first, last]).expect("the effective block declares no dialer");
 
         assert!(
             !was_wrapped(&before, &proxies, "A"),
@@ -2281,14 +2341,15 @@ mod dialer_proxy_tests {
     }
 
     #[test]
-    fn nested_chain_wraps_deepest_first() {
-        // A -> B -> C: A and B are wrapped, C (no dialer-proxy) is untouched.
+    fn nested_chain_wraps_every_layer() {
+        // A -> B -> C: A and B are chained, C (no dialer-proxy) is untouched.
+        // The front hop is resolved at dial time, so neither layer has to wait
+        // for the other to reach its final form.
         let mut proxies = registry(&["A", "B", "C"]);
         let before = proxies.clone();
-        apply_dialer_proxies(
+        apply_chains(
             &mut proxies,
             &[raw_proxy("A", Some("B")), raw_proxy("B", Some("C"))],
-            true,
         )
         .expect("valid nested chain applies");
         assert!(was_wrapped(&before, &proxies, "A"));
@@ -2346,12 +2407,8 @@ mod dialer_proxy_tests {
         proxies.insert(SmolStr::from("A"), parsed_a);
         let before = proxies.clone();
 
-        apply_dialer_proxies(
-            &mut proxies,
-            &[raw_socks5_proxy("A", Some("front"), true)],
-            true,
-        )
-        .expect("valid chain applies");
+        apply_chains(&mut proxies, &[raw_socks5_proxy("A", Some("front"), true)])
+            .expect("valid chain applies");
 
         assert!(was_wrapped(&before, &proxies, "A"), "A should be re-parsed");
         assert!(
@@ -2391,12 +2448,8 @@ mod dialer_proxy_tests {
             let mut proxies = registry(&["A", "front"]);
             let before = proxies.clone();
 
-            apply_dialer_proxies(
-                &mut proxies,
-                &[raw_typed_proxy("A", ty, Some("front"))],
-                true,
-            )
-            .expect("valid chain applies via the wrapper fallback");
+            apply_chains(&mut proxies, &[raw_typed_proxy("A", ty, Some("front"))])
+                .expect("valid chain applies via the wrapper fallback");
 
             let after = proxies.get("A").expect("entry survives");
             assert!(
@@ -2434,8 +2487,7 @@ mod dialer_proxy_tests {
 
         // Must not panic and must not spawn: the parse is rejected before
         // `ShadowsocksAdapter::new` runs, so the fallback wrapper is used.
-        apply_dialer_proxies(&mut proxies, &[raw], true)
-            .expect("valid chain applies via the wrapper fallback");
+        apply_chains(&mut proxies, &[raw]).expect("valid chain applies via the wrapper fallback");
 
         assert!(
             proxies.contains_key("A"),
@@ -2461,7 +2513,7 @@ mod dialer_proxy_tests {
             serde_yaml::Value::Number(serde_yaml::Number::from(2222)),
         );
 
-        apply_dialer_proxies(&mut proxies, &[first, last], true).expect("valid chain applies");
+        apply_chains(&mut proxies, &[first, last]).expect("valid chain applies");
 
         let rebuilt = proxies.get("A").expect("present after");
         assert_eq!(
@@ -2485,7 +2537,7 @@ mod dialer_proxy_tests {
         let before = proxies.clone();
 
         // raw_proxy has no `type` → parse_proxy_with_dialer fails → fallback.
-        apply_dialer_proxies(&mut proxies, &[raw_proxy("A", Some("front"))], true)
+        apply_chains(&mut proxies, &[raw_proxy("A", Some("front"))])
             .expect("valid chain applies via the wrapper fallback");
 
         assert!(
@@ -2619,8 +2671,7 @@ mod dialer_proxy_tests {
             proxy_parser::parse_proxy(&raw_inner, true).expect("parse inner"),
         );
 
-        apply_dialer_proxies(&mut proxies, &[raw_front, raw_inner], true)
-            .expect("valid chain applies");
+        apply_chains(&mut proxies, &[raw_front, raw_inner]).expect("valid chain applies");
 
         // Dial a final target through `inner`; `inner` must reach its own
         // server (127.0.0.1:inner_port) *via* `front`.

--- a/crates/meow-config/src/lib.rs
+++ b/crates/meow-config/src/lib.rs
@@ -577,14 +577,20 @@ pub fn rebuild_from_raw_with_cache_dir(
 /// a direct dial would let traffic egress from the real source path past a
 /// chain the user configured for policy/security reasons (Class A, ADR-0002).
 /// A cycle has to be caught here in particular: late binding would turn it into
-/// unbounded recursion on the first dial.
+/// unbounded recursion on the first dial. The check covers cycles through group
+/// membership too — a group-valued dialer can select the chained proxy itself —
+/// not just proxy→proxy edges, which is all upstream mihomo validates.
+///
+/// Returns the applied `(proxy, dialer)` edges so the caller can re-validate
+/// dialer targets once groups have been built (a *declared* group that failed
+/// to build satisfies `dialable` but never enters the registry).
 fn apply_dialer_proxies(
     proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
     raw_proxies: &[HashMap<String, serde_yaml::Value>],
     raw_groups: &[raw::RawProxyGroup],
     registry: &meow_proxy::dialer::ProxyRegistry,
     ipv6: bool,
-) -> Result<(), anyhow::Error> {
+) -> Result<Vec<(SmolStr, SmolStr)>, anyhow::Error> {
     // Collect proxy -> dialer edges from the raw config.
     //
     // Iterate in reverse and keep only the first sighting (the *last* block in
@@ -601,12 +607,15 @@ fn apply_dialer_proxies(
         if !seen_names.insert(name) {
             continue;
         }
-        let Some(dialer) = raw_proxy
-            .get("dialer-proxy")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-        else {
-            continue;
+        let dialer = match raw_proxy.get("dialer-proxy") {
+            None => continue,
+            Some(v) => match v.as_str() {
+                Some(s) if !s.is_empty() => s,
+                _ => {
+                    warn!("proxy '{name}': ignoring malformed dialer-proxy value");
+                    continue;
+                }
+            },
         };
         if dialer == name {
             anyhow::bail!("proxy '{name}': dialer-proxy points to itself");
@@ -614,7 +623,7 @@ fn apply_dialer_proxies(
         edges.push((SmolStr::from(name), SmolStr::from(dialer)));
     }
     if edges.is_empty() {
-        return Ok(());
+        return Ok(edges);
     }
 
     // Names a dialer may reference. Leaf proxies are in the registry already;
@@ -653,6 +662,77 @@ fn apply_dialer_proxies(
             .map(|(name, dialer)| format!("{name} -> {dialer}"))
             .collect();
         anyhow::bail!("dialer-proxy cycle detected: {}", cycle.join(", "));
+    }
+
+    // A dialer may name a *group*, whose front-hop dial then selects any member
+    // — including, transitively, the proxy that declared the chain. That loop
+    // never reaches I/O: it is synchronous nested polls and exhausts the
+    // native stack on the first dial (mihomo's `validateDialerProxies` has the
+    // same blind spot — it only sees proxy→proxy edges). Reject any edge whose
+    // dialer can reach back to its source over the combined graph of dialer
+    // edges and group-membership edges.
+    //
+    // Group membership is expanded from the *declared* config: `proxies:` may
+    // name leaves or other groups (nested), `include-all-proxies` and an
+    // auto-created `GLOBAL` contain every registry name. Provider-slot members
+    // (`use:` / `include-all`) can never carry a `dialer-proxy` themselves, so
+    // they are dead ends for reachability and are ignored.
+    let all_names: std::collections::HashSet<&str> = proxies
+        .keys()
+        .map(SmolStr::as_str)
+        .chain(raw_groups.iter().map(|group| group.name.as_str()))
+        .collect();
+    let mut members_of: HashMap<&str, Vec<&str>> = HashMap::new();
+    for group in raw_groups {
+        let mut members: Vec<&str> = group
+            .proxies
+            .as_deref()
+            .unwrap_or(&[])
+            .iter()
+            .map(String::as_str)
+            .collect();
+        if group.include_all_proxies.unwrap_or(false) {
+            members.extend(all_names.iter().copied());
+        }
+        members_of.insert(group.name.as_str(), members);
+    }
+    if !raw_groups.iter().any(|group| group.name == "GLOBAL") {
+        // Auto-created GLOBAL selects over the entire registry.
+        members_of.insert("GLOBAL", all_names.iter().copied().collect());
+    }
+    let edge_map: HashMap<&str, &str> = edges
+        .iter()
+        .map(|(name, dialer)| (name.as_str(), dialer.as_str()))
+        .collect();
+    // DFS from each dialer over dialer edges and membership edges; reaching the
+    // edge's source means the first dial recurses without bound.
+    for (name, dialer) in &edges {
+        // A source that never parsed has no entry to wrap, so no chain is
+        // applied and it cannot re-enter itself — skip it rather than rejecting
+        // a config that is otherwise only missing one node.
+        if !proxies.contains_key(name) {
+            continue;
+        }
+        let mut stack: Vec<&str> = vec![dialer.as_str()];
+        let mut visited: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        while let Some(node) = stack.pop() {
+            if node == name.as_str() {
+                anyhow::bail!(
+                    "proxy '{name}': dialer-proxy '{dialer}' can route back to \
+                     '{name}' through group membership, which would recurse \
+                     forever on the first dial"
+                );
+            }
+            if !visited.insert(node) {
+                continue;
+            }
+            if let Some(next) = edge_map.get(node) {
+                stack.push(next);
+            }
+            if let Some(members) = members_of.get(node) {
+                stack.extend(members.iter().copied());
+            }
+        }
     }
 
     // Apply the edges. Order no longer matters — the front hop is resolved at
@@ -714,7 +794,7 @@ fn apply_dialer_proxies(
             }
         }
     }
-    Ok(())
+    Ok(edges)
 }
 
 /// Policy names resolved internally rather than declared as usable outbounds.
@@ -847,7 +927,7 @@ fn rebuild_from_raw_impl(
     // would only cover direct rule references and a grouped node would silently
     // bypass it (issue #513). The front hop is resolved by name at dial time,
     // which is what lets a dialer name a group that does not exist yet here.
-    apply_dialer_proxies(
+    let dialer_edges = apply_dialer_proxies(
         &mut proxies,
         raw.proxies.as_deref().unwrap_or(&[]),
         raw_groups,
@@ -944,6 +1024,29 @@ fn rebuild_from_raw_impl(
         }
     }
 
+    // `dialable` admitted *declared* group names before the group build ran;
+    // a group that failed to build never entered the registry, so re-check
+    // every dialer target against the finished map instead of letting the
+    // first dial report it late.
+    for (name, dialer) in &dialer_edges {
+        if !proxies.contains_key(dialer.as_str()) {
+            anyhow::bail!(
+                "proxy '{name}': dialer-proxy '{dialer}' is declared but did \
+                 not build into a registry entry"
+            );
+        }
+    }
+
+    // Publish the finished registry: the `dialer-proxy` chains bound above
+    // resolve their front hop by name against it, and only now does it hold the
+    // groups they may name (issue #513). Nothing mutates `proxies` after this
+    // point, and publishing *before* the provider fetches below matters: they
+    // dial through `download_proxy`, which may itself be a chained node whose
+    // front hop must already resolve. A later rebuild publishes into its own
+    // registry, so adapters already handed to the tunnel keep resolving the
+    // snapshot they were built from.
+    registry.publish(Arc::new(proxies.clone()));
+
     let download_proxy = internal_http::first_named_proxy(raw.proxies.as_deref(), &proxies);
     // Per-provider `proxy:` overrides resolve against the full registry —
     // groups and provider-sourced proxies included (issue #377).
@@ -1032,13 +1135,6 @@ fn rebuild_from_raw_impl(
             }
         }
     }
-
-    // Publish the finished registry: the `dialer-proxy` chains bound above
-    // resolve their front hop by name against it, and only now does it hold the
-    // groups they may name (issue #513). A later rebuild publishes into its own
-    // registry, so adapters already handed to the tunnel keep resolving the
-    // snapshot they were built from.
-    registry.publish(Arc::new(proxies.clone()));
 
     Ok((proxies, rules))
 }
@@ -2240,8 +2336,18 @@ mod dialer_proxy_tests {
         proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
         raw_proxies: &[HashMap<String, serde_yaml::Value>],
     ) -> Result<(), anyhow::Error> {
+        apply_chains_with_groups(proxies, raw_proxies, &[])
+    }
+
+    /// Same as [`apply_chains`] but with declared `proxy-groups`, so tests can
+    /// exercise group-valued dialers and the membership cycle check.
+    fn apply_chains_with_groups(
+        proxies: &mut HashMap<SmolStr, Arc<dyn Proxy>>,
+        raw_proxies: &[HashMap<String, serde_yaml::Value>],
+        raw_groups: &[raw::RawProxyGroup],
+    ) -> Result<(), anyhow::Error> {
         let registry = meow_proxy::dialer::ProxyRegistry::default();
-        apply_dialer_proxies(proxies, raw_proxies, &[], &registry, true)?;
+        apply_dialer_proxies(proxies, raw_proxies, raw_groups, &registry, true)?;
         registry.publish(Arc::new(proxies.clone()));
         Ok(())
     }
@@ -2310,6 +2416,127 @@ mod dialer_proxy_tests {
         .expect_err("an edge feeding a cycle must not silently dial direct");
         assert!(err.to_string().contains("cycle"), "unexpected: {err}");
         assert!(!was_wrapped(&before, &proxies, "A"));
+    }
+
+    fn raw_group(name: &str, members: &[&str]) -> raw::RawProxyGroup {
+        raw::RawProxyGroup {
+            name: name.to_string(),
+            group_type: "select".to_string(),
+            proxies: Some(members.iter().map(ToString::to_string).collect()),
+            ..Default::default()
+        }
+    }
+
+    /// A group-valued dialer whose membership can route back to the chained
+    /// proxy recurses without ever reaching I/O — synchronous nested polls
+    /// exhaust the native stack on the first dial. The combined
+    /// dialer-edge + membership-edge check must reject it (mihomo's
+    /// `validateDialerProxies` misses this class entirely).
+    #[test]
+    fn group_selecting_self_is_a_config_error() {
+        let mut proxies = registry(&["A", "B"]);
+        let err = apply_chains_with_groups(
+            &mut proxies,
+            &[raw_proxy("A", Some("G"))],
+            &[raw_group("G", &["A", "B"])],
+        )
+        .expect_err("a dialer that can route back to its source must be rejected");
+        assert!(
+            err.to_string().contains("through group membership"),
+            "unexpected: {err}"
+        );
+    }
+
+    /// The same loop one group hop away: `G1` holds `G2`, `G2` holds `A`.
+    #[test]
+    fn nested_group_selecting_self_is_a_config_error() {
+        let mut proxies = registry(&["A", "B"]);
+        let err = apply_chains_with_groups(
+            &mut proxies,
+            &[raw_proxy("A", Some("G1"))],
+            &[raw_group("G1", &["G2"]), raw_group("G2", &["A", "B"])],
+        )
+        .expect_err("a transitive self-route must be rejected");
+        assert!(
+            err.to_string().contains("through group membership"),
+            "unexpected: {err}"
+        );
+    }
+
+    /// A loop that alternates dialer edges and membership edges:
+    /// `A -> G`, `G` holds `B`, `B -> A`.
+    #[test]
+    fn group_and_dialer_cycle_is_a_config_error() {
+        let mut proxies = registry(&["A", "B"]);
+        let err = apply_chains_with_groups(
+            &mut proxies,
+            &[raw_proxy("A", Some("G")), raw_proxy("B", Some("A"))],
+            &[raw_group("G", &["B"])],
+        )
+        .expect_err("a membership+dialer cycle must be rejected");
+        assert!(
+            err.to_string().contains("through group membership"),
+            "unexpected: {err}"
+        );
+    }
+
+    /// The auto-created `GLOBAL` contains every registry entry, so chaining
+    /// through it always routes back to the source.
+    #[test]
+    fn auto_global_dialer_is_a_config_error() {
+        let mut proxies = registry(&["A", "B"]);
+        let err = apply_chains_with_groups(&mut proxies, &[raw_proxy("A", Some("GLOBAL"))], &[])
+            .expect_err("chaining through auto-GLOBAL must be rejected");
+        assert!(
+            err.to_string().contains("through group membership"),
+            "unexpected: {err}"
+        );
+    }
+
+    /// `include-all-proxies` expands to every registry name — same self-route.
+    #[test]
+    fn include_all_proxies_group_is_a_config_error() {
+        let mut proxies = registry(&["A", "B"]);
+        let mut g = raw_group("G", &[]);
+        g.include_all_proxies = Some(true);
+        let err = apply_chains_with_groups(&mut proxies, &[raw_proxy("A", Some("G"))], &[g])
+            .expect_err("an include-all-proxies dialer must be rejected");
+        assert!(
+            err.to_string().contains("through group membership"),
+            "unexpected: {err}"
+        );
+    }
+
+    /// A group-valued dialer that cannot reach back to its source is fine.
+    #[test]
+    fn group_not_containing_self_is_allowed() {
+        let mut proxies = registry(&["A", "B"]);
+        let before = proxies.clone();
+        apply_chains_with_groups(
+            &mut proxies,
+            &[raw_proxy("A", Some("G"))],
+            &[raw_group("G", &["B"])],
+        )
+        .expect("a group dialer that cannot route back is valid");
+        assert!(was_wrapped(&before, &proxies, "A"));
+    }
+
+    /// A malformed `dialer-proxy` value is warned about and skipped — the node
+    /// keeps its direct dialer rather than dying on a typo.
+    #[test]
+    fn malformed_dialer_proxy_is_ignored() {
+        let mut proxies = registry(&["A", "B"]);
+        let before = proxies.clone();
+        let mut raw = raw_proxy("A", None);
+        raw.insert(
+            "dialer-proxy".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(42)),
+        );
+        apply_chains(&mut proxies, &[raw]).expect("malformed dialer-proxy is skipped");
+        assert!(
+            !was_wrapped(&before, &proxies, "A"),
+            "a non-string dialer-proxy must not apply a chain"
+        );
     }
 
     /// Duplicate `name:` blocks: only the *last* block is the effective

--- a/crates/meow-config/tests/dialer_proxy_group.rs
+++ b/crates/meow-config/tests/dialer_proxy_group.rs
@@ -184,6 +184,12 @@ fn group_dialer_routing_back_is_a_config_error() {
         ("G", "  - name: G\n    type: select\n    include-all-proxies: true"),
         // The auto-created GLOBAL contains everything.
         ("GLOBAL", ""),
+        // A declared GLOBAL that fails to build is backstopped by the
+        // auto-created all-members one.
+        ("GLOBAL", "  - name: GLOBAL\n    type: select\n    proxies: [ghost-node]"),
+        // Duplicate group names: the registry keeps the last *successful*
+        // declaration — {A} — not the last-declared {ghost-node} block.
+        ("G", "  - name: G\n    type: select\n    proxies: [A]\n  - name: G\n    type: select\n    proxies: [ghost-node]"),
     ] {
         let raw: RawConfig = serde_yaml::from_str(&format!(
             r#"

--- a/crates/meow-config/tests/dialer_proxy_group.rs
+++ b/crates/meow-config/tests/dialer_proxy_group.rs
@@ -1,0 +1,170 @@
+//! A node's `dialer-proxy` must survive being reached through a proxy group,
+//! and a dialer must be able to name a group (issue #513).
+//!
+//! Proxy groups clone their members eagerly, so applying the chain after the
+//! group build left every group holding the pre-dialer adapter: selecting the
+//! node through the group dialled its own server directly and silently bypassed
+//! the chain the user configured for policy reasons. The dialer pass now runs
+//! before groups are built and binds the front hop *by name* (mihomo
+//! `component/proxydialer/byname.go`), so both paths chain identically and a
+//! group that does not exist yet at build time is still a valid dialer.
+//!
+//! The observable is which mock server each dial physically contacts. Every TLS
+//! handshake fails fast against the plain listeners — the accept counts, not the
+//! dial result, are what these tests assert on.
+
+use meow_common::{Metadata, Network};
+use meow_config::raw::RawConfig;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+/// TCP listener that counts accepts and drops each connection immediately, so
+/// the client-side TLS handshake errors out instead of hanging on a ServerHello
+/// that never arrives.
+async fn counting_listener() -> (SocketAddr, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let count = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&count);
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            counter.fetch_add(1, Ordering::SeqCst);
+            drop(stream);
+        }
+    });
+    (addr, count)
+}
+
+/// `A` chains through the leaf proxy `B`; `C` chains through the group `G2`
+/// (which holds `B`); `G` is a select group over `A`.
+fn config(port_a: u16, port_b: u16, port_c: u16) -> RawConfig {
+    serde_yaml::from_str(&format!(
+        r#"
+mixed-port: 17890
+mode: rule
+proxies:
+  - name: A
+    type: trojan
+    server: 127.0.0.1
+    port: {port_a}
+    password: issue-513
+    dialer-proxy: B
+  - name: B
+    type: trojan
+    server: 127.0.0.1
+    port: {port_b}
+    password: issue-513
+  - name: C
+    type: trojan
+    server: 127.0.0.1
+    port: {port_c}
+    password: issue-513
+    dialer-proxy: G2
+proxy-groups:
+  - name: G
+    type: select
+    proxies: [A]
+  - name: G2
+    type: select
+    proxies: [B]
+rules:
+  - MATCH,DIRECT
+"#
+    ))
+    .unwrap()
+}
+
+/// Registry plus the three mock servers, with per-server accept counters.
+struct Harness {
+    proxies: HashMap<smol_str::SmolStr, Arc<dyn meow_common::Proxy>>,
+    accepts: HashMap<&'static str, Arc<AtomicUsize>>,
+}
+
+impl Harness {
+    fn accepts(&self, server: &str) -> usize {
+        self.accepts[server].load(Ordering::SeqCst)
+    }
+
+    /// Dial `name` and discard the outcome — the handshakes are expected to
+    /// fail, only the physical contact matters.
+    async fn dial(&self, name: &str) {
+        let metadata = Metadata {
+            network: Network::Tcp,
+            host: "127.0.0.1".into(),
+            dst_ip: Some("127.0.0.1".parse().unwrap()),
+            dst_port: 9,
+            ..Default::default()
+        };
+        let proxy = self
+            .proxies
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} must be in the registry"));
+        let _ = proxy.dial_tcp(&metadata).await;
+    }
+}
+
+async fn harness() -> Harness {
+    let (server_a, a_accepts) = counting_listener().await;
+    let (server_b, b_accepts) = counting_listener().await;
+    let (server_c, c_accepts) = counting_listener().await;
+
+    let raw = config(server_a.port(), server_b.port(), server_c.port());
+    let (proxies, _rules) = meow_config::rebuild_from_raw(&raw).expect("rebuild ok");
+
+    Harness {
+        proxies,
+        accepts: HashMap::from([("A", a_accepts), ("B", b_accepts), ("C", c_accepts)]),
+    }
+}
+
+/// The regression: `G` selects `A`, and `A` declares `dialer-proxy: B`. Both
+/// the direct registry dial and the dial through the group must contact B's
+/// server first. Before the fix the group held the pre-dialer `A` and contacted
+/// A's server directly, bypassing the chain.
+#[tokio::test]
+async fn group_member_honours_its_dialer_proxy() {
+    let h = harness().await;
+
+    h.dial("A").await;
+    assert_eq!(h.accepts("B"), 1, "registry A must chain through dialer B");
+    assert_eq!(
+        h.accepts("A"),
+        0,
+        "registry A must not contact its own server directly"
+    );
+
+    h.dial("G").await;
+    assert_eq!(
+        h.accepts("B"),
+        2,
+        "the group must reach the chained A, not a stale pre-dialer copy"
+    );
+    assert_eq!(
+        h.accepts("A"),
+        0,
+        "dialer-proxy bypassed when the node is reached via a group"
+    );
+}
+
+/// A `dialer-proxy` may name a group. The group is built *after* the dialer
+/// pass, so only by-name resolution can find it; capturing an `Arc` at build
+/// time would have nothing to capture.
+#[tokio::test]
+async fn dialer_may_name_a_group_built_later() {
+    let h = harness().await;
+
+    h.dial("C").await;
+    assert_eq!(
+        h.accepts("B"),
+        1,
+        "C must chain through group G2, whose only member is B"
+    );
+    assert_eq!(
+        h.accepts("C"),
+        0,
+        "C must not contact its own server directly"
+    );
+}

--- a/crates/meow-config/tests/dialer_proxy_group.rs
+++ b/crates/meow-config/tests/dialer_proxy_group.rs
@@ -168,3 +168,135 @@ async fn dialer_may_name_a_group_built_later() {
         "C must not contact its own server directly"
     );
 }
+
+/// A dialer that can route back to the chained proxy through group membership
+/// is a hard config error: the loop never reaches I/O, so the first dial
+/// recurses synchronously until the native stack overflows. This includes the
+/// auto-created `GLOBAL`, which selects over every registry entry.
+#[test]
+fn group_dialer_routing_back_is_a_config_error() {
+    for (dialer, groups) in [
+        // G selects A itself.
+        ("G", "  - name: G\n    type: select\n    proxies: [A, B]"),
+        // Nested: G holds G2, G2 selects A.
+        ("G", "  - name: G\n    type: select\n    proxies: [G2]\n  - name: G2\n    type: select\n    proxies: [A]"),
+        // include-all-proxies pulls every registry name in.
+        ("G", "  - name: G\n    type: select\n    include-all-proxies: true"),
+        // The auto-created GLOBAL contains everything.
+        ("GLOBAL", ""),
+    ] {
+        let raw: RawConfig = serde_yaml::from_str(&format!(
+            r#"
+mixed-port: 17890
+proxies:
+  - name: A
+    type: trojan
+    server: 127.0.0.1
+    port: 1
+    password: issue-513
+    dialer-proxy: {dialer}
+  - name: B
+    type: trojan
+    server: 127.0.0.1
+    port: 2
+    password: issue-513
+proxy-groups:
+{groups}
+rules:
+  - MATCH,DIRECT
+"#
+        ))
+        .unwrap();
+        let err = meow_config::rebuild_from_raw(&raw)
+            .err()
+            .expect("a dialer that routes back to its source must be rejected");
+        assert!(
+            err.to_string().contains("through group membership"),
+            "dialer {dialer}: unexpected error: {err}"
+        );
+    }
+}
+
+/// A dialer may name a group only if it actually builds: a *declared* group
+/// whose members all fail to resolve never enters the registry, and the load
+/// must fail at build time rather than on the first dial.
+#[test]
+fn dialer_to_unbuilt_group_is_a_config_error() {
+    let raw: RawConfig = serde_yaml::from_str(
+        r#"
+mixed-port: 17890
+proxies:
+  - name: A
+    type: trojan
+    server: 127.0.0.1
+    port: 1
+    password: issue-513
+    dialer-proxy: G
+proxy-groups:
+  - name: G
+    type: select
+    proxies: [ghost-node]
+rules:
+  - MATCH,DIRECT
+"#,
+    )
+    .unwrap();
+    let err = meow_config::rebuild_from_raw(&raw)
+        .err()
+        .expect("a dialer naming a group that never built must be rejected");
+    assert!(
+        err.to_string()
+            .contains("did not build into a registry entry"),
+        "unexpected: {err}"
+    );
+}
+
+/// A remote rule-provider fetch dials through `download_proxy` — the first
+/// named proxy — *inside* the config build. When that proxy is itself
+/// chained, its front hop must already resolve: publishing the by-name
+/// registry has to happen before provider fetches, not after. The observable
+/// is whether B's server was contacted.
+#[tokio::test]
+async fn provider_fetch_through_chained_download_proxy_resolves() {
+    let (server_b, b_accepts) = counting_listener().await;
+    let (server_a, _a_accepts) = counting_listener().await;
+
+    let raw: RawConfig = serde_yaml::from_str(&format!(
+        r#"
+mixed-port: 17890
+proxies:
+  - name: A
+    type: trojan
+    server: 127.0.0.1
+    port: {port_a}
+    password: issue-513
+    dialer-proxy: B
+  - name: B
+    type: trojan
+    server: 127.0.0.1
+    port: {port_b}
+    password: issue-513
+rule-providers:
+  rp:
+    type: http
+    behavior: domain
+    url: http://127.0.0.1:9/payload.mrs
+rules:
+  - MATCH,DIRECT
+"#,
+        port_a = server_a.port(),
+        port_b = server_b.port(),
+    ))
+    .unwrap();
+
+    // The fetch itself fails — the mock listener drops every connection — so
+    // the provider is warn-skipped, but the dial must have reached B.
+    // `rebuild_from_raw` blocks until the fetch resolves, so it runs on the
+    // blocking pool to keep the accept loop's executor free.
+    let _ = tokio::task::spawn_blocking(move || meow_config::rebuild_from_raw(&raw)).await;
+    assert!(
+        b_accepts.load(Ordering::SeqCst) >= 1,
+        "the provider fetch must chain through B; 0 accepts means the front \
+         hop could not resolve during the build"
+    );
+}

--- a/crates/meow-proxy/src/dialer.rs
+++ b/crates/meow-proxy/src/dialer.rs
@@ -9,13 +9,15 @@
 //!
 //! upstream: mihomo `component/proxydialer` + `BasicOption.NewDialer`.
 
+use std::collections::HashMap;
 use std::io;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use meow_common::{ConnType, Metadata, Network, Proxy, ProxyConn};
 use meow_transport::Stream;
+use smol_str::SmolStr;
 
 /// A pluggable dialer for the underlying connection to a proxy server.
 ///
@@ -162,6 +164,105 @@ impl TcpDialer for ProxyDialer {
             ..Default::default()
         };
         self.dial_metadata(meta).await
+    }
+
+    fn is_proxy(&self) -> bool {
+        true
+    }
+}
+
+/// An immutable snapshot of a finished config build, shared with every
+/// `dialer-proxy` bound from it.
+pub type ProxySnapshot = Arc<HashMap<SmolStr, Arc<dyn Proxy>>>;
+
+/// The proxies built from one config, published when the build completes and
+/// consulted by name on every chained dial.
+///
+/// mihomo resolves `dialer-proxy` the same way (`component/proxydialer/byname.go`).
+/// Capturing the front proxy as an `Arc` while the config is still being built
+/// freezes a stale entry instead: proxy groups clone their members before the
+/// dialer pass replaces them, and a group-valued dialer does not exist yet when
+/// the outbound chaining through it is built (issue #513).
+#[derive(Clone, Default)]
+pub struct ProxyRegistry {
+    proxies: Arc<RwLock<Option<ProxySnapshot>>>,
+}
+
+impl ProxyRegistry {
+    /// Publish the finished registry. Called once per config build, after every
+    /// leaf proxy and group exists; a rebuild publishes into its own registry,
+    /// so adapters from a previous config keep resolving their own snapshot.
+    pub fn publish(&self, proxies: ProxySnapshot) {
+        *self.proxies.write().unwrap() = Some(proxies);
+    }
+
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Proxy>> {
+        self.proxies.read().unwrap().as_ref()?.get(name).cloned()
+    }
+}
+
+/// The front hop of a `dialer-proxy` chain, addressed by name.
+#[derive(Clone)]
+pub struct DialerTarget {
+    name: SmolStr,
+    registry: ProxyRegistry,
+}
+
+impl DialerTarget {
+    pub fn new(name: impl Into<SmolStr>, registry: ProxyRegistry) -> Self {
+        Self {
+            name: name.into(),
+            registry,
+        }
+    }
+
+    /// Registry key of the front proxy, as written in the config.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// `None` when the registry has not been published yet or no longer holds
+    /// the name. Callers must fail loudly — falling back to a direct dial would
+    /// leak past a chain the user configured for policy reasons.
+    pub fn resolve(&self) -> Option<Arc<dyn Proxy>> {
+        self.registry.resolve(&self.name)
+    }
+
+    /// Error for an unresolvable target, worded for the two error types the
+    /// chained dial paths report through.
+    pub fn missing_error(&self) -> String {
+        format!("dialer-proxy '{}' is not in the proxy registry", self.name)
+    }
+}
+
+/// [`TcpDialer`] for a `dialer-proxy` front hop that is resolved by name at
+/// dial time. Equivalent to mihomo's `proxydialer.NewByNameDialer`.
+pub struct NamedProxyDialer {
+    target: DialerTarget,
+}
+
+impl NamedProxyDialer {
+    pub fn new(target: DialerTarget) -> Self {
+        Self { target }
+    }
+}
+
+#[async_trait]
+impl TcpDialer for NamedProxyDialer {
+    async fn dial(&self, host: &str, port: u16) -> io::Result<Box<dyn Stream>> {
+        let front = self
+            .target
+            .resolve()
+            .ok_or_else(|| io::Error::other(self.target.missing_error()))?;
+        ProxyDialer::new(front).dial(host, port).await
+    }
+
+    async fn dial_addr(&self, addr: SocketAddr) -> io::Result<Box<dyn Stream>> {
+        let front = self
+            .target
+            .resolve()
+            .ok_or_else(|| io::Error::other(self.target.missing_error()))?;
+        ProxyDialer::new(front).dial_addr(addr).await
     }
 
     fn is_proxy(&self) -> bool {

--- a/crates/meow-proxy/src/group/dialer_proxy.rs
+++ b/crates/meow-proxy/src/group/dialer_proxy.rs
@@ -18,6 +18,13 @@
 //! presents itself as the inner outbound — same name, type, address, and health
 //! — so dashboards and rules see no difference.
 //!
+//! The front hop is held as a [`DialerTarget`] — a *name* plus a registry
+//! handle — and resolved on every dial, matching mihomo's
+//! `component/proxydialer/byname.go`.  Capturing the front proxy as an `Arc`
+//! while the config is still being built freezes a stale entry instead: proxy
+//! groups clone their members before the `dialer-proxy` pass replaces them, so
+//! a grouped node would silently bypass its chain (issue #513).
+//!
 //! ## Limitations (first implementation)
 //!
 //! - **UDP**: routing a UDP association through an arbitrary dialer requires
@@ -38,26 +45,21 @@ use meow_common::{
 use std::sync::Arc;
 
 use super::relay::relay_tcp;
+use crate::dialer::DialerTarget;
 
 /// Wraps an outbound so its underlying connection is dialled through `dialer`.
 pub struct DialerProxyAdapter {
     /// The actual outbound (SS/Trojan/VLESS/Snell/…); identity is borrowed from
     /// it so the wrapper is transparent to the API and rule engine.
     inner: Arc<dyn Proxy>,
-    /// Front proxy/group the inner outbound dials through.
-    dialer: Arc<dyn Proxy>,
-    /// Pre-built `[dialer, inner]` chain handed to `relay_tcp`.
-    chain: Vec<Arc<dyn Proxy>>,
+    /// Front proxy/group the inner outbound dials through, resolved by name on
+    /// every dial.
+    dialer: DialerTarget,
 }
 
 impl DialerProxyAdapter {
-    pub fn new(inner: Arc<dyn Proxy>, dialer: Arc<dyn Proxy>) -> Self {
-        let chain = vec![Arc::clone(&dialer), Arc::clone(&inner)];
-        Self {
-            inner,
-            dialer,
-            chain,
-        }
+    pub fn new(inner: Arc<dyn Proxy>, dialer: DialerTarget) -> Self {
+        Self { inner, dialer }
     }
 
     /// Name of the front dialer proxy/group (for diagnostics/tests).
@@ -87,8 +89,14 @@ impl ProxyAdapter for DialerProxyAdapter {
 
     async fn dial_tcp(&self, metadata: &Metadata) -> Result<Box<dyn ProxyConn>> {
         // `[dialer, inner]`: dialer dials inner's server, inner connects to the
-        // real target via `connect_over`.
-        relay_tcp(&self.chain, metadata).await
+        // real target via `connect_over`. An unresolvable front hop must fail —
+        // dialling direct would leak past a chain configured for policy reasons.
+        let front = self
+            .dialer
+            .resolve()
+            .ok_or_else(|| MeowError::Proxy(self.dialer.missing_error()))?;
+        let chain = [front, Arc::clone(&self.inner)];
+        relay_tcp(&chain, metadata).await
     }
 
     async fn dial_udp(&self, _metadata: &Metadata) -> Result<Box<dyn ProxyPacketConn>> {
@@ -147,8 +155,11 @@ impl Proxy for DialerProxyAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dialer::ProxyRegistry;
     use crate::group::test_support::MockProxy;
     use meow_common::MeowError;
+    use smol_str::SmolStr;
+    use std::collections::HashMap;
 
     fn meta(host: &str, port: u16) -> Metadata {
         Metadata {
@@ -158,11 +169,22 @@ mod tests {
         }
     }
 
+    /// Publish `dialer` in a registry of its own and hand back the target that
+    /// resolves it — the late-binding shape `meow-config` builds at load time.
+    fn front(dialer: Arc<MockProxy>) -> DialerTarget {
+        let name = SmolStr::from(dialer.name());
+        let registry = ProxyRegistry::default();
+        let mut proxies: HashMap<SmolStr, Arc<dyn Proxy>> = HashMap::new();
+        proxies.insert(name.clone(), dialer);
+        registry.publish(Arc::new(proxies));
+        DialerTarget::new(name, registry)
+    }
+
     #[tokio::test]
     async fn dial_tcp_routes_through_dialer_first() {
         let dialer = MockProxy::new("fast");
         let inner = MockProxy::new("daniel");
-        let adapter = DialerProxyAdapter::new(Arc::clone(&inner) as _, Arc::clone(&dialer) as _);
+        let adapter = DialerProxyAdapter::new(Arc::clone(&inner) as _, front(Arc::clone(&dialer)));
 
         // dialer.dial_tcp errors at relay hop 0 → confirms the chain dials the
         // front proxy first. The inner adapter is only reached via connect_over,
@@ -179,9 +201,31 @@ mod tests {
         );
     }
 
+    /// A front hop that never resolves (registry not published, or the name
+    /// gone after a rebuild) must fail the dial. Falling back to a direct dial
+    /// would leak past a chain the user configured for policy reasons.
+    #[tokio::test]
+    async fn unresolved_front_hop_fails_loudly() {
+        let inner = MockProxy::new("daniel");
+        let adapter = DialerProxyAdapter::new(
+            Arc::clone(&inner) as _,
+            DialerTarget::new("ghost", ProxyRegistry::default()),
+        );
+
+        match adapter.dial_tcp(&meta("example.com", 443)).await {
+            Err(MeowError::Proxy(msg)) => assert!(
+                msg.contains("ghost"),
+                "the error must name the missing dialer: {msg}"
+            ),
+            other => panic!("expected a Proxy error, got {:?}", other.err()),
+        }
+        assert_eq!(inner.dials(), 0, "the inner outbound must not be dialled");
+    }
+
     #[tokio::test]
     async fn udp_is_unsupported() {
-        let adapter = DialerProxyAdapter::new(MockProxy::new("inner"), MockProxy::new_udp("fast"));
+        let adapter =
+            DialerProxyAdapter::new(MockProxy::new("inner"), front(MockProxy::new_udp("fast")));
         assert!(!adapter.support_udp());
         match adapter.dial_udp(&meta("example.com", 53)).await {
             Err(MeowError::UdpNotSupported) => {}
@@ -192,7 +236,7 @@ mod tests {
     #[test]
     fn identity_delegates_to_inner() {
         let inner = MockProxy::new("daniel");
-        let adapter = DialerProxyAdapter::new(inner, MockProxy::new("fast"));
+        let adapter = DialerProxyAdapter::new(inner, front(MockProxy::new("fast")));
         assert_eq!(adapter.name(), "daniel");
         assert_eq!(adapter.dialer_name(), "fast");
         assert_eq!(adapter.adapter_type(), AdapterType::Direct); // MockProxy's type

--- a/crates/meow-rules/src/mrs_parser.rs
+++ b/crates/meow-rules/src/mrs_parser.rs
@@ -128,11 +128,27 @@ pub fn parse_header(data: &[u8]) -> Result<(MrsHeader, &[u8]), MrsError> {
     ))
 }
 
+/// Largest accepted *decompressed* mrs/geosite payload. The HTTP body cap
+/// (`internal_http::MAX_BODY_BYTES`) bounds only the compressed wire bytes;
+/// the zstd expansion ratio is attacker-chosen, so an unbounded `read_to_end`
+/// would let a small payload grow `out` until allocation aborts the process
+/// (issue #513).
+const MAX_DECOMPRESSED_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Decompress the zstd-compressed payload that follows an mrs header.
 pub fn decompress_payload(compressed: &[u8]) -> Result<Vec<u8>, MrsError> {
-    let mut out = Vec::new();
+    decompress_payload_bounded(compressed, MAX_DECOMPRESSED_BYTES)
+}
+
+fn decompress_payload_bounded(compressed: &[u8], max: u64) -> Result<Vec<u8>, MrsError> {
     let mut decoder = zstd::stream::Decoder::new(Cursor::new(compressed))?;
-    decoder.read_to_end(&mut out)?;
+    let mut out = Vec::new();
+    // Read one byte past the bound so an over-limit payload is an error rather
+    // than silently truncated input.
+    let n = std::io::Read::take(&mut decoder, max + 1).read_to_end(&mut out)?;
+    if n as u64 > max {
+        return Err(MrsError::InvalidLength("decompressed_payload", max as i64));
+    }
     Ok(out)
 }
 
@@ -171,7 +187,9 @@ pub fn parse_upstream_ruleset_mrs(bytes: &[u8]) -> Result<UpstreamRuleSetPayload
     if extra_len < 0 {
         return Err(MrsError::InvalidReservedLength(extra_len));
     }
-    let _ = r.read_slice("extra", extra_len as usize)?;
+    let extra_len =
+        usize::try_from(extra_len).map_err(|_| MrsError::InvalidLength("extra_len", extra_len))?;
+    let _ = r.read_slice("extra", extra_len)?;
 
     let body = r.remaining_slice();
     let entries = match behavior {
@@ -182,7 +200,7 @@ pub fn parse_upstream_ruleset_mrs(bytes: &[u8]) -> Result<UpstreamRuleSetPayload
 
     Ok(UpstreamRuleSetPayload {
         behavior,
-        count: count as usize,
+        count: usize::try_from(count).map_err(|_| MrsError::InvalidLength("count", count))?,
         entries,
     })
 }
@@ -199,7 +217,9 @@ fn parse_upstream_domain_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
     if labels_len < 1 {
         return Err(MrsError::InvalidLength("domain_set_labels_len", labels_len));
     }
-    let labels = r.read_slice("domain_set_labels", labels_len as usize)?;
+    let labels_len = usize::try_from(labels_len)
+        .map_err(|_| MrsError::InvalidLength("domain_set_labels_len", labels_len))?;
+    let labels = r.read_slice("domain_set_labels", labels_len)?;
 
     let traversal = DomainSetTraversal {
         leaves: &leaves,
@@ -209,7 +229,7 @@ fn parse_upstream_domain_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
     };
     let mut reversed = Vec::new();
     let mut current = Vec::new();
-    traversal.traverse(0, 0, &mut current, &mut reversed);
+    traversal.traverse(0, 0, &mut current, &mut reversed)?;
 
     Ok(reversed
         .into_iter()
@@ -244,40 +264,72 @@ struct DomainSetTraversal<'a> {
     labels: &'a [u8],
 }
 
+/// Hard bounds on decoded domain-set output. Real-world rule sets top out at a
+/// few million short domains; a hostile file can otherwise turn input bytes
+/// into roughly O(input²) output — each reachable leaf clones a label path of
+/// up to `labels.len()` bytes — exhausting memory without tripping any input
+/// check (issue #513).
+const MAX_DOMAIN_SET_ENTRIES: usize = 4 * 1024 * 1024;
+const MAX_DOMAIN_SET_BYTES: usize = 256 * 1024 * 1024;
+
 impl DomainSetTraversal<'_> {
+    /// Depth-first walk of the label graph, iterative because the input is
+    /// remote-controlled: recursion depth is proportional to input size and
+    /// would overflow the (small) stack of the spawned provider-fetch thread.
+    ///
+    /// Frame discipline: `current` holds one label byte per frame above the
+    /// root, so `current.len() == stack.len() - 1` is an invariant.
     fn traverse(
         &self,
-        node_id: usize,
-        bm_idx: usize,
+        root_node: usize,
+        root_bm: usize,
         current: &mut Vec<u8>,
         out: &mut Vec<Vec<u8>>,
-    ) {
-        if get_bit(self.leaves, node_id) {
+    ) -> Result<(), MrsError> {
+        let mut out_bytes = 0usize;
+        let mut stack: Vec<(usize, usize)> = vec![(root_node, root_bm)];
+        if get_bit(self.leaves, root_node) {
             out.push(current.clone());
         }
-
-        let mut idx = bm_idx;
-        loop {
-            if get_bit(self.label_bitmap, idx) {
-                return;
-            }
-
-            let label_idx = idx.saturating_sub(node_id);
-            let Some(&label) = self.labels.get(label_idx) else {
-                return;
+        while let Some(top) = stack.last_mut() {
+            let (node_id, idx) = *top;
+            // A terminator bit, an out-of-range label, or a missing child node
+            // all end this frame exactly as the recursive `return` did.
+            let child = if get_bit(self.label_bitmap, idx) {
+                None
+            } else {
+                let label_idx = idx.saturating_sub(node_id);
+                let next_node_id = self.label_index.count_zeros(self.label_bitmap, idx + 1);
+                self.labels
+                    .get(label_idx)
+                    .copied()
+                    .zip(self.label_index.select_one(next_node_id.saturating_sub(1)))
+                    .map(|(label, prev_terminator)| (label, next_node_id, prev_terminator + 1))
             };
-            let next_node_id = self.label_index.count_zeros(self.label_bitmap, idx + 1);
-            let Some(prev_terminator) = self.label_index.select_one(next_node_id.saturating_sub(1))
-            else {
-                return;
+            let Some((label, next_node_id, next_bm_idx)) = child else {
+                stack.pop();
+                if !stack.is_empty() {
+                    current.pop();
+                }
+                continue;
             };
-            let next_bm_idx = prev_terminator + 1;
-
+            top.1 = idx + 1;
             current.push(label);
-            self.traverse(next_node_id, next_bm_idx, current, out);
-            current.pop();
-            idx += 1;
+            if get_bit(self.leaves, next_node_id) {
+                if out.len() >= MAX_DOMAIN_SET_ENTRIES
+                    || out_bytes + current.len() > MAX_DOMAIN_SET_BYTES
+                {
+                    return Err(MrsError::InvalidLength(
+                        "domain_set_output",
+                        out.len() as i64,
+                    ));
+                }
+                out_bytes += current.len();
+                out.push(current.clone());
+            }
+            stack.push((next_node_id, next_bm_idx));
         }
+        Ok(())
     }
 }
 
@@ -437,7 +489,11 @@ pub fn parse_geosite_payload(
     // workspace's `panic = "abort"`; cap at what the input can actually hold —
     // an empty category still costs a u16 name length plus a u32 domain count,
     // and an empty domain still costs a u16 length.
-    let mut categories = Vec::with_capacity(bounded_capacity(cat_count, r.remaining(), 6));
+    let mut categories = Vec::with_capacity(bounded_capacity::<(String, Vec<String>)>(
+        cat_count,
+        r.remaining(),
+        6,
+    ));
     for _ in 0..cat_count {
         let name_len = r.read_u16_be("category_name_len")? as usize;
         let name_bytes = r.read_slice("category_name", name_len)?;
@@ -459,7 +515,8 @@ pub fn parse_geosite_payload(
             }
         }
 
-        let mut domains = Vec::with_capacity(bounded_capacity(dom_count, r.remaining(), 2));
+        let mut domains =
+            Vec::with_capacity(bounded_capacity::<String>(dom_count, r.remaining(), 2));
         for _ in 0..dom_count {
             let dom_len = r.read_u16_be("domain_len")? as usize;
             let dom_bytes = r.read_slice("domain", dom_len)?;
@@ -477,8 +534,13 @@ pub fn parse_geosite_payload(
 /// remaining input can actually hold, given the smallest encoded size of one
 /// element. The declared counts are remote-controlled; without the cap a bogus
 /// count becomes an allocation failure rather than a `Truncated` error.
-fn bounded_capacity(declared: usize, remaining: usize, min_element_bytes: usize) -> usize {
-    declared.min(remaining / min_element_bytes)
+///
+/// The divisor also accounts for the element's *decoded* size: without it the
+/// reservation can still reach ~8–12× the input (a 48-byte element against a
+/// 6-byte minimum encoding), which turns a large-but-legitimate input into an
+/// oversized allocation.
+fn bounded_capacity<T>(declared: usize, remaining: usize, min_element_bytes: usize) -> usize {
+    declared.min(remaining / min_element_bytes.max(std::mem::size_of::<T>()))
 }
 
 /// Encode a `GeositePayload` into the uncompressed inner payload bytes.
@@ -713,18 +775,22 @@ mod tests {
             idx += 1;
         }
 
+        encode_domain_set_raw(&leaves, &label_bitmap, &labels)
+    }
+
+    fn encode_domain_set_raw(leaves: &[u64], label_bitmap: &[u64], labels: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
         out.push(1);
         write_i64(&mut out, leaves.len() as i64);
         for word in leaves {
-            write_u64(&mut out, word);
+            write_u64(&mut out, *word);
         }
         write_i64(&mut out, label_bitmap.len() as i64);
         for word in label_bitmap {
-            write_u64(&mut out, word);
+            write_u64(&mut out, *word);
         }
         write_i64(&mut out, labels.len() as i64);
-        out.extend_from_slice(&labels);
+        out.extend_from_slice(labels);
         out
     }
 
@@ -866,9 +932,91 @@ mod tests {
 
         let mut category_without_domains = Vec::new();
         category_without_domains.extend_from_slice(&1u32.to_be_bytes());
-        category_without_domains.extend_from_slice(&2u16.to_be_bytes());
         category_without_domains.extend_from_slice(b"cn");
         category_without_domains.extend_from_slice(&u32::MAX.to_be_bytes());
         assert!(parse_geosite_payload(&category_without_domains, None).is_err());
+    }
+
+    /// The wire cap bounds only the *compressed* bytes; zstd expansion is
+    /// attacker-chosen, so decompression itself must be bounded or a small
+    /// payload can allocate until abort (issue #513).
+    #[test]
+    fn decompress_payload_rejects_output_past_the_bound() {
+        let inner = vec![0u8; 1024];
+        let compressed = zstd::encode_all(Cursor::new(&inner), 0).unwrap();
+        assert_eq!(
+            decompress_payload_bounded(&compressed, 512)
+                .unwrap_err()
+                .to_string(),
+            "mrs: invalid length for decompressed_payload: 512"
+        );
+        assert_eq!(
+            decompress_payload_bounded(&compressed, 1024).unwrap(),
+            inner
+        );
+    }
+
+    /// A crafted label graph can chain one traversal frame per few input
+    /// bytes. The walk must be iterative (no native recursion) and its output
+    /// bounded — the gadget below produces a leaf per level and would
+    /// previously have recursed ~input-size deep.
+    #[test]
+    fn domain_set_traversal_is_iterative_and_bounded() {
+        // labels[i] = 'a'; a linear chain of N levels: leaf bit set only at the
+        // last node, each node's bitmap entry is a single zero bit followed by
+        // its terminator. Depth = level count, not bounded by anything in the
+        // input except size — recursion would overflow a 2 MiB fetch-thread
+        // stack around ~10^5 levels.
+        let levels = 300_000usize;
+        let mut leaves = vec![0u64; levels / 64 + 1];
+        leaves[levels / 64] = 1 << (levels % 64);
+        // Bitmap: level k occupies bit position 2k (label edge), 2k+1 is the
+        // terminator bit marking the end of the node's children. The final
+        // node has no children: just its terminator.
+        let mut bitmap = vec![0u64; (2 * levels + 1) / 64 + 1];
+        for level in 0..=levels {
+            let pos = 2 * level + 1;
+            bitmap[pos / 64] |= 1 << (pos % 64);
+        }
+        let labels = vec![b'a'; levels];
+        let body = encode_domain_set_raw(&leaves, &bitmap, &labels);
+        let parsed = parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, 1, &body))
+            .unwrap_or_else(|e| panic!("iterative traversal must not overflow: {e}"));
+        // One leaf, the deepest: a string of `levels` 'a' labels.
+        assert_eq!(parsed.entries.len(), 1);
+    }
+
+    /// The same traversal must stop rather than amplify input bytes into
+    /// unbounded output: a bitmap of all-zero edges makes every level a leaf.
+    #[test]
+    fn domain_set_output_is_bounded() {
+        // A single node whose label fan-out walks `labels` and whose leaf bit
+        // is set — plus enough sibling edges to emit many copies. Keep it
+        // simple: one node, leaf set, N zero-edge children each needing a
+        // `select_one` — the gadget is fiddly to hand-construct, so instead
+        // bound-check via a wide shallow fan: node 0 has N children, each
+        // child is a leaf.
+        let n = 1_000_000usize;
+        // Node 0: N zero-bits then terminator at bit N. Each child i is node
+        // i+1 (count_zeros gives the running zero count) with its own bitmap
+        // segment [N+1+2(i), N+2+2i]: zero edge (no label left → frame ends)
+        // then terminator.
+        let total_bits = n + 1 + 3 * n + 1;
+        let mut bitmap = vec![0u64; total_bits / 64 + 1];
+        let set = |b: &mut Vec<u64>, pos: usize| b[pos / 64] |= 1 << (pos % 64);
+        set(&mut bitmap, n); // node 0 terminator
+        let mut leaves = vec![0u64; n + 2];
+        // child i is node i+1; make every child a leaf
+        for i in 0..n {
+            let node = i + 1;
+            leaves[node / 64] |= 1 << (node % 64);
+            // child node's bitmap: terminator immediately
+            set(&mut bitmap, n + 1 + 3 * i + 1);
+        }
+        let labels = vec![b'x'; n];
+        let body = encode_domain_set_raw(&leaves, &bitmap, &labels);
+        let parsed = parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, n, &body))
+            .unwrap_or_else(|e| panic!("shallow fan within bounds must parse: {e}"));
+        assert_eq!(parsed.entries.len(), n);
     }
 }

--- a/crates/meow-rules/src/mrs_parser.rs
+++ b/crates/meow-rules/src/mrs_parser.rs
@@ -218,11 +218,19 @@ fn parse_upstream_domain_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
 }
 
 fn read_u64_vec(r: &mut ByteReader<'_>, what: &'static str) -> Result<Vec<u64>, MrsError> {
-    let len = r.read_i64_be(what)?;
-    if len < 1 {
-        return Err(MrsError::InvalidLength(what, len));
+    let declared = r.read_i64_be(what)?;
+    if declared < 1 {
+        return Err(MrsError::InvalidLength(what, declared));
     }
-    let mut out = Vec::with_capacity(len as usize);
+    // The word count comes from a remote rule-provider, so prove the bytes are
+    // actually present before reserving: `with_capacity` on a bogus count trips
+    // the capacity-overflow check and aborts the process (issue #513).
+    let len = usize::try_from(declared).map_err(|_| MrsError::InvalidLength(what, declared))?;
+    let bytes = len
+        .checked_mul(std::mem::size_of::<u64>())
+        .ok_or(MrsError::InvalidLength(what, declared))?;
+    r.need(what, bytes)?;
+    let mut out = Vec::with_capacity(len);
     for _ in 0..len {
         out.push(r.read_u64_be(what)?);
     }
@@ -423,15 +431,20 @@ pub fn parse_geosite_payload(
     allowed: Option<&std::collections::HashSet<String>>,
 ) -> Result<GeositePayload, MrsError> {
     let mut r = ByteReader::new(decompressed);
-    let cat_count = r.read_u32_be("category_count")?;
-    let mut categories = Vec::with_capacity(cat_count as usize);
+    let cat_count = r.read_u32_be("category_count")? as usize;
+    // Both counts come from a remote geodata file. Reserving them verbatim asks
+    // for hundreds of gigabytes on a bogus count, which aborts under the
+    // workspace's `panic = "abort"`; cap at what the input can actually hold —
+    // an empty category still costs a u16 name length plus a u32 domain count,
+    // and an empty domain still costs a u16 length.
+    let mut categories = Vec::with_capacity(bounded_capacity(cat_count, r.remaining(), 6));
     for _ in 0..cat_count {
         let name_len = r.read_u16_be("category_name_len")? as usize;
         let name_bytes = r.read_slice("category_name", name_len)?;
         let name = String::from_utf8(name_bytes.to_vec())
             .map_err(|e| MrsError::Utf8("category_name", e))?
             .to_ascii_lowercase();
-        let dom_count = r.read_u32_be("domain_count")?;
+        let dom_count = r.read_u32_be("domain_count")? as usize;
 
         // If an allow-set is active and this category is not in it, skip its
         // domains at the byte level — read lengths and advance the cursor
@@ -446,7 +459,7 @@ pub fn parse_geosite_payload(
             }
         }
 
-        let mut domains = Vec::with_capacity(dom_count as usize);
+        let mut domains = Vec::with_capacity(bounded_capacity(dom_count, r.remaining(), 2));
         for _ in 0..dom_count {
             let dom_len = r.read_u16_be("domain_len")? as usize;
             let dom_bytes = r.read_slice("domain", dom_len)?;
@@ -458,6 +471,14 @@ pub fn parse_geosite_payload(
         categories.push((name, domains));
     }
     Ok(GeositePayload { categories })
+}
+
+/// Cap a reservation derived from a declared element count at what the
+/// remaining input can actually hold, given the smallest encoded size of one
+/// element. The declared counts are remote-controlled; without the cap a bogus
+/// count becomes an allocation failure rather than a `Truncated` error.
+fn bounded_capacity(declared: usize, remaining: usize, min_element_bytes: usize) -> usize {
+    declared.min(remaining / min_element_bytes)
 }
 
 /// Encode a `GeositePayload` into the uncompressed inner payload bytes.
@@ -526,13 +547,22 @@ impl<'a> ByteReader<'a> {
         &self.data[self.pos..]
     }
 
+    /// Unread byte count. Saturating because a hostile declared length can push
+    /// `pos` arithmetic that would otherwise wrap.
+    fn remaining(&self) -> usize {
+        self.data.len().saturating_sub(self.pos)
+    }
+
     fn need(&self, what: &'static str, n: usize) -> Result<(), MrsError> {
-        if self.pos + n > self.data.len() {
+        // Compare against the remaining length rather than `pos + n`: a declared
+        // length near `usize::MAX` would wrap the sum and pass the check.
+        let have = self.remaining();
+        if n > have {
             return Err(MrsError::Truncated {
                 what,
                 offset: self.pos,
                 need: n,
-                have: self.data.len() - self.pos,
+                have,
             });
         }
         Ok(())
@@ -797,5 +827,48 @@ mod tests {
         let parsed = parse_upstream_ruleset_mrs(&bytes).unwrap();
         assert_eq!(parsed.behavior, TYPE_IPCIDR);
         assert_eq!(parsed.entries, vec!["192.168.0.0/24"]);
+    }
+
+    /// A remote rule-provider can declare an enormous word count in a payload
+    /// only a few dozen bytes long. Both `read_u64_vec` call sites must reject
+    /// it with an error: reserving from the declared count trips the
+    /// capacity-overflow check, which terminates the process under the
+    /// workspace's `panic = "abort"` release profile (issue #513).
+    #[test]
+    fn upstream_ruleset_mrs_oversized_word_counts_are_rejected() {
+        // `i64::MAX` overflows the byte-count multiplication; `i64::MAX / 8 + 1`
+        // does not and must instead be caught by the remaining-input check.
+        for declared in [i64::MAX, i64::MAX / 8 + 1, 100] {
+            let mut leaves = vec![1u8];
+            write_i64(&mut leaves, declared);
+            assert!(
+                parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, 1, &leaves)).is_err(),
+                "leaves_len={declared} must not reserve from the declared count"
+            );
+
+            let mut bitmap = vec![1u8];
+            write_i64(&mut bitmap, 1);
+            write_u64(&mut bitmap, 0);
+            write_i64(&mut bitmap, declared);
+            assert!(
+                parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, 1, &bitmap)).is_err(),
+                "label_bitmap_len={declared} must not reserve from the declared count"
+            );
+        }
+    }
+
+    /// Same class on the geodata path: `category_count` and `domain_count` are
+    /// u32 values from a remote geodata file, so the reservation has to be
+    /// capped by the input rather than asking for hundreds of gigabytes.
+    #[test]
+    fn geosite_payload_declared_counts_are_bounded_by_input() {
+        assert!(parse_geosite_payload(&u32::MAX.to_be_bytes(), None).is_err());
+
+        let mut category_without_domains = Vec::new();
+        category_without_domains.extend_from_slice(&1u32.to_be_bytes());
+        category_without_domains.extend_from_slice(&2u16.to_be_bytes());
+        category_without_domains.extend_from_slice(b"cn");
+        category_without_domains.extend_from_slice(&u32::MAX.to_be_bytes());
+        assert!(parse_geosite_payload(&category_without_domains, None).is_err());
     }
 }

--- a/crates/meow-rules/src/mrs_parser.rs
+++ b/crates/meow-rules/src/mrs_parser.rs
@@ -221,6 +221,22 @@ fn parse_upstream_domain_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
         .map_err(|_| MrsError::InvalidLength("domain_set_labels_len", labels_len))?;
     let labels = r.read_slice("domain_set_labels", labels_len)?;
 
+    // A well-formed trie has exactly one terminator bit per node and every
+    // non-root node owns one incoming label edge, so #ones <= labels + 1.
+    // Enforce the correlation *before* DomainSetIndex materializes one `usize`
+    // per set bit — a mostly-ones bitmap would otherwise amplify the input
+    // ~64x into memory (issue #513).
+    let node_count: usize = label_bitmap
+        .iter()
+        .map(|word| word.count_ones() as usize)
+        .sum();
+    if node_count > labels.len() + 1 {
+        return Err(MrsError::InvalidLength(
+            "domain_set_terminators",
+            node_count as i64,
+        ));
+    }
+
     let traversal = DomainSetTraversal {
         leaves: &leaves,
         label_bitmap: &label_bitmap,
@@ -271,20 +287,47 @@ struct DomainSetTraversal<'a> {
 /// check (issue #513).
 const MAX_DOMAIN_SET_ENTRIES: usize = 4 * 1024 * 1024;
 const MAX_DOMAIN_SET_BYTES: usize = 256 * 1024 * 1024;
+/// A domain never exceeds 253 octets of labels, so a legitimate trie walk is
+/// ~127 frames deep at most; 4 Ki frames is generous headroom. Without the
+/// cap the explicit stack and `current` still grow proportionally to remote
+/// input — a deep-chain gadget turns a bounded payload into GiBs of frames.
+const MAX_DOMAIN_SET_DEPTH: usize = 4 * 1024;
 
 impl DomainSetTraversal<'_> {
-    /// Depth-first walk of the label graph, iterative because the input is
-    /// remote-controlled: recursion depth is proportional to input size and
-    /// would overflow the (small) stack of the spawned provider-fetch thread.
-    ///
-    /// Frame discipline: `current` holds one label byte per frame above the
-    /// root, so `current.len() == stack.len() - 1` is an invariant.
     fn traverse(
         &self,
         root_node: usize,
         root_bm: usize,
         current: &mut Vec<u8>,
         out: &mut Vec<Vec<u8>>,
+    ) -> Result<(), MrsError> {
+        self.traverse_bounded(
+            root_node,
+            root_bm,
+            current,
+            out,
+            MAX_DOMAIN_SET_ENTRIES,
+            MAX_DOMAIN_SET_BYTES,
+            MAX_DOMAIN_SET_DEPTH,
+        )
+    }
+
+    /// Depth-first walk of the label graph, iterative because the input is
+    /// remote-controlled: recursion depth is proportional to input size and
+    /// would overflow the (small) stack of the spawned provider-fetch thread.
+    ///
+    /// Frame discipline: `current` holds one label byte per frame above the
+    /// root, so `current.len() == stack.len() - 1` is an invariant.
+    #[allow(clippy::too_many_arguments, reason = "bounds grouped for tests")]
+    fn traverse_bounded(
+        &self,
+        root_node: usize,
+        root_bm: usize,
+        current: &mut Vec<u8>,
+        out: &mut Vec<Vec<u8>>,
+        max_entries: usize,
+        max_bytes: usize,
+        max_depth: usize,
     ) -> Result<(), MrsError> {
         let mut out_bytes = 0usize;
         let mut stack: Vec<(usize, usize)> = vec![(root_node, root_bm)];
@@ -316,9 +359,7 @@ impl DomainSetTraversal<'_> {
             top.1 = idx + 1;
             current.push(label);
             if get_bit(self.leaves, next_node_id) {
-                if out.len() >= MAX_DOMAIN_SET_ENTRIES
-                    || out_bytes + current.len() > MAX_DOMAIN_SET_BYTES
-                {
+                if out.len() >= max_entries || out_bytes + current.len() > max_bytes {
                     return Err(MrsError::InvalidLength(
                         "domain_set_output",
                         out.len() as i64,
@@ -326,6 +367,12 @@ impl DomainSetTraversal<'_> {
                 }
                 out_bytes += current.len();
                 out.push(current.clone());
+            }
+            if stack.len() >= max_depth {
+                return Err(MrsError::InvalidLength(
+                    "domain_set_depth",
+                    stack.len() as i64,
+                ));
             }
             stack.push((next_node_id, next_bm_idx));
         }
@@ -402,6 +449,14 @@ fn parse_upstream_ipcidr_set(data: &[u8]) -> Result<Vec<String>, MrsError> {
         let from = IpAddr::from(Ipv6Addr::from(from));
         let to = IpAddr::from(Ipv6Addr::from(to));
         push_range_prefixes(from, to, &mut out);
+        // One 32-byte record can expand to over a hundred CIDR strings; bound
+        // the total or a max-size payload amplifies ~100x (issue #513).
+        if out.len() > MAX_DOMAIN_SET_ENTRIES {
+            return Err(MrsError::InvalidLength(
+                "ipcidr_set_output",
+                out.len() as i64,
+            ));
+        }
     }
     Ok(out)
 }
@@ -957,9 +1012,9 @@ mod tests {
     }
 
     /// A crafted label graph can chain one traversal frame per few input
-    /// bytes. The walk must be iterative (no native recursion) and its output
-    /// bounded — the gadget below produces a leaf per level and would
-    /// previously have recursed ~input-size deep.
+    /// bytes. The walk must be iterative (no native recursion), bounded in
+    /// depth, and bounded in output — the gadget below produces a leaf per
+    /// level and would previously have recursed ~input-size deep.
     #[test]
     fn domain_set_traversal_is_iterative_and_bounded() {
         // labels[i] = 'a'; a linear chain of N levels: leaf bit set only at the
@@ -967,40 +1022,50 @@ mod tests {
         // its terminator. Depth = level count, not bounded by anything in the
         // input except size — recursion would overflow a 2 MiB fetch-thread
         // stack around ~10^5 levels.
-        let levels = 300_000usize;
-        let mut leaves = vec![0u64; levels / 64 + 1];
-        leaves[levels / 64] = 1 << (levels % 64);
-        // Bitmap: level k occupies bit position 2k (label edge), 2k+1 is the
-        // terminator bit marking the end of the node's children. The final
-        // node has no children: just its terminator.
-        let mut bitmap = vec![0u64; (2 * levels + 1) / 64 + 1];
-        for level in 0..=levels {
-            let pos = 2 * level + 1;
-            bitmap[pos / 64] |= 1 << (pos % 64);
-        }
-        let labels = vec![b'a'; levels];
-        let body = encode_domain_set_raw(&leaves, &bitmap, &labels);
-        let parsed = parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, 1, &body))
-            .unwrap_or_else(|e| panic!("iterative traversal must not overflow: {e}"));
-        // One leaf, the deepest: a string of `levels` 'a' labels.
+        let deep_chain = |levels: usize| {
+            let mut leaves = vec![0u64; levels / 64 + 1];
+            leaves[levels / 64] = 1 << (levels % 64);
+            // Level k occupies bit position 2k (label edge), 2k+1 is the
+            // terminator marking the end of the node's children.
+            let mut bitmap = vec![0u64; (2 * levels + 1) / 64 + 1];
+            for level in 0..=levels {
+                let pos = 2 * level + 1;
+                bitmap[pos / 64] |= 1 << (pos % 64);
+            }
+            let labels = vec![b'a'; levels];
+            encode_domain_set_raw(&leaves, &bitmap, &labels)
+        };
+        // Just under the depth cap: one leaf, the deepest.
+        let parsed = parse_upstream_ruleset_mrs(&encode_upstream_mrs(
+            TYPE_DOMAIN,
+            1,
+            &deep_chain(MAX_DOMAIN_SET_DEPTH - 100),
+        ))
+        .unwrap_or_else(|e| panic!("iterative traversal must not overflow: {e}"));
         assert_eq!(parsed.entries.len(), 1);
+        // Past the cap the walk is an error, not a stack overflow or a
+        // multi-GiB frame allocation.
+        match parse_upstream_ruleset_mrs(&encode_upstream_mrs(
+            TYPE_DOMAIN,
+            1,
+            &deep_chain(MAX_DOMAIN_SET_DEPTH + 100),
+        ))
+        .map(|_| ())
+        {
+            Err(MrsError::InvalidLength("domain_set_depth", _)) => {}
+            other => panic!("expected InvalidLength(domain_set_depth), got {other:?}"),
+        }
     }
 
     /// The same traversal must stop rather than amplify input bytes into
     /// unbounded output: a bitmap of all-zero edges makes every level a leaf.
     #[test]
     fn domain_set_output_is_bounded() {
-        // A single node whose label fan-out walks `labels` and whose leaf bit
-        // is set — plus enough sibling edges to emit many copies. Keep it
-        // simple: one node, leaf set, N zero-edge children each needing a
-        // `select_one` — the gadget is fiddly to hand-construct, so instead
-        // bound-check via a wide shallow fan: node 0 has N children, each
-        // child is a leaf.
+        // Node 0 has N children, each a leaf: node 0's bitmap run is N zero
+        // bits then a terminator; child i is node i+1 (count_zeros gives the
+        // running zero count) with its own bitmap segment holding an edge
+        // attempt that dies on an out-of-range label, then a terminator.
         let n = 1_000_000usize;
-        // Node 0: N zero-bits then terminator at bit N. Each child i is node
-        // i+1 (count_zeros gives the running zero count) with its own bitmap
-        // segment [N+1+2(i), N+2+2i]: zero edge (no label left → frame ends)
-        // then terminator.
         let total_bits = n + 1 + 3 * n + 1;
         let mut bitmap = vec![0u64; total_bits / 64 + 1];
         let set = |b: &mut Vec<u64>, pos: usize| b[pos / 64] |= 1 << (pos % 64);
@@ -1018,5 +1083,61 @@ mod tests {
         let parsed = parse_upstream_ruleset_mrs(&encode_upstream_mrs(TYPE_DOMAIN, n, &body))
             .unwrap_or_else(|e| panic!("shallow fan within bounds must parse: {e}"));
         assert_eq!(parsed.entries.len(), n);
+    }
+
+    /// A mostly-ones bitmap makes `DomainSetIndex` allocate one `usize` per
+    /// set bit — ~64x input amplification. A well-formed trie has one
+    /// terminator per node and one incoming label edge per non-root node, so
+    /// #ones <= labels + 1 is rejected before the index is built.
+    #[test]
+    fn domain_set_terminators_are_bounded_by_labels() {
+        let body = encode_domain_set_raw(&[0u64], &[u64::MAX; 8], b"x");
+        match parse_upstream_domain_set(&body) {
+            Err(MrsError::InvalidLength("domain_set_terminators", _)) => {}
+            other => panic!("expected InvalidLength(domain_set_terminators), got {other:?}"),
+        }
+    }
+
+    /// The output and depth caps must actually fire: encode a small real trie
+    /// and drive `traverse_bounded` with tiny limits.
+    #[test]
+    fn domain_set_bounds_error_instead_of_amplifying() {
+        let body = encode_domain_set(&["a.example.com", "b.example.com", "c.example.com"]);
+        let mut r = ByteReader::new(&body);
+        assert_eq!(r.read_u8("v").unwrap(), 1);
+        let leaves = read_u64_vec(&mut r, "leaves").unwrap();
+        let label_bitmap = read_u64_vec(&mut r, "bitmap").unwrap();
+        let labels_len = r.read_i64_be("labels_len").unwrap() as usize;
+        let labels = r.read_slice("labels", labels_len).unwrap();
+        let traversal = DomainSetTraversal {
+            leaves: &leaves,
+            label_bitmap: &label_bitmap,
+            label_index: DomainSetIndex::new(&label_bitmap),
+            labels,
+        };
+        let (mut out, mut current) = (Vec::new(), Vec::new());
+        // Three domains in the set; cap at two.
+        assert!(
+            traversal
+                .traverse_bounded(0, 0, &mut current, &mut out, 2, usize::MAX, 4096)
+                .is_err(),
+            "entry cap must error"
+        );
+        let (mut out, mut current) = (Vec::new(), Vec::new());
+        // Depth 1 refuses every descent.
+        assert!(
+            traversal
+                .traverse_bounded(0, 0, &mut current, &mut out, usize::MAX, usize::MAX, 1)
+                .is_err(),
+            "depth cap must error"
+        );
+        let (mut out, mut current) = (Vec::new(), Vec::new());
+        // Byte cap: each emitted domain is longer than 1 byte.
+        assert!(
+            traversal
+                .traverse_bounded(0, 0, &mut current, &mut out, usize::MAX, 1, 4096)
+                .is_err(),
+            "byte cap must error"
+        );
     }
 }

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -10,7 +10,7 @@ use smol_str::SmolStr;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Bundled rules + domain index + proxies map, swapped as one `Arc` on
 /// config reload. Reads on the connection-setup hot path take a single
@@ -274,23 +274,40 @@ impl TunnelInner {
     ) -> (Arc<dyn ProxyAdapter>, SmolStr, SmolStr) {
         match result {
             Some(m) => {
-                let action = if m.adapter_name == "DIRECT" {
+                let target = m.adapter_name;
+                let mut action = if target == "DIRECT" {
                     "DIRECT"
-                } else if m.adapter_name.starts_with("REJECT") {
+                } else if target.starts_with("REJECT") {
                     "REJECT"
                 } else {
                     "PROXY"
                 };
+                let proxy: Arc<dyn ProxyAdapter> = match route.proxies.get(target).cloned() {
+                    Some(p) => p as Arc<dyn ProxyAdapter>,
+                    // DIRECT needs no registry entry: the tunnel owns a direct
+                    // adapter for exactly this.
+                    None if target == "DIRECT" => Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>,
+                    None => {
+                        // Upstream mihomo falls back to DIRECT here, and so do
+                        // we: a subscription that dropped one node has to keep
+                        // routing the rest. What it must not do is hide that —
+                        // the fallback was a `debug!` and `action` was derived
+                        // from the name alone, so at the default log level
+                        // nothing said the connection had left the machine
+                        // directly, and the statistics counted a proxy hop that
+                        // never happened (issue #513).
+                        warn!(
+                            target,
+                            rule = %m.rule_type.as_str(),
+                            "matched rule names a target that is not in the registry; dialling DIRECT as upstream does"
+                        );
+                        action = "DIRECT";
+                        Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>
+                    }
+                };
                 self.stats
                     .rule_match
                     .increment(m.rule_type.as_str(), action);
-                let proxy = route.proxies.get(m.adapter_name).cloned().map_or_else(
-                    || {
-                        debug!("proxy '{}' not found, using DIRECT", m.adapter_name);
-                        Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>
-                    },
-                    |p| p as Arc<dyn ProxyAdapter>,
-                );
                 // `rule_type.as_str()` is a `&'static str` — wrap it
                 // inline without heap.
                 (

--- a/crates/meow-tunnel/src/tunnel.rs
+++ b/crates/meow-tunnel/src/tunnel.rs
@@ -288,18 +288,28 @@ impl TunnelInner {
                     // adapter for exactly this.
                     None if target == "DIRECT" => Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>,
                     None => {
-                        // Upstream mihomo falls back to DIRECT here, and so do
-                        // we: a subscription that dropped one node has to keep
-                        // routing the rest. What it must not do is hide that —
-                        // the fallback was a `debug!` and `action` was derived
-                        // from the name alone, so at the default log level
-                        // nothing said the connection had left the machine
-                        // directly, and the statistics counted a proxy hop that
-                        // never happened (issue #513).
+                        // Deliberate deviation from upstream mihomo: its match
+                        // loop *skips* a rule whose target is absent and keeps
+                        // scanning (`continue`), reaching DIRECT only via the
+                        // no-match tail. meow-rs stops at the first match and
+                        // dials DIRECT — a subscription that dropped one node
+                        // keeps routing the rest, but a later rule upstream
+                        // would have matched is never consulted (issue #513;
+                        // skip-and-continue is tracked as a parity follow-up).
+                        //
+                        // What it must not do is hide the fallback — it was a
+                        // `debug!` and `action` was derived from the name
+                        // alone, so at the default log level nothing said the
+                        // connection left the machine directly, and the
+                        // statistics counted a proxy hop that never happened.
+                        //
+                        // Interpolate into the message itself: the /logs
+                        // broadcast keeps only the `message` field, so
+                        // structured fields would never reach it.
                         warn!(
-                            target,
-                            rule = %m.rule_type.as_str(),
-                            "matched rule names a target that is not in the registry; dialling DIRECT as upstream does"
+                            "rule {} matched target '{target}' which is not in \
+                             the registry; dialling DIRECT",
+                            m.rule_type.as_str()
                         );
                         action = "DIRECT";
                         Arc::clone(&self.direct) as Arc<dyn ProxyAdapter>

--- a/crates/meow-tunnel/tests/rule_target_missing_falls_back_visibly.rs
+++ b/crates/meow-tunnel/tests/rule_target_missing_falls_back_visibly.rs
@@ -1,0 +1,174 @@
+//! A matched rule whose target the registry does not hold falls back to
+//! DIRECT, exactly as upstream mihomo does — but no longer silently
+//! (issue #513).
+//!
+//! The fallback itself is the compatible behaviour and stays: a subscription
+//! that dropped one node has to keep routing the rest, and refusing the
+//! connection instead would break traffic mihomo sends directly. What the rust
+//! port got wrong is that nothing said so. The log line was a `debug!`,
+//! invisible at the default level, and the match statistics derived their
+//! action label from the target *name* before the lookup ran, so a rule naming
+//! `ghost-group` was counted as a PROXY hop that never happened while the bytes
+//! left the machine over the direct adapter. These tests pin the observable
+//! half — same DIRECT dial, honest counter.
+
+use meow_common::{AdapterType, DnsMode, Metadata, Network, Rule, TunnelMode};
+use meow_dns::Resolver;
+use meow_rules::final_rule::FinalRule;
+use meow_trie::DomainTrie;
+use meow_tunnel::Tunnel;
+use std::sync::Arc;
+
+fn resolver() -> Arc<Resolver> {
+    Arc::new(Resolver::new(
+        vec![],
+        vec![],
+        DnsMode::Normal,
+        DomainTrie::new(),
+        true,
+        true,
+    ))
+}
+
+/// A tunnel in rule mode whose registry is the one every real load publishes:
+/// the built-in DIRECT / REJECT / REJECT-DROP entries and nothing else.
+fn tunnel_with_builtin_registry() -> Tunnel {
+    let tunnel = Tunnel::new(resolver());
+    let (proxies, _) = meow_config::rebuild_from_raw(&meow_config::raw::RawConfig::default())
+        .expect("an empty config must build its built-in registry");
+    tunnel.update_proxies(proxies);
+    tunnel.set_mode(TunnelMode::Rule);
+    tunnel
+}
+
+fn metadata() -> Metadata {
+    Metadata {
+        host: "example.test".into(),
+        dst_port: 443,
+        network: Network::Tcp,
+        ..Default::default()
+    }
+}
+
+/// The rules a real config leaves behind when a node was dropped: a `MATCH`
+/// naming something the registry does not hold.
+fn tunnel_with_ghost_target() -> Tunnel {
+    let tunnel = tunnel_with_builtin_registry();
+    let rules: Vec<Box<dyn Rule>> = vec![Box::new(FinalRule::new("ghost-group"))];
+    tunnel.update_rules(rules);
+    tunnel
+}
+
+#[test]
+fn a_matched_rule_with_a_missing_target_still_dials_direct() {
+    let tunnel = tunnel_with_ghost_target();
+
+    let (proxy, rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(rule, "MATCH");
+    assert_eq!(
+        proxy.adapter_type(),
+        AdapterType::Direct,
+        "upstream mihomo falls back to DIRECT here, and so must this"
+    );
+}
+
+#[test]
+fn the_fallback_is_counted_as_the_direct_dial_it_actually_is() {
+    let tunnel = tunnel_with_ghost_target();
+    tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(
+        tunnel.statistics().rule_match.snapshot(),
+        vec![(("MATCH", "DIRECT"), 1)],
+        "the counter must not report a proxy hop that never happened"
+    );
+}
+
+#[tokio::test]
+async fn the_lazy_resolve_path_falls_back_the_same_way() {
+    let tunnel = tunnel_with_ghost_target();
+
+    let mut md = metadata();
+    let (proxy, _rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy_lazy(&mut md)
+        .await
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(proxy.adapter_type(), AdapterType::Direct);
+    assert_eq!(
+        tunnel.statistics().rule_match.snapshot(),
+        vec![(("MATCH", "DIRECT"), 1)],
+        "both resolve paths share `materialize_rule_match`, so both count alike"
+    );
+}
+
+#[test]
+fn a_target_the_registry_holds_is_used_as_is() {
+    let tunnel = tunnel_with_builtin_registry();
+    let rules: Vec<Box<dyn Rule>> = vec![Box::new(FinalRule::new("REJECT-DROP"))];
+    tunnel.update_rules(rules);
+
+    let (proxy, _rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(proxy.adapter_type(), AdapterType::RejectDrop);
+    assert_eq!(
+        tunnel.statistics().rule_match.snapshot(),
+        vec![(("MATCH", "REJECT"), 1)],
+        "a refusal the registry really performed is still counted as one"
+    );
+}
+
+#[test]
+fn a_rule_naming_direct_needs_no_registry_entry() {
+    // DIRECT is a built-in the tunnel owns an adapter for, so a rule naming it
+    // must resolve even before any registry snapshot has been published — and
+    // must not be reported as a fallback, because it is the intended target.
+    let tunnel = Tunnel::new(resolver());
+    tunnel.set_mode(TunnelMode::Rule);
+    let rules: Vec<Box<dyn Rule>> = vec![Box::new(FinalRule::new("DIRECT"))];
+    tunnel.update_rules(rules);
+
+    let (proxy, _rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("a MATCH rule always resolves");
+
+    assert_eq!(proxy.adapter_type(), AdapterType::Direct);
+    assert_eq!(
+        tunnel.statistics().rule_match.snapshot(),
+        vec![(("MATCH", "DIRECT"), 1)]
+    );
+}
+
+#[test]
+fn no_rule_matching_still_falls_through_to_direct() {
+    // Only a *matched* rule with an unresolvable target is relabelled. Nothing
+    // matching at all is the ordinary end of the rule list, which has never
+    // touched the match counters.
+    let tunnel = tunnel_with_builtin_registry();
+    let rules: Vec<Box<dyn Rule>> = vec![];
+    tunnel.update_rules(rules);
+
+    let (proxy, rule, _payload) = tunnel
+        .inner()
+        .resolve_proxy(&metadata())
+        .expect("the no-match path still yields DIRECT");
+
+    assert_eq!(rule, "Final");
+    assert_eq!(proxy.adapter_type(), AdapterType::Direct);
+    assert!(
+        tunnel.statistics().rule_match.snapshot().is_empty(),
+        "the fall-through is not a rule match and must not be counted as one"
+    );
+}

--- a/crates/meow-tunnel/tests/rule_target_missing_falls_back_visibly.rs
+++ b/crates/meow-tunnel/tests/rule_target_missing_falls_back_visibly.rs
@@ -1,16 +1,18 @@
 //! A matched rule whose target the registry does not hold falls back to
-//! DIRECT, exactly as upstream mihomo does — but no longer silently
-//! (issue #513).
+//! DIRECT — no longer silently (issue #513).
 //!
-//! The fallback itself is the compatible behaviour and stays: a subscription
-//! that dropped one node has to keep routing the rest, and refusing the
-//! connection instead would break traffic mihomo sends directly. What the rust
-//! port got wrong is that nothing said so. The log line was a `debug!`,
-//! invisible at the default level, and the match statistics derived their
-//! action label from the target *name* before the lookup ran, so a rule naming
-//! `ghost-group` was counted as a PROXY hop that never happened while the bytes
-//! left the machine over the direct adapter. These tests pin the observable
-//! half — same DIRECT dial, honest counter.
+//! Note the deliberate deviation from upstream mihomo: its match loop *skips*
+//! a rule whose target is absent and keeps scanning later rules, reaching
+//! DIRECT only via the no-match tail (and reporting no rule). meow-rs stops at
+//! the first match and dials DIRECT — a subscription that dropped one node
+//! keeps routing the rest, but a later rule upstream would have matched is
+//! never consulted. The semantic parity question is a separate follow-up;
+//! what this port got wrong regardless is that nothing said so. The log line
+//! was a `debug!`, invisible at the default level, and the match statistics
+//! derived their action label from the target *name* before the lookup ran,
+//! so a rule naming `ghost-group` was counted as a PROXY hop that never
+//! happened while the bytes left the machine over the direct adapter. These
+//! tests pin the observable half — same DIRECT dial, honest counter.
 
 use meow_common::{AdapterType, DnsMode, Metadata, Network, Rule, TunnelMode};
 use meow_dns::Resolver;
@@ -72,7 +74,7 @@ fn a_matched_rule_with_a_missing_target_still_dials_direct() {
     assert_eq!(
         proxy.adapter_type(),
         AdapterType::Direct,
-        "upstream mihomo falls back to DIRECT here, and so must this"
+        "meow-rs dials DIRECT here; upstream instead skips the rule and keeps matching"
     );
 }
 


### PR DESCRIPTION
Replaces #516. That PR closed five of the six findings in #513 and was green
on every CI check; this one carries only the parts that do not change what a
working upstream config does. Three commits, in the order #513 suggests.

## What is in

**1. `fix(rules): bound mrs reservations by the input before allocating`** (P0)

`read_u64_vec` reserved `Vec::with_capacity(len)` from a word count declared by
a remote rule-provider before proving those words existed, so `leaves_len =
i64::MAX` tripped the capacity-overflow panic — an unrecoverable termination
under the release profile's `panic = "abort"`. A 30-byte payload was enough.
The geosite `category_count` / `domain_count` reservations asked for hundreds
of gigabytes on a bogus value the same way.

Both now check the byte requirement against the remaining input with a
saturating comparison (`pos + n` can itself wrap on a hostile length) and only
then reserve. Malformed and truncated mrs return `Truncated` / `InvalidLength`
instead of aborting. This also fires on an ordinary truncated download, not
only on an attacker.

**2. `fix(config): bind dialer-proxy by name so groups cannot bypass it`** (P1)

A node reached through a proxy group silently dialled direct, past the chain
its `dialer-proxy` declared. Groups clone their members eagerly and were built
before the dialer pass replaced the registry entries, so every group kept the
pre-dialer adapter while direct rule references got the chained one — the same
node behaved differently depending on how it was selected.

The front hop is now resolved by name against a registry published when the
build finishes, the way mihomo does (`component/proxydialer/byname.go`), and
the dialer pass runs before groups are built. Late binding also makes a
group-valued `dialer-proxy` work, which eager binding could not. A cycle is
still rejected explicitly, since late binding would otherwise turn it into
unbounded recursion on the first dial.

**3. `fix(tunnel): report the DIRECT fallback a missing rule target causes`**

A matched rule whose target the registry does not hold fell back to DIRECT.
That is what mihomo does and it stays. What is fixed is that nothing said so:
the log line was a `debug!`, invisible at the default level, and the match
statistics derived their action label from the target *name* before the lookup
ran — so a rule naming `ghost-group` was counted as a PROXY hop that never
happened while the bytes left over the direct adapter. The fallback is now a
`warn!` naming the target and the rule type, and the label says DIRECT when
that is what dialled. No new label value; DIRECT / REJECT / PROXY are the
existing three. Traffic goes exactly where it went before.

## What is deliberately not in

#516 also carried findings 3, 5 and 6. All three are pulled here because each
one changes behaviour a working upstream config depends on:

- **Finding 6, first half** (fail the load on any entry it cannot build) was
  the most invasive. Upstream drops the entry with a warning and keeps loading;
  failing the whole config instead would take down a subscription over one node
  mihomo skips — including `tuic`, `wireguard` and `hysteria` v1 nodes, any
  protocol compiled out of the running binary (`--no-default-features` could
  not load a normal config at all), and, worst, a `RULE-SET,<name>` whose
  rule-provider failed to fetch or whose `.mrs` did not parse. A rule-provider
  URL being briefly unreachable is routine. Only the second half, above, is
  kept.

- **Finding 5** (keep provider content away from the SIP003 plugin launcher)
  needed `allow-external-plugin` on `proxy-provider` — a config key mihomo does
  not have — and without that key it dropped provider nodes mihomo launches
  fine. The underlying observation still stands: an external plugin becomes the
  executable handed to `Command::new` inside `ShadowsocksAdapter::new`, and
  that constructor runs while the node is parsed, on first load and on every
  provider refresh. It needs a design that does not add a field or refuse a
  node upstream accepts.

- **Finding 3** (VMess body AEAD nonce budget) is a real defect but the fix
  changed runtime behaviour: mihomo's record counter is `wrapping_add`, so a
  connection past 65,536 records keeps running there, and the budget check
  retired it here — at roughly 1 GiB per physical connection, sooner for mux,
  whose logical streams share one counter. Exploiting the reuse also needs an
  outer transport that is not encrypting. Worth fixing, but not as part of a
  compatibility-scoped PR.

Finding 4 is untouched and still open.

## Compatibility

No new config keys. No config or subscription that loads in mihomo fails here,
and no traffic mihomo would send is refused. Commit 2 adds no new config
rejection — the `dialer-proxy` self-reference, not-found and cycle errors all
predate this branch.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default, `--all-features`, `--no-default-features`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --workspace --no-fail-fast` — one pre-existing environmental failure, `raii_guard_test::close_connection_cancels_blocked_prefix_write`, reproduces identically on a clean `a663364` checkout (a 16 MiB prefix write fits this host's loopback socket buffers); it runs in `TunnelMode::Direct` and never reaches the changed code
- [x] new `rule_target_missing_falls_back_visibly` — 6 tests pinning the DIRECT fallback, the honest counter on both resolve paths, an existing REJECT-DROP target, a registry-less `DIRECT` rule, and the uncounted no-match fall-through
- [x] `dialer_proxy_group` — a grouped node obeys the same chain a direct reference does
- [ ] real-node smoke per AGENTS.md, left to the reviewer

#513 stays open.